### PR TITLE
fix(core,gcp): honor T.Service.rootUrl and preserve {+name} reserved-expansion

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -444,7 +444,15 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
             : credentials;
           const client = yield* HttpClient.HttpClient;
 
-          const baseUrl = config.getBaseUrl(creds as ResolvedCreds);
+          // Fall back to the Service trait when the consumer leaves
+          // `getBaseUrl` empty (per-service hosts rather than per-credentials).
+          let baseUrl = config.getBaseUrl(creds as ResolvedCreds);
+          if (!baseUrl) {
+            const svcTrait = Traits.getServiceTrait(inputSchema.ast);
+            if (svcTrait?.rootUrl) {
+              baseUrl = svcTrait.rootUrl + (svcTrait.servicePath ?? "");
+            }
+          }
           const authHeaders = config.getAuthHeaders(creds as ResolvedCreds);
 
           // Use schema-aware request builder for proper camelCase → wire_name mapping

--- a/packages/core/src/traits.ts
+++ b/packages/core/src/traits.ts
@@ -623,6 +623,14 @@ const unwrapRedactedDeep = (value: unknown): unknown => {
   return value;
 };
 
+/**
+ * RFC 6570 §3.2.3 reserved-expansion: encode everything outside the RFC 3986
+ * unreserved (`A-Za-z0-9-._~`) and reserved (`:/?#[]@!$&'()*+,;=`) sets.
+ */
+const RFC3986_NEEDS_ENCODING = /[^A-Za-z0-9\-._~:/?#\[\]@!$&'()*+,;=]/g;
+const encodeReserved = (v: string): string =>
+  v.replace(RFC3986_NEEDS_ENCODING, encodeURIComponent);
+
 export const buildRequestParts = (
   ast: AST.AST,
   httpTrait: HttpTrait,
@@ -653,14 +661,20 @@ export const buildRequestParts = (
       continue;
     }
 
-    // Path parameter
+    // Path parameter — `{+name}` is RFC 6570 reserved-expansion (preserves
+    // `/` and other RFC 3986 reserved chars); `{name}` is simple expansion.
     const pathWireName = getPathParamWireName(prop);
     if (pathWireName !== undefined) {
       nonBodyKeys.add(tsName);
-      path = path.replace(
-        `{${pathWireName}}`,
-        encodeURIComponent(String(value)),
-      );
+      const reservedPlaceholder = `{+${pathWireName}}`;
+      if (path.includes(reservedPlaceholder)) {
+        path = path.replace(reservedPlaceholder, encodeReserved(String(value)));
+      } else {
+        path = path.replace(
+          `{${pathWireName}}`,
+          encodeURIComponent(String(value)),
+        );
+      }
       continue;
     }
 

--- a/packages/core/test/build-request-parts.test.ts
+++ b/packages/core/test/build-request-parts.test.ts
@@ -1,0 +1,70 @@
+import * as Schema from "effect/Schema";
+import { describe, expect, it } from "vitest";
+import * as T from "../src/traits.ts";
+
+// RFC 6570 expansion semantics in `buildRequestParts`: `{+name}` keeps
+// `/` literal, `{name}` percent-encodes it.
+
+describe("buildRequestParts — RFC 6570 path expansion", () => {
+  it("reserved expansion {+name} preserves `/` literally", () => {
+    const Input = Schema.Struct({
+      name: Schema.String.pipe(T.HttpPath("name")),
+    }).pipe(T.Http({ method: "GET", path: "v3/{+name}" }));
+
+    const parts = T.buildRequestParts(
+      Input.ast,
+      T.getHttpTrait(Input.ast)!,
+      { name: "projects/my-project" },
+      Input,
+    );
+
+    expect(parts.path).toBe("v3/projects/my-project");
+  });
+
+  it("simple expansion {name} percent-encodes `/`", () => {
+    const Input = Schema.Struct({
+      name: Schema.String.pipe(T.HttpPath("name")),
+    }).pipe(T.Http({ method: "GET", path: "v3/{name}" }));
+
+    const parts = T.buildRequestParts(
+      Input.ast,
+      T.getHttpTrait(Input.ast)!,
+      { name: "projects/my-project" },
+      Input,
+    );
+
+    expect(parts.path).toBe("v3/projects%2Fmy-project");
+  });
+
+  it("reserved expansion still encodes characters outside RFC 3986 reserved+unreserved", () => {
+    const Input = Schema.Struct({
+      name: Schema.String.pipe(T.HttpPath("name")),
+    }).pipe(T.Http({ method: "GET", path: "v3/{+name}" }));
+
+    const parts = T.buildRequestParts(
+      Input.ast,
+      T.getHttpTrait(Input.ast)!,
+      { name: "projects/with space" },
+      Input,
+    );
+
+    expect(parts.path).toBe("v3/projects/with%20space");
+  });
+
+  it("reserved expansion preserves a value that is purely RFC 3986 reserved", () => {
+    const Input = Schema.Struct({
+      resource: Schema.String.pipe(T.HttpPath("resource")),
+    }).pipe(T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }));
+
+    const parts = T.buildRequestParts(
+      Input.ast,
+      T.getHttpTrait(Input.ast)!,
+      { resource: "projects/p/locations/global/keyRings/kr" },
+      Input,
+    );
+
+    expect(parts.path).toBe(
+      "v1/projects/p/locations/global/keyRings/kr:getIamPolicy",
+    );
+  });
+});

--- a/packages/gcp/patches/cloudbilling/getBillingInfoProjects.json
+++ b/packages/gcp/patches/cloudbilling/getBillingInfoProjects.json
@@ -1,0 +1,6 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "Forbidden": [{ "httpStatus": 403 }]
+  }
+}

--- a/packages/gcp/patches/cloudbilling/updateBillingInfoProjects.json
+++ b/packages/gcp/patches/cloudbilling/updateBillingInfoProjects.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/createProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/createProjectsLocationsClusters.json
@@ -1,0 +1,7 @@
+{
+  "errors": {
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/createProjectsLocationsClustersNodePools.json
+++ b/packages/gcp/patches/container/createProjectsLocationsClustersNodePools.json
@@ -1,0 +1,7 @@
+{
+  "errors": {
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/deleteProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/deleteProjectsLocationsClusters.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/deleteProjectsLocationsClustersNodePools.json
+++ b/packages/gcp/patches/container/deleteProjectsLocationsClustersNodePools.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/getProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/getProjectsLocationsClusters.json
@@ -1,0 +1,6 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "Forbidden": [{ "httpStatus": 403 }]
+  }
+}

--- a/packages/gcp/patches/container/getProjectsLocationsClustersNodePools.json
+++ b/packages/gcp/patches/container/getProjectsLocationsClustersNodePools.json
@@ -1,0 +1,6 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "Forbidden": [{ "httpStatus": 403 }]
+  }
+}

--- a/packages/gcp/patches/container/getProjectsLocationsOperations.json
+++ b/packages/gcp/patches/container/getProjectsLocationsOperations.json
@@ -1,0 +1,6 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "Forbidden": [{ "httpStatus": 403 }]
+  }
+}

--- a/packages/gcp/patches/container/setAddonsProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/setAddonsProjectsLocationsClusters.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/setAutoscalingProjectsLocationsClustersNodePools.json
+++ b/packages/gcp/patches/container/setAutoscalingProjectsLocationsClustersNodePools.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/setLegacyAbacProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/setLegacyAbacProjectsLocationsClusters.json
@@ -1,0 +1,7 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }]
+  }
+}

--- a/packages/gcp/patches/container/setLocationsProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/setLocationsProjectsLocationsClusters.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/setLoggingProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/setLoggingProjectsLocationsClusters.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/setMaintenancePolicyProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/setMaintenancePolicyProjectsLocationsClusters.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/setManagementProjectsLocationsClustersNodePools.json
+++ b/packages/gcp/patches/container/setManagementProjectsLocationsClustersNodePools.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/setMasterAuthProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/setMasterAuthProjectsLocationsClusters.json
@@ -1,0 +1,7 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }]
+  }
+}

--- a/packages/gcp/patches/container/setMonitoringProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/setMonitoringProjectsLocationsClusters.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/setNetworkPolicyProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/setNetworkPolicyProjectsLocationsClusters.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/setResourceLabelsProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/setResourceLabelsProjectsLocationsClusters.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/setSizeProjectsLocationsClustersNodePools.json
+++ b/packages/gcp/patches/container/setSizeProjectsLocationsClustersNodePools.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/updateProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/updateProjectsLocationsClusters.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/updateProjectsLocationsClustersNodePools.json
+++ b/packages/gcp/patches/container/updateProjectsLocationsClustersNodePools.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/serviceusage/disableServices.json
+++ b/packages/gcp/patches/serviceusage/disableServices.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/serviceusage/enableServices.json
+++ b/packages/gcp/patches/serviceusage/enableServices.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/serviceusage/getOperations.json
+++ b/packages/gcp/patches/serviceusage/getOperations.json
@@ -1,0 +1,6 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "Forbidden": [{ "httpStatus": 403 }]
+  }
+}

--- a/packages/gcp/patches/serviceusage/getServices.json
+++ b/packages/gcp/patches/serviceusage/getServices.json
@@ -1,0 +1,6 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "Forbidden": [{ "httpStatus": 403 }]
+  }
+}

--- a/packages/gcp/scripts/generate.ts
+++ b/packages/gcp/scripts/generate.ts
@@ -1060,15 +1060,11 @@ function methodToOperation(
     functionName,
     resourcePath,
     httpMethod: method.httpMethod,
-    // Prefer `path` (the templated form, e.g. `v3/{+name}`) over
-    // `flatPath` (a documentation-only form, e.g.
-    // `v3/projects/{projectsId}`). `flatPath` uses synthesized variable
-    // names that don't match the `parameters.*` keys, so substitution
-    // via `T.HttpPath(<paramName>)` would silently fail at runtime.
-    // Strip RFC 6570 reserved-expansion markers (`{+name}` -> `{name}`)
-    // so the emitted template variables align with the schema field
-    // wire names.
-    path: stripReservedExpansion(method.path ?? method.flatPath),
+    // Prefer `path` (templated, e.g. `v3/{+name}`) over `flatPath`
+    // (documentation-only, e.g. `v3/projects/{projectsId}`). flatPath's
+    // synthesized variable names don't match `parameters.*` keys, so
+    // `T.HttpPath(<paramName>)` substitution would silently miss.
+    path: method.path ?? method.flatPath,
     parameters,
     requestRef: method.request?.$ref,
     responseRef: method.response?.$ref,
@@ -1190,22 +1186,6 @@ function collectPropertyDeps(prop: PropertySchema, deps: string[]): void {
 function capitalize(s: string): string {
   if (!s) return s;
   return s[0]!.toUpperCase() + s.slice(1);
-}
-
-/**
- * Strip RFC 6570 reserved-expansion markers from a Discovery Document
- * URL template. GCP publishes path templates like `v3/{+name}` to
- * indicate that the `name` parameter should be expanded without
- * percent-encoding the `/` characters within its value. Distilled's
- * `buildRequestParts` always `encodeURIComponent`s path values; GCP's
- * REST endpoints accept `%2F` as equivalent to `/` in resource-name
- * path segments, so we drop the `+` marker and let the standard
- * substitution path handle the rest. The variable name itself
- * (`name`) is preserved so it lines up with the
- * `T.HttpPath(<paramName>)` annotation on the request schema.
- */
-function stripReservedExpansion(path: string): string {
-  return path.replace(/\{\+([^}]+)\}/g, "{$1}");
 }
 
 function safeIdentifier(name: string): string {

--- a/packages/gcp/src/client/api.ts
+++ b/packages/gcp/src/client/api.ts
@@ -48,13 +48,13 @@ const matchError = (
 };
 
 /**
- * GCP API client.
- * Note: GCP uses per-service base URLs from the Discovery Documents,
- * so the base URL is set per-service via the Service trait, not globally.
+ * GCP API client. Per-service hosts come from each service file's
+ * `T.Service({ rootUrl })` trait; `core.makeAPI` reads the trait when
+ * `getBaseUrl` returns an empty string.
  */
 const _API = makeAPI<Credentials>({
   credentials: Credentials as any,
-  getBaseUrl: (_creds: any) => "", // Set per-service via Http trait
+  getBaseUrl: (_creds: any) => "",
   getAuthHeaders: (creds: any) => ({
     Authorization: `Bearer ${Redacted.value(creds.accessToken)}`,
   }),

--- a/packages/gcp/src/services/abusiveexperiencereport-v1.ts
+++ b/packages/gcp/src/services/abusiveexperiencereport-v1.ts
@@ -104,7 +104,7 @@ export interface GetSitesRequest {
 export const GetSitesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetSitesRequest>;
 

--- a/packages/gcp/src/services/accessapproval-v1.ts
+++ b/packages/gcp/src/services/accessapproval-v1.ts
@@ -380,7 +380,7 @@ export const UpdateAccessApprovalSettingsFoldersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AccessApprovalSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAccessApprovalSettingsFoldersRequest>;
 
@@ -412,7 +412,7 @@ export const GetServiceAccountFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetServiceAccountFoldersRequest>;
 
@@ -443,7 +443,7 @@ export const DeleteAccessApprovalSettingsFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccessApprovalSettingsFoldersRequest>;
 
@@ -474,7 +474,7 @@ export const GetAccessApprovalSettingsFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccessApprovalSettingsFoldersRequest>;
 
@@ -505,7 +505,7 @@ export const GetFoldersApprovalRequestsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersApprovalRequestsRequest>;
 
@@ -539,7 +539,7 @@ export const DismissFoldersApprovalRequestsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DismissApprovalRequestMessage).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:dismiss", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:dismiss", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DismissFoldersApprovalRequestsRequest>;
 
@@ -573,7 +573,7 @@ export const ApproveFoldersApprovalRequestsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ApproveApprovalRequestMessage).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:approve", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:approve", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ApproveFoldersApprovalRequestsRequest>;
 
@@ -607,7 +607,7 @@ export const InvalidateFoldersApprovalRequestsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(InvalidateApprovalRequestMessage).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:invalidate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:invalidate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<InvalidateFoldersApprovalRequestsRequest>;
 
@@ -647,7 +647,7 @@ export const ListFoldersApprovalRequestsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/approvalRequests" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/approvalRequests" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersApprovalRequestsRequest>;
 
@@ -688,7 +688,7 @@ export const UpdateAccessApprovalSettingsProjectsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AccessApprovalSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAccessApprovalSettingsProjectsRequest>;
 
@@ -720,7 +720,7 @@ export const GetServiceAccountProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetServiceAccountProjectsRequest>;
 
@@ -751,7 +751,7 @@ export const DeleteAccessApprovalSettingsProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccessApprovalSettingsProjectsRequest>;
 
@@ -782,7 +782,7 @@ export const GetAccessApprovalSettingsProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccessApprovalSettingsProjectsRequest>;
 
@@ -813,7 +813,7 @@ export const GetProjectsApprovalRequestsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsApprovalRequestsRequest>;
 
@@ -847,7 +847,7 @@ export const DismissProjectsApprovalRequestsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DismissApprovalRequestMessage).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:dismiss", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:dismiss", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DismissProjectsApprovalRequestsRequest>;
 
@@ -881,7 +881,7 @@ export const ApproveProjectsApprovalRequestsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ApproveApprovalRequestMessage).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:approve", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:approve", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ApproveProjectsApprovalRequestsRequest>;
 
@@ -915,7 +915,7 @@ export const InvalidateProjectsApprovalRequestsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(InvalidateApprovalRequestMessage).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:invalidate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:invalidate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<InvalidateProjectsApprovalRequestsRequest>;
 
@@ -955,7 +955,7 @@ export const ListProjectsApprovalRequestsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/approvalRequests" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/approvalRequests" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsApprovalRequestsRequest>;
 
@@ -990,7 +990,7 @@ export const DeleteAccessApprovalSettingsOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccessApprovalSettingsOrganizationsRequest>;
 
@@ -1027,7 +1027,7 @@ export const UpdateAccessApprovalSettingsOrganizationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AccessApprovalSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAccessApprovalSettingsOrganizationsRequest>;
 
@@ -1059,7 +1059,7 @@ export const GetServiceAccountOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetServiceAccountOrganizationsRequest>;
 
@@ -1091,7 +1091,7 @@ export const GetAccessApprovalSettingsOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccessApprovalSettingsOrganizationsRequest>;
 
@@ -1123,7 +1123,7 @@ export const GetOrganizationsApprovalRequestsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsApprovalRequestsRequest>;
 
@@ -1157,7 +1157,7 @@ export const DismissOrganizationsApprovalRequestsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DismissApprovalRequestMessage).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:dismiss", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:dismiss", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DismissOrganizationsApprovalRequestsRequest>;
 
@@ -1197,7 +1197,7 @@ export const ListOrganizationsApprovalRequestsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/approvalRequests" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/approvalRequests" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsApprovalRequestsRequest>;
 
@@ -1236,7 +1236,7 @@ export const ApproveOrganizationsApprovalRequestsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ApproveApprovalRequestMessage).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:approve", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:approve", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ApproveOrganizationsApprovalRequestsRequest>;
 
@@ -1270,7 +1270,7 @@ export const InvalidateOrganizationsApprovalRequestsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(InvalidateApprovalRequestMessage).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:invalidate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:invalidate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<InvalidateOrganizationsApprovalRequestsRequest>;
 

--- a/packages/gcp/src/services/accesscontextmanager-v1.ts
+++ b/packages/gcp/src/services/accesscontextmanager-v1.ts
@@ -994,7 +994,7 @@ export const ListOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("returnPartialSuccess"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<ListOperationsRequest>;
 
@@ -1028,7 +1028,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -1058,7 +1058,7 @@ export const DeleteOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOperationsRequest>;
 
@@ -1091,7 +1091,7 @@ export const CancelOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOperationsRequest>;
 
@@ -1162,7 +1162,7 @@ export const GetAccessPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccessPoliciesRequest>;
 
@@ -1230,7 +1230,7 @@ export const PatchAccessPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AccessPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccessPoliciesRequest>;
 
@@ -1261,7 +1261,7 @@ export const DeleteAccessPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccessPoliciesRequest>;
 
@@ -1297,7 +1297,7 @@ export const SetIamPolicyAccessPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1335,7 +1335,7 @@ export const GetIamPolicyAccessPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1373,7 +1373,7 @@ export const TestIamPermissionsAccessPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1422,7 +1422,7 @@ export const ListAccessPoliciesAccessLevelsRequest =
       T.HttpQuery("accessLevelFormat"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/accessLevels" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/accessLevels" }),
     svc,
   ) as unknown as Schema.Schema<ListAccessPoliciesAccessLevelsRequest>;
 
@@ -1466,7 +1466,7 @@ export const GetAccessPoliciesAccessLevelsRequest =
       T.HttpQuery("accessLevelFormat"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccessPoliciesAccessLevelsRequest>;
 
@@ -1500,7 +1500,11 @@ export const CreateAccessPoliciesAccessLevelsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(AccessLevel).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/accessLevels", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/accessLevels",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateAccessPoliciesAccessLevelsRequest>;
 
@@ -1537,7 +1541,7 @@ export const PatchAccessPoliciesAccessLevelsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AccessLevel).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccessPoliciesAccessLevelsRequest>;
 
@@ -1568,7 +1572,7 @@ export const DeleteAccessPoliciesAccessLevelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccessPoliciesAccessLevelsRequest>;
 
@@ -1604,7 +1608,7 @@ export const ReplaceAllAccessPoliciesAccessLevelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/accessLevels:replaceAll",
+      path: "v1/{+parent}/accessLevels:replaceAll",
       hasBody: true,
     }),
     svc,
@@ -1642,7 +1646,7 @@ export const TestIamPermissionsAccessPoliciesAccessLevelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1682,7 +1686,7 @@ export const ListAccessPoliciesServicePerimetersRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/servicePerimeters" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/servicePerimeters" }),
     svc,
   ) as unknown as Schema.Schema<ListAccessPoliciesServicePerimetersRequest>;
 
@@ -1718,7 +1722,7 @@ export const GetAccessPoliciesServicePerimetersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccessPoliciesServicePerimetersRequest>;
 
@@ -1754,7 +1758,7 @@ export const CreateAccessPoliciesServicePerimetersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/servicePerimeters",
+      path: "v1/{+parent}/servicePerimeters",
       hasBody: true,
     }),
     svc,
@@ -1793,7 +1797,7 @@ export const PatchAccessPoliciesServicePerimetersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ServicePerimeter).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccessPoliciesServicePerimetersRequest>;
 
@@ -1824,7 +1828,7 @@ export const DeleteAccessPoliciesServicePerimetersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccessPoliciesServicePerimetersRequest>;
 
@@ -1860,7 +1864,7 @@ export const ReplaceAllAccessPoliciesServicePerimetersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/servicePerimeters:replaceAll",
+      path: "v1/{+parent}/servicePerimeters:replaceAll",
       hasBody: true,
     }),
     svc,
@@ -1898,7 +1902,7 @@ export const CommitAccessPoliciesServicePerimetersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/servicePerimeters:commit",
+      path: "v1/{+parent}/servicePerimeters:commit",
       hasBody: true,
     }),
     svc,
@@ -1936,7 +1940,7 @@ export const TestIamPermissionsAccessPoliciesServicePerimetersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1977,7 +1981,7 @@ export const ListAccessPoliciesAuthorizedOrgsDescsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/authorizedOrgsDescs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/authorizedOrgsDescs" }),
     svc,
   ) as unknown as Schema.Schema<ListAccessPoliciesAuthorizedOrgsDescsRequest>;
 
@@ -2013,7 +2017,7 @@ export const GetAccessPoliciesAuthorizedOrgsDescsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccessPoliciesAuthorizedOrgsDescsRequest>;
 
@@ -2049,7 +2053,7 @@ export const CreateAccessPoliciesAuthorizedOrgsDescsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/authorizedOrgsDescs",
+      path: "v1/{+parent}/authorizedOrgsDescs",
       hasBody: true,
     }),
     svc,
@@ -2088,7 +2092,7 @@ export const PatchAccessPoliciesAuthorizedOrgsDescsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AuthorizedOrgsDesc).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccessPoliciesAuthorizedOrgsDescsRequest>;
 
@@ -2119,7 +2123,7 @@ export const DeleteAccessPoliciesAuthorizedOrgsDescsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccessPoliciesAuthorizedOrgsDescsRequest>;
 
@@ -2222,7 +2226,7 @@ export const ListOrganizationsGcpUserAccessBindingsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/gcpUserAccessBindings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/gcpUserAccessBindings" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsGcpUserAccessBindingsRequest>;
 
@@ -2258,7 +2262,7 @@ export const GetOrganizationsGcpUserAccessBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsGcpUserAccessBindingsRequest>;
 
@@ -2295,7 +2299,7 @@ export const CreateOrganizationsGcpUserAccessBindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/gcpUserAccessBindings",
+      path: "v1/{+parent}/gcpUserAccessBindings",
       hasBody: true,
     }),
     svc,
@@ -2337,7 +2341,7 @@ export const PatchOrganizationsGcpUserAccessBindingsRequest =
     append: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("append")),
     body: Schema.optional(GcpUserAccessBinding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsGcpUserAccessBindingsRequest>;
 
@@ -2368,7 +2372,7 @@ export const DeleteOrganizationsGcpUserAccessBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsGcpUserAccessBindingsRequest>;
 

--- a/packages/gcp/src/services/adexchangebuyer2-v2beta1.ts
+++ b/packages/gcp/src/services/adexchangebuyer2-v2beta1.ts
@@ -2265,7 +2265,7 @@ export const CreateBuyersFilterSetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{ownerName}/filterSets",
+      path: "v2beta1/{+ownerName}/filterSets",
       hasBody: true,
     }),
     svc,
@@ -2304,7 +2304,7 @@ export const ListBuyersFilterSetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{ownerName}/filterSets" }),
+    T.Http({ method: "GET", path: "v2beta1/{+ownerName}/filterSets" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersFilterSetsRequest>;
 
@@ -2339,7 +2339,7 @@ export const GetBuyersFilterSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBuyersFilterSetsRequest>;
 
@@ -2370,7 +2370,7 @@ export const DeleteBuyersFilterSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteBuyersFilterSetsRequest>;
 
@@ -2408,7 +2408,7 @@ export const ListBuyersFilterSetsBidResponsesWithoutBidsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/bidResponsesWithoutBids",
+      path: "v2beta1/{+filterSetName}/bidResponsesWithoutBids",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersFilterSetsBidResponsesWithoutBidsRequest>;
@@ -2453,7 +2453,7 @@ export const ListBuyersFilterSetsBidResponseErrorsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/bidResponseErrors",
+      path: "v2beta1/{+filterSetName}/bidResponseErrors",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersFilterSetsBidResponseErrorsRequest>;
@@ -2498,7 +2498,7 @@ export const ListBuyersFilterSetsFilteredBidRequestsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/filteredBidRequests",
+      path: "v2beta1/{+filterSetName}/filteredBidRequests",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersFilterSetsFilteredBidRequestsRequest>;
@@ -2541,7 +2541,7 @@ export const ListBuyersFilterSetsLosingBidsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filterSetName: Schema.String.pipe(T.HttpPath("filterSetName")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{filterSetName}/losingBids" }),
+    T.Http({ method: "GET", path: "v2beta1/{+filterSetName}/losingBids" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersFilterSetsLosingBidsRequest>;
 
@@ -2584,7 +2584,7 @@ export const ListBuyersFilterSetsImpressionMetricsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/impressionMetrics",
+      path: "v2beta1/{+filterSetName}/impressionMetrics",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersFilterSetsImpressionMetricsRequest>;
@@ -2629,7 +2629,7 @@ export const ListBuyersFilterSetsNonBillableWinningBidsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/nonBillableWinningBids",
+      path: "v2beta1/{+filterSetName}/nonBillableWinningBids",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersFilterSetsNonBillableWinningBidsRequest>;
@@ -2672,7 +2672,7 @@ export const ListBuyersFilterSetsFilteredBidsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filterSetName: Schema.String.pipe(T.HttpPath("filterSetName")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{filterSetName}/filteredBids" }),
+    T.Http({ method: "GET", path: "v2beta1/{+filterSetName}/filteredBids" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersFilterSetsFilteredBidsRequest>;
 
@@ -2718,7 +2718,7 @@ export const ListBuyersFilterSetsFilteredBidsDetailsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/filteredBids/{creativeStatusId}/details",
+      path: "v2beta1/{+filterSetName}/filteredBids/{creativeStatusId}/details",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersFilterSetsFilteredBidsDetailsRequest>;
@@ -2766,7 +2766,7 @@ export const ListBuyersFilterSetsFilteredBidsCreativesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/filteredBids/{creativeStatusId}/creatives",
+      path: "v2beta1/{+filterSetName}/filteredBids/{creativeStatusId}/creatives",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersFilterSetsFilteredBidsCreativesRequest>;
@@ -2809,7 +2809,7 @@ export const ListBuyersFilterSetsBidMetricsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filterSetName: Schema.String.pipe(T.HttpPath("filterSetName")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{filterSetName}/bidMetrics" }),
+    T.Http({ method: "GET", path: "v2beta1/{+filterSetName}/bidMetrics" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersFilterSetsBidMetricsRequest>;
 
@@ -2844,7 +2844,7 @@ export const GetBiddersAccountsFilterSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBiddersAccountsFilterSetsRequest>;
 
@@ -2875,7 +2875,7 @@ export const DeleteBiddersAccountsFilterSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteBiddersAccountsFilterSetsRequest>;
 
@@ -2916,7 +2916,7 @@ export const CreateBiddersAccountsFilterSetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{ownerName}/filterSets",
+      path: "v2beta1/{+ownerName}/filterSets",
       hasBody: true,
     }),
     svc,
@@ -2955,7 +2955,7 @@ export const ListBiddersAccountsFilterSetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{ownerName}/filterSets" }),
+    T.Http({ method: "GET", path: "v2beta1/{+ownerName}/filterSets" }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersAccountsFilterSetsRequest>;
 
@@ -2998,7 +2998,7 @@ export const ListBiddersAccountsFilterSetsFilteredBidRequestsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/filteredBidRequests",
+      path: "v2beta1/{+filterSetName}/filteredBidRequests",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersAccountsFilterSetsFilteredBidRequestsRequest>;
@@ -3042,7 +3042,7 @@ export const ListBiddersAccountsFilterSetsLosingBidsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filterSetName: Schema.String.pipe(T.HttpPath("filterSetName")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{filterSetName}/losingBids" }),
+    T.Http({ method: "GET", path: "v2beta1/{+filterSetName}/losingBids" }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersAccountsFilterSetsLosingBidsRequest>;
 
@@ -3086,7 +3086,7 @@ export const ListBiddersAccountsFilterSetsBidResponsesWithoutBidsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/bidResponsesWithoutBids",
+      path: "v2beta1/{+filterSetName}/bidResponsesWithoutBids",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersAccountsFilterSetsBidResponsesWithoutBidsRequest>;
@@ -3132,7 +3132,7 @@ export const ListBiddersAccountsFilterSetsBidResponseErrorsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/bidResponseErrors",
+      path: "v2beta1/{+filterSetName}/bidResponseErrors",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersAccountsFilterSetsBidResponseErrorsRequest>;
@@ -3175,7 +3175,7 @@ export const ListBiddersAccountsFilterSetsFilteredBidsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{filterSetName}/filteredBids" }),
+    T.Http({ method: "GET", path: "v2beta1/{+filterSetName}/filteredBids" }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersAccountsFilterSetsFilteredBidsRequest>;
 
@@ -3222,7 +3222,7 @@ export const ListBiddersAccountsFilterSetsFilteredBidsCreativesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/filteredBids/{creativeStatusId}/creatives",
+      path: "v2beta1/{+filterSetName}/filteredBids/{creativeStatusId}/creatives",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersAccountsFilterSetsFilteredBidsCreativesRequest>;
@@ -3271,7 +3271,7 @@ export const ListBiddersAccountsFilterSetsFilteredBidsDetailsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/filteredBids/{creativeStatusId}/details",
+      path: "v2beta1/{+filterSetName}/filteredBids/{creativeStatusId}/details",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersAccountsFilterSetsFilteredBidsDetailsRequest>;
@@ -3315,7 +3315,7 @@ export const ListBiddersAccountsFilterSetsBidMetricsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filterSetName: Schema.String.pipe(T.HttpPath("filterSetName")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{filterSetName}/bidMetrics" }),
+    T.Http({ method: "GET", path: "v2beta1/{+filterSetName}/bidMetrics" }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersAccountsFilterSetsBidMetricsRequest>;
 
@@ -3359,7 +3359,7 @@ export const ListBiddersAccountsFilterSetsImpressionMetricsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/impressionMetrics",
+      path: "v2beta1/{+filterSetName}/impressionMetrics",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersAccountsFilterSetsImpressionMetricsRequest>;
@@ -3404,7 +3404,7 @@ export const ListBiddersAccountsFilterSetsNonBillableWinningBidsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/nonBillableWinningBids",
+      path: "v2beta1/{+filterSetName}/nonBillableWinningBids",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersAccountsFilterSetsNonBillableWinningBidsRequest>;
@@ -3442,7 +3442,7 @@ export const GetBiddersFilterSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBiddersFilterSetsRequest>;
 
@@ -3473,7 +3473,7 @@ export const DeleteBiddersFilterSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteBiddersFilterSetsRequest>;
 
@@ -3510,7 +3510,7 @@ export const ListBiddersFilterSetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{ownerName}/filterSets" }),
+    T.Http({ method: "GET", path: "v2beta1/{+ownerName}/filterSets" }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersFilterSetsRequest>;
 
@@ -3555,7 +3555,7 @@ export const CreateBiddersFilterSetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{ownerName}/filterSets",
+      path: "v2beta1/{+ownerName}/filterSets",
       hasBody: true,
     }),
     svc,
@@ -3596,7 +3596,7 @@ export const ListBiddersFilterSetsBidResponsesWithoutBidsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/bidResponsesWithoutBids",
+      path: "v2beta1/{+filterSetName}/bidResponsesWithoutBids",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersFilterSetsBidResponsesWithoutBidsRequest>;
@@ -3641,7 +3641,7 @@ export const ListBiddersFilterSetsBidResponseErrorsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/bidResponseErrors",
+      path: "v2beta1/{+filterSetName}/bidResponseErrors",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersFilterSetsBidResponseErrorsRequest>;
@@ -3686,7 +3686,7 @@ export const ListBiddersFilterSetsFilteredBidRequestsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/filteredBidRequests",
+      path: "v2beta1/{+filterSetName}/filteredBidRequests",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersFilterSetsFilteredBidRequestsRequest>;
@@ -3729,7 +3729,7 @@ export const ListBiddersFilterSetsLosingBidsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{filterSetName}/losingBids" }),
+    T.Http({ method: "GET", path: "v2beta1/{+filterSetName}/losingBids" }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersFilterSetsLosingBidsRequest>;
 
@@ -3772,7 +3772,7 @@ export const ListBiddersFilterSetsImpressionMetricsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/impressionMetrics",
+      path: "v2beta1/{+filterSetName}/impressionMetrics",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersFilterSetsImpressionMetricsRequest>;
@@ -3817,7 +3817,7 @@ export const ListBiddersFilterSetsNonBillableWinningBidsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/nonBillableWinningBids",
+      path: "v2beta1/{+filterSetName}/nonBillableWinningBids",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersFilterSetsNonBillableWinningBidsRequest>;
@@ -3860,7 +3860,7 @@ export const ListBiddersFilterSetsFilteredBidsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{filterSetName}/filteredBids" }),
+    T.Http({ method: "GET", path: "v2beta1/{+filterSetName}/filteredBids" }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersFilterSetsFilteredBidsRequest>;
 
@@ -3907,7 +3907,7 @@ export const ListBiddersFilterSetsFilteredBidsCreativesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/filteredBids/{creativeStatusId}/creatives",
+      path: "v2beta1/{+filterSetName}/filteredBids/{creativeStatusId}/creatives",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersFilterSetsFilteredBidsCreativesRequest>;
@@ -3955,7 +3955,7 @@ export const ListBiddersFilterSetsFilteredBidsDetailsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta1/{filterSetName}/filteredBids/{creativeStatusId}/details",
+      path: "v2beta1/{+filterSetName}/filteredBids/{creativeStatusId}/details",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersFilterSetsFilteredBidsDetailsRequest>;
@@ -3998,7 +3998,7 @@ export const ListBiddersFilterSetsBidMetricsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{filterSetName}/bidMetrics" }),
+    T.Http({ method: "GET", path: "v2beta1/{+filterSetName}/bidMetrics" }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersFilterSetsBidMetricsRequest>;
 

--- a/packages/gcp/src/services/adexperiencereport-v1.ts
+++ b/packages/gcp/src/services/adexperiencereport-v1.ts
@@ -100,7 +100,7 @@ export interface GetSitesRequest {
 export const GetSitesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetSitesRequest>;
 

--- a/packages/gcp/src/services/admin-directory_v1.ts
+++ b/packages/gcp/src/services/admin-directory_v1.ts
@@ -6827,7 +6827,7 @@ export const BatchCreatePrintServersCustomersChromePrintServersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "admin/directory/v1/{parent}/chrome/printServers:batchCreatePrintServers",
+      path: "admin/directory/v1/{+parent}/chrome/printServers:batchCreatePrintServers",
       hasBody: true,
     }),
     svc,
@@ -6879,7 +6879,7 @@ export const ListCustomersChromePrintServersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "admin/directory/v1/{parent}/chrome/printServers",
+      path: "admin/directory/v1/{+parent}/chrome/printServers",
     }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersChromePrintServersRequest>;
@@ -6915,7 +6915,7 @@ export const GetCustomersChromePrintServersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "admin/directory/v1/{name}" }),
+    T.Http({ method: "GET", path: "admin/directory/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersChromePrintServersRequest>;
 
@@ -6954,7 +6954,7 @@ export const PatchCustomersChromePrintServersRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "admin/directory/v1/{name}",
+      path: "admin/directory/v1/{+name}",
       hasBody: true,
     }),
     svc,
@@ -6992,7 +6992,7 @@ export const CreateCustomersChromePrintServersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "admin/directory/v1/{parent}/chrome/printServers",
+      path: "admin/directory/v1/{+parent}/chrome/printServers",
       hasBody: true,
     }),
     svc,
@@ -7030,7 +7030,7 @@ export const BatchDeletePrintServersCustomersChromePrintServersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "admin/directory/v1/{parent}/chrome/printServers:batchDeletePrintServers",
+      path: "admin/directory/v1/{+parent}/chrome/printServers:batchDeletePrintServers",
       hasBody: true,
     }),
     svc,
@@ -7065,7 +7065,7 @@ export const DeleteCustomersChromePrintServersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "admin/directory/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "admin/directory/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteCustomersChromePrintServersRequest>;
 
@@ -7096,7 +7096,7 @@ export const DeleteCustomersChromePrintersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "admin/directory/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "admin/directory/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteCustomersChromePrintersRequest>;
 
@@ -7132,7 +7132,7 @@ export const CreateCustomersChromePrintersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "admin/directory/v1/{parent}/chrome/printers",
+      path: "admin/directory/v1/{+parent}/chrome/printers",
       hasBody: true,
     }),
     svc,
@@ -7176,7 +7176,7 @@ export const ListPrinterModelsCustomersChromePrintersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "admin/directory/v1/{parent}/chrome/printers:listPrinterModels",
+      path: "admin/directory/v1/{+parent}/chrome/printers:listPrinterModels",
     }),
     svc,
   ) as unknown as Schema.Schema<ListPrinterModelsCustomersChromePrintersRequest>;
@@ -7224,7 +7224,7 @@ export const PatchCustomersChromePrintersRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "admin/directory/v1/{name}",
+      path: "admin/directory/v1/{+name}",
       hasBody: true,
     }),
     svc,
@@ -7262,7 +7262,7 @@ export const BatchDeletePrintersCustomersChromePrintersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "admin/directory/v1/{parent}/chrome/printers:batchDeletePrinters",
+      path: "admin/directory/v1/{+parent}/chrome/printers:batchDeletePrinters",
       hasBody: true,
     }),
     svc,
@@ -7296,7 +7296,7 @@ export const GetCustomersChromePrintersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "admin/directory/v1/{name}" }),
+    T.Http({ method: "GET", path: "admin/directory/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersChromePrintersRequest>;
 
@@ -7332,7 +7332,7 @@ export const BatchCreatePrintersCustomersChromePrintersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "admin/directory/v1/{parent}/chrome/printers:batchCreatePrinters",
+      path: "admin/directory/v1/{+parent}/chrome/printers:batchCreatePrinters",
       hasBody: true,
     }),
     svc,
@@ -7383,7 +7383,7 @@ export const ListCustomersChromePrintersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "admin/directory/v1/{parent}/chrome/printers",
+      path: "admin/directory/v1/{+parent}/chrome/printers",
     }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersChromePrintersRequest>;
@@ -7423,7 +7423,7 @@ export const DeleteOrgunitsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "DELETE",
-    path: "admin/directory/v1/customer/{customerId}/orgunits/{orgUnitPath}",
+    path: "admin/directory/v1/customer/{customerId}/orgunits/{+orgUnitPath}",
   }),
   svc,
 ) as unknown as Schema.Schema<DeleteOrgunitsRequest>;
@@ -7464,7 +7464,7 @@ export const PatchOrgunitsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "admin/directory/v1/customer/{customerId}/orgunits/{orgUnitPath}",
+    path: "admin/directory/v1/customer/{customerId}/orgunits/{+orgUnitPath}",
     hasBody: true,
   }),
   svc,
@@ -7500,7 +7500,7 @@ export const GetOrgunitsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "GET",
-    path: "admin/directory/v1/customer/{customerId}/orgunits/{orgUnitPath}",
+    path: "admin/directory/v1/customer/{customerId}/orgunits/{+orgUnitPath}",
   }),
   svc,
 ) as unknown as Schema.Schema<GetOrgunitsRequest>;
@@ -7574,7 +7574,7 @@ export const UpdateOrgunitsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PUT",
-    path: "admin/directory/v1/customer/{customerId}/orgunits/{orgUnitPath}",
+    path: "admin/directory/v1/customer/{customerId}/orgunits/{+orgUnitPath}",
     hasBody: true,
   }),
   svc,

--- a/packages/gcp/src/services/admob-v1.ts
+++ b/packages/gcp/src/services/admob-v1.ts
@@ -618,7 +618,7 @@ export interface GetAccountsRequest {
 export const GetAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetAccountsRequest>;
 
@@ -690,7 +690,7 @@ export const GenerateAccountsNetworkReportRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/networkReport:generate",
+      path: "v1/{+parent}/networkReport:generate",
       hasBody: true,
     }),
     svc,
@@ -730,7 +730,7 @@ export const ListAccountsAdUnitsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/adUnits" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/adUnits" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAdUnitsRequest>;
 
@@ -770,7 +770,7 @@ export const GenerateAccountsMediationReportRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/mediationReport:generate",
+      path: "v1/{+parent}/mediationReport:generate",
       hasBody: true,
     }),
     svc,
@@ -810,7 +810,7 @@ export const ListAccountsAppsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/apps" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/apps" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAppsRequest>;
 

--- a/packages/gcp/src/services/admob-v1beta.ts
+++ b/packages/gcp/src/services/admob-v1beta.ts
@@ -1054,7 +1054,7 @@ export interface GetAccountsRequest {
 export const GetAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta/{name}" }),
+  T.Http({ method: "GET", path: "v1beta/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetAccountsRequest>;
 
@@ -1126,7 +1126,7 @@ export const GenerateAccountsNetworkReportRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/networkReport:generate",
+      path: "v1beta/{+parent}/networkReport:generate",
       hasBody: true,
     }),
     svc,
@@ -1166,7 +1166,7 @@ export const ListAccountsAdSourcesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/adSources" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/adSources" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAdSourcesRequest>;
 
@@ -1207,7 +1207,7 @@ export const ListAccountsAdSourcesAdaptersRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/adapters" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/adapters" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAdSourcesAdaptersRequest>;
 
@@ -1251,7 +1251,7 @@ export const ListAccountsMediationGroupsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/mediationGroups" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/mediationGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsMediationGroupsRequest>;
 
@@ -1291,7 +1291,7 @@ export const CreateAccountsMediationGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/mediationGroups",
+      path: "v1beta/{+parent}/mediationGroups",
       hasBody: true,
     }),
     svc,
@@ -1330,7 +1330,7 @@ export const PatchAccountsMediationGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MediationGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsMediationGroupsRequest>;
 
@@ -1366,7 +1366,7 @@ export const CreateAccountsMediationGroupsMediationAbExperimentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/mediationAbExperiments",
+      path: "v1beta/{+parent}/mediationAbExperiments",
       hasBody: true,
     }),
     svc,
@@ -1404,7 +1404,7 @@ export const StopAccountsMediationGroupsMediationAbExperimentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopMediationAbExperimentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopAccountsMediationGroupsMediationAbExperimentsRequest>;
 
@@ -1442,7 +1442,7 @@ export const BatchCreateAccountsAdUnitMappingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/adUnitMappings:batchCreate",
+      path: "v1beta/{+parent}/adUnitMappings:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -1481,7 +1481,7 @@ export const GenerateAccountsCampaignReportRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/campaignReport:generate",
+      path: "v1beta/{+parent}/campaignReport:generate",
       hasBody: true,
     }),
     svc,
@@ -1521,7 +1521,7 @@ export const ListAccountsAdUnitsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/adUnits" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/adUnits" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAdUnitsRequest>;
 
@@ -1559,7 +1559,7 @@ export const CreateAccountsAdUnitsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(AdUnit).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/adUnits", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/adUnits", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateAccountsAdUnitsRequest>;
 
@@ -1594,7 +1594,7 @@ export const CreateAccountsAdUnitsAdUnitMappingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/adUnitMappings",
+      path: "v1beta/{+parent}/adUnitMappings",
       hasBody: true,
     }),
     svc,
@@ -1636,7 +1636,7 @@ export const ListAccountsAdUnitsAdUnitMappingsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/adUnitMappings" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/adUnitMappings" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAdUnitsAdUnitMappingsRequest>;
 
@@ -1677,7 +1677,7 @@ export const GenerateAccountsMediationReportRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/mediationReport:generate",
+      path: "v1beta/{+parent}/mediationReport:generate",
       hasBody: true,
     }),
     svc,
@@ -1717,7 +1717,7 @@ export const ListAccountsAppsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/apps" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/apps" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAppsRequest>;
 
@@ -1755,7 +1755,7 @@ export const CreateAccountsAppsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(App).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/apps", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/apps", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateAccountsAppsRequest>;
 

--- a/packages/gcp/src/services/adsense-v2.ts
+++ b/packages/gcp/src/services/adsense-v2.ts
@@ -627,7 +627,7 @@ export interface GetAccountsRequest {
 export const GetAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{name}" }),
+  T.Http({ method: "GET", path: "v2/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetAccountsRequest>;
 
@@ -663,7 +663,7 @@ export const ListChildAccountsAccountsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}:listChildAccounts" }),
+    T.Http({ method: "GET", path: "v2/{+parent}:listChildAccounts" }),
     svc,
   ) as unknown as Schema.Schema<ListChildAccountsAccountsRequest>;
 
@@ -735,7 +735,7 @@ export const GetAdBlockingRecoveryTagAccountsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/adBlockingRecoveryTag" }),
+    T.Http({ method: "GET", path: "v2/{+name}/adBlockingRecoveryTag" }),
     svc,
   ) as unknown as Schema.Schema<GetAdBlockingRecoveryTagAccountsRequest>;
 
@@ -766,7 +766,7 @@ export const GetAccountsPolicyIssuesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsPolicyIssuesRequest>;
 
@@ -803,7 +803,7 @@ export const ListAccountsPolicyIssuesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/policyIssues" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/policyIssues" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsPolicyIssuesRequest>;
 
@@ -838,7 +838,7 @@ export const ListAccountsPaymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/payments" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/payments" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsPaymentsRequest>;
 
@@ -869,7 +869,7 @@ export const GetAccountsSitesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsSitesRequest>;
 
@@ -905,7 +905,7 @@ export const ListAccountsSitesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/sites" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/sites" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsSitesRequest>;
 
@@ -940,7 +940,7 @@ export const GetSavedAccountsReportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/saved" }),
+    T.Http({ method: "GET", path: "v2/{+name}/saved" }),
     svc,
   ) as unknown as Schema.Schema<GetSavedAccountsReportsRequest>;
 
@@ -1151,7 +1151,7 @@ export const GenerateCsvAccountsReportsRequest =
       T.HttpQuery("reportingTimeZone"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{account}/reports:generateCsv" }),
+    T.Http({ method: "GET", path: "v2/{+account}/reports:generateCsv" }),
     svc,
   ) as unknown as Schema.Schema<GenerateCsvAccountsReportsRequest>;
 
@@ -1362,7 +1362,7 @@ export const GenerateAccountsReportsRequest =
       T.HttpQuery("reportingTimeZone"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{account}/reports:generate" }),
+    T.Http({ method: "GET", path: "v2/{+account}/reports:generate" }),
     svc,
   ) as unknown as Schema.Schema<GenerateAccountsReportsRequest>;
 
@@ -1454,7 +1454,7 @@ export const GenerateCsvAccountsReportsSavedRequest =
       T.HttpQuery("startDate.month"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/saved:generateCsv" }),
+    T.Http({ method: "GET", path: "v2/{+name}/saved:generateCsv" }),
     svc,
   ) as unknown as Schema.Schema<GenerateCsvAccountsReportsSavedRequest>;
 
@@ -1491,7 +1491,7 @@ export const ListAccountsReportsSavedRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/reports/saved" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/reports/saved" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsReportsSavedRequest>;
 
@@ -1587,7 +1587,7 @@ export const GenerateAccountsReportsSavedRequest =
       T.HttpQuery("startDate.month"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/saved:generate" }),
+    T.Http({ method: "GET", path: "v2/{+name}/saved:generate" }),
     svc,
   ) as unknown as Schema.Schema<GenerateAccountsReportsSavedRequest>;
 
@@ -1624,7 +1624,7 @@ export const ListAccountsAdclientsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/adclients" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/adclients" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAdclientsRequest>;
 
@@ -1659,7 +1659,7 @@ export const GetAdcodeAccountsAdclientsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/adcode" }),
+    T.Http({ method: "GET", path: "v2/{+name}/adcode" }),
     svc,
   ) as unknown as Schema.Schema<GetAdcodeAccountsAdclientsRequest>;
 
@@ -1690,7 +1690,7 @@ export const GetAccountsAdclientsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsAdclientsRequest>;
 
@@ -1727,7 +1727,7 @@ export const ListAccountsAdclientsAdunitsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/adunits" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/adunits" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAdclientsAdunitsRequest>;
 
@@ -1765,7 +1765,7 @@ export const CreateAccountsAdclientsAdunitsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(AdUnit).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/adunits", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/adunits", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateAccountsAdclientsAdunitsRequest>;
 
@@ -1802,7 +1802,7 @@ export const ListLinkedCustomChannelsAccountsAdclientsAdunitsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}:listLinkedCustomChannels" }),
+    T.Http({ method: "GET", path: "v2/{+parent}:listLinkedCustomChannels" }),
     svc,
   ) as unknown as Schema.Schema<ListLinkedCustomChannelsAccountsAdclientsAdunitsRequest>;
 
@@ -1839,7 +1839,7 @@ export const GetAccountsAdclientsAdunitsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsAdclientsAdunitsRequest>;
 
@@ -1876,7 +1876,7 @@ export const PatchAccountsAdclientsAdunitsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AdUnit).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsAdclientsAdunitsRequest>;
 
@@ -1907,7 +1907,7 @@ export const GetAdcodeAccountsAdclientsAdunitsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/adcode" }),
+    T.Http({ method: "GET", path: "v2/{+name}/adcode" }),
     svc,
   ) as unknown as Schema.Schema<GetAdcodeAccountsAdclientsAdunitsRequest>;
 
@@ -1938,7 +1938,7 @@ export const GetAccountsAdclientsUrlchannelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsAdclientsUrlchannelsRequest>;
 
@@ -1975,7 +1975,7 @@ export const ListAccountsAdclientsUrlchannelsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/urlchannels" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/urlchannels" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAdclientsUrlchannelsRequest>;
 
@@ -2010,7 +2010,7 @@ export const GetAccountsAdclientsCustomchannelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsAdclientsCustomchannelsRequest>;
 
@@ -2047,7 +2047,7 @@ export const ListAccountsAdclientsCustomchannelsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/customchannels" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/customchannels" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAdclientsCustomchannelsRequest>;
 
@@ -2088,7 +2088,7 @@ export const CreateAccountsAdclientsCustomchannelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/customchannels",
+      path: "v2/{+parent}/customchannels",
       hasBody: true,
     }),
     svc,
@@ -2127,7 +2127,7 @@ export const ListLinkedAdUnitsAccountsAdclientsCustomchannelsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}:listLinkedAdUnits" }),
+    T.Http({ method: "GET", path: "v2/{+parent}:listLinkedAdUnits" }),
     svc,
   ) as unknown as Schema.Schema<ListLinkedAdUnitsAccountsAdclientsCustomchannelsRequest>;
 
@@ -2170,7 +2170,7 @@ export const PatchAccountsAdclientsCustomchannelsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(CustomChannel).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsAdclientsCustomchannelsRequest>;
 
@@ -2201,7 +2201,7 @@ export const DeleteAccountsAdclientsCustomchannelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsAdclientsCustomchannelsRequest>;
 
@@ -2237,7 +2237,7 @@ export const ListAccountsAlertsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/alerts" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/alerts" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAlertsRequest>;
 

--- a/packages/gcp/src/services/adsenseplatform-v1.ts
+++ b/packages/gcp/src/services/adsenseplatform-v1.ts
@@ -228,7 +228,7 @@ export const ClosePlatformsAccountsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CloseAccountRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:close", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:close", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ClosePlatformsAccountsRequest>;
 
@@ -265,7 +265,7 @@ export const ListPlatformsAccountsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/accounts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/accounts" }),
     svc,
   ) as unknown as Schema.Schema<ListPlatformsAccountsRequest>;
 
@@ -300,7 +300,7 @@ export const GetPlatformsAccountsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPlatformsAccountsRequest>;
 
@@ -333,7 +333,7 @@ export const CreatePlatformsAccountsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Account).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/accounts", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/accounts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreatePlatformsAccountsRequest>;
 
@@ -369,7 +369,7 @@ export const LookupPlatformsAccountsRequest =
     ),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/accounts:lookup" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/accounts:lookup" }),
     svc,
   ) as unknown as Schema.Schema<LookupPlatformsAccountsRequest>;
 
@@ -400,7 +400,7 @@ export const GetPlatformsAccountsSitesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPlatformsAccountsSitesRequest>;
 
@@ -434,7 +434,7 @@ export const CreatePlatformsAccountsSitesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Site).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/sites", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/sites", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreatePlatformsAccountsSitesRequest>;
 
@@ -465,7 +465,7 @@ export const DeletePlatformsAccountsSitesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePlatformsAccountsSitesRequest>;
 
@@ -502,7 +502,7 @@ export const ListPlatformsAccountsSitesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sites" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sites" }),
     svc,
   ) as unknown as Schema.Schema<ListPlatformsAccountsSitesRequest>;
 
@@ -537,7 +537,7 @@ export const RequestReviewPlatformsAccountsSitesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:requestReview", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:requestReview", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RequestReviewPlatformsAccountsSitesRequest>;
 
@@ -572,7 +572,7 @@ export const CreatePlatformsAccountsEventsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Event).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/events", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/events", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreatePlatformsAccountsEventsRequest>;
 

--- a/packages/gcp/src/services/adsenseplatform-v1alpha.ts
+++ b/packages/gcp/src/services/adsenseplatform-v1alpha.ts
@@ -323,7 +323,7 @@ export const ListAccountsPlatformsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/platforms" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/platforms" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsPlatformsRequest>;
 
@@ -358,7 +358,7 @@ export const GetAccountsPlatformsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsPlatformsRequest>;
 
@@ -389,7 +389,7 @@ export const GetAccountsPlatformsGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsPlatformsGroupsRequest>;
 
@@ -426,7 +426,7 @@ export const ListAccountsPlatformsGroupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/groups" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/groups" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsPlatformsGroupsRequest>;
 
@@ -467,7 +467,7 @@ export const PatchAccountsPlatformsGroupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(PlatformGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsPlatformsGroupsRequest>;
 
@@ -504,7 +504,7 @@ export const ListAccountsPlatformsChildAccountsSitesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/sites" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/sites" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsPlatformsChildAccountsSitesRequest>;
 
@@ -546,7 +546,7 @@ export const PatchAccountsPlatformsChildAccountsSitesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(PlatformChildSite).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsPlatformsChildAccountsSitesRequest>;
 
@@ -578,7 +578,7 @@ export const GetAccountsPlatformsChildAccountsSitesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsPlatformsChildAccountsSitesRequest>;
 
@@ -612,7 +612,7 @@ export const ClosePlatformsAccountsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CloseAccountRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:close", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:close", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ClosePlatformsAccountsRequest>;
 
@@ -643,7 +643,7 @@ export const GetPlatformsAccountsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPlatformsAccountsRequest>;
 
@@ -678,7 +678,7 @@ export const LookupPlatformsAccountsRequest =
       T.HttpQuery("creationRequestId"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/accounts:lookup" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/accounts:lookup" }),
     svc,
   ) as unknown as Schema.Schema<LookupPlatformsAccountsRequest>;
 
@@ -714,7 +714,7 @@ export const CreatePlatformsAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/accounts",
+      path: "v1alpha/{+parent}/accounts",
       hasBody: true,
     }),
     svc,
@@ -753,7 +753,7 @@ export const ListPlatformsAccountsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/accounts" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/accounts" }),
     svc,
   ) as unknown as Schema.Schema<ListPlatformsAccountsRequest>;
 
@@ -791,7 +791,7 @@ export const CreatePlatformsAccountsEventsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Event).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{parent}/events", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+parent}/events", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreatePlatformsAccountsEventsRequest>;
 
@@ -822,7 +822,7 @@ export const GetPlatformsAccountsSitesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPlatformsAccountsSitesRequest>;
 
@@ -856,7 +856,7 @@ export const CreatePlatformsAccountsSitesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Site).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{parent}/sites", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+parent}/sites", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreatePlatformsAccountsSitesRequest>;
 
@@ -893,7 +893,7 @@ export const ListPlatformsAccountsSitesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/sites" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/sites" }),
     svc,
   ) as unknown as Schema.Schema<ListPlatformsAccountsSitesRequest>;
 
@@ -930,7 +930,7 @@ export const RequestReviewPlatformsAccountsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{name}:requestReview",
+      path: "v1alpha/{+name}:requestReview",
       hasBody: true,
     }),
     svc,
@@ -964,7 +964,7 @@ export const DeletePlatformsAccountsSitesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePlatformsAccountsSitesRequest>;
 

--- a/packages/gcp/src/services/advisorynotifications-v1.ts
+++ b/packages/gcp/src/services/advisorynotifications-v1.ts
@@ -221,7 +221,7 @@ export const GetSettingsProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSettingsProjectsLocationsRequest>;
 
@@ -258,7 +258,7 @@ export const UpdateSettingsProjectsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSettingsProjectsLocationsRequest>;
 
@@ -304,7 +304,7 @@ export const ListProjectsLocationsNotificationsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/notifications" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/notifications" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNotificationsRequest>;
 
@@ -345,7 +345,7 @@ export const GetProjectsLocationsNotificationsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNotificationsRequest>;
 
@@ -377,7 +377,7 @@ export const GetSettingsOrganizationsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSettingsOrganizationsLocationsRequest>;
 
@@ -414,7 +414,7 @@ export const UpdateSettingsOrganizationsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSettingsOrganizationsLocationsRequest>;
 
@@ -460,7 +460,7 @@ export const ListOrganizationsLocationsNotificationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/notifications" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/notifications" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsNotificationsRequest>;
 
@@ -501,7 +501,7 @@ export const GetOrganizationsLocationsNotificationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsNotificationsRequest>;
 

--- a/packages/gcp/src/services/agentregistry-v1alpha.ts
+++ b/packages/gcp/src/services/agentregistry-v1alpha.ts
@@ -657,7 +657,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -692,7 +692,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -737,7 +737,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -772,7 +772,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -803,7 +803,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -837,7 +837,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -880,7 +880,7 @@ export const ListProjectsLocationsAgentsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/agents" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/agents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsRequest>;
 
@@ -920,7 +920,7 @@ export const SearchProjectsLocationsAgentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/agents:search",
+      path: "v1alpha/{+parent}/agents:search",
       hasBody: true,
     }),
     svc,
@@ -953,7 +953,7 @@ export const GetProjectsLocationsAgentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsRequest>;
 
@@ -993,7 +993,7 @@ export const ListProjectsLocationsEndpointsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/endpoints" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/endpoints" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEndpointsRequest>;
 
@@ -1028,7 +1028,7 @@ export const GetProjectsLocationsEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEndpointsRequest>;
 
@@ -1071,7 +1071,7 @@ export const ListProjectsLocationsMcpServersRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/mcpServers" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/mcpServers" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMcpServersRequest>;
 
@@ -1111,7 +1111,7 @@ export const SearchProjectsLocationsMcpServersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/mcpServers:search",
+      path: "v1alpha/{+parent}/mcpServers:search",
       hasBody: true,
     }),
     svc,
@@ -1145,7 +1145,7 @@ export const GetProjectsLocationsMcpServersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMcpServersRequest>;
 
@@ -1185,7 +1185,7 @@ export const ListProjectsLocationsServicesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/services" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/services" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesRequest>;
 
@@ -1220,7 +1220,7 @@ export const GetProjectsLocationsServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesRequest>;
 
@@ -1262,7 +1262,7 @@ export const CreateProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/services",
+      path: "v1alpha/{+parent}/services",
       hasBody: true,
     }),
     svc,
@@ -1304,7 +1304,7 @@ export const PatchProjectsLocationsServicesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServicesRequest>;
 
@@ -1338,7 +1338,7 @@ export const DeleteProjectsLocationsServicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesRequest>;
 
@@ -1381,7 +1381,7 @@ export const ListProjectsLocationsBindingsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/bindings" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/bindings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBindingsRequest>;
 
@@ -1416,7 +1416,7 @@ export const GetProjectsLocationsBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBindingsRequest>;
 
@@ -1458,7 +1458,7 @@ export const CreateProjectsLocationsBindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/bindings",
+      path: "v1alpha/{+parent}/bindings",
       hasBody: true,
     }),
     svc,
@@ -1500,7 +1500,7 @@ export const PatchProjectsLocationsBindingsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Binding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBindingsRequest>;
 
@@ -1534,7 +1534,7 @@ export const DeleteProjectsLocationsBindingsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBindingsRequest>;
 
@@ -1581,7 +1581,10 @@ export const FetchAvailableProjectsLocationsBindingsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/bindings:fetchAvailable" }),
+    T.Http({
+      method: "GET",
+      path: "v1alpha/{+parent}/bindings:fetchAvailable",
+    }),
     svc,
   ) as unknown as Schema.Schema<FetchAvailableProjectsLocationsBindingsRequest>;
 

--- a/packages/gcp/src/services/aiplatform-v1.ts
+++ b/packages/gcp/src/services/aiplatform-v1.ts
@@ -27553,7 +27553,7 @@ export const PatchReasoningEnginesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchReasoningEnginesRequest>;
 
@@ -27589,7 +27589,7 @@ export const ExecuteCodeReasoningEnginesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:executeCode", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:executeCode", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteCodeReasoningEnginesRequest>;
 
@@ -27657,7 +27657,7 @@ export const GetReasoningEnginesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesRequest>;
 
@@ -27694,7 +27694,7 @@ export const QueryReasoningEnginesRequest =
       GoogleCloudAiplatformV1QueryReasoningEngineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryReasoningEnginesRequest>;
 
@@ -27776,7 +27776,7 @@ export const StreamQueryReasoningEnginesRequest =
       GoogleCloudAiplatformV1StreamQueryReasoningEngineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:streamQuery", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:streamQuery", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StreamQueryReasoningEnginesRequest>;
 
@@ -27810,7 +27810,7 @@ export const DeleteReasoningEnginesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesRequest>;
 
@@ -27841,7 +27841,7 @@ export const GetReasoningEnginesMemoriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesMemoriesOperationsRequest>;
 
@@ -27876,7 +27876,7 @@ export const WaitReasoningEnginesMemoriesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitReasoningEnginesMemoriesOperationsRequest>;
 
@@ -27908,7 +27908,7 @@ export const DeleteReasoningEnginesMemoriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesMemoriesOperationsRequest>;
 
@@ -27940,7 +27940,7 @@ export const CancelReasoningEnginesMemoriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelReasoningEnginesMemoriesOperationsRequest>;
 
@@ -27986,7 +27986,7 @@ export const ListReasoningEnginesMemoriesOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesMemoriesOperationsRequest>;
 
@@ -28029,7 +28029,7 @@ export const CreateReasoningEnginesSandboxEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/sandboxEnvironments",
+      path: "v1/{+parent}/sandboxEnvironments",
       hasBody: true,
     }),
     svc,
@@ -28063,7 +28063,7 @@ export const GetReasoningEnginesSandboxEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -28100,7 +28100,7 @@ export const ExecuteReasoningEnginesSandboxEnvironmentsRequest =
       GoogleCloudAiplatformV1ExecuteSandboxEnvironmentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:execute", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:execute", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -28141,7 +28141,7 @@ export const ListReasoningEnginesSandboxEnvironmentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sandboxEnvironments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sandboxEnvironments" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -28182,7 +28182,7 @@ export const SnapshotReasoningEnginesSandboxEnvironmentsRequest =
       GoogleCloudAiplatformV1SandboxEnvironmentSnapshot,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:snapshot", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:snapshot", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SnapshotReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -28214,7 +28214,7 @@ export const DeleteReasoningEnginesSandboxEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -28246,7 +28246,7 @@ export const GetReasoningEnginesSandboxEnvironmentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesSandboxEnvironmentsOperationsRequest>;
 
@@ -28279,7 +28279,7 @@ export const DeleteReasoningEnginesSandboxEnvironmentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesSandboxEnvironmentsOperationsRequest>;
 
@@ -28312,7 +28312,7 @@ export const CancelReasoningEnginesSandboxEnvironmentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelReasoningEnginesSandboxEnvironmentsOperationsRequest>;
 
@@ -28348,7 +28348,7 @@ export const WaitReasoningEnginesSandboxEnvironmentsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitReasoningEnginesSandboxEnvironmentsOperationsRequest>;
 
@@ -28381,7 +28381,7 @@ export const GetReasoningEnginesSandboxEnvironmentSnapshotsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesSandboxEnvironmentSnapshotsRequest>;
 
@@ -28413,7 +28413,7 @@ export const DeleteReasoningEnginesSandboxEnvironmentSnapshotsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesSandboxEnvironmentSnapshotsRequest>;
 
@@ -28455,7 +28455,7 @@ export const ListReasoningEnginesSandboxEnvironmentSnapshotsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sandboxEnvironmentSnapshots" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sandboxEnvironmentSnapshots" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesSandboxEnvironmentSnapshotsRequest>;
 
@@ -28492,7 +28492,7 @@ export const GetReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest>;
 
@@ -28525,7 +28525,7 @@ export const DeleteReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest>;
 
@@ -28558,7 +28558,7 @@ export const CancelReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest>;
 
@@ -28594,7 +28594,7 @@ export const WaitReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest>;
 
@@ -28627,7 +28627,7 @@ export const GetReasoningEnginesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesOperationsRequest>;
 
@@ -28661,7 +28661,7 @@ export const WaitReasoningEnginesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitReasoningEnginesOperationsRequest>;
 
@@ -28706,7 +28706,7 @@ export const ListReasoningEnginesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesOperationsRequest>;
 
@@ -28742,7 +28742,7 @@ export const DeleteReasoningEnginesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesOperationsRequest>;
 
@@ -28773,7 +28773,7 @@ export const CancelReasoningEnginesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelReasoningEnginesOperationsRequest>;
 
@@ -28818,7 +28818,7 @@ export const ListReasoningEnginesSessionsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesSessionsOperationsRequest>;
 
@@ -28854,7 +28854,7 @@ export const DeleteReasoningEnginesSessionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesSessionsOperationsRequest>;
 
@@ -28886,7 +28886,7 @@ export const CancelReasoningEnginesSessionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelReasoningEnginesSessionsOperationsRequest>;
 
@@ -28918,7 +28918,7 @@ export const GetReasoningEnginesSessionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesSessionsOperationsRequest>;
 
@@ -28953,7 +28953,7 @@ export const WaitReasoningEnginesSessionsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitReasoningEnginesSessionsOperationsRequest>;
 
@@ -28990,7 +28990,7 @@ export const StreamQueryReasoningEnginesRuntimeRevisionsRequest =
       GoogleCloudAiplatformV1StreamQueryReasoningEngineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:streamQuery", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:streamQuery", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StreamQueryReasoningEnginesRuntimeRevisionsRequest>;
 
@@ -29027,7 +29027,7 @@ export const QueryReasoningEnginesRuntimeRevisionsRequest =
       GoogleCloudAiplatformV1QueryReasoningEngineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryReasoningEnginesRuntimeRevisionsRequest>;
 
@@ -29068,7 +29068,7 @@ export const ListReasoningEnginesSandboxEnvironmentTemplatesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sandboxEnvironmentTemplates" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sandboxEnvironmentTemplates" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesSandboxEnvironmentTemplatesRequest>;
 
@@ -29112,7 +29112,7 @@ export const CreateReasoningEnginesSandboxEnvironmentTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/sandboxEnvironmentTemplates",
+      path: "v1/{+parent}/sandboxEnvironmentTemplates",
       hasBody: true,
     }),
     svc,
@@ -29147,7 +29147,7 @@ export const GetReasoningEnginesSandboxEnvironmentTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesSandboxEnvironmentTemplatesRequest>;
 
@@ -29179,7 +29179,7 @@ export const DeleteReasoningEnginesSandboxEnvironmentTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesSandboxEnvironmentTemplatesRequest>;
 
@@ -29212,7 +29212,7 @@ export const GetReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest>;
 
@@ -29245,7 +29245,7 @@ export const DeleteReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest>;
 
@@ -29278,7 +29278,7 @@ export const CancelReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest>;
 
@@ -29314,7 +29314,7 @@ export const WaitReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest>;
 
@@ -29347,7 +29347,7 @@ export const DeletePersistentResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePersistentResourcesOperationsRequest>;
 
@@ -29378,7 +29378,7 @@ export const CancelPersistentResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelPersistentResourcesOperationsRequest>;
 
@@ -29423,7 +29423,7 @@ export const ListPersistentResourcesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListPersistentResourcesOperationsRequest>;
 
@@ -29459,7 +29459,7 @@ export const GetPersistentResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPersistentResourcesOperationsRequest>;
 
@@ -29494,7 +29494,7 @@ export const WaitPersistentResourcesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitPersistentResourcesOperationsRequest>;
 
@@ -29574,7 +29574,7 @@ export interface DeleteDatasetsRequest {
 export const DeleteDatasetsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v1/{name}" }),
+  T.Http({ method: "DELETE", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteDatasetsRequest>;
 
@@ -29610,7 +29610,7 @@ export const PatchDatasetsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(GoogleCloudAiplatformV1Dataset).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchDatasetsRequest>;
 
@@ -29643,7 +29643,7 @@ export const GetDatasetsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetDatasetsRequest>;
 
@@ -29707,7 +29707,7 @@ export const DeleteDatasetsDatasetVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDatasetsDatasetVersionsRequest>;
 
@@ -29753,7 +29753,7 @@ export const ListDatasetsDatasetVersionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/datasetVersions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/datasetVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListDatasetsDatasetVersionsRequest>;
 
@@ -29792,7 +29792,7 @@ export const GetDatasetsDatasetVersionsRequest =
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDatasetsDatasetVersionsRequest>;
 
@@ -29831,7 +29831,7 @@ export const CreateDatasetsDatasetVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/datasetVersions",
+      path: "v1/{+parent}/datasetVersions",
       hasBody: true,
     }),
     svc,
@@ -29872,7 +29872,7 @@ export const PatchDatasetsDatasetVersionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchDatasetsDatasetVersionsRequest>;
 
@@ -29904,7 +29904,7 @@ export const RestoreDatasetsDatasetVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:restore" }),
+    T.Http({ method: "GET", path: "v1/{+name}:restore" }),
     svc,
   ) as unknown as Schema.Schema<RestoreDatasetsDatasetVersionsRequest>;
 
@@ -29935,7 +29935,7 @@ export const GetDatasetsDataItemsAnnotationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -29970,7 +29970,7 @@ export const WaitDatasetsDataItemsAnnotationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -30002,7 +30002,7 @@ export const DeleteDatasetsDataItemsAnnotationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -30034,7 +30034,7 @@ export const CancelDatasetsDataItemsAnnotationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -30080,7 +30080,7 @@ export const ListDatasetsDataItemsAnnotationsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -30130,7 +30130,7 @@ export const ListDatasetsDataItemsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListDatasetsDataItemsOperationsRequest>;
 
@@ -30166,7 +30166,7 @@ export const DeleteDatasetsDataItemsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDatasetsDataItemsOperationsRequest>;
 
@@ -30197,7 +30197,7 @@ export const CancelDatasetsDataItemsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelDatasetsDataItemsOperationsRequest>;
 
@@ -30228,7 +30228,7 @@ export const GetDatasetsDataItemsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDatasetsDataItemsOperationsRequest>;
 
@@ -30262,7 +30262,7 @@ export const WaitDatasetsDataItemsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitDatasetsDataItemsOperationsRequest>;
 
@@ -30294,7 +30294,7 @@ export const GetDatasetsSavedQueriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDatasetsSavedQueriesOperationsRequest>;
 
@@ -30329,7 +30329,7 @@ export const WaitDatasetsSavedQueriesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitDatasetsSavedQueriesOperationsRequest>;
 
@@ -30375,7 +30375,7 @@ export const ListDatasetsSavedQueriesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListDatasetsSavedQueriesOperationsRequest>;
 
@@ -30411,7 +30411,7 @@ export const DeleteDatasetsSavedQueriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDatasetsSavedQueriesOperationsRequest>;
 
@@ -30442,7 +30442,7 @@ export const CancelDatasetsSavedQueriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelDatasetsSavedQueriesOperationsRequest>;
 
@@ -30473,7 +30473,7 @@ export const GetDatasetsAnnotationSpecsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -30508,7 +30508,7 @@ export const WaitDatasetsAnnotationSpecsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -30540,7 +30540,7 @@ export const DeleteDatasetsAnnotationSpecsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -30572,7 +30572,7 @@ export const CancelDatasetsAnnotationSpecsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -30618,7 +30618,7 @@ export const ListDatasetsAnnotationSpecsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -30654,7 +30654,7 @@ export const GetDatasetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDatasetsOperationsRequest>;
 
@@ -30688,7 +30688,7 @@ export const WaitDatasetsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitDatasetsOperationsRequest>;
 
@@ -30719,7 +30719,7 @@ export const DeleteDatasetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDatasetsOperationsRequest>;
 
@@ -30750,7 +30750,7 @@ export const CancelDatasetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelDatasetsOperationsRequest>;
 
@@ -30795,7 +30795,7 @@ export const ListDatasetsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListDatasetsOperationsRequest>;
 
@@ -30845,7 +30845,7 @@ export const ListPipelineJobsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListPipelineJobsOperationsRequest>;
 
@@ -30881,7 +30881,7 @@ export const DeletePipelineJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePipelineJobsOperationsRequest>;
 
@@ -30912,7 +30912,7 @@ export const CancelPipelineJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelPipelineJobsOperationsRequest>;
 
@@ -30943,7 +30943,7 @@ export const GetPipelineJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPipelineJobsOperationsRequest>;
 
@@ -30977,7 +30977,7 @@ export const WaitPipelineJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitPipelineJobsOperationsRequest>;
 
@@ -31008,7 +31008,7 @@ export const GetHyperparameterTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetHyperparameterTuningJobsOperationsRequest>;
 
@@ -31043,7 +31043,7 @@ export const WaitHyperparameterTuningJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitHyperparameterTuningJobsOperationsRequest>;
 
@@ -31089,7 +31089,7 @@ export const ListHyperparameterTuningJobsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListHyperparameterTuningJobsOperationsRequest>;
 
@@ -31125,7 +31125,7 @@ export const DeleteHyperparameterTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteHyperparameterTuningJobsOperationsRequest>;
 
@@ -31157,7 +31157,7 @@ export const CancelHyperparameterTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelHyperparameterTuningJobsOperationsRequest>;
 
@@ -31189,7 +31189,7 @@ export const GetTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTuningJobsOperationsRequest>;
 
@@ -31220,7 +31220,7 @@ export const DeleteTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteTuningJobsOperationsRequest>;
 
@@ -31251,7 +31251,7 @@ export const CancelTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelTuningJobsOperationsRequest>;
 
@@ -31296,7 +31296,7 @@ export const ListTuningJobsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListTuningJobsOperationsRequest>;
 
@@ -31332,7 +31332,7 @@ export const DeleteMetadataStoresContextsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteMetadataStoresContextsOperationsRequest>;
 
@@ -31364,7 +31364,7 @@ export const CancelMetadataStoresContextsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelMetadataStoresContextsOperationsRequest>;
 
@@ -31410,7 +31410,7 @@ export const ListMetadataStoresContextsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListMetadataStoresContextsOperationsRequest>;
 
@@ -31446,7 +31446,7 @@ export const GetMetadataStoresContextsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetMetadataStoresContextsOperationsRequest>;
 
@@ -31481,7 +31481,7 @@ export const WaitMetadataStoresContextsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitMetadataStoresContextsOperationsRequest>;
 
@@ -31513,7 +31513,7 @@ export const GetMetadataStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetMetadataStoresOperationsRequest>;
 
@@ -31547,7 +31547,7 @@ export const WaitMetadataStoresOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitMetadataStoresOperationsRequest>;
 
@@ -31592,7 +31592,7 @@ export const ListMetadataStoresOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListMetadataStoresOperationsRequest>;
 
@@ -31628,7 +31628,7 @@ export const DeleteMetadataStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteMetadataStoresOperationsRequest>;
 
@@ -31659,7 +31659,7 @@ export const CancelMetadataStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelMetadataStoresOperationsRequest>;
 
@@ -31690,7 +31690,7 @@ export const GetMetadataStoresExecutionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetMetadataStoresExecutionsOperationsRequest>;
 
@@ -31725,7 +31725,7 @@ export const WaitMetadataStoresExecutionsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitMetadataStoresExecutionsOperationsRequest>;
 
@@ -31771,7 +31771,7 @@ export const ListMetadataStoresExecutionsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListMetadataStoresExecutionsOperationsRequest>;
 
@@ -31807,7 +31807,7 @@ export const DeleteMetadataStoresExecutionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteMetadataStoresExecutionsOperationsRequest>;
 
@@ -31839,7 +31839,7 @@ export const CancelMetadataStoresExecutionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelMetadataStoresExecutionsOperationsRequest>;
 
@@ -31871,7 +31871,7 @@ export const GetMetadataStoresArtifactsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetMetadataStoresArtifactsOperationsRequest>;
 
@@ -31906,7 +31906,7 @@ export const WaitMetadataStoresArtifactsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitMetadataStoresArtifactsOperationsRequest>;
 
@@ -31938,7 +31938,7 @@ export const DeleteMetadataStoresArtifactsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteMetadataStoresArtifactsOperationsRequest>;
 
@@ -31970,7 +31970,7 @@ export const CancelMetadataStoresArtifactsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelMetadataStoresArtifactsOperationsRequest>;
 
@@ -32016,7 +32016,7 @@ export const ListMetadataStoresArtifactsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListMetadataStoresArtifactsOperationsRequest>;
 
@@ -32066,7 +32066,7 @@ export const ListModelDeploymentMonitoringJobsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -32102,7 +32102,7 @@ export const DeleteModelDeploymentMonitoringJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -32134,7 +32134,7 @@ export const CancelModelDeploymentMonitoringJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -32166,7 +32166,7 @@ export const GetModelDeploymentMonitoringJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -32201,7 +32201,7 @@ export const WaitModelDeploymentMonitoringJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -32233,7 +32233,7 @@ export const GetSchedulesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSchedulesOperationsRequest>;
 
@@ -32267,7 +32267,7 @@ export const WaitSchedulesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitSchedulesOperationsRequest>;
 
@@ -32312,7 +32312,7 @@ export const ListSchedulesOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListSchedulesOperationsRequest>;
 
@@ -32348,7 +32348,7 @@ export const DeleteSchedulesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteSchedulesOperationsRequest>;
 
@@ -32379,7 +32379,7 @@ export const CancelSchedulesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelSchedulesOperationsRequest>;
 
@@ -32410,7 +32410,7 @@ export const GetFeatureGroupsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFeatureGroupsOperationsRequest>;
 
@@ -32441,7 +32441,7 @@ export const DeleteFeatureGroupsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFeatureGroupsOperationsRequest>;
 
@@ -32475,7 +32475,7 @@ export const WaitFeatureGroupsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitFeatureGroupsOperationsRequest>;
 
@@ -32520,7 +32520,7 @@ export const ListWaitFeatureGroupsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:wait" }),
+    T.Http({ method: "GET", path: "v1/{+name}:wait" }),
     svc,
   ) as unknown as Schema.Schema<ListWaitFeatureGroupsOperationsRequest>;
 
@@ -32556,7 +32556,7 @@ export const GetFeatureGroupsFeaturesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFeatureGroupsFeaturesOperationsRequest>;
 
@@ -32588,7 +32588,7 @@ export const DeleteFeatureGroupsFeaturesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFeatureGroupsFeaturesOperationsRequest>;
 
@@ -32622,7 +32622,7 @@ export const WaitFeatureGroupsFeaturesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitFeatureGroupsFeaturesOperationsRequest>;
 
@@ -32668,7 +32668,7 @@ export const ListWaitFeatureGroupsFeaturesOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:wait" }),
+    T.Http({ method: "GET", path: "v1/{+name}:wait" }),
     svc,
   ) as unknown as Schema.Schema<ListWaitFeatureGroupsFeaturesOperationsRequest>;
 
@@ -32710,7 +32710,7 @@ export const UploadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "v1/{parent}/ragFiles:upload",
+    path: "v1/{+parent}/ragFiles:upload",
     hasBody: true,
   }),
   svc,
@@ -32743,7 +32743,7 @@ export const GetTensorboardsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTensorboardsOperationsRequest>;
 
@@ -32777,7 +32777,7 @@ export const WaitTensorboardsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitTensorboardsOperationsRequest>;
 
@@ -32808,7 +32808,7 @@ export const DeleteTensorboardsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteTensorboardsOperationsRequest>;
 
@@ -32839,7 +32839,7 @@ export const CancelTensorboardsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelTensorboardsOperationsRequest>;
 
@@ -32884,7 +32884,7 @@ export const ListTensorboardsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListTensorboardsOperationsRequest>;
 
@@ -32920,7 +32920,7 @@ export const DeleteTensorboardsExperimentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteTensorboardsExperimentsOperationsRequest>;
 
@@ -32952,7 +32952,7 @@ export const CancelTensorboardsExperimentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelTensorboardsExperimentsOperationsRequest>;
 
@@ -32998,7 +32998,7 @@ export const ListTensorboardsExperimentsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListTensorboardsExperimentsOperationsRequest>;
 
@@ -33034,7 +33034,7 @@ export const GetTensorboardsExperimentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTensorboardsExperimentsOperationsRequest>;
 
@@ -33069,7 +33069,7 @@ export const WaitTensorboardsExperimentsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitTensorboardsExperimentsOperationsRequest>;
 
@@ -33101,7 +33101,7 @@ export const GetTensorboardsExperimentsRunsTimeSeriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -33137,7 +33137,7 @@ export const WaitTensorboardsExperimentsRunsTimeSeriesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -33184,7 +33184,7 @@ export const ListTensorboardsExperimentsRunsTimeSeriesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -33221,7 +33221,7 @@ export const DeleteTensorboardsExperimentsRunsTimeSeriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -33254,7 +33254,7 @@ export const CancelTensorboardsExperimentsRunsTimeSeriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -33287,7 +33287,7 @@ export const DeleteTensorboardsExperimentsRunsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -33319,7 +33319,7 @@ export const CancelTensorboardsExperimentsRunsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -33365,7 +33365,7 @@ export const ListTensorboardsExperimentsRunsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -33401,7 +33401,7 @@ export const GetTensorboardsExperimentsRunsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -33436,7 +33436,7 @@ export const WaitTensorboardsExperimentsRunsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -33473,7 +33473,7 @@ export const PredictEndpointsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{endpoint}:predict", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+endpoint}:predict", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PredictEndpointsRequest>;
 
@@ -33510,7 +33510,7 @@ export const FetchPredictOperationEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:fetchPredictOperation",
+      path: "v1/{+endpoint}:fetchPredictOperation",
       hasBody: true,
     }),
     svc,
@@ -33550,7 +33550,7 @@ export const CountTokensEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:countTokens",
+      path: "v1/{+endpoint}:countTokens",
       hasBody: true,
     }),
     svc,
@@ -33591,7 +33591,7 @@ export const ComputeTokensEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:computeTokens",
+      path: "v1/{+endpoint}:computeTokens",
       hasBody: true,
     }),
     svc,
@@ -33632,7 +33632,7 @@ export const PredictLongRunningEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:predictLongRunning",
+      path: "v1/{+endpoint}:predictLongRunning",
       hasBody: true,
     }),
     svc,
@@ -33671,7 +33671,7 @@ export const GenerateContentEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{model}:generateContent",
+      path: "v1/{+model}:generateContent",
       hasBody: true,
     }),
     svc,
@@ -33712,7 +33712,7 @@ export const StreamGenerateContentEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{model}:streamGenerateContent",
+      path: "v1/{+model}:streamGenerateContent",
       hasBody: true,
     }),
     svc,
@@ -33746,7 +33746,7 @@ export const GetEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEndpointsOperationsRequest>;
 
@@ -33780,7 +33780,7 @@ export const WaitEndpointsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitEndpointsOperationsRequest>;
 
@@ -33825,7 +33825,7 @@ export const ListEndpointsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListEndpointsOperationsRequest>;
 
@@ -33861,7 +33861,7 @@ export const DeleteEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteEndpointsOperationsRequest>;
 
@@ -33892,7 +33892,7 @@ export const CancelEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelEndpointsOperationsRequest>;
 
@@ -33928,7 +33928,7 @@ export const CompletionsEndpointsChatRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}/chat/completions",
+      path: "v1/{+endpoint}/chat/completions",
       hasBody: true,
     }),
     svc,
@@ -34080,7 +34080,7 @@ export const ListRagEngineConfigOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListRagEngineConfigOperationsRequest>;
 
@@ -34116,7 +34116,7 @@ export const DeleteRagEngineConfigOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteRagEngineConfigOperationsRequest>;
 
@@ -34147,7 +34147,7 @@ export const CancelRagEngineConfigOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelRagEngineConfigOperationsRequest>;
 
@@ -34178,7 +34178,7 @@ export const GetRagEngineConfigOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetRagEngineConfigOperationsRequest>;
 
@@ -34212,7 +34212,7 @@ export const WaitRagEngineConfigOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitRagEngineConfigOperationsRequest>;
 
@@ -34243,7 +34243,7 @@ export const DeleteSpecialistPoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteSpecialistPoolsOperationsRequest>;
 
@@ -34274,7 +34274,7 @@ export const CancelSpecialistPoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelSpecialistPoolsOperationsRequest>;
 
@@ -34319,7 +34319,7 @@ export const ListSpecialistPoolsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListSpecialistPoolsOperationsRequest>;
 
@@ -34355,7 +34355,7 @@ export const GetSpecialistPoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSpecialistPoolsOperationsRequest>;
 
@@ -34389,7 +34389,7 @@ export const WaitSpecialistPoolsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitSpecialistPoolsOperationsRequest>;
 
@@ -34420,7 +34420,7 @@ export const GetIndexEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetIndexEndpointsOperationsRequest>;
 
@@ -34454,7 +34454,7 @@ export const WaitIndexEndpointsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitIndexEndpointsOperationsRequest>;
 
@@ -34499,7 +34499,7 @@ export const ListIndexEndpointsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListIndexEndpointsOperationsRequest>;
 
@@ -34535,7 +34535,7 @@ export const DeleteIndexEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteIndexEndpointsOperationsRequest>;
 
@@ -34566,7 +34566,7 @@ export const CancelIndexEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelIndexEndpointsOperationsRequest>;
 
@@ -34602,7 +34602,7 @@ export const UpdateCacheConfigProjectsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateCacheConfigProjectsRequest>;
 
@@ -34633,7 +34633,7 @@ export const GetCacheConfigProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCacheConfigProjectsRequest>;
 
@@ -34664,7 +34664,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -34702,7 +34702,7 @@ export const GenerateSyntheticDataProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{location}:generateSyntheticData",
+      path: "v1/{+location}:generateSyntheticData",
       hasBody: true,
     }),
     svc,
@@ -34750,7 +34750,7 @@ export const ListProjectsLocationsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -34786,7 +34786,7 @@ export const GetRagEngineConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetRagEngineConfigProjectsLocationsRequest>;
 
@@ -34825,7 +34825,7 @@ export const GenerateInstanceRubricsProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{location}:generateInstanceRubrics",
+      path: "v1/{+location}:generateInstanceRubrics",
       hasBody: true,
     }),
     svc,
@@ -34866,7 +34866,7 @@ export const AugmentPromptProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:augmentPrompt",
+      path: "v1/{+parent}:augmentPrompt",
       hasBody: true,
     }),
     svc,
@@ -34907,7 +34907,7 @@ export const EvaluateInstancesProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{location}:evaluateInstances",
+      path: "v1/{+location}:evaluateInstances",
       hasBody: true,
     }),
     svc,
@@ -34948,7 +34948,7 @@ export const RetrieveContextsProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:retrieveContexts",
+      path: "v1/{+parent}:retrieveContexts",
       hasBody: true,
     }),
     svc,
@@ -34987,7 +34987,7 @@ export const AskContextsProjectsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:askContexts", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}:askContexts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AskContextsProjectsLocationsRequest>;
 
@@ -35026,7 +35026,7 @@ export const AsyncRetrieveContextsProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:asyncRetrieveContexts",
+      path: "v1/{+parent}:asyncRetrieveContexts",
       hasBody: true,
     }),
     svc,
@@ -35065,7 +35065,7 @@ export const DeployProjectsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{destination}:deploy", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+destination}:deploy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeployProjectsLocationsRequest>;
 
@@ -35103,7 +35103,7 @@ export const CorroborateContentProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:corroborateContent",
+      path: "v1/{+parent}:corroborateContent",
       hasBody: true,
     }),
     svc,
@@ -35142,7 +35142,7 @@ export const UpdateRagEngineConfigProjectsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateRagEngineConfigProjectsLocationsRequest>;
 
@@ -35181,7 +35181,7 @@ export const EvaluateDatasetProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{location}:evaluateDataset",
+      path: "v1/{+location}:evaluateDataset",
       hasBody: true,
     }),
     svc,
@@ -35218,7 +35218,7 @@ export const PatchProjectsLocationsRagCorporaRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudAiplatformV1RagCorpus).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRagCorporaRequest>;
 
@@ -35250,7 +35250,7 @@ export const GetProjectsLocationsRagCorporaRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRagCorporaRequest>;
 
@@ -35285,7 +35285,7 @@ export const CreateProjectsLocationsRagCorporaRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudAiplatformV1RagCorpus).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/ragCorpora", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/ragCorpora", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRagCorporaRequest>;
 
@@ -35323,7 +35323,7 @@ export const ListProjectsLocationsRagCorporaRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/ragCorpora" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/ragCorpora" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRagCorporaRequest>;
 
@@ -35362,7 +35362,7 @@ export const DeleteProjectsLocationsRagCorporaRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRagCorporaRequest>;
 
@@ -35394,7 +35394,7 @@ export const GetProjectsLocationsRagCorporaOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRagCorporaOperationsRequest>;
 
@@ -35429,7 +35429,7 @@ export const WaitProjectsLocationsRagCorporaOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsRagCorporaOperationsRequest>;
 
@@ -35475,7 +35475,7 @@ export const ListProjectsLocationsRagCorporaOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRagCorporaOperationsRequest>;
 
@@ -35511,7 +35511,7 @@ export const DeleteProjectsLocationsRagCorporaOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRagCorporaOperationsRequest>;
 
@@ -35543,7 +35543,7 @@ export const CancelProjectsLocationsRagCorporaOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsRagCorporaOperationsRequest>;
 
@@ -35582,7 +35582,7 @@ export const ImportProjectsLocationsRagCorporaRagFilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/ragFiles:import",
+      path: "v1/{+parent}/ragFiles:import",
       hasBody: true,
     }),
     svc,
@@ -35616,7 +35616,7 @@ export const GetProjectsLocationsRagCorporaRagFilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRagCorporaRagFilesRequest>;
 
@@ -35653,7 +35653,7 @@ export const DeleteProjectsLocationsRagCorporaRagFilesRequest =
       T.HttpQuery("forceDelete"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRagCorporaRagFilesRequest>;
 
@@ -35691,7 +35691,7 @@ export const ListProjectsLocationsRagCorporaRagFilesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/ragFiles" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/ragFiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRagCorporaRagFilesRequest>;
 
@@ -35727,7 +35727,7 @@ export const DeleteProjectsLocationsRagCorporaRagFilesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRagCorporaRagFilesOperationsRequest>;
 
@@ -35760,7 +35760,7 @@ export const CancelProjectsLocationsRagCorporaRagFilesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsRagCorporaRagFilesOperationsRequest>;
 
@@ -35807,7 +35807,7 @@ export const ListProjectsLocationsRagCorporaRagFilesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRagCorporaRagFilesOperationsRequest>;
 
@@ -35844,7 +35844,7 @@ export const GetProjectsLocationsRagCorporaRagFilesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRagCorporaRagFilesOperationsRequest>;
 
@@ -35880,7 +35880,7 @@ export const WaitProjectsLocationsRagCorporaRagFilesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsRagCorporaRagFilesOperationsRequest>;
 
@@ -35916,7 +35916,7 @@ export const CreateProjectsLocationsCustomJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudAiplatformV1CustomJob).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/customJobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/customJobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCustomJobsRequest>;
 
@@ -35948,7 +35948,7 @@ export const GetProjectsLocationsCustomJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCustomJobsRequest>;
 
@@ -35992,7 +35992,7 @@ export const ListProjectsLocationsCustomJobsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customJobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/customJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCustomJobsRequest>;
 
@@ -36028,7 +36028,7 @@ export const DeleteProjectsLocationsCustomJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCustomJobsRequest>;
 
@@ -36065,7 +36065,7 @@ export const CancelProjectsLocationsCustomJobsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsCustomJobsRequest>;
 
@@ -36096,7 +36096,7 @@ export const GetProjectsLocationsCustomJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCustomJobsOperationsRequest>;
 
@@ -36131,7 +36131,7 @@ export const WaitProjectsLocationsCustomJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsCustomJobsOperationsRequest>;
 
@@ -36177,7 +36177,7 @@ export const ListProjectsLocationsCustomJobsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCustomJobsOperationsRequest>;
 
@@ -36213,7 +36213,7 @@ export const DeleteProjectsLocationsCustomJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCustomJobsOperationsRequest>;
 
@@ -36245,7 +36245,7 @@ export const CancelProjectsLocationsCustomJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsCustomJobsOperationsRequest>;
 
@@ -36277,7 +36277,7 @@ export const GetProjectsLocationsEvaluationRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEvaluationRunsRequest>;
 
@@ -36316,7 +36316,7 @@ export const CreateProjectsLocationsEvaluationRunsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/evaluationRuns",
+      path: "v1/{+parent}/evaluationRuns",
       hasBody: true,
     }),
     svc,
@@ -36362,7 +36362,7 @@ export const ListProjectsLocationsEvaluationRunsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/evaluationRuns" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/evaluationRuns" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEvaluationRunsRequest>;
 
@@ -36398,7 +36398,7 @@ export const DeleteProjectsLocationsEvaluationRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEvaluationRunsRequest>;
 
@@ -36435,7 +36435,7 @@ export const CancelProjectsLocationsEvaluationRunsRequest =
       GoogleCloudAiplatformV1CancelEvaluationRunRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsEvaluationRunsRequest>;
 
@@ -36473,7 +36473,7 @@ export const AssignProjectsLocationsNotebookRuntimesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/notebookRuntimes:assign",
+      path: "v1/{+parent}/notebookRuntimes:assign",
       hasBody: true,
     }),
     svc,
@@ -36507,7 +36507,7 @@ export const GetProjectsLocationsNotebookRuntimesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNotebookRuntimesRequest>;
 
@@ -36544,7 +36544,7 @@ export const StartProjectsLocationsNotebookRuntimesRequest =
       GoogleCloudAiplatformV1StartNotebookRuntimeRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsLocationsNotebookRuntimesRequest>;
 
@@ -36591,7 +36591,7 @@ export const ListProjectsLocationsNotebookRuntimesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/notebookRuntimes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/notebookRuntimes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNotebookRuntimesRequest>;
 
@@ -36632,7 +36632,7 @@ export const StopProjectsLocationsNotebookRuntimesRequest =
       GoogleCloudAiplatformV1StopNotebookRuntimeRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsNotebookRuntimesRequest>;
 
@@ -36669,7 +36669,7 @@ export const UpgradeProjectsLocationsNotebookRuntimesRequest =
       GoogleCloudAiplatformV1UpgradeNotebookRuntimeRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:upgrade", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:upgrade", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpgradeProjectsLocationsNotebookRuntimesRequest>;
 
@@ -36701,7 +36701,7 @@ export const DeleteProjectsLocationsNotebookRuntimesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNotebookRuntimesRequest>;
 
@@ -36733,7 +36733,7 @@ export const GetProjectsLocationsNotebookRuntimesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNotebookRuntimesOperationsRequest>;
 
@@ -36768,7 +36768,7 @@ export const WaitProjectsLocationsNotebookRuntimesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsNotebookRuntimesOperationsRequest>;
 
@@ -36801,7 +36801,7 @@ export const DeleteProjectsLocationsNotebookRuntimesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNotebookRuntimesOperationsRequest>;
 
@@ -36834,7 +36834,7 @@ export const CancelProjectsLocationsNotebookRuntimesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsNotebookRuntimesOperationsRequest>;
 
@@ -36881,7 +36881,7 @@ export const ListProjectsLocationsNotebookRuntimesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNotebookRuntimesOperationsRequest>;
 
@@ -36925,7 +36925,7 @@ export const TestIamPermissionsProjectsLocationsFeatureOnlineStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -36968,7 +36968,7 @@ export const PatchProjectsLocationsFeatureOnlineStoresRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFeatureOnlineStoresRequest>;
 
@@ -37005,7 +37005,7 @@ export const SetIamPolicyProjectsLocationsFeatureOnlineStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -37052,7 +37052,7 @@ export const CreateProjectsLocationsFeatureOnlineStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/featureOnlineStores",
+      path: "v1/{+parent}/featureOnlineStores",
       hasBody: true,
     }),
     svc,
@@ -37086,7 +37086,7 @@ export const GetProjectsLocationsFeatureOnlineStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureOnlineStoresRequest>;
 
@@ -37125,7 +37125,7 @@ export const GetIamPolicyProjectsLocationsFeatureOnlineStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -37172,7 +37172,7 @@ export const ListProjectsLocationsFeatureOnlineStoresRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/featureOnlineStores" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/featureOnlineStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeatureOnlineStoresRequest>;
 
@@ -37211,7 +37211,7 @@ export const DeleteProjectsLocationsFeatureOnlineStoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeatureOnlineStoresRequest>;
 
@@ -37250,7 +37250,7 @@ export const SearchNearestEntitiesProjectsLocationsFeatureOnlineStoresFeatureVie
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{featureView}:searchNearestEntities",
+      path: "v1/{+featureView}:searchNearestEntities",
       hasBody: true,
     }),
     svc,
@@ -37302,7 +37302,11 @@ export const CreateProjectsLocationsFeatureOnlineStoresFeatureViewsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/featureViews", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/featureViews",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsFeatureOnlineStoresFeatureViewsRequest>;
 
@@ -37342,7 +37346,7 @@ export const GetIamPolicyProjectsLocationsFeatureOnlineStoresFeatureViewsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -37389,7 +37393,7 @@ export const ListProjectsLocationsFeatureOnlineStoresFeatureViewsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/featureViews" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/featureViews" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeatureOnlineStoresFeatureViewsRequest>;
 
@@ -37426,7 +37430,7 @@ export const DeleteProjectsLocationsFeatureOnlineStoresFeatureViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeatureOnlineStoresFeatureViewsRequest>;
 
@@ -37466,7 +37470,7 @@ export const TestIamPermissionsProjectsLocationsFeatureOnlineStoresFeatureViewsR
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -37510,7 +37514,7 @@ export const FetchFeatureValuesProjectsLocationsFeatureOnlineStoresFeatureViewsR
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{featureView}:fetchFeatureValues",
+      path: "v1/{+featureView}:fetchFeatureValues",
       hasBody: true,
     }),
     svc,
@@ -37552,7 +37556,7 @@ export const SyncProjectsLocationsFeatureOnlineStoresFeatureViewsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{featureView}:sync", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+featureView}:sync", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SyncProjectsLocationsFeatureOnlineStoresFeatureViewsRequest>;
 
@@ -37585,7 +37589,7 @@ export const GetProjectsLocationsFeatureOnlineStoresFeatureViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureOnlineStoresFeatureViewsRequest>;
 
@@ -37625,7 +37629,7 @@ export const GenerateFetchAccessTokenProjectsLocationsFeatureOnlineStoresFeature
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{featureView}:generateFetchAccessToken",
+      path: "v1/{+featureView}:generateFetchAccessToken",
       hasBody: true,
     }),
     svc,
@@ -37667,7 +37671,7 @@ export const SetIamPolicyProjectsLocationsFeatureOnlineStoresFeatureViewsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -37709,7 +37713,7 @@ export const DirectWriteProjectsLocationsFeatureOnlineStoresFeatureViewsRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{featureView}:directWrite",
+      path: "v1/{+featureView}:directWrite",
       hasBody: true,
     }),
     svc,
@@ -37752,7 +37756,7 @@ export const PatchProjectsLocationsFeatureOnlineStoresFeatureViewsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFeatureOnlineStoresFeatureViewsRequest>;
 
@@ -37799,7 +37803,7 @@ export const ListWaitProjectsLocationsFeatureOnlineStoresFeatureViewsOperationsR
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:wait" }),
+    T.Http({ method: "GET", path: "v1/{+name}:wait" }),
     svc,
   ) as unknown as Schema.Schema<ListWaitProjectsLocationsFeatureOnlineStoresFeatureViewsOperationsRequest>;
 
@@ -37838,7 +37842,7 @@ export const GetProjectsLocationsFeatureOnlineStoresFeatureViewsOperationsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureOnlineStoresFeatureViewsOperationsRequest>;
 
@@ -37871,7 +37875,7 @@ export const DeleteProjectsLocationsFeatureOnlineStoresFeatureViewsOperationsReq
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeatureOnlineStoresFeatureViewsOperationsRequest>;
 
@@ -37909,7 +37913,7 @@ export const WaitProjectsLocationsFeatureOnlineStoresFeatureViewsOperationsReque
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsFeatureOnlineStoresFeatureViewsOperationsRequest>;
 
@@ -37955,7 +37959,7 @@ export const ListProjectsLocationsFeatureOnlineStoresFeatureViewsFeatureViewSync
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/featureViewSyncs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/featureViewSyncs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeatureOnlineStoresFeatureViewsFeatureViewSyncsRequest>;
 
@@ -37994,7 +37998,7 @@ export const GetProjectsLocationsFeatureOnlineStoresFeatureViewsFeatureViewSyncs
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureOnlineStoresFeatureViewsFeatureViewSyncsRequest>;
 
@@ -38043,7 +38047,7 @@ export const ListWaitProjectsLocationsFeatureOnlineStoresOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:wait" }),
+    T.Http({ method: "GET", path: "v1/{+name}:wait" }),
     svc,
   ) as unknown as Schema.Schema<ListWaitProjectsLocationsFeatureOnlineStoresOperationsRequest>;
 
@@ -38080,7 +38084,7 @@ export const GetProjectsLocationsFeatureOnlineStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureOnlineStoresOperationsRequest>;
 
@@ -38113,7 +38117,7 @@ export const DeleteProjectsLocationsFeatureOnlineStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeatureOnlineStoresOperationsRequest>;
 
@@ -38149,7 +38153,7 @@ export const WaitProjectsLocationsFeatureOnlineStoresOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsFeatureOnlineStoresOperationsRequest>;
 
@@ -38189,7 +38193,7 @@ export const CreateProjectsLocationsCachedContentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/cachedContents",
+      path: "v1/{+parent}/cachedContents",
       hasBody: true,
     }),
     svc,
@@ -38223,7 +38227,7 @@ export const GetProjectsLocationsCachedContentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCachedContentsRequest>;
 
@@ -38263,7 +38267,7 @@ export const PatchProjectsLocationsCachedContentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCachedContentsRequest>;
 
@@ -38295,7 +38299,7 @@ export const DeleteProjectsLocationsCachedContentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCachedContentsRequest>;
 
@@ -38332,7 +38336,7 @@ export const ListProjectsLocationsCachedContentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/cachedContents" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/cachedContents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCachedContentsRequest>;
 
@@ -38374,7 +38378,7 @@ export const ListProjectsLocationsDeploymentResourcePoolsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deploymentResourcePools" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deploymentResourcePools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeploymentResourcePoolsRequest>;
 
@@ -38410,7 +38414,7 @@ export const DeleteProjectsLocationsDeploymentResourcePoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDeploymentResourcePoolsRequest>;
 
@@ -38450,7 +38454,7 @@ export const PatchProjectsLocationsDeploymentResourcePoolsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDeploymentResourcePoolsRequest>;
 
@@ -38482,7 +38486,7 @@ export const GetProjectsLocationsDeploymentResourcePoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeploymentResourcePoolsRequest>;
 
@@ -38524,7 +38528,7 @@ export const QueryDeployedModelsProjectsLocationsDeploymentResourcePoolsRequest 
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{deploymentResourcePool}:queryDeployedModels",
+      path: "v1/{+deploymentResourcePool}:queryDeployedModels",
     }),
     svc,
   ) as unknown as Schema.Schema<QueryDeployedModelsProjectsLocationsDeploymentResourcePoolsRequest>;
@@ -38569,7 +38573,7 @@ export const CreateProjectsLocationsDeploymentResourcePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/deploymentResourcePools",
+      path: "v1/{+parent}/deploymentResourcePools",
       hasBody: true,
     }),
     svc,
@@ -38603,7 +38607,7 @@ export const GetProjectsLocationsDeploymentResourcePoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeploymentResourcePoolsOperationsRequest>;
 
@@ -38639,7 +38643,7 @@ export const WaitProjectsLocationsDeploymentResourcePoolsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsDeploymentResourcePoolsOperationsRequest>;
 
@@ -38672,7 +38676,7 @@ export const DeleteProjectsLocationsDeploymentResourcePoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDeploymentResourcePoolsOperationsRequest>;
 
@@ -38705,7 +38709,7 @@ export const CancelProjectsLocationsDeploymentResourcePoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDeploymentResourcePoolsOperationsRequest>;
 
@@ -38752,7 +38756,7 @@ export const ListProjectsLocationsDeploymentResourcePoolsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeploymentResourcePoolsOperationsRequest>;
 
@@ -38796,7 +38800,7 @@ export const GenerateContentProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{model}:generateContent",
+      path: "v1/{+model}:generateContent",
       hasBody: true,
     }),
     svc,
@@ -38838,7 +38842,7 @@ export const StreamGenerateContentProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{model}:streamGenerateContent",
+      path: "v1/{+model}:streamGenerateContent",
       hasBody: true,
     }),
     svc,
@@ -38880,7 +38884,7 @@ export const ServerStreamingPredictProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:serverStreamingPredict",
+      path: "v1/{+endpoint}:serverStreamingPredict",
       hasBody: true,
     }),
     svc,
@@ -38922,7 +38926,7 @@ export const PredictLongRunningProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:predictLongRunning",
+      path: "v1/{+endpoint}:predictLongRunning",
       hasBody: true,
     }),
     svc,
@@ -38963,7 +38967,7 @@ export const CountTokensProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:countTokens",
+      path: "v1/{+endpoint}:countTokens",
       hasBody: true,
     }),
     svc,
@@ -39004,7 +39008,7 @@ export const ComputeTokensProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:computeTokens",
+      path: "v1/{+endpoint}:computeTokens",
       hasBody: true,
     }),
     svc,
@@ -39043,7 +39047,7 @@ export const PredictProjectsLocationsPublishersModelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{endpoint}:predict", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+endpoint}:predict", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PredictProjectsLocationsPublishersModelsRequest>;
 
@@ -39081,7 +39085,7 @@ export const StreamRawPredictProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:streamRawPredict",
+      path: "v1/{+endpoint}:streamRawPredict",
       hasBody: true,
     }),
     svc,
@@ -39121,7 +39125,7 @@ export const EmbedContentProjectsLocationsPublishersModelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{model}:embedContent", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+model}:embedContent", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EmbedContentProjectsLocationsPublishersModelsRequest>;
 
@@ -39158,7 +39162,11 @@ export const RawPredictProjectsLocationsPublishersModelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{endpoint}:rawPredict", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+endpoint}:rawPredict",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<RawPredictProjectsLocationsPublishersModelsRequest>;
 
@@ -39197,7 +39205,7 @@ export const FetchPredictOperationProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:fetchPredictOperation",
+      path: "v1/{+endpoint}:fetchPredictOperation",
       hasBody: true,
     }),
     svc,
@@ -39241,7 +39249,7 @@ export const InvokeProjectsLocationsPublishersModelsInvokeRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}/invoke/{invokeId}",
+      path: "v1/{+endpoint}/invoke/{+invokeId}",
       hasBody: true,
     }),
     svc,
@@ -39282,7 +39290,7 @@ export const CreateProjectsLocationsDataLabelingJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/dataLabelingJobs",
+      path: "v1/{+parent}/dataLabelingJobs",
       hasBody: true,
     }),
     svc,
@@ -39316,7 +39324,7 @@ export const GetProjectsLocationsDataLabelingJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataLabelingJobsRequest>;
 
@@ -39363,7 +39371,7 @@ export const ListProjectsLocationsDataLabelingJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dataLabelingJobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dataLabelingJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataLabelingJobsRequest>;
 
@@ -39399,7 +39407,7 @@ export const DeleteProjectsLocationsDataLabelingJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataLabelingJobsRequest>;
 
@@ -39436,7 +39444,7 @@ export const CancelProjectsLocationsDataLabelingJobsRequest =
       GoogleCloudAiplatformV1CancelDataLabelingJobRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDataLabelingJobsRequest>;
 
@@ -39468,7 +39476,7 @@ export const GetProjectsLocationsDataLabelingJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataLabelingJobsOperationsRequest>;
 
@@ -39503,7 +39511,7 @@ export const WaitProjectsLocationsDataLabelingJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsDataLabelingJobsOperationsRequest>;
 
@@ -39536,7 +39544,7 @@ export const DeleteProjectsLocationsDataLabelingJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataLabelingJobsOperationsRequest>;
 
@@ -39569,7 +39577,7 @@ export const CancelProjectsLocationsDataLabelingJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDataLabelingJobsOperationsRequest>;
 
@@ -39616,7 +39624,7 @@ export const ListProjectsLocationsDataLabelingJobsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataLabelingJobsOperationsRequest>;
 
@@ -39653,7 +39661,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -39684,7 +39692,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -39729,7 +39737,7 @@ export const ListProjectsLocationsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -39765,7 +39773,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -39799,7 +39807,7 @@ export const WaitProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsOperationsRequest>;
 
@@ -39838,7 +39846,7 @@ export const SearchProjectsLocationsMigratableResourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/migratableResources:search",
+      path: "v1/{+parent}/migratableResources:search",
       hasBody: true,
     }),
     svc,
@@ -39879,7 +39887,7 @@ export const BatchMigrateProjectsLocationsMigratableResourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/migratableResources:batchMigrate",
+      path: "v1/{+parent}/migratableResources:batchMigrate",
       hasBody: true,
     }),
     svc,
@@ -39928,7 +39936,7 @@ export const ListProjectsLocationsMigratableResourcesOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMigratableResourcesOperationsRequest>;
 
@@ -39965,7 +39973,7 @@ export const DeleteProjectsLocationsMigratableResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMigratableResourcesOperationsRequest>;
 
@@ -39998,7 +40006,7 @@ export const CancelProjectsLocationsMigratableResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsMigratableResourcesOperationsRequest>;
 
@@ -40031,7 +40039,7 @@ export const GetProjectsLocationsMigratableResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMigratableResourcesOperationsRequest>;
 
@@ -40067,7 +40075,7 @@ export const WaitProjectsLocationsMigratableResourcesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsMigratableResourcesOperationsRequest>;
 
@@ -40112,7 +40120,7 @@ export const CreateProjectsLocationsFeaturestoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/featurestores",
+      path: "v1/{+parent}/featurestores",
       hasBody: true,
     }),
     svc,
@@ -40151,7 +40159,7 @@ export const SetIamPolicyProjectsLocationsFeaturestoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -40185,7 +40193,7 @@ export const GetProjectsLocationsFeaturestoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeaturestoresRequest>;
 
@@ -40224,7 +40232,7 @@ export const BatchReadFeatureValuesProjectsLocationsFeaturestoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{featurestore}:batchReadFeatureValues",
+      path: "v1/{+featurestore}:batchReadFeatureValues",
       hasBody: true,
     }),
     svc,
@@ -40270,7 +40278,7 @@ export const SearchFeaturesProjectsLocationsFeaturestoresRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{location}/featurestores:searchFeatures",
+      path: "v1/{+location}/featurestores:searchFeatures",
     }),
     svc,
   ) as unknown as Schema.Schema<SearchFeaturesProjectsLocationsFeaturestoresRequest>;
@@ -40314,7 +40322,7 @@ export const TestIamPermissionsProjectsLocationsFeaturestoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -40357,7 +40365,7 @@ export const PatchProjectsLocationsFeaturestoresRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFeaturestoresRequest>;
 
@@ -40392,7 +40400,7 @@ export const DeleteProjectsLocationsFeaturestoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeaturestoresRequest>;
 
@@ -40431,7 +40439,7 @@ export const GetIamPolicyProjectsLocationsFeaturestoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -40480,7 +40488,7 @@ export const ListProjectsLocationsFeaturestoresRequest =
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/featurestores" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/featurestores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeaturestoresRequest>;
 
@@ -40522,7 +40530,7 @@ export const PatchProjectsLocationsFeaturestoresEntityTypesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudAiplatformV1EntityType).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFeaturestoresEntityTypesRequest>;
 
@@ -40561,7 +40569,7 @@ export const ImportFeatureValuesProjectsLocationsFeaturestoresEntityTypesRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{entityType}:importFeatureValues",
+      path: "v1/{+entityType}:importFeatureValues",
       hasBody: true,
     }),
     svc,
@@ -40603,7 +40611,7 @@ export const ReadFeatureValuesProjectsLocationsFeaturestoresEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{entityType}:readFeatureValues",
+      path: "v1/{+entityType}:readFeatureValues",
       hasBody: true,
     }),
     svc,
@@ -40645,7 +40653,7 @@ export const ExportFeatureValuesProjectsLocationsFeaturestoresEntityTypesRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{entityType}:exportFeatureValues",
+      path: "v1/{+entityType}:exportFeatureValues",
       hasBody: true,
     }),
     svc,
@@ -40687,7 +40695,7 @@ export const DeleteFeatureValuesProjectsLocationsFeaturestoresEntityTypesRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{entityType}:deleteFeatureValues",
+      path: "v1/{+entityType}:deleteFeatureValues",
       hasBody: true,
     }),
     svc,
@@ -40727,7 +40735,7 @@ export const SetIamPolicyProjectsLocationsFeaturestoresEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -40769,7 +40777,7 @@ export const StreamingReadFeatureValuesProjectsLocationsFeaturestoresEntityTypes
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{entityType}:streamingReadFeatureValues",
+      path: "v1/{+entityType}:streamingReadFeatureValues",
       hasBody: true,
     }),
     svc,
@@ -40813,7 +40821,7 @@ export const TestIamPermissionsProjectsLocationsFeaturestoresEntityTypesRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -40848,7 +40856,7 @@ export const GetProjectsLocationsFeaturestoresEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeaturestoresEntityTypesRequest>;
 
@@ -40887,7 +40895,7 @@ export const WriteFeatureValuesProjectsLocationsFeaturestoresEntityTypesRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{entityType}:writeFeatureValues",
+      path: "v1/{+entityType}:writeFeatureValues",
       hasBody: true,
     }),
     svc,
@@ -40929,7 +40937,7 @@ export const GetIamPolicyProjectsLocationsFeaturestoresEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -40979,7 +40987,7 @@ export const ListProjectsLocationsFeaturestoresEntityTypesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeaturestoresEntityTypesRequest>;
 
@@ -41018,7 +41026,7 @@ export const DeleteProjectsLocationsFeaturestoresEntityTypesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeaturestoresEntityTypesRequest>;
 
@@ -41059,7 +41067,7 @@ export const CreateProjectsLocationsFeaturestoresEntityTypesRequest =
     ),
     body: Schema.optional(GoogleCloudAiplatformV1EntityType).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/entityTypes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/entityTypes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsFeaturestoresEntityTypesRequest>;
 
@@ -41098,7 +41106,7 @@ export const PatchProjectsLocationsFeaturestoresEntityTypesFeaturesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudAiplatformV1Feature).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFeaturestoresEntityTypesFeaturesRequest>;
 
@@ -41137,7 +41145,7 @@ export const CreateProjectsLocationsFeaturestoresEntityTypesFeaturesRequest =
     featureId: Schema.optional(Schema.String).pipe(T.HttpQuery("featureId")),
     body: Schema.optional(GoogleCloudAiplatformV1Feature).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/features", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/features", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsFeaturestoresEntityTypesFeaturesRequest>;
 
@@ -41177,7 +41185,7 @@ export const BatchCreateProjectsLocationsFeaturestoresEntityTypesFeaturesRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/features:batchCreate",
+      path: "v1/{+parent}/features:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -41212,7 +41220,7 @@ export const GetProjectsLocationsFeaturestoresEntityTypesFeaturesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeaturestoresEntityTypesFeaturesRequest>;
 
@@ -41265,7 +41273,7 @@ export const ListProjectsLocationsFeaturestoresEntityTypesFeaturesRequest =
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/features" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/features" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeaturestoresEntityTypesFeaturesRequest>;
 
@@ -41302,7 +41310,7 @@ export const DeleteProjectsLocationsFeaturestoresEntityTypesFeaturesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeaturestoresEntityTypesFeaturesRequest>;
 
@@ -41335,7 +41343,7 @@ export const GetProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsReque
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -41372,7 +41380,7 @@ export const WaitProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsRequ
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -41406,7 +41414,7 @@ export const DeleteProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsRe
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -41441,7 +41449,7 @@ export const CancelProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsRe
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -41490,7 +41498,7 @@ export const ListProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsRequ
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -41528,7 +41536,7 @@ export const DeleteProjectsLocationsFeaturestoresEntityTypesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeaturestoresEntityTypesOperationsRequest>;
 
@@ -41561,7 +41569,7 @@ export const CancelProjectsLocationsFeaturestoresEntityTypesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsFeaturestoresEntityTypesOperationsRequest>;
 
@@ -41608,7 +41616,7 @@ export const ListProjectsLocationsFeaturestoresEntityTypesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeaturestoresEntityTypesOperationsRequest>;
 
@@ -41645,7 +41653,7 @@ export const GetProjectsLocationsFeaturestoresEntityTypesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeaturestoresEntityTypesOperationsRequest>;
 
@@ -41681,7 +41689,7 @@ export const WaitProjectsLocationsFeaturestoresEntityTypesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsFeaturestoresEntityTypesOperationsRequest>;
 
@@ -41714,7 +41722,7 @@ export const GetProjectsLocationsFeaturestoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeaturestoresOperationsRequest>;
 
@@ -41749,7 +41757,7 @@ export const WaitProjectsLocationsFeaturestoresOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsFeaturestoresOperationsRequest>;
 
@@ -41795,7 +41803,7 @@ export const ListProjectsLocationsFeaturestoresOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeaturestoresOperationsRequest>;
 
@@ -41831,7 +41839,7 @@ export const DeleteProjectsLocationsFeaturestoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeaturestoresOperationsRequest>;
 
@@ -41863,7 +41871,7 @@ export const CancelProjectsLocationsFeaturestoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsFeaturestoresOperationsRequest>;
 
@@ -41907,7 +41915,7 @@ export const ListProjectsLocationsTrainingPipelinesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/trainingPipelines" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/trainingPipelines" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTrainingPipelinesRequest>;
 
@@ -41943,7 +41951,7 @@ export const DeleteProjectsLocationsTrainingPipelinesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTrainingPipelinesRequest>;
 
@@ -41980,7 +41988,7 @@ export const CancelProjectsLocationsTrainingPipelinesRequest =
       GoogleCloudAiplatformV1CancelTrainingPipelineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsTrainingPipelinesRequest>;
 
@@ -42019,7 +42027,7 @@ export const CreateProjectsLocationsTrainingPipelinesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/trainingPipelines",
+      path: "v1/{+parent}/trainingPipelines",
       hasBody: true,
     }),
     svc,
@@ -42053,7 +42061,7 @@ export const GetProjectsLocationsTrainingPipelinesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTrainingPipelinesRequest>;
 
@@ -42099,7 +42107,7 @@ export const ListProjectsLocationsTrainingPipelinesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTrainingPipelinesOperationsRequest>;
 
@@ -42136,7 +42144,7 @@ export const DeleteProjectsLocationsTrainingPipelinesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTrainingPipelinesOperationsRequest>;
 
@@ -42169,7 +42177,7 @@ export const CancelProjectsLocationsTrainingPipelinesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsTrainingPipelinesOperationsRequest>;
 
@@ -42202,7 +42210,7 @@ export const GetProjectsLocationsTrainingPipelinesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTrainingPipelinesOperationsRequest>;
 
@@ -42238,7 +42246,7 @@ export const WaitProjectsLocationsTrainingPipelinesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsTrainingPipelinesOperationsRequest>;
 
@@ -42271,7 +42279,7 @@ export const GetProjectsLocationsEvaluationSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEvaluationSetsRequest>;
 
@@ -42310,7 +42318,7 @@ export const CreateProjectsLocationsEvaluationSetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/evaluationSets",
+      path: "v1/{+parent}/evaluationSets",
       hasBody: true,
     }),
     svc,
@@ -42352,7 +42360,7 @@ export const PatchProjectsLocationsEvaluationSetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEvaluationSetsRequest>;
 
@@ -42384,7 +42392,7 @@ export const DeleteProjectsLocationsEvaluationSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEvaluationSetsRequest>;
 
@@ -42428,7 +42436,7 @@ export const ListProjectsLocationsEvaluationSetsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/evaluationSets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/evaluationSets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEvaluationSetsRequest>;
 
@@ -42464,7 +42472,7 @@ export const DeleteProjectsLocationsBatchPredictionJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBatchPredictionJobsRequest>;
 
@@ -42501,7 +42509,7 @@ export const CancelProjectsLocationsBatchPredictionJobsRequest =
       GoogleCloudAiplatformV1CancelBatchPredictionJobRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsBatchPredictionJobsRequest>;
 
@@ -42545,7 +42553,7 @@ export const ListProjectsLocationsBatchPredictionJobsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/batchPredictionJobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/batchPredictionJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBatchPredictionJobsRequest>;
 
@@ -42588,7 +42596,7 @@ export const CreateProjectsLocationsBatchPredictionJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/batchPredictionJobs",
+      path: "v1/{+parent}/batchPredictionJobs",
       hasBody: true,
     }),
     svc,
@@ -42622,7 +42630,7 @@ export const GetProjectsLocationsBatchPredictionJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBatchPredictionJobsRequest>;
 
@@ -42661,7 +42669,7 @@ export const GetIamPolicyProjectsLocationsNotebookRuntimeTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -42711,7 +42719,7 @@ export const ListProjectsLocationsNotebookRuntimeTemplatesRequest =
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/notebookRuntimeTemplates" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/notebookRuntimeTemplates" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNotebookRuntimeTemplatesRequest>;
 
@@ -42747,7 +42755,7 @@ export const DeleteProjectsLocationsNotebookRuntimeTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNotebookRuntimeTemplatesRequest>;
 
@@ -42787,7 +42795,7 @@ export const TestIamPermissionsProjectsLocationsNotebookRuntimeTemplatesRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -42830,7 +42838,7 @@ export const PatchProjectsLocationsNotebookRuntimeTemplatesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsNotebookRuntimeTemplatesRequest>;
 
@@ -42867,7 +42875,7 @@ export const SetIamPolicyProjectsLocationsNotebookRuntimeTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -42914,7 +42922,7 @@ export const CreateProjectsLocationsNotebookRuntimeTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/notebookRuntimeTemplates",
+      path: "v1/{+parent}/notebookRuntimeTemplates",
       hasBody: true,
     }),
     svc,
@@ -42949,7 +42957,7 @@ export const GetProjectsLocationsNotebookRuntimeTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNotebookRuntimeTemplatesRequest>;
 
@@ -42995,7 +43003,7 @@ export const ListProjectsLocationsNotebookRuntimeTemplatesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -43032,7 +43040,7 @@ export const DeleteProjectsLocationsNotebookRuntimeTemplatesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -43065,7 +43073,7 @@ export const CancelProjectsLocationsNotebookRuntimeTemplatesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -43098,7 +43106,7 @@ export const GetProjectsLocationsNotebookRuntimeTemplatesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -43134,7 +43142,7 @@ export const WaitProjectsLocationsNotebookRuntimeTemplatesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -43179,7 +43187,7 @@ export const ListProjectsLocationsIndexesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/indexes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/indexes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIndexesRequest>;
 
@@ -43215,7 +43223,7 @@ export const DeleteProjectsLocationsIndexesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsIndexesRequest>;
 
@@ -43253,7 +43261,7 @@ export const UpsertDatapointsProjectsLocationsIndexesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{index}:upsertDatapoints",
+      path: "v1/{+index}:upsertDatapoints",
       hasBody: true,
     }),
     svc,
@@ -43293,7 +43301,7 @@ export const PatchProjectsLocationsIndexesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudAiplatformV1Index).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsIndexesRequest>;
 
@@ -43331,7 +43339,7 @@ export const RemoveDatapointsProjectsLocationsIndexesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{index}:removeDatapoints",
+      path: "v1/{+index}:removeDatapoints",
       hasBody: true,
     }),
     svc,
@@ -43368,7 +43376,7 @@ export const CreateProjectsLocationsIndexesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudAiplatformV1Index).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/indexes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/indexes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsIndexesRequest>;
 
@@ -43399,7 +43407,7 @@ export const GetProjectsLocationsIndexesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIndexesRequest>;
 
@@ -43430,7 +43438,7 @@ export const GetProjectsLocationsIndexesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIndexesOperationsRequest>;
 
@@ -43465,7 +43473,7 @@ export const WaitProjectsLocationsIndexesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsIndexesOperationsRequest>;
 
@@ -43511,7 +43519,7 @@ export const ListProjectsLocationsIndexesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIndexesOperationsRequest>;
 
@@ -43547,7 +43555,7 @@ export const DeleteProjectsLocationsIndexesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsIndexesOperationsRequest>;
 
@@ -43579,7 +43587,7 @@ export const CancelProjectsLocationsIndexesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsIndexesOperationsRequest>;
 
@@ -43623,7 +43631,7 @@ export const CreateProjectsLocationsNotebookExecutionJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/notebookExecutionJobs",
+      path: "v1/{+parent}/notebookExecutionJobs",
       hasBody: true,
     }),
     svc,
@@ -43664,7 +43672,7 @@ export const GetProjectsLocationsNotebookExecutionJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNotebookExecutionJobsRequest>;
 
@@ -43696,7 +43704,7 @@ export const DeleteProjectsLocationsNotebookExecutionJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNotebookExecutionJobsRequest>;
 
@@ -43747,7 +43755,7 @@ export const ListProjectsLocationsNotebookExecutionJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/notebookExecutionJobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/notebookExecutionJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNotebookExecutionJobsRequest>;
 
@@ -43797,7 +43805,7 @@ export const ListProjectsLocationsNotebookExecutionJobsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNotebookExecutionJobsOperationsRequest>;
 
@@ -43834,7 +43842,7 @@ export const DeleteProjectsLocationsNotebookExecutionJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNotebookExecutionJobsOperationsRequest>;
 
@@ -43867,7 +43875,7 @@ export const CancelProjectsLocationsNotebookExecutionJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsNotebookExecutionJobsOperationsRequest>;
 
@@ -43900,7 +43908,7 @@ export const GetProjectsLocationsNotebookExecutionJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNotebookExecutionJobsOperationsRequest>;
 
@@ -43936,7 +43944,7 @@ export const WaitProjectsLocationsNotebookExecutionJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsNotebookExecutionJobsOperationsRequest>;
 
@@ -43972,7 +43980,7 @@ export const CreateProjectsLocationsStudiesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudAiplatformV1Study).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/studies", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/studies", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsStudiesRequest>;
 
@@ -44004,7 +44012,7 @@ export const GetProjectsLocationsStudiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsStudiesRequest>;
 
@@ -44042,7 +44050,7 @@ export const LookupProjectsLocationsStudiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/studies:lookup",
+      path: "v1/{+parent}/studies:lookup",
       hasBody: true,
     }),
     svc,
@@ -44076,7 +44084,7 @@ export const DeleteProjectsLocationsStudiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsStudiesRequest>;
 
@@ -44113,7 +44121,7 @@ export const ListProjectsLocationsStudiesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/studies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/studies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsStudiesRequest>;
 
@@ -44149,7 +44157,7 @@ export const DeleteProjectsLocationsStudiesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsStudiesOperationsRequest>;
 
@@ -44181,7 +44189,7 @@ export const CancelProjectsLocationsStudiesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsStudiesOperationsRequest>;
 
@@ -44227,7 +44235,7 @@ export const ListProjectsLocationsStudiesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsStudiesOperationsRequest>;
 
@@ -44263,7 +44271,7 @@ export const GetProjectsLocationsStudiesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsStudiesOperationsRequest>;
 
@@ -44298,7 +44306,7 @@ export const WaitProjectsLocationsStudiesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsStudiesOperationsRequest>;
 
@@ -44330,7 +44338,7 @@ export const DeleteProjectsLocationsStudiesTrialsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsStudiesTrialsRequest>;
 
@@ -44367,7 +44375,7 @@ export const ListProjectsLocationsStudiesTrialsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/trials" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/trials" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsStudiesTrialsRequest>;
 
@@ -44403,7 +44411,7 @@ export const GetProjectsLocationsStudiesTrialsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsStudiesTrialsRequest>;
 
@@ -44442,7 +44450,7 @@ export const SuggestProjectsLocationsStudiesTrialsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/trials:suggest",
+      path: "v1/{+parent}/trials:suggest",
       hasBody: true,
     }),
     svc,
@@ -44483,7 +44491,7 @@ export const ListOptimalTrialsProjectsLocationsStudiesTrialsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/trials:listOptimalTrials",
+      path: "v1/{+parent}/trials:listOptimalTrials",
       hasBody: true,
     }),
     svc,
@@ -44525,7 +44533,7 @@ export const AddTrialMeasurementProjectsLocationsStudiesTrialsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{trialName}:addTrialMeasurement",
+      path: "v1/{+trialName}:addTrialMeasurement",
       hasBody: true,
     }),
     svc,
@@ -44565,7 +44573,7 @@ export const StopProjectsLocationsStudiesTrialsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsStudiesTrialsRequest>;
 
@@ -44600,7 +44608,7 @@ export const CreateProjectsLocationsStudiesTrialsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudAiplatformV1Trial).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/trials", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/trials", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsStudiesTrialsRequest>;
 
@@ -44639,7 +44647,7 @@ export const CheckTrialEarlyStoppingStateProjectsLocationsStudiesTrialsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{trialName}:checkTrialEarlyStoppingState",
+      path: "v1/{+trialName}:checkTrialEarlyStoppingState",
       hasBody: true,
     }),
     svc,
@@ -44679,7 +44687,7 @@ export const CompleteProjectsLocationsStudiesTrialsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:complete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:complete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CompleteProjectsLocationsStudiesTrialsRequest>;
 
@@ -44711,7 +44719,7 @@ export const GetProjectsLocationsStudiesTrialsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsStudiesTrialsOperationsRequest>;
 
@@ -44746,7 +44754,7 @@ export const WaitProjectsLocationsStudiesTrialsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsStudiesTrialsOperationsRequest>;
 
@@ -44778,7 +44786,7 @@ export const DeleteProjectsLocationsStudiesTrialsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsStudiesTrialsOperationsRequest>;
 
@@ -44810,7 +44818,7 @@ export const CancelProjectsLocationsStudiesTrialsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsStudiesTrialsOperationsRequest>;
 
@@ -44856,7 +44864,7 @@ export const ListProjectsLocationsStudiesTrialsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsStudiesTrialsOperationsRequest>;
 
@@ -44897,7 +44905,7 @@ export const CopyProjectsLocationsModelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/models:copy", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/models:copy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CopyProjectsLocationsModelsRequest>;
 
@@ -44934,7 +44942,7 @@ export const PatchProjectsLocationsModelsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudAiplatformV1Model).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsModelsRequest>;
 
@@ -44972,7 +44980,7 @@ export const UpdateExplanationDatasetProjectsLocationsModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{model}:updateExplanationDataset",
+      path: "v1/{+model}:updateExplanationDataset",
       hasBody: true,
     }),
     svc,
@@ -45012,7 +45020,7 @@ export const SetIamPolicyProjectsLocationsModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -45052,7 +45060,7 @@ export const MergeVersionAliasesProjectsLocationsModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:mergeVersionAliases",
+      path: "v1/{+name}:mergeVersionAliases",
       hasBody: true,
     }),
     svc,
@@ -45092,7 +45100,7 @@ export const ListCheckpointsProjectsLocationsModelsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:listCheckpoints" }),
+    T.Http({ method: "GET", path: "v1/{+name}:listCheckpoints" }),
     svc,
   ) as unknown as Schema.Schema<ListCheckpointsProjectsLocationsModelsRequest>;
 
@@ -45143,7 +45151,7 @@ export const ListVersionsProjectsLocationsModelsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:listVersions" }),
+    T.Http({ method: "GET", path: "v1/{+name}:listVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListVersionsProjectsLocationsModelsRequest>;
 
@@ -45186,7 +45194,7 @@ export const TestIamPermissionsProjectsLocationsModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -45220,7 +45228,7 @@ export const GetProjectsLocationsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsModelsRequest>;
 
@@ -45256,7 +45264,7 @@ export const ExportProjectsLocationsModelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsModelsRequest>;
 
@@ -45294,7 +45302,7 @@ export const GetIamPolicyProjectsLocationsModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -45342,7 +45350,7 @@ export const ListProjectsLocationsModelsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/models" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/models" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsModelsRequest>;
 
@@ -45378,7 +45386,7 @@ export const DeleteProjectsLocationsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsModelsRequest>;
 
@@ -45409,7 +45417,7 @@ export const DeleteVersionProjectsLocationsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}:deleteVersion" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}:deleteVersion" }),
     svc,
   ) as unknown as Schema.Schema<DeleteVersionProjectsLocationsModelsRequest>;
 
@@ -45448,7 +45456,7 @@ export const UploadProjectsLocationsModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/models:upload",
+      path: "v1/{+parent}/models:upload",
       hasBody: true,
     }),
     svc,
@@ -45481,7 +45489,7 @@ export const GetProjectsLocationsModelsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsModelsOperationsRequest>;
 
@@ -45516,7 +45524,7 @@ export const WaitProjectsLocationsModelsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsModelsOperationsRequest>;
 
@@ -45562,7 +45570,7 @@ export const ListProjectsLocationsModelsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsModelsOperationsRequest>;
 
@@ -45598,7 +45606,7 @@ export const DeleteProjectsLocationsModelsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsModelsOperationsRequest>;
 
@@ -45630,7 +45638,7 @@ export const CancelProjectsLocationsModelsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsModelsOperationsRequest>;
 
@@ -45674,7 +45682,7 @@ export const ListProjectsLocationsModelsEvaluationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/evaluations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/evaluations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsModelsEvaluationsRequest>;
 
@@ -45717,7 +45725,7 @@ export const ImportProjectsLocationsModelsEvaluationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/evaluations:import",
+      path: "v1/{+parent}/evaluations:import",
       hasBody: true,
     }),
     svc,
@@ -45751,7 +45759,7 @@ export const GetProjectsLocationsModelsEvaluationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsModelsEvaluationsRequest>;
 
@@ -45797,7 +45805,7 @@ export const ListProjectsLocationsModelsEvaluationsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsModelsEvaluationsOperationsRequest>;
 
@@ -45834,7 +45842,7 @@ export const DeleteProjectsLocationsModelsEvaluationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsModelsEvaluationsOperationsRequest>;
 
@@ -45867,7 +45875,7 @@ export const CancelProjectsLocationsModelsEvaluationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsModelsEvaluationsOperationsRequest>;
 
@@ -45900,7 +45908,7 @@ export const GetProjectsLocationsModelsEvaluationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsModelsEvaluationsOperationsRequest>;
 
@@ -45936,7 +45944,7 @@ export const WaitProjectsLocationsModelsEvaluationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsModelsEvaluationsOperationsRequest>;
 
@@ -45974,7 +45982,7 @@ export const BatchImportProjectsLocationsModelsEvaluationsSlicesRequest =
       GoogleCloudAiplatformV1BatchImportEvaluatedAnnotationsRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:batchImport", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}:batchImport", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<BatchImportProjectsLocationsModelsEvaluationsSlicesRequest>;
 
@@ -46019,7 +46027,7 @@ export const ListProjectsLocationsModelsEvaluationsSlicesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/slices" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/slices" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsModelsEvaluationsSlicesRequest>;
 
@@ -46055,7 +46063,7 @@ export const GetProjectsLocationsModelsEvaluationsSlicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsModelsEvaluationsSlicesRequest>;
 
@@ -46094,7 +46102,7 @@ export const CreateProjectsLocationsIndexEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/indexEndpoints",
+      path: "v1/{+parent}/indexEndpoints",
       hasBody: true,
     }),
     svc,
@@ -46135,7 +46143,7 @@ export const DeployIndexProjectsLocationsIndexEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{indexEndpoint}:deployIndex",
+      path: "v1/{+indexEndpoint}:deployIndex",
       hasBody: true,
     }),
     svc,
@@ -46176,7 +46184,7 @@ export const ReadIndexDatapointsProjectsLocationsIndexEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{indexEndpoint}:readIndexDatapoints",
+      path: "v1/{+indexEndpoint}:readIndexDatapoints",
       hasBody: true,
     }),
     svc,
@@ -46219,7 +46227,7 @@ export const PatchProjectsLocationsIndexEndpointsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsIndexEndpointsRequest>;
 
@@ -46258,7 +46266,7 @@ export const FindNeighborsProjectsLocationsIndexEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{indexEndpoint}:findNeighbors",
+      path: "v1/{+indexEndpoint}:findNeighbors",
       hasBody: true,
     }),
     svc,
@@ -46292,7 +46300,7 @@ export const GetProjectsLocationsIndexEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIndexEndpointsRequest>;
 
@@ -46336,7 +46344,7 @@ export const ListProjectsLocationsIndexEndpointsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/indexEndpoints" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/indexEndpoints" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIndexEndpointsRequest>;
 
@@ -46379,7 +46387,7 @@ export const UndeployIndexProjectsLocationsIndexEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{indexEndpoint}:undeployIndex",
+      path: "v1/{+indexEndpoint}:undeployIndex",
       hasBody: true,
     }),
     svc,
@@ -46420,7 +46428,7 @@ export const MutateDeployedIndexProjectsLocationsIndexEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{indexEndpoint}:mutateDeployedIndex",
+      path: "v1/{+indexEndpoint}:mutateDeployedIndex",
       hasBody: true,
     }),
     svc,
@@ -46455,7 +46463,7 @@ export const DeleteProjectsLocationsIndexEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsIndexEndpointsRequest>;
 
@@ -46487,7 +46495,7 @@ export const GetProjectsLocationsIndexEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIndexEndpointsOperationsRequest>;
 
@@ -46522,7 +46530,7 @@ export const WaitProjectsLocationsIndexEndpointsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsIndexEndpointsOperationsRequest>;
 
@@ -46568,7 +46576,7 @@ export const ListProjectsLocationsIndexEndpointsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIndexEndpointsOperationsRequest>;
 
@@ -46604,7 +46612,7 @@ export const DeleteProjectsLocationsIndexEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsIndexEndpointsOperationsRequest>;
 
@@ -46637,7 +46645,7 @@ export const CancelProjectsLocationsIndexEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsIndexEndpointsOperationsRequest>;
 
@@ -46670,7 +46678,7 @@ export const GetProjectsLocationsRagEngineConfigOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRagEngineConfigOperationsRequest>;
 
@@ -46705,7 +46713,7 @@ export const WaitProjectsLocationsRagEngineConfigOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsRagEngineConfigOperationsRequest>;
 
@@ -46737,7 +46745,7 @@ export const DeleteProjectsLocationsRagEngineConfigOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRagEngineConfigOperationsRequest>;
 
@@ -46770,7 +46778,7 @@ export const CancelProjectsLocationsRagEngineConfigOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsRagEngineConfigOperationsRequest>;
 
@@ -46817,7 +46825,7 @@ export const ListProjectsLocationsRagEngineConfigOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRagEngineConfigOperationsRequest>;
 
@@ -46860,7 +46868,7 @@ export const CreateProjectsLocationsSpecialistPoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/specialistPools",
+      path: "v1/{+parent}/specialistPools",
       hasBody: true,
     }),
     svc,
@@ -46894,7 +46902,7 @@ export const GetProjectsLocationsSpecialistPoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSpecialistPoolsRequest>;
 
@@ -46934,7 +46942,7 @@ export const PatchProjectsLocationsSpecialistPoolsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSpecialistPoolsRequest>;
 
@@ -46969,7 +46977,7 @@ export const DeleteProjectsLocationsSpecialistPoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSpecialistPoolsRequest>;
 
@@ -47010,7 +47018,7 @@ export const ListProjectsLocationsSpecialistPoolsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/specialistPools" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/specialistPools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSpecialistPoolsRequest>;
 
@@ -47046,7 +47054,7 @@ export const GetProjectsLocationsSpecialistPoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSpecialistPoolsOperationsRequest>;
 
@@ -47081,7 +47089,7 @@ export const WaitProjectsLocationsSpecialistPoolsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsSpecialistPoolsOperationsRequest>;
 
@@ -47113,7 +47121,7 @@ export const DeleteProjectsLocationsSpecialistPoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSpecialistPoolsOperationsRequest>;
 
@@ -47146,7 +47154,7 @@ export const CancelProjectsLocationsSpecialistPoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsSpecialistPoolsOperationsRequest>;
 
@@ -47193,7 +47201,7 @@ export const ListProjectsLocationsSpecialistPoolsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSpecialistPoolsOperationsRequest>;
 
@@ -47235,7 +47243,7 @@ export const CreateProjectsLocationsEndpointsRequest =
     endpointId: Schema.optional(Schema.String).pipe(T.HttpQuery("endpointId")),
     body: Schema.optional(GoogleCloudAiplatformV1Endpoint).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/endpoints", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/endpoints", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsEndpointsRequest>;
 
@@ -47274,7 +47282,7 @@ export const UndeployModelProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:undeployModel",
+      path: "v1/{+endpoint}:undeployModel",
       hasBody: true,
     }),
     svc,
@@ -47315,7 +47323,7 @@ export const MutateDeployedModelProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:mutateDeployedModel",
+      path: "v1/{+endpoint}:mutateDeployedModel",
       hasBody: true,
     }),
     svc,
@@ -47356,7 +47364,7 @@ export const StreamRawPredictProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:streamRawPredict",
+      path: "v1/{+endpoint}:streamRawPredict",
       hasBody: true,
     }),
     svc,
@@ -47397,7 +47405,7 @@ export const ComputeTokensProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:computeTokens",
+      path: "v1/{+endpoint}:computeTokens",
       hasBody: true,
     }),
     svc,
@@ -47431,7 +47439,7 @@ export const GetProjectsLocationsEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEndpointsRequest>;
 
@@ -47481,7 +47489,7 @@ export const ListProjectsLocationsEndpointsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/endpoints" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/endpoints" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEndpointsRequest>;
 
@@ -47522,7 +47530,7 @@ export const UpdateProjectsLocationsEndpointsRequest =
       GoogleCloudAiplatformV1UpdateEndpointLongRunningRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:update", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:update", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsEndpointsRequest>;
 
@@ -47561,7 +47569,7 @@ export const ServerStreamingPredictProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:serverStreamingPredict",
+      path: "v1/{+endpoint}:serverStreamingPredict",
       hasBody: true,
     }),
     svc,
@@ -47596,7 +47604,7 @@ export const DeleteProjectsLocationsEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEndpointsRequest>;
 
@@ -47635,7 +47643,7 @@ export const DeployModelProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:deployModel",
+      path: "v1/{+endpoint}:deployModel",
       hasBody: true,
     }),
     svc,
@@ -47676,7 +47684,7 @@ export const DirectRawPredictProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:directRawPredict",
+      path: "v1/{+endpoint}:directRawPredict",
       hasBody: true,
     }),
     svc,
@@ -47715,7 +47723,11 @@ export const RawPredictProjectsLocationsEndpointsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{endpoint}:rawPredict", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+endpoint}:rawPredict",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<RawPredictProjectsLocationsEndpointsRequest>;
 
@@ -47753,7 +47765,7 @@ export const FetchPredictOperationProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:fetchPredictOperation",
+      path: "v1/{+endpoint}:fetchPredictOperation",
       hasBody: true,
     }),
     svc,
@@ -47795,7 +47807,7 @@ export const DirectPredictProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:directPredict",
+      path: "v1/{+endpoint}:directPredict",
       hasBody: true,
     }),
     svc,
@@ -47835,7 +47847,7 @@ export const PatchProjectsLocationsEndpointsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudAiplatformV1Endpoint).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEndpointsRequest>;
 
@@ -47874,7 +47886,7 @@ export const CountTokensProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:countTokens",
+      path: "v1/{+endpoint}:countTokens",
       hasBody: true,
     }),
     svc,
@@ -47913,7 +47925,7 @@ export const PredictProjectsLocationsEndpointsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{endpoint}:predict", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+endpoint}:predict", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PredictProjectsLocationsEndpointsRequest>;
 
@@ -47949,7 +47961,7 @@ export const ExplainProjectsLocationsEndpointsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{endpoint}:explain", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+endpoint}:explain", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExplainProjectsLocationsEndpointsRequest>;
 
@@ -47988,7 +48000,7 @@ export const GenerateContentProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{model}:generateContent",
+      path: "v1/{+model}:generateContent",
       hasBody: true,
     }),
     svc,
@@ -48029,7 +48041,7 @@ export const StreamGenerateContentProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{model}:streamGenerateContent",
+      path: "v1/{+model}:streamGenerateContent",
       hasBody: true,
     }),
     svc,
@@ -48071,7 +48083,7 @@ export const PredictLongRunningProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:predictLongRunning",
+      path: "v1/{+endpoint}:predictLongRunning",
       hasBody: true,
     }),
     svc,
@@ -48113,7 +48125,7 @@ export const InvokeProjectsLocationsEndpointsInvokeRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}/invoke/{invokeId}",
+      path: "v1/{+endpoint}/invoke/{+invokeId}",
       hasBody: true,
     }),
     svc,
@@ -48158,7 +48170,7 @@ export const InvokeProjectsLocationsEndpointsDeployedModelsInvokeRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}/deployedModels/{deployedModelId}/invoke/{invokeId}",
+      path: "v1/{+endpoint}/deployedModels/{deployedModelId}/invoke/{+invokeId}",
       hasBody: true,
     }),
     svc,
@@ -48203,7 +48215,7 @@ export const InferenceProjectsLocationsEndpointsGoogleScienceRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}/science/inference",
+      path: "v1/{+endpoint}/science/inference",
       hasBody: true,
     }),
     svc,
@@ -48252,7 +48264,7 @@ export const ListProjectsLocationsEndpointsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEndpointsOperationsRequest>;
 
@@ -48288,7 +48300,7 @@ export const DeleteProjectsLocationsEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEndpointsOperationsRequest>;
 
@@ -48320,7 +48332,7 @@ export const CancelProjectsLocationsEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsEndpointsOperationsRequest>;
 
@@ -48352,7 +48364,7 @@ export const GetProjectsLocationsEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEndpointsOperationsRequest>;
 
@@ -48387,7 +48399,7 @@ export const WaitProjectsLocationsEndpointsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsEndpointsOperationsRequest>;
 
@@ -48427,7 +48439,11 @@ export const EmbeddingsProjectsLocationsEndpointsOpenapiRequest =
     ),
     body: Schema.optional(GoogleApiHttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{endpoint}/embeddings", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+endpoint}/embeddings",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<EmbeddingsProjectsLocationsEndpointsOpenapiRequest>;
 
@@ -48469,7 +48485,7 @@ export const CompletionsProjectsLocationsEndpointsOpenapiRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}/completions",
+      path: "v1/{+endpoint}/completions",
       hasBody: true,
     }),
     svc,
@@ -48511,7 +48527,7 @@ export const ResponsesProjectsLocationsEndpointsOpenapiRequest =
     endpoint: Schema.String.pipe(T.HttpPath("endpoint")),
     body: Schema.optional(GoogleApiHttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{endpoint}/responses", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+endpoint}/responses", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResponsesProjectsLocationsEndpointsOpenapiRequest>;
 
@@ -48548,7 +48564,7 @@ export const CompletionsProjectsLocationsEndpointsChatRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}/chat/completions",
+      path: "v1/{+endpoint}/chat/completions",
       hasBody: true,
     }),
     svc,
@@ -48589,7 +48605,7 @@ export const CreateProjectsLocationsEvaluationItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/evaluationItems",
+      path: "v1/{+parent}/evaluationItems",
       hasBody: true,
     }),
     svc,
@@ -48623,7 +48639,7 @@ export const GetProjectsLocationsEvaluationItemsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEvaluationItemsRequest>;
 
@@ -48655,7 +48671,7 @@ export const DeleteProjectsLocationsEvaluationItemsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEvaluationItemsRequest>;
 
@@ -48699,7 +48715,7 @@ export const ListProjectsLocationsEvaluationItemsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/evaluationItems" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/evaluationItems" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEvaluationItemsRequest>;
 
@@ -48735,7 +48751,7 @@ export const DeleteProjectsLocationsTensorboardsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTensorboardsRequest>;
 
@@ -48772,7 +48788,7 @@ export const BatchReadProjectsLocationsTensorboardsRequest =
     ),
     tensorboard: Schema.String.pipe(T.HttpPath("tensorboard")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{tensorboard}:batchRead" }),
+    T.Http({ method: "GET", path: "v1/{+tensorboard}:batchRead" }),
     svc,
   ) as unknown as Schema.Schema<BatchReadProjectsLocationsTensorboardsRequest>;
 
@@ -48804,7 +48820,7 @@ export const ReadUsageProjectsLocationsTensorboardsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     tensorboard: Schema.String.pipe(T.HttpPath("tensorboard")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{tensorboard}:readUsage" }),
+    T.Http({ method: "GET", path: "v1/{+tensorboard}:readUsage" }),
     svc,
   ) as unknown as Schema.Schema<ReadUsageProjectsLocationsTensorboardsRequest>;
 
@@ -48851,7 +48867,7 @@ export const ListProjectsLocationsTensorboardsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/tensorboards" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/tensorboards" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTensorboardsRequest>;
 
@@ -48887,7 +48903,7 @@ export const GetProjectsLocationsTensorboardsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTensorboardsRequest>;
 
@@ -48919,7 +48935,7 @@ export const ReadSizeProjectsLocationsTensorboardsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     tensorboard: Schema.String.pipe(T.HttpPath("tensorboard")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{tensorboard}:readSize" }),
+    T.Http({ method: "GET", path: "v1/{+tensorboard}:readSize" }),
     svc,
   ) as unknown as Schema.Schema<ReadSizeProjectsLocationsTensorboardsRequest>;
 
@@ -48956,7 +48972,11 @@ export const CreateProjectsLocationsTensorboardsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/tensorboards", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/tensorboards",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTensorboardsRequest>;
 
@@ -48996,7 +49016,7 @@ export const PatchProjectsLocationsTensorboardsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTensorboardsRequest>;
 
@@ -49028,7 +49048,7 @@ export const GetProjectsLocationsTensorboardsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTensorboardsOperationsRequest>;
 
@@ -49063,7 +49083,7 @@ export const WaitProjectsLocationsTensorboardsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsTensorboardsOperationsRequest>;
 
@@ -49109,7 +49129,7 @@ export const ListProjectsLocationsTensorboardsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTensorboardsOperationsRequest>;
 
@@ -49145,7 +49165,7 @@ export const DeleteProjectsLocationsTensorboardsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTensorboardsOperationsRequest>;
 
@@ -49177,7 +49197,7 @@ export const CancelProjectsLocationsTensorboardsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsTensorboardsOperationsRequest>;
 
@@ -49209,7 +49229,7 @@ export const DeleteProjectsLocationsTensorboardsExperimentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTensorboardsExperimentsRequest>;
 
@@ -49256,7 +49276,7 @@ export const ListProjectsLocationsTensorboardsExperimentsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/experiments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/experiments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTensorboardsExperimentsRequest>;
 
@@ -49301,7 +49321,7 @@ export const WriteProjectsLocationsTensorboardsExperimentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{tensorboardExperiment}:write",
+      path: "v1/{+tensorboardExperiment}:write",
       hasBody: true,
     }),
     svc,
@@ -49345,7 +49365,7 @@ export const CreateProjectsLocationsTensorboardsExperimentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/experiments", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/experiments", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTensorboardsExperimentsRequest>;
 
@@ -49382,7 +49402,7 @@ export const BatchCreateProjectsLocationsTensorboardsExperimentsRequest =
       GoogleCloudAiplatformV1BatchCreateTensorboardTimeSeriesRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:batchCreate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}:batchCreate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<BatchCreateProjectsLocationsTensorboardsExperimentsRequest>;
 
@@ -49415,7 +49435,7 @@ export const GetProjectsLocationsTensorboardsExperimentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTensorboardsExperimentsRequest>;
 
@@ -49455,7 +49475,7 @@ export const PatchProjectsLocationsTensorboardsExperimentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTensorboardsExperimentsRequest>;
 
@@ -49501,7 +49521,7 @@ export const ListProjectsLocationsTensorboardsExperimentsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTensorboardsExperimentsOperationsRequest>;
 
@@ -49538,7 +49558,7 @@ export const DeleteProjectsLocationsTensorboardsExperimentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTensorboardsExperimentsOperationsRequest>;
 
@@ -49571,7 +49591,7 @@ export const CancelProjectsLocationsTensorboardsExperimentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsTensorboardsExperimentsOperationsRequest>;
 
@@ -49604,7 +49624,7 @@ export const GetProjectsLocationsTensorboardsExperimentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTensorboardsExperimentsOperationsRequest>;
 
@@ -49640,7 +49660,7 @@ export const WaitProjectsLocationsTensorboardsExperimentsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsTensorboardsExperimentsOperationsRequest>;
 
@@ -49673,7 +49693,7 @@ export const DeleteProjectsLocationsTensorboardsExperimentsRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTensorboardsExperimentsRunsRequest>;
 
@@ -49721,7 +49741,7 @@ export const ListProjectsLocationsTensorboardsExperimentsRunsRequest =
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/runs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/runs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTensorboardsExperimentsRunsRequest>;
 
@@ -49765,7 +49785,7 @@ export const WriteProjectsLocationsTensorboardsExperimentsRunsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{tensorboardRun}:write",
+      path: "v1/{+tensorboardRun}:write",
       hasBody: true,
     }),
     svc,
@@ -49800,7 +49820,7 @@ export const GetProjectsLocationsTensorboardsExperimentsRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTensorboardsExperimentsRunsRequest>;
 
@@ -49843,7 +49863,7 @@ export const CreateProjectsLocationsTensorboardsExperimentsRunsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/runs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/runs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTensorboardsExperimentsRunsRequest>;
 
@@ -49883,7 +49903,7 @@ export const BatchCreateProjectsLocationsTensorboardsExperimentsRunsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/runs:batchCreate",
+      path: "v1/{+parent}/runs:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -49926,7 +49946,7 @@ export const PatchProjectsLocationsTensorboardsExperimentsRunsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTensorboardsExperimentsRunsRequest>;
 
@@ -49959,7 +49979,7 @@ export const DeleteProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest>;
 
@@ -49997,7 +50017,7 @@ export const ReadBlobDataProjectsLocationsTensorboardsExperimentsRunsTimeSeriesR
       T.HttpQuery("blobIds"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{timeSeries}:readBlobData" }),
+    T.Http({ method: "GET", path: "v1/{+timeSeries}:readBlobData" }),
     svc,
   ) as unknown as Schema.Schema<ReadBlobDataProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest>;
 
@@ -50042,7 +50062,7 @@ export const ReadProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{tensorboardTimeSeries}:read" }),
+    T.Http({ method: "GET", path: "v1/{+tensorboardTimeSeries}:read" }),
     svc,
   ) as unknown as Schema.Schema<ReadProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest>;
 
@@ -50090,7 +50110,7 @@ export const ListProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/timeSeries" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/timeSeries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest>;
 
@@ -50127,7 +50147,7 @@ export const GetProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest>;
 
@@ -50170,7 +50190,7 @@ export const CreateProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/timeSeries", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/timeSeries", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest>;
 
@@ -50212,7 +50232,7 @@ export const ExportTensorboardTimeSeriesProjectsLocationsTensorboardsExperiments
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{tensorboardTimeSeries}:exportTensorboardTimeSeries",
+      path: "v1/{+tensorboardTimeSeries}:exportTensorboardTimeSeries",
       hasBody: true,
     }),
     svc,
@@ -50257,7 +50277,7 @@ export const PatchProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest 
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest>;
 
@@ -50290,7 +50310,7 @@ export const GetProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperations
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -50328,7 +50348,7 @@ export const WaitProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperation
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -50377,7 +50397,7 @@ export const ListProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperation
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -50416,7 +50436,7 @@ export const DeleteProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperati
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -50451,7 +50471,7 @@ export const CancelProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperati
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -50500,7 +50520,7 @@ export const ListProjectsLocationsTensorboardsExperimentsRunsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -50537,7 +50557,7 @@ export const DeleteProjectsLocationsTensorboardsExperimentsRunsOperationsRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -50570,7 +50590,7 @@ export const CancelProjectsLocationsTensorboardsExperimentsRunsOperationsRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -50603,7 +50623,7 @@ export const GetProjectsLocationsTensorboardsExperimentsRunsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -50639,7 +50659,7 @@ export const WaitProjectsLocationsTensorboardsExperimentsRunsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -50675,7 +50695,7 @@ export const DeleteProjectsLocationsFeatureGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeatureGroupsRequest>;
 
@@ -50714,7 +50734,7 @@ export const GetIamPolicyProjectsLocationsFeatureGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -50760,7 +50780,7 @@ export const ListProjectsLocationsFeatureGroupsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/featureGroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/featureGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeatureGroupsRequest>;
 
@@ -50796,7 +50816,7 @@ export const GetProjectsLocationsFeatureGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureGroupsRequest>;
 
@@ -50840,7 +50860,7 @@ export const CreateProjectsLocationsFeatureGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/featureGroups",
+      path: "v1/{+parent}/featureGroups",
       hasBody: true,
     }),
     svc,
@@ -50879,7 +50899,7 @@ export const SetIamPolicyProjectsLocationsFeatureGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -50920,7 +50940,7 @@ export const TestIamPermissionsProjectsLocationsFeatureGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -50963,7 +50983,7 @@ export const PatchProjectsLocationsFeatureGroupsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFeatureGroupsRequest>;
 
@@ -50995,7 +51015,7 @@ export const GetProjectsLocationsFeatureGroupsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureGroupsOperationsRequest>;
 
@@ -51027,7 +51047,7 @@ export const DeleteProjectsLocationsFeatureGroupsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeatureGroupsOperationsRequest>;
 
@@ -51062,7 +51082,7 @@ export const WaitProjectsLocationsFeatureGroupsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsFeatureGroupsOperationsRequest>;
 
@@ -51108,7 +51128,7 @@ export const ListWaitProjectsLocationsFeatureGroupsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:wait" }),
+    T.Http({ method: "GET", path: "v1/{+name}:wait" }),
     svc,
   ) as unknown as Schema.Schema<ListWaitProjectsLocationsFeatureGroupsOperationsRequest>;
 
@@ -51151,7 +51171,7 @@ export const PatchProjectsLocationsFeatureGroupsFeaturesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudAiplatformV1Feature).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFeatureGroupsFeaturesRequest>;
 
@@ -51183,7 +51203,7 @@ export const GetProjectsLocationsFeatureGroupsFeaturesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureGroupsFeaturesRequest>;
 
@@ -51221,7 +51241,7 @@ export const CreateProjectsLocationsFeatureGroupsFeaturesRequest =
     featureId: Schema.optional(Schema.String).pipe(T.HttpQuery("featureId")),
     body: Schema.optional(GoogleCloudAiplatformV1Feature).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/features", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/features", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsFeatureGroupsFeaturesRequest>;
 
@@ -51260,7 +51280,7 @@ export const BatchCreateProjectsLocationsFeatureGroupsFeaturesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/features:batchCreate",
+      path: "v1/{+parent}/features:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -51315,7 +51335,7 @@ export const ListProjectsLocationsFeatureGroupsFeaturesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/features" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/features" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeatureGroupsFeaturesRequest>;
 
@@ -51351,7 +51371,7 @@ export const DeleteProjectsLocationsFeatureGroupsFeaturesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeatureGroupsFeaturesRequest>;
 
@@ -51397,7 +51417,7 @@ export const ListWaitProjectsLocationsFeatureGroupsFeaturesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:wait" }),
+    T.Http({ method: "GET", path: "v1/{+name}:wait" }),
     svc,
   ) as unknown as Schema.Schema<ListWaitProjectsLocationsFeatureGroupsFeaturesOperationsRequest>;
 
@@ -51434,7 +51454,7 @@ export const GetProjectsLocationsFeatureGroupsFeaturesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureGroupsFeaturesOperationsRequest>;
 
@@ -51467,7 +51487,7 @@ export const DeleteProjectsLocationsFeatureGroupsFeaturesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeatureGroupsFeaturesOperationsRequest>;
 
@@ -51503,7 +51523,7 @@ export const WaitProjectsLocationsFeatureGroupsFeaturesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsFeatureGroupsFeaturesOperationsRequest>;
 
@@ -51539,7 +51559,7 @@ export const CreateProjectsLocationsTuningJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudAiplatformV1TuningJob).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/tuningJobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/tuningJobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTuningJobsRequest>;
 
@@ -51571,7 +51591,7 @@ export const GetProjectsLocationsTuningJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTuningJobsRequest>;
 
@@ -51610,7 +51630,7 @@ export const RebaseTunedModelProjectsLocationsTuningJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/tuningJobs:rebaseTunedModel",
+      path: "v1/{+parent}/tuningJobs:rebaseTunedModel",
       hasBody: true,
     }),
     svc,
@@ -51653,7 +51673,7 @@ export const ListProjectsLocationsTuningJobsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/tuningJobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/tuningJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTuningJobsRequest>;
 
@@ -51694,7 +51714,7 @@ export const CancelProjectsLocationsTuningJobsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsTuningJobsRequest>;
 
@@ -51739,7 +51759,7 @@ export const ListProjectsLocationsTuningJobsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTuningJobsOperationsRequest>;
 
@@ -51775,7 +51795,7 @@ export const GetProjectsLocationsTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTuningJobsOperationsRequest>;
 
@@ -51807,7 +51827,7 @@ export const DeleteProjectsLocationsTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTuningJobsOperationsRequest>;
 
@@ -51839,7 +51859,7 @@ export const CancelProjectsLocationsTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsTuningJobsOperationsRequest>;
 
@@ -51878,7 +51898,7 @@ export const CreateProjectsLocationsHyperparameterTuningJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/hyperparameterTuningJobs",
+      path: "v1/{+parent}/hyperparameterTuningJobs",
       hasBody: true,
     }),
     svc,
@@ -51913,7 +51933,7 @@ export const GetProjectsLocationsHyperparameterTuningJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsHyperparameterTuningJobsRequest>;
 
@@ -51957,7 +51977,7 @@ export const ListProjectsLocationsHyperparameterTuningJobsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/hyperparameterTuningJobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/hyperparameterTuningJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsHyperparameterTuningJobsRequest>;
 
@@ -51993,7 +52013,7 @@ export const DeleteProjectsLocationsHyperparameterTuningJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsHyperparameterTuningJobsRequest>;
 
@@ -52031,7 +52051,7 @@ export const CancelProjectsLocationsHyperparameterTuningJobsRequest =
       GoogleCloudAiplatformV1CancelHyperparameterTuningJobRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsHyperparameterTuningJobsRequest>;
 
@@ -52064,7 +52084,7 @@ export const DeleteProjectsLocationsHyperparameterTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsHyperparameterTuningJobsOperationsRequest>;
 
@@ -52097,7 +52117,7 @@ export const CancelProjectsLocationsHyperparameterTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsHyperparameterTuningJobsOperationsRequest>;
 
@@ -52144,7 +52164,7 @@ export const ListProjectsLocationsHyperparameterTuningJobsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsHyperparameterTuningJobsOperationsRequest>;
 
@@ -52181,7 +52201,7 @@ export const GetProjectsLocationsHyperparameterTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsHyperparameterTuningJobsOperationsRequest>;
 
@@ -52217,7 +52237,7 @@ export const WaitProjectsLocationsHyperparameterTuningJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsHyperparameterTuningJobsOperationsRequest>;
 
@@ -52255,7 +52275,7 @@ export const PauseProjectsLocationsModelDeploymentMonitoringJobsRequest =
       GoogleCloudAiplatformV1PauseModelDeploymentMonitoringJobRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsLocationsModelDeploymentMonitoringJobsRequest>;
 
@@ -52293,7 +52313,7 @@ export const ResumeProjectsLocationsModelDeploymentMonitoringJobsRequest =
       GoogleCloudAiplatformV1ResumeModelDeploymentMonitoringJobRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsModelDeploymentMonitoringJobsRequest>;
 
@@ -52334,7 +52354,7 @@ export const PatchProjectsLocationsModelDeploymentMonitoringJobsRequest =
       GoogleCloudAiplatformV1ModelDeploymentMonitoringJob,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsModelDeploymentMonitoringJobsRequest>;
 
@@ -52367,7 +52387,7 @@ export const GetProjectsLocationsModelDeploymentMonitoringJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsModelDeploymentMonitoringJobsRequest>;
 
@@ -52407,7 +52427,7 @@ export const CreateProjectsLocationsModelDeploymentMonitoringJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/modelDeploymentMonitoringJobs",
+      path: "v1/{+parent}/modelDeploymentMonitoringJobs",
       hasBody: true,
     }),
     svc,
@@ -52456,7 +52476,7 @@ export const ListProjectsLocationsModelDeploymentMonitoringJobsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/modelDeploymentMonitoringJobs",
+      path: "v1/{+parent}/modelDeploymentMonitoringJobs",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsModelDeploymentMonitoringJobsRequest>;
@@ -52503,7 +52523,7 @@ export const SearchModelDeploymentMonitoringStatsAnomaliesProjectsLocationsModel
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{modelDeploymentMonitoringJob}:searchModelDeploymentMonitoringStatsAnomalies",
+      path: "v1/{+modelDeploymentMonitoringJob}:searchModelDeploymentMonitoringStatsAnomalies",
       hasBody: true,
     }),
     svc,
@@ -52540,7 +52560,7 @@ export const DeleteProjectsLocationsModelDeploymentMonitoringJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsModelDeploymentMonitoringJobsRequest>;
 
@@ -52573,7 +52593,7 @@ export const GetProjectsLocationsModelDeploymentMonitoringJobsOperationsRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -52609,7 +52629,7 @@ export const WaitProjectsLocationsModelDeploymentMonitoringJobsOperationsRequest
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -52642,7 +52662,7 @@ export const DeleteProjectsLocationsModelDeploymentMonitoringJobsOperationsReque
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -52676,7 +52696,7 @@ export const CancelProjectsLocationsModelDeploymentMonitoringJobsOperationsReque
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -52724,7 +52744,7 @@ export const ListProjectsLocationsModelDeploymentMonitoringJobsOperationsRequest
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -52767,7 +52787,7 @@ export const ListProjectsLocationsMetadataStoresRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/metadataStores" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/metadataStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataStoresRequest>;
 
@@ -52803,7 +52823,7 @@ export const GetProjectsLocationsMetadataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataStoresRequest>;
 
@@ -52838,7 +52858,7 @@ export const DeleteProjectsLocationsMetadataStoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMetadataStoresRequest>;
 
@@ -52882,7 +52902,7 @@ export const CreateProjectsLocationsMetadataStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/metadataStores",
+      path: "v1/{+parent}/metadataStores",
       hasBody: true,
     }),
     svc,
@@ -52922,7 +52942,7 @@ export const CreateProjectsLocationsMetadataStoresContextsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudAiplatformV1Context).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/contexts", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/contexts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsMetadataStoresContextsRequest>;
 
@@ -52954,7 +52974,10 @@ export const QueryContextLineageSubgraphProjectsLocationsMetadataStoresContextsR
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     context: Schema.String.pipe(T.HttpPath("context")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{context}:queryContextLineageSubgraph" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+context}:queryContextLineageSubgraph",
+    }),
     svc,
   ) as unknown as Schema.Schema<QueryContextLineageSubgraphProjectsLocationsMetadataStoresContextsRequest>;
 
@@ -52996,7 +53019,7 @@ export const AddContextArtifactsAndExecutionsProjectsLocationsMetadataStoresCont
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{context}:addContextArtifactsAndExecutions",
+      path: "v1/{+context}:addContextArtifactsAndExecutions",
       hasBody: true,
     }),
     svc,
@@ -53040,7 +53063,7 @@ export const PurgeProjectsLocationsMetadataStoresContextsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/contexts:purge",
+      path: "v1/{+parent}/contexts:purge",
       hasBody: true,
     }),
     svc,
@@ -53074,7 +53097,7 @@ export const GetProjectsLocationsMetadataStoresContextsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataStoresContextsRequest>;
 
@@ -53113,7 +53136,7 @@ export const AddContextChildrenProjectsLocationsMetadataStoresContextsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{context}:addContextChildren",
+      path: "v1/{+context}:addContextChildren",
       hasBody: true,
     }),
     svc,
@@ -53159,7 +53182,7 @@ export const PatchProjectsLocationsMetadataStoresContextsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudAiplatformV1Context).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMetadataStoresContextsRequest>;
 
@@ -53198,7 +53221,7 @@ export const RemoveContextChildrenProjectsLocationsMetadataStoresContextsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{context}:removeContextChildren",
+      path: "v1/{+context}:removeContextChildren",
       hasBody: true,
     }),
     svc,
@@ -53239,7 +53262,7 @@ export const DeleteProjectsLocationsMetadataStoresContextsRequest =
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMetadataStoresContextsRequest>;
 
@@ -53283,7 +53306,7 @@ export const ListProjectsLocationsMetadataStoresContextsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/contexts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataStoresContextsRequest>;
 
@@ -53333,7 +53356,7 @@ export const ListProjectsLocationsMetadataStoresContextsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataStoresContextsOperationsRequest>;
 
@@ -53370,7 +53393,7 @@ export const DeleteProjectsLocationsMetadataStoresContextsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMetadataStoresContextsOperationsRequest>;
 
@@ -53403,7 +53426,7 @@ export const CancelProjectsLocationsMetadataStoresContextsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsMetadataStoresContextsOperationsRequest>;
 
@@ -53436,7 +53459,7 @@ export const GetProjectsLocationsMetadataStoresContextsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataStoresContextsOperationsRequest>;
 
@@ -53472,7 +53495,7 @@ export const WaitProjectsLocationsMetadataStoresContextsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsMetadataStoresContextsOperationsRequest>;
 
@@ -53519,7 +53542,7 @@ export const ListProjectsLocationsMetadataStoresOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataStoresOperationsRequest>;
 
@@ -53555,7 +53578,7 @@ export const DeleteProjectsLocationsMetadataStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMetadataStoresOperationsRequest>;
 
@@ -53588,7 +53611,7 @@ export const CancelProjectsLocationsMetadataStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsMetadataStoresOperationsRequest>;
 
@@ -53621,7 +53644,7 @@ export const GetProjectsLocationsMetadataStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataStoresOperationsRequest>;
 
@@ -53656,7 +53679,7 @@ export const WaitProjectsLocationsMetadataStoresOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsMetadataStoresOperationsRequest>;
 
@@ -53699,7 +53722,7 @@ export const PatchProjectsLocationsMetadataStoresExecutionsRequest =
     ),
     body: Schema.optional(GoogleCloudAiplatformV1Execution).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMetadataStoresExecutionsRequest>;
 
@@ -53731,7 +53754,7 @@ export const GetProjectsLocationsMetadataStoresExecutionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataStoresExecutionsRequest>;
 
@@ -53771,7 +53794,7 @@ export const CreateProjectsLocationsMetadataStoresExecutionsRequest =
     ),
     body: Schema.optional(GoogleCloudAiplatformV1Execution).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/executions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/executions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsMetadataStoresExecutionsRequest>;
 
@@ -53811,7 +53834,7 @@ export const AddExecutionEventsProjectsLocationsMetadataStoresExecutionsRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{execution}:addExecutionEvents",
+      path: "v1/{+execution}:addExecutionEvents",
       hasBody: true,
     }),
     svc,
@@ -53858,7 +53881,7 @@ export const ListProjectsLocationsMetadataStoresExecutionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/executions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/executions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataStoresExecutionsRequest>;
 
@@ -53897,7 +53920,7 @@ export const DeleteProjectsLocationsMetadataStoresExecutionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMetadataStoresExecutionsRequest>;
 
@@ -53937,7 +53960,7 @@ export const PurgeProjectsLocationsMetadataStoresExecutionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/executions:purge",
+      path: "v1/{+parent}/executions:purge",
       hasBody: true,
     }),
     svc,
@@ -53973,7 +53996,7 @@ export const QueryExecutionInputsAndOutputsProjectsLocationsMetadataStoresExecut
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{execution}:queryExecutionInputsAndOutputs",
+      path: "v1/{+execution}:queryExecutionInputsAndOutputs",
     }),
     svc,
   ) as unknown as Schema.Schema<QueryExecutionInputsAndOutputsProjectsLocationsMetadataStoresExecutionsRequest>;
@@ -54009,7 +54032,7 @@ export const DeleteProjectsLocationsMetadataStoresExecutionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMetadataStoresExecutionsOperationsRequest>;
 
@@ -54042,7 +54065,7 @@ export const CancelProjectsLocationsMetadataStoresExecutionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsMetadataStoresExecutionsOperationsRequest>;
 
@@ -54089,7 +54112,7 @@ export const ListProjectsLocationsMetadataStoresExecutionsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataStoresExecutionsOperationsRequest>;
 
@@ -54126,7 +54149,7 @@ export const GetProjectsLocationsMetadataStoresExecutionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataStoresExecutionsOperationsRequest>;
 
@@ -54162,7 +54185,7 @@ export const WaitProjectsLocationsMetadataStoresExecutionsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsMetadataStoresExecutionsOperationsRequest>;
 
@@ -54204,7 +54227,7 @@ export const ListProjectsLocationsMetadataStoresMetadataSchemasRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/metadataSchemas" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/metadataSchemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataStoresMetadataSchemasRequest>;
 
@@ -54241,7 +54264,7 @@ export const GetProjectsLocationsMetadataStoresMetadataSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataStoresMetadataSchemasRequest>;
 
@@ -54286,7 +54309,7 @@ export const CreateProjectsLocationsMetadataStoresMetadataSchemasRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/metadataSchemas",
+      path: "v1/{+parent}/metadataSchemas",
       hasBody: true,
     }),
     svc,
@@ -54328,7 +54351,7 @@ export const PurgeProjectsLocationsMetadataStoresArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/artifacts:purge",
+      path: "v1/{+parent}/artifacts:purge",
       hasBody: true,
     }),
     svc,
@@ -54365,7 +54388,7 @@ export const DeleteProjectsLocationsMetadataStoresArtifactsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMetadataStoresArtifactsRequest>;
 
@@ -54409,7 +54432,7 @@ export const ListProjectsLocationsMetadataStoresArtifactsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/artifacts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/artifacts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataStoresArtifactsRequest>;
 
@@ -54451,7 +54474,7 @@ export const CreateProjectsLocationsMetadataStoresArtifactsRequest =
     artifactId: Schema.optional(Schema.String).pipe(T.HttpQuery("artifactId")),
     body: Schema.optional(GoogleCloudAiplatformV1Artifact).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/artifacts", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/artifacts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsMetadataStoresArtifactsRequest>;
 
@@ -54483,7 +54506,7 @@ export const GetProjectsLocationsMetadataStoresArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataStoresArtifactsRequest>;
 
@@ -54526,7 +54549,7 @@ export const PatchProjectsLocationsMetadataStoresArtifactsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudAiplatformV1Artifact).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMetadataStoresArtifactsRequest>;
 
@@ -54566,7 +54589,7 @@ export const QueryArtifactLineageSubgraphProjectsLocationsMetadataStoresArtifact
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{artifact}:queryArtifactLineageSubgraph",
+      path: "v1/{+artifact}:queryArtifactLineageSubgraph",
     }),
     svc,
   ) as unknown as Schema.Schema<QueryArtifactLineageSubgraphProjectsLocationsMetadataStoresArtifactsRequest>;
@@ -54602,7 +54625,7 @@ export const GetProjectsLocationsMetadataStoresArtifactsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataStoresArtifactsOperationsRequest>;
 
@@ -54638,7 +54661,7 @@ export const WaitProjectsLocationsMetadataStoresArtifactsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsMetadataStoresArtifactsOperationsRequest>;
 
@@ -54671,7 +54694,7 @@ export const DeleteProjectsLocationsMetadataStoresArtifactsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMetadataStoresArtifactsOperationsRequest>;
 
@@ -54704,7 +54727,7 @@ export const CancelProjectsLocationsMetadataStoresArtifactsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsMetadataStoresArtifactsOperationsRequest>;
 
@@ -54751,7 +54774,7 @@ export const ListProjectsLocationsMetadataStoresArtifactsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataStoresArtifactsOperationsRequest>;
 
@@ -54793,7 +54816,7 @@ export const PauseProjectsLocationsSchedulesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsLocationsSchedulesRequest>;
 
@@ -54829,7 +54852,7 @@ export const ResumeProjectsLocationsSchedulesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsSchedulesRequest>;
 
@@ -54866,7 +54889,7 @@ export const PatchProjectsLocationsSchedulesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudAiplatformV1Schedule).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSchedulesRequest>;
 
@@ -54898,7 +54921,7 @@ export const GetProjectsLocationsSchedulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchedulesRequest>;
 
@@ -54933,7 +54956,7 @@ export const CreateProjectsLocationsSchedulesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudAiplatformV1Schedule).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/schedules", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/schedules", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSchedulesRequest>;
 
@@ -54977,7 +55000,7 @@ export const ListProjectsLocationsSchedulesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/schedules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/schedules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchedulesRequest>;
 
@@ -55013,7 +55036,7 @@ export const DeleteProjectsLocationsSchedulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSchedulesRequest>;
 
@@ -55045,7 +55068,7 @@ export const GetProjectsLocationsSchedulesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchedulesOperationsRequest>;
 
@@ -55080,7 +55103,7 @@ export const WaitProjectsLocationsSchedulesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsSchedulesOperationsRequest>;
 
@@ -55112,7 +55135,7 @@ export const DeleteProjectsLocationsSchedulesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSchedulesOperationsRequest>;
 
@@ -55144,7 +55167,7 @@ export const CancelProjectsLocationsSchedulesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsSchedulesOperationsRequest>;
 
@@ -55190,7 +55213,7 @@ export const ListProjectsLocationsSchedulesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchedulesOperationsRequest>;
 
@@ -55241,7 +55264,7 @@ export const ListProjectsLocationsPipelineJobsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/pipelineJobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/pipelineJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPipelineJobsRequest>;
 
@@ -55284,7 +55307,7 @@ export const BatchDeleteProjectsLocationsPipelineJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/pipelineJobs:batchDelete",
+      path: "v1/{+parent}/pipelineJobs:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -55318,7 +55341,7 @@ export const DeleteProjectsLocationsPipelineJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPipelineJobsRequest>;
 
@@ -55355,7 +55378,7 @@ export const CancelProjectsLocationsPipelineJobsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsPipelineJobsRequest>;
 
@@ -55393,7 +55416,7 @@ export const BatchCancelProjectsLocationsPipelineJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/pipelineJobs:batchCancel",
+      path: "v1/{+parent}/pipelineJobs:batchCancel",
       hasBody: true,
     }),
     svc,
@@ -55437,7 +55460,11 @@ export const CreateProjectsLocationsPipelineJobsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/pipelineJobs", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/pipelineJobs",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsPipelineJobsRequest>;
 
@@ -55469,7 +55496,7 @@ export const GetProjectsLocationsPipelineJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPipelineJobsRequest>;
 
@@ -55515,7 +55542,7 @@ export const ListProjectsLocationsPipelineJobsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPipelineJobsOperationsRequest>;
 
@@ -55551,7 +55578,7 @@ export const DeleteProjectsLocationsPipelineJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPipelineJobsOperationsRequest>;
 
@@ -55583,7 +55610,7 @@ export const CancelProjectsLocationsPipelineJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsPipelineJobsOperationsRequest>;
 
@@ -55615,7 +55642,7 @@ export const GetProjectsLocationsPipelineJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPipelineJobsOperationsRequest>;
 
@@ -55650,7 +55677,7 @@ export const WaitProjectsLocationsPipelineJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsPipelineJobsOperationsRequest>;
 
@@ -55689,7 +55716,7 @@ export const GetIamPolicyProjectsLocationsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -55737,7 +55764,7 @@ export const ListProjectsLocationsDatasetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/datasets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/datasets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsRequest>;
 
@@ -55778,7 +55805,7 @@ export const ExportProjectsLocationsDatasetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsDatasetsRequest>;
 
@@ -55865,7 +55892,7 @@ export const SearchDataItemsProjectsLocationsDatasetsRequest =
     ),
     dataset: Schema.String.pipe(T.HttpPath("dataset")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{dataset}:searchDataItems" }),
+    T.Http({ method: "GET", path: "v1/{+dataset}:searchDataItems" }),
     svc,
   ) as unknown as Schema.Schema<SearchDataItemsProjectsLocationsDatasetsRequest>;
 
@@ -55901,7 +55928,7 @@ export const DeleteProjectsLocationsDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsRequest>;
 
@@ -55940,7 +55967,7 @@ export const TestIamPermissionsProjectsLocationsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -55980,7 +56007,7 @@ export const PatchProjectsLocationsDatasetsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudAiplatformV1Dataset).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsRequest>;
 
@@ -56015,7 +56042,7 @@ export const GetProjectsLocationsDatasetsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsRequest>;
 
@@ -56052,7 +56079,7 @@ export const ImportProjectsLocationsDatasetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:import", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:import", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsLocationsDatasetsRequest>;
 
@@ -56089,7 +56116,7 @@ export const SetIamPolicyProjectsLocationsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -56125,7 +56152,7 @@ export const CreateProjectsLocationsDatasetsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudAiplatformV1Dataset).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/datasets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/datasets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDatasetsRequest>;
 
@@ -56172,7 +56199,7 @@ export const ListProjectsLocationsDatasetsDataItemsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dataItems" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dataItems" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsDataItemsRequest>;
 
@@ -56208,7 +56235,7 @@ export const GetProjectsLocationsDatasetsDataItemsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsDataItemsOperationsRequest>;
 
@@ -56244,7 +56271,7 @@ export const WaitProjectsLocationsDatasetsDataItemsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsDatasetsDataItemsOperationsRequest>;
 
@@ -56291,7 +56318,7 @@ export const ListProjectsLocationsDatasetsDataItemsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsDataItemsOperationsRequest>;
 
@@ -56328,7 +56355,7 @@ export const DeleteProjectsLocationsDatasetsDataItemsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsDataItemsOperationsRequest>;
 
@@ -56361,7 +56388,7 @@ export const CancelProjectsLocationsDatasetsDataItemsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDatasetsDataItemsOperationsRequest>;
 
@@ -56409,7 +56436,7 @@ export const ListProjectsLocationsDatasetsDataItemsAnnotationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/annotations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/annotations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsDataItemsAnnotationsRequest>;
 
@@ -56446,7 +56473,7 @@ export const GetProjectsLocationsDatasetsDataItemsAnnotationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -56482,7 +56509,7 @@ export const WaitProjectsLocationsDatasetsDataItemsAnnotationsOperationsRequest 
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -56515,7 +56542,7 @@ export const DeleteProjectsLocationsDatasetsDataItemsAnnotationsOperationsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -56548,7 +56575,7 @@ export const CancelProjectsLocationsDatasetsDataItemsAnnotationsOperationsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -56595,7 +56622,7 @@ export const ListProjectsLocationsDatasetsDataItemsAnnotationsOperationsRequest 
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -56635,7 +56662,7 @@ export const GetProjectsLocationsDatasetsDatasetVersionsRequest =
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsDatasetVersionsRequest>;
 
@@ -56674,7 +56701,7 @@ export const CreateProjectsLocationsDatasetsDatasetVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/datasetVersions",
+      path: "v1/{+parent}/datasetVersions",
       hasBody: true,
     }),
     svc,
@@ -56716,7 +56743,7 @@ export const PatchProjectsLocationsDatasetsDatasetVersionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsDatasetVersionsRequest>;
 
@@ -56748,7 +56775,7 @@ export const RestoreProjectsLocationsDatasetsDatasetVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:restore" }),
+    T.Http({ method: "GET", path: "v1/{+name}:restore" }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsDatasetsDatasetVersionsRequest>;
 
@@ -56781,7 +56808,7 @@ export const DeleteProjectsLocationsDatasetsDatasetVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsDatasetVersionsRequest>;
 
@@ -56828,7 +56855,7 @@ export const ListProjectsLocationsDatasetsDatasetVersionsRequest =
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/datasetVersions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/datasetVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsDatasetVersionsRequest>;
 
@@ -56864,7 +56891,7 @@ export const DeleteProjectsLocationsDatasetsSavedQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsSavedQueriesRequest>;
 
@@ -56911,7 +56938,7 @@ export const ListProjectsLocationsDatasetsSavedQueriesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/savedQueries" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/savedQueries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsSavedQueriesRequest>;
 
@@ -56947,7 +56974,7 @@ export const DeleteProjectsLocationsDatasetsSavedQueriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsSavedQueriesOperationsRequest>;
 
@@ -56980,7 +57007,7 @@ export const CancelProjectsLocationsDatasetsSavedQueriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDatasetsSavedQueriesOperationsRequest>;
 
@@ -57027,7 +57054,7 @@ export const ListProjectsLocationsDatasetsSavedQueriesOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsSavedQueriesOperationsRequest>;
 
@@ -57064,7 +57091,7 @@ export const GetProjectsLocationsDatasetsSavedQueriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsSavedQueriesOperationsRequest>;
 
@@ -57100,7 +57127,7 @@ export const WaitProjectsLocationsDatasetsSavedQueriesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsDatasetsSavedQueriesOperationsRequest>;
 
@@ -57136,7 +57163,7 @@ export const GetProjectsLocationsDatasetsAnnotationSpecsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsAnnotationSpecsRequest>;
 
@@ -57182,7 +57209,7 @@ export const ListProjectsLocationsDatasetsAnnotationSpecsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -57219,7 +57246,7 @@ export const DeleteProjectsLocationsDatasetsAnnotationSpecsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -57252,7 +57279,7 @@ export const CancelProjectsLocationsDatasetsAnnotationSpecsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -57285,7 +57312,7 @@ export const GetProjectsLocationsDatasetsAnnotationSpecsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -57321,7 +57348,7 @@ export const WaitProjectsLocationsDatasetsAnnotationSpecsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -57354,7 +57381,7 @@ export const GetProjectsLocationsDatasetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsOperationsRequest>;
 
@@ -57389,7 +57416,7 @@ export const WaitProjectsLocationsDatasetsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsDatasetsOperationsRequest>;
 
@@ -57435,7 +57462,7 @@ export const ListProjectsLocationsDatasetsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsOperationsRequest>;
 
@@ -57471,7 +57498,7 @@ export const DeleteProjectsLocationsDatasetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsOperationsRequest>;
 
@@ -57503,7 +57530,7 @@ export const CancelProjectsLocationsDatasetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDatasetsOperationsRequest>;
 
@@ -57535,7 +57562,7 @@ export const GetProjectsLocationsPersistentResourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPersistentResourcesRequest>;
 
@@ -57572,7 +57599,7 @@ export const RebootProjectsLocationsPersistentResourcesRequest =
       GoogleCloudAiplatformV1RebootPersistentResourceRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:reboot", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:reboot", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RebootProjectsLocationsPersistentResourcesRequest>;
 
@@ -57616,7 +57643,7 @@ export const CreateProjectsLocationsPersistentResourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/persistentResources",
+      path: "v1/{+parent}/persistentResources",
       hasBody: true,
     }),
     svc,
@@ -57658,7 +57685,7 @@ export const PatchProjectsLocationsPersistentResourcesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPersistentResourcesRequest>;
 
@@ -57690,7 +57717,7 @@ export const DeleteProjectsLocationsPersistentResourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPersistentResourcesRequest>;
 
@@ -57728,7 +57755,7 @@ export const ListProjectsLocationsPersistentResourcesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/persistentResources" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/persistentResources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPersistentResourcesRequest>;
 
@@ -57764,7 +57791,7 @@ export const DeleteProjectsLocationsPersistentResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPersistentResourcesOperationsRequest>;
 
@@ -57797,7 +57824,7 @@ export const CancelProjectsLocationsPersistentResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsPersistentResourcesOperationsRequest>;
 
@@ -57844,7 +57871,7 @@ export const ListProjectsLocationsPersistentResourcesOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPersistentResourcesOperationsRequest>;
 
@@ -57881,7 +57908,7 @@ export const GetProjectsLocationsPersistentResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPersistentResourcesOperationsRequest>;
 
@@ -57917,7 +57944,7 @@ export const WaitProjectsLocationsPersistentResourcesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsPersistentResourcesOperationsRequest>;
 
@@ -57950,7 +57977,7 @@ export const GetProjectsLocationsNasJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNasJobsRequest>;
 
@@ -57984,7 +58011,7 @@ export const CreateProjectsLocationsNasJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudAiplatformV1NasJob).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/nasJobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/nasJobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsNasJobsRequest>;
 
@@ -58016,7 +58043,7 @@ export const DeleteProjectsLocationsNasJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNasJobsRequest>;
 
@@ -58052,7 +58079,7 @@ export const CancelProjectsLocationsNasJobsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsNasJobsRequest>;
 
@@ -58095,7 +58122,7 @@ export const ListProjectsLocationsNasJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/nasJobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/nasJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNasJobsRequest>;
 
@@ -58137,7 +58164,7 @@ export const ListProjectsLocationsNasJobsNasTrialDetailsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/nasTrialDetails" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/nasTrialDetails" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNasJobsNasTrialDetailsRequest>;
 
@@ -58173,7 +58200,7 @@ export const GetProjectsLocationsNasJobsNasTrialDetailsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNasJobsNasTrialDetailsRequest>;
 
@@ -58210,7 +58237,7 @@ export const ExecuteCodeProjectsLocationsReasoningEnginesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:executeCode", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:executeCode", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteCodeProjectsLocationsReasoningEnginesRequest>;
 
@@ -58249,7 +58276,7 @@ export const TestIamPermissionsProjectsLocationsReasoningEnginesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -58292,7 +58319,7 @@ export const PatchProjectsLocationsReasoningEnginesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsReasoningEnginesRequest>;
 
@@ -58324,7 +58351,7 @@ export const GetProjectsLocationsReasoningEnginesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesRequest>;
 
@@ -58363,7 +58390,7 @@ export const GetIamPolicyProjectsLocationsReasoningEnginesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -58406,7 +58433,7 @@ export const ListProjectsLocationsReasoningEnginesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/reasoningEngines" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/reasoningEngines" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesRequest>;
 
@@ -58447,7 +58474,7 @@ export const StreamQueryProjectsLocationsReasoningEnginesRequest =
       GoogleCloudAiplatformV1StreamQueryReasoningEngineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:streamQuery", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:streamQuery", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StreamQueryProjectsLocationsReasoningEnginesRequest>;
 
@@ -58482,7 +58509,7 @@ export const DeleteProjectsLocationsReasoningEnginesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesRequest>;
 
@@ -58519,7 +58546,7 @@ export const SetIamPolicyProjectsLocationsReasoningEnginesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -58560,7 +58587,7 @@ export const CreateProjectsLocationsReasoningEnginesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/reasoningEngines",
+      path: "v1/{+parent}/reasoningEngines",
       hasBody: true,
     }),
     svc,
@@ -58599,7 +58626,7 @@ export const QueryProjectsLocationsReasoningEnginesRequest =
       GoogleCloudAiplatformV1QueryReasoningEngineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryProjectsLocationsReasoningEnginesRequest>;
 
@@ -58638,7 +58665,7 @@ export const PurgeProjectsLocationsReasoningEnginesMemoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/memories:purge",
+      path: "v1/{+parent}/memories:purge",
       hasBody: true,
     }),
     svc,
@@ -58677,7 +58704,7 @@ export const RollbackProjectsLocationsReasoningEnginesMemoriesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:rollback", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:rollback", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RollbackProjectsLocationsReasoningEnginesMemoriesRequest>;
 
@@ -58717,7 +58744,7 @@ export const RetrieveProjectsLocationsReasoningEnginesMemoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/memories:retrieve",
+      path: "v1/{+parent}/memories:retrieve",
       hasBody: true,
     }),
     svc,
@@ -58758,7 +58785,7 @@ export const CreateProjectsLocationsReasoningEnginesMemoriesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudAiplatformV1Memory).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/memories", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/memories", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsReasoningEnginesMemoriesRequest>;
 
@@ -58791,7 +58818,7 @@ export const DeleteProjectsLocationsReasoningEnginesMemoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesMemoriesRequest>;
 
@@ -58836,7 +58863,7 @@ export const ListProjectsLocationsReasoningEnginesMemoriesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/memories" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/memories" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesMemoriesRequest>;
 
@@ -58872,7 +58899,7 @@ export const GetProjectsLocationsReasoningEnginesMemoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesMemoriesRequest>;
 
@@ -58911,7 +58938,7 @@ export const GenerateProjectsLocationsReasoningEnginesMemoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/memories:generate",
+      path: "v1/{+parent}/memories:generate",
       hasBody: true,
     }),
     svc,
@@ -58952,7 +58979,7 @@ export const PatchProjectsLocationsReasoningEnginesMemoriesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudAiplatformV1Memory).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsReasoningEnginesMemoriesRequest>;
 
@@ -58984,7 +59011,7 @@ export const DeleteProjectsLocationsReasoningEnginesMemoriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesMemoriesOperationsRequest>;
 
@@ -59017,7 +59044,7 @@ export const CancelProjectsLocationsReasoningEnginesMemoriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsReasoningEnginesMemoriesOperationsRequest>;
 
@@ -59064,7 +59091,7 @@ export const ListProjectsLocationsReasoningEnginesMemoriesOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesMemoriesOperationsRequest>;
 
@@ -59101,7 +59128,7 @@ export const GetProjectsLocationsReasoningEnginesMemoriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesMemoriesOperationsRequest>;
 
@@ -59137,7 +59164,7 @@ export const WaitProjectsLocationsReasoningEnginesMemoriesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsReasoningEnginesMemoriesOperationsRequest>;
 
@@ -59179,7 +59206,7 @@ export const ListProjectsLocationsReasoningEnginesMemoriesRevisionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/revisions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/revisions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesMemoriesRevisionsRequest>;
 
@@ -59216,7 +59243,7 @@ export const GetProjectsLocationsReasoningEnginesMemoriesRevisionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesMemoriesRevisionsRequest>;
 
@@ -59249,7 +59276,7 @@ export const DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -59287,7 +59314,7 @@ export const ExecuteProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest 
       GoogleCloudAiplatformV1ExecuteSandboxEnvironmentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:execute", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:execute", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -59329,7 +59356,7 @@ export const ListProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sandboxEnvironments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sandboxEnvironments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -59371,7 +59398,7 @@ export const SnapshotProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest
       GoogleCloudAiplatformV1SandboxEnvironmentSnapshot,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:snapshot", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:snapshot", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SnapshotProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -59411,7 +59438,7 @@ export const CreateProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/sandboxEnvironments",
+      path: "v1/{+parent}/sandboxEnvironments",
       hasBody: true,
     }),
     svc,
@@ -59446,7 +59473,7 @@ export const GetProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -59479,7 +59506,7 @@ export const GetProjectsLocationsReasoningEnginesSandboxEnvironmentsOperationsRe
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesSandboxEnvironmentsOperationsRequest>;
 
@@ -59514,7 +59541,7 @@ export const DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentsOperation
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentsOperationsRequest>;
 
@@ -59549,7 +59576,7 @@ export const CancelProjectsLocationsReasoningEnginesSandboxEnvironmentsOperation
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsReasoningEnginesSandboxEnvironmentsOperationsRequest>;
 
@@ -59587,7 +59614,7 @@ export const WaitProjectsLocationsReasoningEnginesSandboxEnvironmentsOperationsR
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsReasoningEnginesSandboxEnvironmentsOperationsRequest>;
 
@@ -59622,7 +59649,7 @@ export const GetProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsRequ
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsRequest>;
 
@@ -59656,7 +59683,7 @@ export const DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsR
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsRequest>;
 
@@ -59700,7 +59727,7 @@ export const ListProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsReq
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sandboxEnvironmentSnapshots" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sandboxEnvironmentSnapshots" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsRequest>;
 
@@ -59739,7 +59766,7 @@ export const GetProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsOper
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest>;
 
@@ -59774,7 +59801,7 @@ export const DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsO
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest>;
 
@@ -59809,7 +59836,7 @@ export const CancelProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsO
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest>;
 
@@ -59847,7 +59874,7 @@ export const WaitProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsOpe
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest>;
 
@@ -59896,7 +59923,7 @@ export const ListProjectsLocationsReasoningEnginesOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesOperationsRequest>;
 
@@ -59933,7 +59960,7 @@ export const DeleteProjectsLocationsReasoningEnginesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesOperationsRequest>;
 
@@ -59966,7 +59993,7 @@ export const CancelProjectsLocationsReasoningEnginesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsReasoningEnginesOperationsRequest>;
 
@@ -59999,7 +60026,7 @@ export const GetProjectsLocationsReasoningEnginesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesOperationsRequest>;
 
@@ -60034,7 +60061,7 @@ export const WaitProjectsLocationsReasoningEnginesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsReasoningEnginesOperationsRequest>;
 
@@ -60072,7 +60099,7 @@ export const QueryProjectsLocationsReasoningEnginesRuntimeRevisionsRequest =
       GoogleCloudAiplatformV1QueryReasoningEngineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryProjectsLocationsReasoningEnginesRuntimeRevisionsRequest>;
 
@@ -60110,7 +60137,7 @@ export const StreamQueryProjectsLocationsReasoningEnginesRuntimeRevisionsRequest
       GoogleCloudAiplatformV1StreamQueryReasoningEngineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:streamQuery", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:streamQuery", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StreamQueryProjectsLocationsReasoningEnginesRuntimeRevisionsRequest>;
 
@@ -60150,7 +60177,7 @@ export const CreateProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesR
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/sandboxEnvironmentTemplates",
+      path: "v1/{+parent}/sandboxEnvironmentTemplates",
       hasBody: true,
     }),
     svc,
@@ -60187,7 +60214,7 @@ export const GetProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesRequ
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesRequest>;
 
@@ -60221,7 +60248,7 @@ export const DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesR
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesRequest>;
 
@@ -60265,7 +60292,7 @@ export const ListProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesReq
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sandboxEnvironmentTemplates" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sandboxEnvironmentTemplates" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesRequest>;
 
@@ -60304,7 +60331,7 @@ export const GetProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesOper
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest>;
 
@@ -60339,7 +60366,7 @@ export const DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesO
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest>;
 
@@ -60374,7 +60401,7 @@ export const CancelProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesO
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest>;
 
@@ -60412,7 +60439,7 @@ export const WaitProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesOpe
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest>;
 
@@ -60447,7 +60474,7 @@ export const GetProjectsLocationsReasoningEnginesSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesSessionsRequest>;
 
@@ -60484,7 +60511,7 @@ export const AppendEventProjectsLocationsReasoningEnginesSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:appendEvent", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:appendEvent", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AppendEventProjectsLocationsReasoningEnginesSessionsRequest>;
 
@@ -60523,7 +60550,7 @@ export const CreateProjectsLocationsReasoningEnginesSessionsRequest =
     sessionId: Schema.optional(Schema.String).pipe(T.HttpQuery("sessionId")),
     body: Schema.optional(GoogleCloudAiplatformV1Session).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/sessions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/sessions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsReasoningEnginesSessionsRequest>;
 
@@ -60562,7 +60589,7 @@ export const PatchProjectsLocationsReasoningEnginesSessionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudAiplatformV1Session).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsReasoningEnginesSessionsRequest>;
 
@@ -60594,7 +60621,7 @@ export const DeleteProjectsLocationsReasoningEnginesSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesSessionsRequest>;
 
@@ -60639,7 +60666,7 @@ export const ListProjectsLocationsReasoningEnginesSessionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sessions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sessions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesSessionsRequest>;
 
@@ -60675,7 +60702,7 @@ export const GetProjectsLocationsReasoningEnginesSessionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesSessionsOperationsRequest>;
 
@@ -60711,7 +60738,7 @@ export const WaitProjectsLocationsReasoningEnginesSessionsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsReasoningEnginesSessionsOperationsRequest>;
 
@@ -60744,7 +60771,7 @@ export const DeleteProjectsLocationsReasoningEnginesSessionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesSessionsOperationsRequest>;
 
@@ -60777,7 +60804,7 @@ export const CancelProjectsLocationsReasoningEnginesSessionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsReasoningEnginesSessionsOperationsRequest>;
 
@@ -60824,7 +60851,7 @@ export const ListProjectsLocationsReasoningEnginesSessionsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesSessionsOperationsRequest>;
 
@@ -60873,7 +60900,7 @@ export const ListProjectsLocationsReasoningEnginesSessionsEventsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/events" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/events" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesSessionsEventsRequest>;
 
@@ -60924,7 +60951,7 @@ export const ListStudiesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListStudiesOperationsRequest>;
 
@@ -60960,7 +60987,7 @@ export const DeleteStudiesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteStudiesOperationsRequest>;
 
@@ -60991,7 +61018,7 @@ export const CancelStudiesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelStudiesOperationsRequest>;
 
@@ -61022,7 +61049,7 @@ export const GetStudiesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetStudiesOperationsRequest>;
 
@@ -61056,7 +61083,7 @@ export const WaitStudiesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitStudiesOperationsRequest>;
 
@@ -61101,7 +61128,7 @@ export const ListStudiesTrialsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListStudiesTrialsOperationsRequest>;
 
@@ -61137,7 +61164,7 @@ export const DeleteStudiesTrialsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteStudiesTrialsOperationsRequest>;
 
@@ -61168,7 +61195,7 @@ export const CancelStudiesTrialsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelStudiesTrialsOperationsRequest>;
 
@@ -61199,7 +61226,7 @@ export const GetStudiesTrialsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetStudiesTrialsOperationsRequest>;
 
@@ -61233,7 +61260,7 @@ export const WaitStudiesTrialsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitStudiesTrialsOperationsRequest>;
 
@@ -61264,7 +61291,7 @@ export const DeleteModelsEvaluationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteModelsEvaluationsOperationsRequest>;
 
@@ -61295,7 +61322,7 @@ export const CancelModelsEvaluationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelModelsEvaluationsOperationsRequest>;
 
@@ -61340,7 +61367,7 @@ export const ListModelsEvaluationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListModelsEvaluationsOperationsRequest>;
 
@@ -61376,7 +61403,7 @@ export const GetModelsEvaluationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetModelsEvaluationsOperationsRequest>;
 
@@ -61410,7 +61437,7 @@ export const WaitModelsEvaluationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitModelsEvaluationsOperationsRequest>;
 
@@ -61456,7 +61483,7 @@ export const ListModelsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListModelsOperationsRequest>;
 
@@ -61492,7 +61519,7 @@ export const DeleteModelsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteModelsOperationsRequest>;
 
@@ -61523,7 +61550,7 @@ export const CancelModelsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelModelsOperationsRequest>;
 
@@ -61554,7 +61581,7 @@ export const GetModelsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetModelsOperationsRequest>;
 
@@ -61588,7 +61615,7 @@ export const WaitModelsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitModelsOperationsRequest>;
 
@@ -61619,7 +61646,7 @@ export const GetNotebookRuntimeTemplatesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -61654,7 +61681,7 @@ export const WaitNotebookRuntimeTemplatesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -61686,7 +61713,7 @@ export const DeleteNotebookRuntimeTemplatesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -61718,7 +61745,7 @@ export const CancelNotebookRuntimeTemplatesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -61764,7 +61791,7 @@ export const ListNotebookRuntimeTemplatesOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -61800,7 +61827,7 @@ export const GetIndexesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetIndexesOperationsRequest>;
 
@@ -61834,7 +61861,7 @@ export const WaitIndexesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitIndexesOperationsRequest>;
 
@@ -61879,7 +61906,7 @@ export const ListIndexesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListIndexesOperationsRequest>;
 
@@ -61915,7 +61942,7 @@ export const DeleteIndexesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteIndexesOperationsRequest>;
 
@@ -61946,7 +61973,7 @@ export const CancelIndexesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelIndexesOperationsRequest>;
 
@@ -61977,7 +62004,7 @@ export const DeleteNotebookExecutionJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNotebookExecutionJobsOperationsRequest>;
 
@@ -62008,7 +62035,7 @@ export const CancelNotebookExecutionJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelNotebookExecutionJobsOperationsRequest>;
 
@@ -62053,7 +62080,7 @@ export const ListNotebookExecutionJobsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListNotebookExecutionJobsOperationsRequest>;
 
@@ -62089,7 +62116,7 @@ export const GetNotebookExecutionJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNotebookExecutionJobsOperationsRequest>;
 
@@ -62124,7 +62151,7 @@ export const WaitNotebookExecutionJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitNotebookExecutionJobsOperationsRequest>;
 
@@ -62156,7 +62183,7 @@ export const GetFeaturestoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFeaturestoresOperationsRequest>;
 
@@ -62190,7 +62217,7 @@ export const WaitFeaturestoresOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitFeaturestoresOperationsRequest>;
 
@@ -62235,7 +62262,7 @@ export const ListFeaturestoresOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListFeaturestoresOperationsRequest>;
 
@@ -62271,7 +62298,7 @@ export const DeleteFeaturestoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFeaturestoresOperationsRequest>;
 
@@ -62302,7 +62329,7 @@ export const CancelFeaturestoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelFeaturestoresOperationsRequest>;
 
@@ -62333,7 +62360,7 @@ export const GetFeaturestoresEntityTypesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFeaturestoresEntityTypesOperationsRequest>;
 
@@ -62368,7 +62395,7 @@ export const WaitFeaturestoresEntityTypesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitFeaturestoresEntityTypesOperationsRequest>;
 
@@ -62414,7 +62441,7 @@ export const ListFeaturestoresEntityTypesOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListFeaturestoresEntityTypesOperationsRequest>;
 
@@ -62450,7 +62477,7 @@ export const DeleteFeaturestoresEntityTypesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFeaturestoresEntityTypesOperationsRequest>;
 
@@ -62482,7 +62509,7 @@ export const CancelFeaturestoresEntityTypesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelFeaturestoresEntityTypesOperationsRequest>;
 
@@ -62528,7 +62555,7 @@ export const ListFeaturestoresEntityTypesFeaturesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -62564,7 +62591,7 @@ export const DeleteFeaturestoresEntityTypesFeaturesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -62597,7 +62624,7 @@ export const CancelFeaturestoresEntityTypesFeaturesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -62630,7 +62657,7 @@ export const GetFeaturestoresEntityTypesFeaturesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -62665,7 +62692,7 @@ export const WaitFeaturestoresEntityTypesFeaturesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -62697,7 +62724,7 @@ export const DeleteTrainingPipelinesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteTrainingPipelinesOperationsRequest>;
 
@@ -62728,7 +62755,7 @@ export const CancelTrainingPipelinesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelTrainingPipelinesOperationsRequest>;
 
@@ -62773,7 +62800,7 @@ export const ListTrainingPipelinesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListTrainingPipelinesOperationsRequest>;
 
@@ -62809,7 +62836,7 @@ export const GetTrainingPipelinesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTrainingPipelinesOperationsRequest>;
 
@@ -62843,7 +62870,7 @@ export const WaitTrainingPipelinesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitTrainingPipelinesOperationsRequest>;
 
@@ -62912,7 +62939,7 @@ export const GetBatchPredictionJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBatchPredictionJobsRequest>;
 
@@ -63040,7 +63067,7 @@ export const DeleteOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOperationsRequest>;
 
@@ -63071,7 +63098,7 @@ export const CancelOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOperationsRequest>;
 
@@ -63101,7 +63128,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -63134,7 +63161,7 @@ export const WaitOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
 }).pipe(
-  T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+  T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<WaitOperationsRequest>;
 
@@ -63179,7 +63206,7 @@ export const ListMigratableResourcesOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListMigratableResourcesOperationsRequest>;
 
@@ -63215,7 +63242,7 @@ export const DeleteMigratableResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteMigratableResourcesOperationsRequest>;
 
@@ -63246,7 +63273,7 @@ export const CancelMigratableResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelMigratableResourcesOperationsRequest>;
 
@@ -63277,7 +63304,7 @@ export const GetMigratableResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetMigratableResourcesOperationsRequest>;
 
@@ -63312,7 +63339,7 @@ export const WaitMigratableResourcesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitMigratableResourcesOperationsRequest>;
 
@@ -63358,7 +63385,7 @@ export const ListDataLabelingJobsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListDataLabelingJobsOperationsRequest>;
 
@@ -63394,7 +63421,7 @@ export const DeleteDataLabelingJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDataLabelingJobsOperationsRequest>;
 
@@ -63425,7 +63452,7 @@ export const CancelDataLabelingJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelDataLabelingJobsOperationsRequest>;
 
@@ -63456,7 +63483,7 @@ export const GetDataLabelingJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDataLabelingJobsOperationsRequest>;
 
@@ -63490,7 +63517,7 @@ export const WaitDataLabelingJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitDataLabelingJobsOperationsRequest>;
 
@@ -63521,7 +63548,7 @@ export const GetDeploymentResourcePoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDeploymentResourcePoolsOperationsRequest>;
 
@@ -63556,7 +63583,7 @@ export const WaitDeploymentResourcePoolsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitDeploymentResourcePoolsOperationsRequest>;
 
@@ -63602,7 +63629,7 @@ export const ListDeploymentResourcePoolsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListDeploymentResourcePoolsOperationsRequest>;
 
@@ -63638,7 +63665,7 @@ export const DeleteDeploymentResourcePoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDeploymentResourcePoolsOperationsRequest>;
 
@@ -63670,7 +63697,7 @@ export const CancelDeploymentResourcePoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelDeploymentResourcePoolsOperationsRequest>;
 
@@ -63707,7 +63734,7 @@ export const PredictPublishersModelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{endpoint}:predict", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+endpoint}:predict", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PredictPublishersModelsRequest>;
 
@@ -63745,7 +63772,7 @@ export const FetchPredictOperationPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:fetchPredictOperation",
+      path: "v1/{+endpoint}:fetchPredictOperation",
       hasBody: true,
     }),
     svc,
@@ -63802,7 +63829,7 @@ export const GetPublishersModelsRequest =
     ),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPublishersModelsRequest>;
 
@@ -63840,7 +63867,7 @@ export const CountTokensPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:countTokens",
+      path: "v1/{+endpoint}:countTokens",
       hasBody: true,
     }),
     svc,
@@ -63881,7 +63908,7 @@ export const ComputeTokensPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:computeTokens",
+      path: "v1/{+endpoint}:computeTokens",
       hasBody: true,
     }),
     svc,
@@ -63922,7 +63949,7 @@ export const PredictLongRunningPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{endpoint}:predictLongRunning",
+      path: "v1/{+endpoint}:predictLongRunning",
       hasBody: true,
     }),
     svc,
@@ -63962,7 +63989,7 @@ export const GenerateContentPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{model}:generateContent",
+      path: "v1/{+model}:generateContent",
       hasBody: true,
     }),
     svc,
@@ -64003,7 +64030,7 @@ export const StreamGenerateContentPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{model}:streamGenerateContent",
+      path: "v1/{+model}:streamGenerateContent",
       hasBody: true,
     }),
     svc,
@@ -64051,7 +64078,7 @@ export const ListWaitFeatureOnlineStoresOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:wait" }),
+    T.Http({ method: "GET", path: "v1/{+name}:wait" }),
     svc,
   ) as unknown as Schema.Schema<ListWaitFeatureOnlineStoresOperationsRequest>;
 
@@ -64087,7 +64114,7 @@ export const GetFeatureOnlineStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFeatureOnlineStoresOperationsRequest>;
 
@@ -64119,7 +64146,7 @@ export const DeleteFeatureOnlineStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFeatureOnlineStoresOperationsRequest>;
 
@@ -64153,7 +64180,7 @@ export const WaitFeatureOnlineStoresOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitFeatureOnlineStoresOperationsRequest>;
 
@@ -64185,7 +64212,7 @@ export const GetFeatureOnlineStoresFeatureViewsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFeatureOnlineStoresFeatureViewsOperationsRequest>;
 
@@ -64217,7 +64244,7 @@ export const DeleteFeatureOnlineStoresFeatureViewsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFeatureOnlineStoresFeatureViewsOperationsRequest>;
 
@@ -64253,7 +64280,7 @@ export const WaitFeatureOnlineStoresFeatureViewsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitFeatureOnlineStoresFeatureViewsOperationsRequest>;
 
@@ -64299,7 +64326,7 @@ export const ListWaitFeatureOnlineStoresFeatureViewsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:wait" }),
+    T.Http({ method: "GET", path: "v1/{+name}:wait" }),
     svc,
   ) as unknown as Schema.Schema<ListWaitFeatureOnlineStoresFeatureViewsOperationsRequest>;
 
@@ -64350,7 +64377,7 @@ export const ListNotebookRuntimesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListNotebookRuntimesOperationsRequest>;
 
@@ -64386,7 +64413,7 @@ export const DeleteNotebookRuntimesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNotebookRuntimesOperationsRequest>;
 
@@ -64417,7 +64444,7 @@ export const CancelNotebookRuntimesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelNotebookRuntimesOperationsRequest>;
 
@@ -64448,7 +64475,7 @@ export const GetNotebookRuntimesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNotebookRuntimesOperationsRequest>;
 
@@ -64482,7 +64509,7 @@ export const WaitNotebookRuntimesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitNotebookRuntimesOperationsRequest>;
 
@@ -64527,7 +64554,7 @@ export const ListRagCorporaOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListRagCorporaOperationsRequest>;
 
@@ -64563,7 +64590,7 @@ export const DeleteRagCorporaOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteRagCorporaOperationsRequest>;
 
@@ -64594,7 +64621,7 @@ export const CancelRagCorporaOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelRagCorporaOperationsRequest>;
 
@@ -64625,7 +64652,7 @@ export const GetRagCorporaOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetRagCorporaOperationsRequest>;
 
@@ -64659,7 +64686,7 @@ export const WaitRagCorporaOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitRagCorporaOperationsRequest>;
 
@@ -64704,7 +64731,7 @@ export const ListRagCorporaRagFilesOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListRagCorporaRagFilesOperationsRequest>;
 
@@ -64740,7 +64767,7 @@ export const DeleteRagCorporaRagFilesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteRagCorporaRagFilesOperationsRequest>;
 
@@ -64771,7 +64798,7 @@ export const CancelRagCorporaRagFilesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelRagCorporaRagFilesOperationsRequest>;
 
@@ -64802,7 +64829,7 @@ export const GetRagCorporaRagFilesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetRagCorporaRagFilesOperationsRequest>;
 
@@ -64837,7 +64864,7 @@ export const WaitRagCorporaRagFilesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitRagCorporaRagFilesOperationsRequest>;
 
@@ -64869,7 +64896,7 @@ export const GetCustomJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomJobsOperationsRequest>;
 
@@ -64903,7 +64930,7 @@ export const WaitCustomJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitCustomJobsOperationsRequest>;
 
@@ -64934,7 +64961,7 @@ export const DeleteCustomJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteCustomJobsOperationsRequest>;
 
@@ -64965,7 +64992,7 @@ export const CancelCustomJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelCustomJobsOperationsRequest>;
 
@@ -65010,7 +65037,7 @@ export const ListCustomJobsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomJobsOperationsRequest>;
 

--- a/packages/gcp/src/services/aiplatform-v1beta1.ts
+++ b/packages/gcp/src/services/aiplatform-v1beta1.ts
@@ -34127,7 +34127,7 @@ export const GetSemanticGovernancePoliciesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSemanticGovernancePoliciesOperationsRequest>;
 
@@ -34159,7 +34159,7 @@ export const CancelSemanticGovernancePoliciesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelSemanticGovernancePoliciesOperationsRequest>;
 
@@ -34205,7 +34205,7 @@ export const ListSemanticGovernancePoliciesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListSemanticGovernancePoliciesOperationsRequest>;
 
@@ -34241,7 +34241,7 @@ export const DeleteSemanticGovernancePoliciesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteSemanticGovernancePoliciesOperationsRequest>;
 
@@ -34276,7 +34276,7 @@ export const WaitSemanticGovernancePoliciesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitSemanticGovernancePoliciesOperationsRequest>;
 
@@ -34308,7 +34308,7 @@ export const DeleteCustomJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteCustomJobsOperationsRequest>;
 
@@ -34342,7 +34342,7 @@ export const WaitCustomJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitCustomJobsOperationsRequest>;
 
@@ -34373,7 +34373,7 @@ export const GetCustomJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomJobsOperationsRequest>;
 
@@ -34404,7 +34404,7 @@ export const CancelCustomJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelCustomJobsOperationsRequest>;
 
@@ -34449,7 +34449,7 @@ export const ListCustomJobsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomJobsOperationsRequest>;
 
@@ -34485,7 +34485,7 @@ export const DeleteModelsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteModelsOperationsRequest>;
 
@@ -34519,7 +34519,7 @@ export const WaitModelsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitModelsOperationsRequest>;
 
@@ -34550,7 +34550,7 @@ export const GetModelsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetModelsOperationsRequest>;
 
@@ -34581,7 +34581,7 @@ export const CancelModelsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelModelsOperationsRequest>;
 
@@ -34626,7 +34626,7 @@ export const ListModelsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListModelsOperationsRequest>;
 
@@ -34676,7 +34676,7 @@ export const ListModelsEvaluationsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListModelsEvaluationsOperationsRequest>;
 
@@ -34712,7 +34712,7 @@ export const GetModelsEvaluationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetModelsEvaluationsOperationsRequest>;
 
@@ -34743,7 +34743,7 @@ export const CancelModelsEvaluationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelModelsEvaluationsOperationsRequest>;
 
@@ -34774,7 +34774,7 @@ export const DeleteModelsEvaluationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteModelsEvaluationsOperationsRequest>;
 
@@ -34808,7 +34808,7 @@ export const WaitModelsEvaluationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitModelsEvaluationsOperationsRequest>;
 
@@ -34840,7 +34840,7 @@ export const GetAgentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAgentsOperationsRequest>;
 
@@ -34871,7 +34871,7 @@ export const CancelAgentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelAgentsOperationsRequest>;
 
@@ -34916,7 +34916,7 @@ export const ListAgentsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListAgentsOperationsRequest>;
 
@@ -34952,7 +34952,7 @@ export const DeleteAgentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAgentsOperationsRequest>;
 
@@ -34986,7 +34986,7 @@ export const WaitAgentsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitAgentsOperationsRequest>;
 
@@ -35023,7 +35023,7 @@ export const UploadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "v1beta1/{parent}/ragFiles:upload",
+    path: "v1beta1/{+parent}/ragFiles:upload",
     hasBody: true,
   }),
   svc,
@@ -35057,7 +35057,7 @@ export const GetSolversOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSolversOperationsRequest>;
 
@@ -35102,7 +35102,7 @@ export const ListSolversOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListSolversOperationsRequest>;
 
@@ -35138,7 +35138,7 @@ export const DeleteSolversOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteSolversOperationsRequest>;
 
@@ -35169,7 +35169,7 @@ export const DeleteRagEngineConfigOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteRagEngineConfigOperationsRequest>;
 
@@ -35203,7 +35203,7 @@ export const WaitRagEngineConfigOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitRagEngineConfigOperationsRequest>;
 
@@ -35248,7 +35248,7 @@ export const ListRagEngineConfigOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListRagEngineConfigOperationsRequest>;
 
@@ -35284,7 +35284,7 @@ export const GetRagEngineConfigOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetRagEngineConfigOperationsRequest>;
 
@@ -35315,7 +35315,7 @@ export const CancelRagEngineConfigOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelRagEngineConfigOperationsRequest>;
 
@@ -35346,7 +35346,7 @@ export const DeleteDeploymentResourcePoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDeploymentResourcePoolsOperationsRequest>;
 
@@ -35381,7 +35381,7 @@ export const WaitDeploymentResourcePoolsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitDeploymentResourcePoolsOperationsRequest>;
 
@@ -35413,7 +35413,7 @@ export const GetDeploymentResourcePoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDeploymentResourcePoolsOperationsRequest>;
 
@@ -35445,7 +35445,7 @@ export const CancelDeploymentResourcePoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelDeploymentResourcePoolsOperationsRequest>;
 
@@ -35491,7 +35491,7 @@ export const ListDeploymentResourcePoolsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListDeploymentResourcePoolsOperationsRequest>;
 
@@ -35532,7 +35532,7 @@ export const UpdateCacheConfigProjectsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateCacheConfigProjectsRequest>;
 
@@ -35563,7 +35563,7 @@ export const GetCacheConfigProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCacheConfigProjectsRequest>;
 
@@ -35602,7 +35602,7 @@ export const SetPublisherModelConfigProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:setPublisherModelConfig",
+      path: "v1beta1/{+name}:setPublisherModelConfig",
       hasBody: true,
     }),
     svc,
@@ -35636,7 +35636,10 @@ export const FetchPublisherModelConfigProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:fetchPublisherModelConfig" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+name}:fetchPublisherModelConfig",
+    }),
     svc,
   ) as unknown as Schema.Schema<FetchPublisherModelConfigProjectsRequest>;
 
@@ -35675,7 +35678,7 @@ export const CheckProjectsModelGardenEulaRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/modelGardenEula:check",
+      path: "v1beta1/{+parent}/modelGardenEula:check",
       hasBody: true,
     }),
     svc,
@@ -35716,7 +35719,7 @@ export const AcceptProjectsModelGardenEulaRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/modelGardenEula:accept",
+      path: "v1beta1/{+parent}/modelGardenEula:accept",
       hasBody: true,
     }),
     svc,
@@ -35760,7 +35763,7 @@ export const EnableModelProjectsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/{name}:enableModel",
+      path: "v1beta1/{+parent}/{+name}:enableModel",
       hasBody: true,
     }),
     svc,
@@ -35801,7 +35804,7 @@ export const DeployPublisherModelProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{destination}:deployPublisherModel",
+      path: "v1beta1/{+destination}:deployPublisherModel",
       hasBody: true,
     }),
     svc,
@@ -35835,7 +35838,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -35880,7 +35883,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -35923,7 +35926,7 @@ export const CorroborateContentProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:corroborateContent",
+      path: "v1beta1/{+parent}:corroborateContent",
       hasBody: true,
     }),
     svc,
@@ -35964,7 +35967,7 @@ export const EvaluateInstancesProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{location}:evaluateInstances",
+      path: "v1beta1/{+location}:evaluateInstances",
       hasBody: true,
     }),
     svc,
@@ -36003,7 +36006,7 @@ export const UpdateRagEngineConfigProjectsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateRagEngineConfigProjectsLocationsRequest>;
 
@@ -36042,7 +36045,7 @@ export const RetrieveContextsProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:retrieveContexts",
+      path: "v1beta1/{+parent}:retrieveContexts",
       hasBody: true,
     }),
     svc,
@@ -36083,7 +36086,7 @@ export const AugmentPromptProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:augmentPrompt",
+      path: "v1beta1/{+parent}:augmentPrompt",
       hasBody: true,
     }),
     svc,
@@ -36124,7 +36127,7 @@ export const RecommendSpecProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:recommendSpec",
+      path: "v1beta1/{+parent}:recommendSpec",
       hasBody: true,
     }),
     svc,
@@ -36165,7 +36168,7 @@ export const GenerateUserScenariosProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{location}:generateUserScenarios",
+      path: "v1beta1/{+location}:generateUserScenarios",
       hasBody: true,
     }),
     svc,
@@ -36206,7 +36209,7 @@ export const EvaluateDatasetProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{location}:evaluateDataset",
+      path: "v1beta1/{+location}:evaluateDataset",
       hasBody: true,
     }),
     svc,
@@ -36247,7 +36250,7 @@ export const AskContextsProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:askContexts",
+      path: "v1beta1/{+parent}:askContexts",
       hasBody: true,
     }),
     svc,
@@ -36288,7 +36291,7 @@ export const GenerateSyntheticDataProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{location}:generateSyntheticData",
+      path: "v1beta1/{+location}:generateSyntheticData",
       hasBody: true,
     }),
     svc,
@@ -36322,7 +36325,7 @@ export const GetRagEngineConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetRagEngineConfigProjectsLocationsRequest>;
 
@@ -36361,7 +36364,7 @@ export const DeployProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{destination}:deploy",
+      path: "v1beta1/{+destination}:deploy",
       hasBody: true,
     }),
     svc,
@@ -36401,7 +36404,7 @@ export const GenerateLossClustersProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{location}:generateLossClusters",
+      path: "v1beta1/{+location}:generateLossClusters",
       hasBody: true,
     }),
     svc,
@@ -36442,7 +36445,7 @@ export const AsyncRetrieveContextsProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:asyncRetrieveContexts",
+      path: "v1beta1/{+parent}:asyncRetrieveContexts",
       hasBody: true,
     }),
     svc,
@@ -36483,7 +36486,7 @@ export const GenerateInstanceRubricsProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{location}:generateInstanceRubrics",
+      path: "v1beta1/{+location}:generateInstanceRubrics",
       hasBody: true,
     }),
     svc,
@@ -36524,7 +36527,7 @@ export const TestIamPermissionsProjectsLocationsFeatureOnlineStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -36571,7 +36574,7 @@ export const CreateProjectsLocationsFeatureOnlineStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/featureOnlineStores",
+      path: "v1beta1/{+parent}/featureOnlineStores",
       hasBody: true,
     }),
     svc,
@@ -36610,7 +36613,7 @@ export const SetIamPolicyProjectsLocationsFeatureOnlineStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -36657,7 +36660,7 @@ export const ListProjectsLocationsFeatureOnlineStoresRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/featureOnlineStores" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/featureOnlineStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeatureOnlineStoresRequest>;
 
@@ -36693,7 +36696,7 @@ export const GetProjectsLocationsFeatureOnlineStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureOnlineStoresRequest>;
 
@@ -36732,7 +36735,7 @@ export const GetIamPolicyProjectsLocationsFeatureOnlineStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -36770,7 +36773,7 @@ export const DeleteProjectsLocationsFeatureOnlineStoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeatureOnlineStoresRequest>;
 
@@ -36810,7 +36813,7 @@ export const PatchProjectsLocationsFeatureOnlineStoresRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFeatureOnlineStoresRequest>;
 
@@ -36849,7 +36852,7 @@ export const GenerateFetchAccessTokenProjectsLocationsFeatureOnlineStoresFeature
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{featureView}:generateFetchAccessToken",
+      path: "v1beta1/{+featureView}:generateFetchAccessToken",
       hasBody: true,
     }),
     svc,
@@ -36891,7 +36894,7 @@ export const SetIamPolicyProjectsLocationsFeatureOnlineStoresFeatureViewsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -36926,7 +36929,7 @@ export const GetProjectsLocationsFeatureOnlineStoresFeatureViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureOnlineStoresFeatureViewsRequest>;
 
@@ -36971,7 +36974,7 @@ export const ListProjectsLocationsFeatureOnlineStoresFeatureViewsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/featureViews" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/featureViews" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeatureOnlineStoresFeatureViewsRequest>;
 
@@ -37025,7 +37028,7 @@ export const CreateProjectsLocationsFeatureOnlineStoresFeatureViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/featureViews",
+      path: "v1beta1/{+parent}/featureViews",
       hasBody: true,
     }),
     svc,
@@ -37067,7 +37070,7 @@ export const SyncProjectsLocationsFeatureOnlineStoresFeatureViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{featureView}:sync",
+      path: "v1beta1/{+featureView}:sync",
       hasBody: true,
     }),
     svc,
@@ -37109,7 +37112,7 @@ export const SearchNearestEntitiesProjectsLocationsFeatureOnlineStoresFeatureVie
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{featureView}:searchNearestEntities",
+      path: "v1beta1/{+featureView}:searchNearestEntities",
       hasBody: true,
     }),
     svc,
@@ -37154,7 +37157,7 @@ export const PatchProjectsLocationsFeatureOnlineStoresFeatureViewsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFeatureOnlineStoresFeatureViewsRequest>;
 
@@ -37194,7 +37197,7 @@ export const StreamingFetchFeatureValuesProjectsLocationsFeatureOnlineStoresFeat
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{featureView}:streamingFetchFeatureValues",
+      path: "v1beta1/{+featureView}:streamingFetchFeatureValues",
       hasBody: true,
     }),
     svc,
@@ -37238,7 +37241,7 @@ export const TestIamPermissionsProjectsLocationsFeatureOnlineStoresFeatureViewsR
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -37282,7 +37285,7 @@ export const FetchFeatureValuesProjectsLocationsFeatureOnlineStoresFeatureViewsR
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{featureView}:fetchFeatureValues",
+      path: "v1beta1/{+featureView}:fetchFeatureValues",
       hasBody: true,
     }),
     svc,
@@ -37326,7 +37329,7 @@ export const DirectWriteProjectsLocationsFeatureOnlineStoresFeatureViewsRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{featureView}:directWrite",
+      path: "v1beta1/{+featureView}:directWrite",
       hasBody: true,
     }),
     svc,
@@ -37361,7 +37364,7 @@ export const DeleteProjectsLocationsFeatureOnlineStoresFeatureViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeatureOnlineStoresFeatureViewsRequest>;
 
@@ -37401,7 +37404,7 @@ export const GetIamPolicyProjectsLocationsFeatureOnlineStoresFeatureViewsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -37436,7 +37439,7 @@ export const GetProjectsLocationsFeatureOnlineStoresFeatureViewsFeatureViewSyncs
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureOnlineStoresFeatureViewsFeatureViewSyncsRequest>;
 
@@ -37483,7 +37486,7 @@ export const ListProjectsLocationsFeatureOnlineStoresFeatureViewsFeatureViewSync
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/featureViewSyncs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/featureViewSyncs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeatureOnlineStoresFeatureViewsFeatureViewSyncsRequest>;
 
@@ -37522,7 +37525,7 @@ export const GetProjectsLocationsFeatureOnlineStoresFeatureViewsOperationsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureOnlineStoresFeatureViewsOperationsRequest>;
 
@@ -37555,7 +37558,7 @@ export const DeleteProjectsLocationsFeatureOnlineStoresFeatureViewsOperationsReq
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeatureOnlineStoresFeatureViewsOperationsRequest>;
 
@@ -37593,7 +37596,7 @@ export const WaitProjectsLocationsFeatureOnlineStoresFeatureViewsOperationsReque
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsFeatureOnlineStoresFeatureViewsOperationsRequest>;
 
@@ -37641,7 +37644,7 @@ export const ListProjectsLocationsFeatureOnlineStoresFeatureViewsOperationsReque
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeatureOnlineStoresFeatureViewsOperationsRequest>;
 
@@ -37679,7 +37682,7 @@ export const GetProjectsLocationsFeatureOnlineStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureOnlineStoresOperationsRequest>;
 
@@ -37712,7 +37715,7 @@ export const DeleteProjectsLocationsFeatureOnlineStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeatureOnlineStoresOperationsRequest>;
 
@@ -37748,7 +37751,7 @@ export const WaitProjectsLocationsFeatureOnlineStoresOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsFeatureOnlineStoresOperationsRequest>;
 
@@ -37795,7 +37798,7 @@ export const ListProjectsLocationsFeatureOnlineStoresOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeatureOnlineStoresOperationsRequest>;
 
@@ -37839,7 +37842,7 @@ export const CountTokensProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:countTokens",
+      path: "v1beta1/{+endpoint}:countTokens",
       hasBody: true,
     }),
     svc,
@@ -37873,7 +37876,7 @@ export const DeleteProjectsLocationsEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEndpointsRequest>;
 
@@ -37912,7 +37915,7 @@ export const PredictProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:predict",
+      path: "v1beta1/{+endpoint}:predict",
       hasBody: true,
     }),
     svc,
@@ -37952,7 +37955,7 @@ export const PredictLongRunningProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:predictLongRunning",
+      path: "v1beta1/{+endpoint}:predictLongRunning",
       hasBody: true,
     }),
     svc,
@@ -37992,7 +37995,7 @@ export const StreamGenerateContentProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{model}:streamGenerateContent",
+      path: "v1beta1/{+model}:streamGenerateContent",
       hasBody: true,
     }),
     svc,
@@ -38034,7 +38037,7 @@ export const ComputeTokensProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:computeTokens",
+      path: "v1beta1/{+endpoint}:computeTokens",
       hasBody: true,
     }),
     svc,
@@ -38075,7 +38078,7 @@ export const TestIamPermissionsProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -38116,7 +38119,7 @@ export const RawPredictProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:rawPredict",
+      path: "v1beta1/{+endpoint}:rawPredict",
       hasBody: true,
     }),
     svc,
@@ -38159,7 +38162,7 @@ export const CreateProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/endpoints",
+      path: "v1beta1/{+parent}/endpoints",
       hasBody: true,
     }),
     svc,
@@ -38208,7 +38211,7 @@ export const ListProjectsLocationsEndpointsRequest =
     gdcZone: Schema.optional(Schema.String).pipe(T.HttpQuery("gdcZone")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/endpoints" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/endpoints" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEndpointsRequest>;
 
@@ -38251,7 +38254,7 @@ export const GenerateContentProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{model}:generateContent",
+      path: "v1beta1/{+model}:generateContent",
       hasBody: true,
     }),
     svc,
@@ -38292,7 +38295,7 @@ export const StreamRawPredictProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:streamRawPredict",
+      path: "v1beta1/{+endpoint}:streamRawPredict",
       hasBody: true,
     }),
     svc,
@@ -38333,7 +38336,7 @@ export const FetchPredictOperationProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:fetchPredictOperation",
+      path: "v1beta1/{+endpoint}:fetchPredictOperation",
       hasBody: true,
     }),
     svc,
@@ -38375,7 +38378,7 @@ export const DirectPredictProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:directPredict",
+      path: "v1beta1/{+endpoint}:directPredict",
       hasBody: true,
     }),
     svc,
@@ -38414,7 +38417,7 @@ export const UpdateProjectsLocationsEndpointsRequest =
       GoogleCloudAiplatformV1beta1UpdateEndpointLongRunningRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:update", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:update", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsEndpointsRequest>;
 
@@ -38453,7 +38456,7 @@ export const GetIamPolicyProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -38493,7 +38496,7 @@ export const ExplainProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:explain",
+      path: "v1beta1/{+endpoint}:explain",
       hasBody: true,
     }),
     svc,
@@ -38535,7 +38538,7 @@ export const PatchProjectsLocationsEndpointsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEndpointsRequest>;
 
@@ -38574,7 +38577,7 @@ export const MutateDeployedModelProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:mutateDeployedModel",
+      path: "v1beta1/{+endpoint}:mutateDeployedModel",
       hasBody: true,
     }),
     svc,
@@ -38615,7 +38618,7 @@ export const ServerStreamingPredictProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:serverStreamingPredict",
+      path: "v1beta1/{+endpoint}:serverStreamingPredict",
       hasBody: true,
     }),
     svc,
@@ -38650,7 +38653,7 @@ export const GetProjectsLocationsEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEndpointsRequest>;
 
@@ -38689,7 +38692,7 @@ export const DeployModelProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:deployModel",
+      path: "v1beta1/{+endpoint}:deployModel",
       hasBody: true,
     }),
     svc,
@@ -38730,7 +38733,7 @@ export const UndeployModelProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:undeployModel",
+      path: "v1beta1/{+endpoint}:undeployModel",
       hasBody: true,
     }),
     svc,
@@ -38771,7 +38774,7 @@ export const DirectRawPredictProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:directRawPredict",
+      path: "v1beta1/{+endpoint}:directRawPredict",
       hasBody: true,
     }),
     svc,
@@ -38810,7 +38813,7 @@ export const SetIamPolicyProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -38853,7 +38856,7 @@ export const EmbeddingsProjectsLocationsEndpointsOpenapiRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}/embeddings",
+      path: "v1beta1/{+endpoint}/embeddings",
       hasBody: true,
     }),
     svc,
@@ -38897,7 +38900,7 @@ export const CompletionsProjectsLocationsEndpointsOpenapiRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}/completions",
+      path: "v1beta1/{+endpoint}/completions",
       hasBody: true,
     }),
     svc,
@@ -38941,7 +38944,7 @@ export const ResponsesProjectsLocationsEndpointsOpenapiRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}/responses",
+      path: "v1beta1/{+endpoint}/responses",
       hasBody: true,
     }),
     svc,
@@ -38980,7 +38983,7 @@ export const CompletionsProjectsLocationsEndpointsChatRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}/chat/completions",
+      path: "v1beta1/{+endpoint}/chat/completions",
       hasBody: true,
     }),
     svc,
@@ -39024,7 +39027,7 @@ export const InferenceProjectsLocationsEndpointsGoogleScienceRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}/science/inference",
+      path: "v1beta1/{+endpoint}/science/inference",
       hasBody: true,
     }),
     svc,
@@ -39073,7 +39076,7 @@ export const ListProjectsLocationsEndpointsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEndpointsOperationsRequest>;
 
@@ -39109,7 +39112,7 @@ export const GetProjectsLocationsEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEndpointsOperationsRequest>;
 
@@ -39141,7 +39144,7 @@ export const CancelProjectsLocationsEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsEndpointsOperationsRequest>;
 
@@ -39173,7 +39176,7 @@ export const DeleteProjectsLocationsEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEndpointsOperationsRequest>;
 
@@ -39208,7 +39211,7 @@ export const WaitProjectsLocationsEndpointsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsEndpointsOperationsRequest>;
 
@@ -39249,7 +39252,7 @@ export const InvokeProjectsLocationsEndpointsInvokeRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}/invoke/{invokeId}",
+      path: "v1beta1/{+endpoint}/invoke/{+invokeId}",
       hasBody: true,
     }),
     svc,
@@ -39294,7 +39297,7 @@ export const InvokeProjectsLocationsEndpointsDeployedModelsInvokeRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}/deployedModels/{deployedModelId}/invoke/{invokeId}",
+      path: "v1beta1/{+endpoint}/deployedModels/{deployedModelId}/invoke/{+invokeId}",
       hasBody: true,
     }),
     svc,
@@ -39343,7 +39346,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -39379,7 +39382,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -39410,7 +39413,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -39441,7 +39444,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -39475,7 +39478,7 @@ export const WaitProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsOperationsRequest>;
 
@@ -39514,7 +39517,7 @@ export const FindNeighborsProjectsLocationsIndexEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{indexEndpoint}:findNeighbors",
+      path: "v1beta1/{+indexEndpoint}:findNeighbors",
       hasBody: true,
     }),
     svc,
@@ -39555,7 +39558,7 @@ export const ReadIndexDatapointsProjectsLocationsIndexEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{indexEndpoint}:readIndexDatapoints",
+      path: "v1beta1/{+indexEndpoint}:readIndexDatapoints",
       hasBody: true,
     }),
     svc,
@@ -39598,7 +39601,7 @@ export const PatchProjectsLocationsIndexEndpointsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsIndexEndpointsRequest>;
 
@@ -39630,7 +39633,7 @@ export const GetProjectsLocationsIndexEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIndexEndpointsRequest>;
 
@@ -39669,7 +39672,7 @@ export const CreateProjectsLocationsIndexEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/indexEndpoints",
+      path: "v1beta1/{+parent}/indexEndpoints",
       hasBody: true,
     }),
     svc,
@@ -39715,7 +39718,7 @@ export const ListProjectsLocationsIndexEndpointsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/indexEndpoints" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/indexEndpoints" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIndexEndpointsRequest>;
 
@@ -39758,7 +39761,7 @@ export const MutateDeployedIndexProjectsLocationsIndexEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{indexEndpoint}:mutateDeployedIndex",
+      path: "v1beta1/{+indexEndpoint}:mutateDeployedIndex",
       hasBody: true,
     }),
     svc,
@@ -39793,7 +39796,7 @@ export const DeleteProjectsLocationsIndexEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsIndexEndpointsRequest>;
 
@@ -39832,7 +39835,7 @@ export const DeployIndexProjectsLocationsIndexEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{indexEndpoint}:deployIndex",
+      path: "v1beta1/{+indexEndpoint}:deployIndex",
       hasBody: true,
     }),
     svc,
@@ -39873,7 +39876,7 @@ export const UndeployIndexProjectsLocationsIndexEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{indexEndpoint}:undeployIndex",
+      path: "v1beta1/{+indexEndpoint}:undeployIndex",
       hasBody: true,
     }),
     svc,
@@ -39907,7 +39910,7 @@ export const GetProjectsLocationsIndexEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIndexEndpointsOperationsRequest>;
 
@@ -39939,7 +39942,7 @@ export const CancelProjectsLocationsIndexEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsIndexEndpointsOperationsRequest>;
 
@@ -39986,7 +39989,7 @@ export const ListProjectsLocationsIndexEndpointsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIndexEndpointsOperationsRequest>;
 
@@ -40022,7 +40025,7 @@ export const DeleteProjectsLocationsIndexEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsIndexEndpointsOperationsRequest>;
 
@@ -40058,7 +40061,7 @@ export const WaitProjectsLocationsIndexEndpointsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsIndexEndpointsOperationsRequest>;
 
@@ -40090,7 +40093,7 @@ export const GetProjectsLocationsAppsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsOperationsRequest>;
 
@@ -40122,7 +40125,7 @@ export const CancelProjectsLocationsAppsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsAppsOperationsRequest>;
 
@@ -40167,7 +40170,7 @@ export const ListProjectsLocationsAppsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsOperationsRequest>;
 
@@ -40203,7 +40206,7 @@ export const DeleteProjectsLocationsAppsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsOperationsRequest>;
 
@@ -40237,7 +40240,7 @@ export const WaitProjectsLocationsAppsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsAppsOperationsRequest>;
 
@@ -40281,7 +40284,7 @@ export const ListProjectsLocationsEvaluationRunsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/evaluationRuns" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/evaluationRuns" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEvaluationRunsRequest>;
 
@@ -40324,7 +40327,7 @@ export const CreateProjectsLocationsEvaluationRunsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/evaluationRuns",
+      path: "v1beta1/{+parent}/evaluationRuns",
       hasBody: true,
     }),
     svc,
@@ -40358,7 +40361,7 @@ export const GetProjectsLocationsEvaluationRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEvaluationRunsRequest>;
 
@@ -40395,7 +40398,7 @@ export const CancelProjectsLocationsEvaluationRunsRequest =
       GoogleCloudAiplatformV1beta1CancelEvaluationRunRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsEvaluationRunsRequest>;
 
@@ -40426,7 +40429,7 @@ export const DeleteProjectsLocationsEvaluationRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEvaluationRunsRequest>;
 
@@ -40472,7 +40475,7 @@ export const ListProjectsLocationsEvaluationRunsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEvaluationRunsOperationsRequest>;
 
@@ -40508,7 +40511,7 @@ export const DeleteProjectsLocationsEvaluationRunsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEvaluationRunsOperationsRequest>;
 
@@ -40544,7 +40547,7 @@ export const WaitProjectsLocationsEvaluationRunsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsEvaluationRunsOperationsRequest>;
 
@@ -40576,7 +40579,7 @@ export const GetProjectsLocationsEvaluationRunsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEvaluationRunsOperationsRequest>;
 
@@ -40608,7 +40611,7 @@ export const GetProjectsLocationsPersistentResourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPersistentResourcesRequest>;
 
@@ -40646,7 +40649,7 @@ export const ListProjectsLocationsPersistentResourcesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/persistentResources" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/persistentResources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPersistentResourcesRequest>;
 
@@ -40694,7 +40697,7 @@ export const CreateProjectsLocationsPersistentResourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/persistentResources",
+      path: "v1beta1/{+parent}/persistentResources",
       hasBody: true,
     }),
     svc,
@@ -40733,7 +40736,7 @@ export const RebootProjectsLocationsPersistentResourcesRequest =
       GoogleCloudAiplatformV1beta1RebootPersistentResourceRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:reboot", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:reboot", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RebootProjectsLocationsPersistentResourcesRequest>;
 
@@ -40773,7 +40776,7 @@ export const PatchProjectsLocationsPersistentResourcesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPersistentResourcesRequest>;
 
@@ -40805,7 +40808,7 @@ export const DeleteProjectsLocationsPersistentResourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPersistentResourcesRequest>;
 
@@ -40851,7 +40854,7 @@ export const ListProjectsLocationsPersistentResourcesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPersistentResourcesOperationsRequest>;
 
@@ -40888,7 +40891,7 @@ export const GetProjectsLocationsPersistentResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPersistentResourcesOperationsRequest>;
 
@@ -40921,7 +40924,7 @@ export const CancelProjectsLocationsPersistentResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsPersistentResourcesOperationsRequest>;
 
@@ -40954,7 +40957,7 @@ export const DeleteProjectsLocationsPersistentResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPersistentResourcesOperationsRequest>;
 
@@ -40990,7 +40993,7 @@ export const WaitProjectsLocationsPersistentResourcesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsPersistentResourcesOperationsRequest>;
 
@@ -41030,7 +41033,7 @@ export const ReportEventProjectsLocationsNotebookExecutionJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:reportEvent",
+      path: "v1beta1/{+name}:reportEvent",
       hasBody: true,
     }),
     svc,
@@ -41071,7 +41074,7 @@ export const GenerateAccessTokenProjectsLocationsNotebookExecutionJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:generateAccessToken",
+      path: "v1beta1/{+name}:generateAccessToken",
       hasBody: true,
     }),
     svc,
@@ -41106,7 +41109,7 @@ export const DeleteProjectsLocationsNotebookExecutionJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNotebookExecutionJobsRequest>;
 
@@ -41145,7 +41148,7 @@ export const GetProjectsLocationsNotebookExecutionJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNotebookExecutionJobsRequest>;
 
@@ -41196,7 +41199,7 @@ export const ListProjectsLocationsNotebookExecutionJobsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/notebookExecutionJobs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/notebookExecutionJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNotebookExecutionJobsRequest>;
 
@@ -41244,7 +41247,7 @@ export const CreateProjectsLocationsNotebookExecutionJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/notebookExecutionJobs",
+      path: "v1beta1/{+parent}/notebookExecutionJobs",
       hasBody: true,
     }),
     svc,
@@ -41278,7 +41281,7 @@ export const GetProjectsLocationsNotebookExecutionJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNotebookExecutionJobsOperationsRequest>;
 
@@ -41311,7 +41314,7 @@ export const CancelProjectsLocationsNotebookExecutionJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsNotebookExecutionJobsOperationsRequest>;
 
@@ -41358,7 +41361,7 @@ export const ListProjectsLocationsNotebookExecutionJobsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNotebookExecutionJobsOperationsRequest>;
 
@@ -41395,7 +41398,7 @@ export const DeleteProjectsLocationsNotebookExecutionJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNotebookExecutionJobsOperationsRequest>;
 
@@ -41431,7 +41434,7 @@ export const WaitProjectsLocationsNotebookExecutionJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsNotebookExecutionJobsOperationsRequest>;
 
@@ -41469,7 +41472,7 @@ export const SetIamPolicyProjectsLocationsReasoningEnginesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -41510,7 +41513,7 @@ export const TestIamPermissionsProjectsLocationsReasoningEnginesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -41550,7 +41553,7 @@ export const QueryProjectsLocationsReasoningEnginesRequest =
       GoogleCloudAiplatformV1beta1QueryReasoningEngineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryProjectsLocationsReasoningEnginesRequest>;
 
@@ -41589,7 +41592,7 @@ export const StreamQueryProjectsLocationsReasoningEnginesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:streamQuery",
+      path: "v1beta1/{+name}:streamQuery",
       hasBody: true,
     }),
     svc,
@@ -41631,7 +41634,7 @@ export const PatchProjectsLocationsReasoningEnginesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsReasoningEnginesRequest>;
 
@@ -41672,7 +41675,7 @@ export const ListProjectsLocationsReasoningEnginesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/reasoningEngines" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/reasoningEngines" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesRequest>;
 
@@ -41715,7 +41718,7 @@ export const CreateProjectsLocationsReasoningEnginesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/reasoningEngines",
+      path: "v1beta1/{+parent}/reasoningEngines",
       hasBody: true,
     }),
     svc,
@@ -41756,7 +41759,7 @@ export const ExecuteCodeProjectsLocationsReasoningEnginesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:executeCode",
+      path: "v1beta1/{+name}:executeCode",
       hasBody: true,
     }),
     svc,
@@ -41797,7 +41800,7 @@ export const GetIamPolicyProjectsLocationsReasoningEnginesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -41831,7 +41834,7 @@ export const GetProjectsLocationsReasoningEnginesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesRequest>;
 
@@ -41866,7 +41869,7 @@ export const DeleteProjectsLocationsReasoningEnginesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesRequest>;
 
@@ -41906,7 +41909,7 @@ export const ExtendedAgentCardProjectsLocationsReasoningEnginesA2aRequest =
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<ExtendedAgentCardProjectsLocationsReasoningEnginesA2aRequest>;
 
@@ -41948,7 +41951,7 @@ export const TasksProjectsLocationsReasoningEnginesA2aRequest =
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<TasksProjectsLocationsReasoningEnginesA2aRequest>;
 
@@ -41989,7 +41992,7 @@ export const CardProjectsLocationsReasoningEnginesA2aRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<CardProjectsLocationsReasoningEnginesA2aRequest>;
 
@@ -42027,7 +42030,7 @@ export const CancelProjectsLocationsReasoningEnginesA2aTasksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:cancel",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:cancel",
       hasBody: true,
     }),
     svc,
@@ -42071,7 +42074,7 @@ export const PushNotificationConfigsProjectsLocationsReasoningEnginesA2aTasksReq
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<PushNotificationConfigsProjectsLocationsReasoningEnginesA2aTasksRequest>;
 
@@ -42115,7 +42118,7 @@ export const A2aGetReasoningEngineProjectsLocationsReasoningEnginesA2aTasksReque
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<A2aGetReasoningEngineProjectsLocationsReasoningEnginesA2aTasksRequest>;
 
@@ -42155,7 +42158,7 @@ export const SubscribeProjectsLocationsReasoningEnginesA2aTasksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:subscribe",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:subscribe",
     }),
     svc,
   ) as unknown as Schema.Schema<SubscribeProjectsLocationsReasoningEnginesA2aTasksRequest>;
@@ -42197,7 +42200,7 @@ export const A2aGetReasoningEngineProjectsLocationsReasoningEnginesA2aTasksPushN
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<A2aGetReasoningEngineProjectsLocationsReasoningEnginesA2aTasksPushNotificationConfigsRequest>;
 
@@ -42238,7 +42241,7 @@ export const StreamProjectsLocationsReasoningEnginesA2aMessageRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:stream",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:stream",
       hasBody: true,
     }),
     svc,
@@ -42278,7 +42281,7 @@ export const SendProjectsLocationsReasoningEnginesA2aMessageRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:send",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:send",
       hasBody: true,
     }),
     svc,
@@ -42322,7 +42325,7 @@ export const TasksProjectsLocationsReasoningEnginesA2aV1Request =
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<TasksProjectsLocationsReasoningEnginesA2aV1Request>;
 
@@ -42363,7 +42366,7 @@ export const CardProjectsLocationsReasoningEnginesA2aV1Request =
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<CardProjectsLocationsReasoningEnginesA2aV1Request>;
 
@@ -42404,7 +42407,7 @@ export const ExtendedAgentCardProjectsLocationsReasoningEnginesA2aV1Request =
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<ExtendedAgentCardProjectsLocationsReasoningEnginesA2aV1Request>;
 
@@ -42443,7 +42446,7 @@ export const StreamProjectsLocationsReasoningEnginesA2aV1MessageRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:stream",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:stream",
       hasBody: true,
     }),
     svc,
@@ -42483,7 +42486,7 @@ export const SendProjectsLocationsReasoningEnginesA2aV1MessageRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:send",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:send",
       hasBody: true,
     }),
     svc,
@@ -42524,7 +42527,7 @@ export const CancelProjectsLocationsReasoningEnginesA2aV1TasksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:cancel",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:cancel",
       hasBody: true,
     }),
     svc,
@@ -42568,7 +42571,7 @@ export const PushNotificationConfigsProjectsLocationsReasoningEnginesA2aV1TasksR
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<PushNotificationConfigsProjectsLocationsReasoningEnginesA2aV1TasksRequest>;
 
@@ -42612,7 +42615,7 @@ export const A2aGetReasoningEngineProjectsLocationsReasoningEnginesA2aV1TasksReq
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<A2aGetReasoningEngineProjectsLocationsReasoningEnginesA2aV1TasksRequest>;
 
@@ -42653,7 +42656,7 @@ export const SubscribeProjectsLocationsReasoningEnginesA2aV1TasksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:subscribe",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:subscribe",
     }),
     svc,
   ) as unknown as Schema.Schema<SubscribeProjectsLocationsReasoningEnginesA2aV1TasksRequest>;
@@ -42695,7 +42698,7 @@ export const A2aGetReasoningEngineProjectsLocationsReasoningEnginesA2aV1TasksPus
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<A2aGetReasoningEngineProjectsLocationsReasoningEnginesA2aV1TasksPushNotificationConfigsRequest>;
 
@@ -42731,7 +42734,7 @@ export const DeleteProjectsLocationsReasoningEnginesMemoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesMemoriesRequest>;
 
@@ -42776,7 +42779,7 @@ export const ListProjectsLocationsReasoningEnginesMemoriesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/memories" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/memories" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesMemoriesRequest>;
 
@@ -42822,7 +42825,7 @@ export const CreateProjectsLocationsReasoningEnginesMemoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/memories",
+      path: "v1beta1/{+parent}/memories",
       hasBody: true,
     }),
     svc,
@@ -42864,7 +42867,7 @@ export const RetrieveProfilesProjectsLocationsReasoningEnginesMemoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/memories:retrieveProfiles",
+      path: "v1beta1/{+parent}/memories:retrieveProfiles",
       hasBody: true,
     }),
     svc,
@@ -42899,7 +42902,7 @@ export const GetProjectsLocationsReasoningEnginesMemoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesMemoriesRequest>;
 
@@ -42938,7 +42941,7 @@ export const RetrieveProjectsLocationsReasoningEnginesMemoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/memories:retrieve",
+      path: "v1beta1/{+parent}/memories:retrieve",
       hasBody: true,
     }),
     svc,
@@ -42981,7 +42984,7 @@ export const PatchProjectsLocationsReasoningEnginesMemoriesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsReasoningEnginesMemoriesRequest>;
 
@@ -43020,7 +43023,7 @@ export const GenerateProjectsLocationsReasoningEnginesMemoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/memories:generate",
+      path: "v1beta1/{+parent}/memories:generate",
       hasBody: true,
     }),
     svc,
@@ -43062,7 +43065,7 @@ export const PurgeProjectsLocationsReasoningEnginesMemoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/memories:purge",
+      path: "v1beta1/{+parent}/memories:purge",
       hasBody: true,
     }),
     svc,
@@ -43101,7 +43104,7 @@ export const RollbackProjectsLocationsReasoningEnginesMemoriesRequest =
       GoogleCloudAiplatformV1beta1RollbackMemoryRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:rollback", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:rollback", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RollbackProjectsLocationsReasoningEnginesMemoriesRequest>;
 
@@ -43141,7 +43144,7 @@ export const IngestEventsProjectsLocationsReasoningEnginesMemoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/memories:ingestEvents",
+      path: "v1beta1/{+parent}/memories:ingestEvents",
       hasBody: true,
     }),
     svc,
@@ -43176,7 +43179,7 @@ export const DeleteProjectsLocationsReasoningEnginesMemoriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesMemoriesOperationsRequest>;
 
@@ -43212,7 +43215,7 @@ export const WaitProjectsLocationsReasoningEnginesMemoriesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsReasoningEnginesMemoriesOperationsRequest>;
 
@@ -43259,7 +43262,7 @@ export const ListProjectsLocationsReasoningEnginesMemoriesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesMemoriesOperationsRequest>;
 
@@ -43296,7 +43299,7 @@ export const GetProjectsLocationsReasoningEnginesMemoriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesMemoriesOperationsRequest>;
 
@@ -43329,7 +43332,7 @@ export const CancelProjectsLocationsReasoningEnginesMemoriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsReasoningEnginesMemoriesOperationsRequest>;
 
@@ -43362,7 +43365,7 @@ export const GetProjectsLocationsReasoningEnginesMemoriesRevisionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesMemoriesRevisionsRequest>;
 
@@ -43404,7 +43407,7 @@ export const ListProjectsLocationsReasoningEnginesMemoriesRevisionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/revisions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/revisions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesMemoriesRevisionsRequest>;
 
@@ -43446,7 +43449,7 @@ export const QueryProjectsLocationsReasoningEnginesRuntimeRevisionsRequest =
       GoogleCloudAiplatformV1beta1QueryReasoningEngineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryProjectsLocationsReasoningEnginesRuntimeRevisionsRequest>;
 
@@ -43488,7 +43491,7 @@ export const ListProjectsLocationsReasoningEnginesRuntimeRevisionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/runtimeRevisions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/runtimeRevisions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesRuntimeRevisionsRequest>;
 
@@ -43525,7 +43528,7 @@ export const GetProjectsLocationsReasoningEnginesRuntimeRevisionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesRuntimeRevisionsRequest>;
 
@@ -43558,7 +43561,7 @@ export const DeleteProjectsLocationsReasoningEnginesRuntimeRevisionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesRuntimeRevisionsRequest>;
 
@@ -43598,7 +43601,7 @@ export const StreamQueryProjectsLocationsReasoningEnginesRuntimeRevisionsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:streamQuery",
+      path: "v1beta1/{+name}:streamQuery",
       hasBody: true,
     }),
     svc,
@@ -43641,7 +43644,7 @@ export const ExtendedAgentCardProjectsLocationsReasoningEnginesRuntimeRevisionsA
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<ExtendedAgentCardProjectsLocationsReasoningEnginesRuntimeRevisionsA2aRequest>;
 
@@ -43685,7 +43688,7 @@ export const TasksProjectsLocationsReasoningEnginesRuntimeRevisionsA2aRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<TasksProjectsLocationsReasoningEnginesRuntimeRevisionsA2aRequest>;
 
@@ -43727,7 +43730,7 @@ export const CardProjectsLocationsReasoningEnginesRuntimeRevisionsA2aRequest =
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<CardProjectsLocationsReasoningEnginesRuntimeRevisionsA2aRequest>;
 
@@ -43766,7 +43769,7 @@ export const StreamProjectsLocationsReasoningEnginesRuntimeRevisionsA2aMessageRe
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:stream",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:stream",
       hasBody: true,
     }),
     svc,
@@ -43808,7 +43811,7 @@ export const SendProjectsLocationsReasoningEnginesRuntimeRevisionsA2aMessageRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:send",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:send",
       hasBody: true,
     }),
     svc,
@@ -43853,7 +43856,7 @@ export const TasksProjectsLocationsReasoningEnginesRuntimeRevisionsA2aV1Request 
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<TasksProjectsLocationsReasoningEnginesRuntimeRevisionsA2aV1Request>;
 
@@ -43895,7 +43898,7 @@ export const CardProjectsLocationsReasoningEnginesRuntimeRevisionsA2aV1Request =
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<CardProjectsLocationsReasoningEnginesRuntimeRevisionsA2aV1Request>;
 
@@ -43937,7 +43940,7 @@ export const ExtendedAgentCardProjectsLocationsReasoningEnginesRuntimeRevisionsA
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<ExtendedAgentCardProjectsLocationsReasoningEnginesRuntimeRevisionsA2aV1Request>;
 
@@ -43978,7 +43981,7 @@ export const SendProjectsLocationsReasoningEnginesRuntimeRevisionsA2aV1MessageRe
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:send",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:send",
       hasBody: true,
     }),
     svc,
@@ -44021,7 +44024,7 @@ export const StreamProjectsLocationsReasoningEnginesRuntimeRevisionsA2aV1Message
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:stream",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:stream",
       hasBody: true,
     }),
     svc,
@@ -44063,7 +44066,7 @@ export const SubscribeProjectsLocationsReasoningEnginesRuntimeRevisionsA2aV1Task
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:subscribe",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:subscribe",
     }),
     svc,
   ) as unknown as Schema.Schema<SubscribeProjectsLocationsReasoningEnginesRuntimeRevisionsA2aV1TasksRequest>;
@@ -44107,7 +44110,7 @@ export const PushNotificationConfigsProjectsLocationsReasoningEnginesRuntimeRevi
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<PushNotificationConfigsProjectsLocationsReasoningEnginesRuntimeRevisionsA2aV1TasksRequest>;
 
@@ -44151,7 +44154,7 @@ export const A2aGetReasoningEngineProjectsLocationsReasoningEnginesRuntimeRevisi
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<A2aGetReasoningEngineProjectsLocationsReasoningEnginesRuntimeRevisionsA2aV1TasksRequest>;
 
@@ -44192,7 +44195,7 @@ export const CancelProjectsLocationsReasoningEnginesRuntimeRevisionsA2aV1TasksRe
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:cancel",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:cancel",
       hasBody: true,
     }),
     svc,
@@ -44238,7 +44241,7 @@ export const A2aGetReasoningEngineProjectsLocationsReasoningEnginesRuntimeRevisi
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<A2aGetReasoningEngineProjectsLocationsReasoningEnginesRuntimeRevisionsA2aV1TasksPushNotificationConfigsRequest>;
 
@@ -44279,7 +44282,7 @@ export const SubscribeProjectsLocationsReasoningEnginesRuntimeRevisionsA2aTasksR
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:subscribe",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:subscribe",
     }),
     svc,
   ) as unknown as Schema.Schema<SubscribeProjectsLocationsReasoningEnginesRuntimeRevisionsA2aTasksRequest>;
@@ -44323,7 +44326,7 @@ export const PushNotificationConfigsProjectsLocationsReasoningEnginesRuntimeRevi
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<PushNotificationConfigsProjectsLocationsReasoningEnginesRuntimeRevisionsA2aTasksRequest>;
 
@@ -44367,7 +44370,7 @@ export const A2aGetReasoningEngineProjectsLocationsReasoningEnginesRuntimeRevisi
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<A2aGetReasoningEngineProjectsLocationsReasoningEnginesRuntimeRevisionsA2aTasksRequest>;
 
@@ -44408,7 +44411,7 @@ export const CancelProjectsLocationsReasoningEnginesRuntimeRevisionsA2aTasksRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:cancel",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:cancel",
       hasBody: true,
     }),
     svc,
@@ -44453,7 +44456,7 @@ export const A2aGetReasoningEngineProjectsLocationsReasoningEnginesRuntimeRevisi
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<A2aGetReasoningEngineProjectsLocationsReasoningEnginesRuntimeRevisionsA2aTasksPushNotificationConfigsRequest>;
 
@@ -44489,7 +44492,7 @@ export const GetProjectsLocationsReasoningEnginesRuntimeRevisionsOperationsReque
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesRuntimeRevisionsOperationsRequest>;
 
@@ -44523,7 +44526,7 @@ export const CancelProjectsLocationsReasoningEnginesRuntimeRevisionsOperationsRe
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsReasoningEnginesRuntimeRevisionsOperationsRequest>;
 
@@ -44572,7 +44575,7 @@ export const ListProjectsLocationsReasoningEnginesRuntimeRevisionsOperationsRequ
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesRuntimeRevisionsOperationsRequest>;
 
@@ -44610,7 +44613,7 @@ export const DeleteProjectsLocationsReasoningEnginesRuntimeRevisionsOperationsRe
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesRuntimeRevisionsOperationsRequest>;
 
@@ -44648,7 +44651,7 @@ export const WaitProjectsLocationsReasoningEnginesRuntimeRevisionsOperationsRequ
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsReasoningEnginesRuntimeRevisionsOperationsRequest>;
 
@@ -44693,7 +44696,7 @@ export const ListProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesReq
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/sandboxEnvironmentTemplates",
+      path: "v1beta1/{+parent}/sandboxEnvironmentTemplates",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesRequest>;
@@ -44740,7 +44743,7 @@ export const CreateProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesR
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/sandboxEnvironmentTemplates",
+      path: "v1beta1/{+parent}/sandboxEnvironmentTemplates",
       hasBody: true,
     }),
     svc,
@@ -44777,7 +44780,7 @@ export const DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesR
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesRequest>;
 
@@ -44812,7 +44815,7 @@ export const GetProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesRequ
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesRequest>;
 
@@ -44846,7 +44849,7 @@ export const GetProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesOper
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest>;
 
@@ -44881,7 +44884,7 @@ export const CancelProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesO
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest>;
 
@@ -44930,7 +44933,7 @@ export const ListProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesOpe
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest>;
 
@@ -44969,7 +44972,7 @@ export const DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesO
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest>;
 
@@ -45007,7 +45010,7 @@ export const WaitProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesOpe
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest>;
 
@@ -45042,7 +45045,7 @@ export const GetProjectsLocationsReasoningEnginesFeedbackEntriesOperationsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesFeedbackEntriesOperationsRequest>;
 
@@ -45075,7 +45078,7 @@ export const CancelProjectsLocationsReasoningEnginesFeedbackEntriesOperationsReq
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsReasoningEnginesFeedbackEntriesOperationsRequest>;
 
@@ -45124,7 +45127,7 @@ export const ListProjectsLocationsReasoningEnginesFeedbackEntriesOperationsReque
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesFeedbackEntriesOperationsRequest>;
 
@@ -45162,7 +45165,7 @@ export const DeleteProjectsLocationsReasoningEnginesFeedbackEntriesOperationsReq
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesFeedbackEntriesOperationsRequest>;
 
@@ -45200,7 +45203,7 @@ export const WaitProjectsLocationsReasoningEnginesFeedbackEntriesOperationsReque
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsReasoningEnginesFeedbackEntriesOperationsRequest>;
 
@@ -45242,7 +45245,7 @@ export const PatchProjectsLocationsReasoningEnginesSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsReasoningEnginesSessionsRequest>;
 
@@ -45274,7 +45277,7 @@ export const DeleteProjectsLocationsReasoningEnginesSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesSessionsRequest>;
 
@@ -45314,7 +45317,7 @@ export const AppendEventProjectsLocationsReasoningEnginesSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:appendEvent",
+      path: "v1beta1/{+name}:appendEvent",
       hasBody: true,
     }),
     svc,
@@ -45349,7 +45352,7 @@ export const GetProjectsLocationsReasoningEnginesSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesSessionsRequest>;
 
@@ -45393,7 +45396,7 @@ export const ListProjectsLocationsReasoningEnginesSessionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/sessions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/sessions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesSessionsRequest>;
 
@@ -45439,7 +45442,7 @@ export const CreateProjectsLocationsReasoningEnginesSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/sessions",
+      path: "v1beta1/{+parent}/sessions",
       hasBody: true,
     }),
     svc,
@@ -45474,7 +45477,7 @@ export const GetProjectsLocationsReasoningEnginesSessionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesSessionsOperationsRequest>;
 
@@ -45507,7 +45510,7 @@ export const CancelProjectsLocationsReasoningEnginesSessionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsReasoningEnginesSessionsOperationsRequest>;
 
@@ -45554,7 +45557,7 @@ export const ListProjectsLocationsReasoningEnginesSessionsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesSessionsOperationsRequest>;
 
@@ -45591,7 +45594,7 @@ export const DeleteProjectsLocationsReasoningEnginesSessionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesSessionsOperationsRequest>;
 
@@ -45627,7 +45630,7 @@ export const WaitProjectsLocationsReasoningEnginesSessionsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsReasoningEnginesSessionsOperationsRequest>;
 
@@ -45672,7 +45675,7 @@ export const ListProjectsLocationsReasoningEnginesSessionsEventsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/events" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/events" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesSessionsEventsRequest>;
 
@@ -45709,7 +45712,7 @@ export const DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsR
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsRequest>;
 
@@ -45755,7 +45758,7 @@ export const ListProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsReq
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/sandboxEnvironmentSnapshots",
+      path: "v1beta1/{+parent}/sandboxEnvironmentSnapshots",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsRequest>;
@@ -45795,7 +45798,7 @@ export const GetProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsRequ
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsRequest>;
 
@@ -45829,7 +45832,7 @@ export const DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsO
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest>;
 
@@ -45867,7 +45870,7 @@ export const WaitProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsOpe
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest>;
 
@@ -45902,7 +45905,7 @@ export const GetProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsOper
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest>;
 
@@ -45937,7 +45940,7 @@ export const CancelProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsO
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest>;
 
@@ -45986,7 +45989,7 @@ export const ListProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsOpe
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest>;
 
@@ -46025,7 +46028,7 @@ export const GetProjectsLocationsReasoningEnginesExamplesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesExamplesOperationsRequest>;
 
@@ -46058,7 +46061,7 @@ export const CancelProjectsLocationsReasoningEnginesExamplesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsReasoningEnginesExamplesOperationsRequest>;
 
@@ -46091,7 +46094,7 @@ export const DeleteProjectsLocationsReasoningEnginesExamplesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesExamplesOperationsRequest>;
 
@@ -46127,7 +46130,7 @@ export const WaitProjectsLocationsReasoningEnginesExamplesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsReasoningEnginesExamplesOperationsRequest>;
 
@@ -46160,7 +46163,7 @@ export const DeleteProjectsLocationsReasoningEnginesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesOperationsRequest>;
 
@@ -46196,7 +46199,7 @@ export const WaitProjectsLocationsReasoningEnginesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsReasoningEnginesOperationsRequest>;
 
@@ -46243,7 +46246,7 @@ export const ListProjectsLocationsReasoningEnginesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesOperationsRequest>;
 
@@ -46280,7 +46283,7 @@ export const GetProjectsLocationsReasoningEnginesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesOperationsRequest>;
 
@@ -46312,7 +46315,7 @@ export const CancelProjectsLocationsReasoningEnginesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsReasoningEnginesOperationsRequest>;
 
@@ -46345,7 +46348,7 @@ export const DeleteProjectsLocationsReasoningEnginesA2aTasksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesA2aTasksRequest>;
 
@@ -46385,7 +46388,7 @@ export const AppendEventsProjectsLocationsReasoningEnginesA2aTasksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:appendEvents",
+      path: "v1beta1/{+name}:appendEvents",
       hasBody: true,
     }),
     svc,
@@ -46430,7 +46433,7 @@ export const CreateProjectsLocationsReasoningEnginesA2aTasksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/a2aTasks",
+      path: "v1beta1/{+parent}/a2aTasks",
       hasBody: true,
     }),
     svc,
@@ -46477,7 +46480,7 @@ export const ListProjectsLocationsReasoningEnginesA2aTasksRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/a2aTasks" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/a2aTasks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesA2aTasksRequest>;
 
@@ -46513,7 +46516,7 @@ export const GetProjectsLocationsReasoningEnginesA2aTasksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesA2aTasksRequest>;
 
@@ -46557,7 +46560,7 @@ export const ListProjectsLocationsReasoningEnginesA2aTasksEventsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/events" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/events" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesA2aTasksEventsRequest>;
 
@@ -46594,7 +46597,7 @@ export const GetProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -46632,7 +46635,7 @@ export const ExecuteProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest 
       GoogleCloudAiplatformV1beta1ExecuteSandboxEnvironmentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:execute", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:execute", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -46674,7 +46677,7 @@ export const ListProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/sandboxEnvironments" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/sandboxEnvironments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -46716,7 +46719,7 @@ export const SnapshotProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest
       GoogleCloudAiplatformV1beta1SandboxEnvironmentSnapshot,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:snapshot", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:snapshot", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SnapshotProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -46756,7 +46759,7 @@ export const CreateProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/sandboxEnvironments",
+      path: "v1beta1/{+parent}/sandboxEnvironments",
       hasBody: true,
     }),
     svc,
@@ -46791,7 +46794,7 @@ export const DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -46824,7 +46827,7 @@ export const DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentsOperation
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReasoningEnginesSandboxEnvironmentsOperationsRequest>;
 
@@ -46862,7 +46865,7 @@ export const WaitProjectsLocationsReasoningEnginesSandboxEnvironmentsOperationsR
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsReasoningEnginesSandboxEnvironmentsOperationsRequest>;
 
@@ -46897,7 +46900,7 @@ export const GetProjectsLocationsReasoningEnginesSandboxEnvironmentsOperationsRe
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReasoningEnginesSandboxEnvironmentsOperationsRequest>;
 
@@ -46932,7 +46935,7 @@ export const CancelProjectsLocationsReasoningEnginesSandboxEnvironmentsOperation
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsReasoningEnginesSandboxEnvironmentsOperationsRequest>;
 
@@ -46981,7 +46984,7 @@ export const ListProjectsLocationsReasoningEnginesSandboxEnvironmentsOperationsR
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReasoningEnginesSandboxEnvironmentsOperationsRequest>;
 
@@ -47027,7 +47030,7 @@ export const ImportProjectsLocationsExtensionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/extensions:import",
+      path: "v1beta1/{+parent}/extensions:import",
       hasBody: true,
     }),
     svc,
@@ -47061,7 +47064,7 @@ export const GetProjectsLocationsExtensionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsExtensionsRequest>;
 
@@ -47098,7 +47101,7 @@ export const ExecuteProjectsLocationsExtensionsRequest =
       GoogleCloudAiplatformV1beta1ExecuteExtensionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:execute", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:execute", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteProjectsLocationsExtensionsRequest>;
 
@@ -47142,7 +47145,7 @@ export const ListProjectsLocationsExtensionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/extensions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/extensions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsExtensionsRequest>;
 
@@ -47183,7 +47186,7 @@ export const QueryProjectsLocationsExtensionsRequest =
       GoogleCloudAiplatformV1beta1QueryExtensionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryProjectsLocationsExtensionsRequest>;
 
@@ -47223,7 +47226,7 @@ export const PatchProjectsLocationsExtensionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsExtensionsRequest>;
 
@@ -47255,7 +47258,7 @@ export const DeleteProjectsLocationsExtensionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsExtensionsRequest>;
 
@@ -47301,7 +47304,7 @@ export const ListProjectsLocationsExtensionsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsExtensionsOperationsRequest>;
 
@@ -47337,7 +47340,7 @@ export const GetProjectsLocationsExtensionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsExtensionsOperationsRequest>;
 
@@ -47369,7 +47372,7 @@ export const CancelProjectsLocationsExtensionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsExtensionsOperationsRequest>;
 
@@ -47401,7 +47404,7 @@ export const DeleteProjectsLocationsExtensionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsExtensionsOperationsRequest>;
 
@@ -47436,7 +47439,7 @@ export const WaitProjectsLocationsExtensionsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsExtensionsOperationsRequest>;
 
@@ -47468,7 +47471,7 @@ export const DeleteProjectsLocationsDataLabelingJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataLabelingJobsRequest>;
 
@@ -47515,7 +47518,7 @@ export const ListProjectsLocationsDataLabelingJobsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dataLabelingJobs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/dataLabelingJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataLabelingJobsRequest>;
 
@@ -47558,7 +47561,7 @@ export const CreateProjectsLocationsDataLabelingJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/dataLabelingJobs",
+      path: "v1beta1/{+parent}/dataLabelingJobs",
       hasBody: true,
     }),
     svc,
@@ -47592,7 +47595,7 @@ export const GetProjectsLocationsDataLabelingJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataLabelingJobsRequest>;
 
@@ -47629,7 +47632,7 @@ export const CancelProjectsLocationsDataLabelingJobsRequest =
       GoogleCloudAiplatformV1beta1CancelDataLabelingJobRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDataLabelingJobsRequest>;
 
@@ -47675,7 +47678,7 @@ export const ListProjectsLocationsDataLabelingJobsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataLabelingJobsOperationsRequest>;
 
@@ -47712,7 +47715,7 @@ export const GetProjectsLocationsDataLabelingJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataLabelingJobsOperationsRequest>;
 
@@ -47744,7 +47747,7 @@ export const CancelProjectsLocationsDataLabelingJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDataLabelingJobsOperationsRequest>;
 
@@ -47777,7 +47780,7 @@ export const DeleteProjectsLocationsDataLabelingJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataLabelingJobsOperationsRequest>;
 
@@ -47813,7 +47816,7 @@ export const WaitProjectsLocationsDataLabelingJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsDataLabelingJobsOperationsRequest>;
 
@@ -47846,7 +47849,7 @@ export const GetProjectsLocationsEvaluationMetricsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEvaluationMetricsRequest>;
 
@@ -47890,7 +47893,7 @@ export const ListProjectsLocationsEvaluationMetricsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/evaluationMetrics" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/evaluationMetrics" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEvaluationMetricsRequest>;
 
@@ -47938,7 +47941,7 @@ export const CreateProjectsLocationsEvaluationMetricsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/evaluationMetrics",
+      path: "v1beta1/{+parent}/evaluationMetrics",
       hasBody: true,
     }),
     svc,
@@ -47972,7 +47975,7 @@ export const DeleteProjectsLocationsEvaluationMetricsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEvaluationMetricsRequest>;
 
@@ -48004,7 +48007,7 @@ export const GetProjectsLocationsEvaluationMetricsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEvaluationMetricsOperationsRequest>;
 
@@ -48037,7 +48040,7 @@ export const DeleteProjectsLocationsEvaluationMetricsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEvaluationMetricsOperationsRequest>;
 
@@ -48084,7 +48087,7 @@ export const ListProjectsLocationsEvaluationMetricsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEvaluationMetricsOperationsRequest>;
 
@@ -48128,7 +48131,7 @@ export const SearchProjectsLocationsMigratableResourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/migratableResources:search",
+      path: "v1beta1/{+parent}/migratableResources:search",
       hasBody: true,
     }),
     svc,
@@ -48169,7 +48172,7 @@ export const BatchMigrateProjectsLocationsMigratableResourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/migratableResources:batchMigrate",
+      path: "v1beta1/{+parent}/migratableResources:batchMigrate",
       hasBody: true,
     }),
     svc,
@@ -48204,7 +48207,7 @@ export const DeleteProjectsLocationsMigratableResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMigratableResourcesOperationsRequest>;
 
@@ -48240,7 +48243,7 @@ export const WaitProjectsLocationsMigratableResourcesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsMigratableResourcesOperationsRequest>;
 
@@ -48287,7 +48290,7 @@ export const ListProjectsLocationsMigratableResourcesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMigratableResourcesOperationsRequest>;
 
@@ -48324,7 +48327,7 @@ export const GetProjectsLocationsMigratableResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMigratableResourcesOperationsRequest>;
 
@@ -48357,7 +48360,7 @@ export const CancelProjectsLocationsMigratableResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsMigratableResourcesOperationsRequest>;
 
@@ -48390,7 +48393,7 @@ export const GetProjectsLocationsEvaluationTasksOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEvaluationTasksOperationsRequest>;
 
@@ -48422,7 +48425,7 @@ export const DeleteProjectsLocationsEvaluationTasksOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEvaluationTasksOperationsRequest>;
 
@@ -48458,7 +48461,7 @@ export const WaitProjectsLocationsEvaluationTasksOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsEvaluationTasksOperationsRequest>;
 
@@ -48504,7 +48507,7 @@ export const ListProjectsLocationsEvaluationTasksOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEvaluationTasksOperationsRequest>;
 
@@ -48548,7 +48551,7 @@ export const PatchProjectsLocationsOnlineEvaluatorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsOnlineEvaluatorsRequest>;
 
@@ -48580,7 +48583,7 @@ export const DeleteProjectsLocationsOnlineEvaluatorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOnlineEvaluatorsRequest>;
 
@@ -48617,7 +48620,7 @@ export const SuspendProjectsLocationsOnlineEvaluatorsRequest =
       GoogleCloudAiplatformV1beta1SuspendOnlineEvaluatorRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:suspend", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:suspend", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SuspendProjectsLocationsOnlineEvaluatorsRequest>;
 
@@ -48661,7 +48664,7 @@ export const ListProjectsLocationsOnlineEvaluatorsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/onlineEvaluators" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/onlineEvaluators" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOnlineEvaluatorsRequest>;
 
@@ -48702,7 +48705,7 @@ export const ActivateProjectsLocationsOnlineEvaluatorsRequest =
       GoogleCloudAiplatformV1beta1ActivateOnlineEvaluatorRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:activate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:activate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ActivateProjectsLocationsOnlineEvaluatorsRequest>;
 
@@ -48741,7 +48744,7 @@ export const CreateProjectsLocationsOnlineEvaluatorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/onlineEvaluators",
+      path: "v1beta1/{+parent}/onlineEvaluators",
       hasBody: true,
     }),
     svc,
@@ -48775,7 +48778,7 @@ export const GetProjectsLocationsOnlineEvaluatorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOnlineEvaluatorsRequest>;
 
@@ -48807,7 +48810,7 @@ export const DeleteProjectsLocationsOnlineEvaluatorsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOnlineEvaluatorsOperationsRequest>;
 
@@ -48843,7 +48846,7 @@ export const WaitProjectsLocationsOnlineEvaluatorsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsOnlineEvaluatorsOperationsRequest>;
 
@@ -48876,7 +48879,7 @@ export const GetProjectsLocationsOnlineEvaluatorsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOnlineEvaluatorsOperationsRequest>;
 
@@ -48908,7 +48911,7 @@ export const CancelProjectsLocationsOnlineEvaluatorsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOnlineEvaluatorsOperationsRequest>;
 
@@ -48955,7 +48958,7 @@ export const ListProjectsLocationsOnlineEvaluatorsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOnlineEvaluatorsOperationsRequest>;
 
@@ -48992,7 +48995,7 @@ export const DeleteProjectsLocationsAgentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsOperationsRequest>;
 
@@ -49027,7 +49030,7 @@ export const WaitProjectsLocationsAgentsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsAgentsOperationsRequest>;
 
@@ -49059,7 +49062,7 @@ export const GetProjectsLocationsAgentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsOperationsRequest>;
 
@@ -49091,7 +49094,7 @@ export const CancelProjectsLocationsAgentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsAgentsOperationsRequest>;
 
@@ -49137,7 +49140,7 @@ export const ListProjectsLocationsAgentsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsOperationsRequest>;
 
@@ -49180,7 +49183,7 @@ export const UpdateExplanationDatasetProjectsLocationsModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{model}:updateExplanationDataset",
+      path: "v1beta1/{+model}:updateExplanationDataset",
       hasBody: true,
     }),
     svc,
@@ -49221,7 +49224,7 @@ export const ListCheckpointsProjectsLocationsModelsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:listCheckpoints" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:listCheckpoints" }),
     svc,
   ) as unknown as Schema.Schema<ListCheckpointsProjectsLocationsModelsRequest>;
 
@@ -49269,7 +49272,7 @@ export const ListProjectsLocationsModelsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/models" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/models" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsModelsRequest>;
 
@@ -49305,7 +49308,7 @@ export const GetProjectsLocationsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsModelsRequest>;
 
@@ -49342,7 +49345,7 @@ export const SetIamPolicyProjectsLocationsModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -49390,7 +49393,7 @@ export const ListVersionsProjectsLocationsModelsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:listVersions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:listVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListVersionsProjectsLocationsModelsRequest>;
 
@@ -49433,7 +49436,7 @@ export const MergeVersionAliasesProjectsLocationsModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:mergeVersionAliases",
+      path: "v1beta1/{+name}:mergeVersionAliases",
       hasBody: true,
     }),
     svc,
@@ -49467,7 +49470,7 @@ export const DeleteProjectsLocationsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsModelsRequest>;
 
@@ -49505,7 +49508,7 @@ export const CopyProjectsLocationsModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/models:copy",
+      path: "v1beta1/{+parent}/models:copy",
       hasBody: true,
     }),
     svc,
@@ -49543,7 +49546,7 @@ export const ExportProjectsLocationsModelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsModelsRequest>;
 
@@ -49574,7 +49577,7 @@ export const DeleteVersionProjectsLocationsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}:deleteVersion" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}:deleteVersion" }),
     svc,
   ) as unknown as Schema.Schema<DeleteVersionProjectsLocationsModelsRequest>;
 
@@ -49613,7 +49616,7 @@ export const GetIamPolicyProjectsLocationsModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -49652,7 +49655,7 @@ export const PatchProjectsLocationsModelsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudAiplatformV1beta1Model).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsModelsRequest>;
 
@@ -49691,7 +49694,7 @@ export const TestIamPermissionsProjectsLocationsModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -49732,7 +49735,7 @@ export const UploadProjectsLocationsModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/models:upload",
+      path: "v1beta1/{+parent}/models:upload",
       hasBody: true,
     }),
     svc,
@@ -49765,7 +49768,7 @@ export const GetProjectsLocationsModelsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsModelsOperationsRequest>;
 
@@ -49797,7 +49800,7 @@ export const CancelProjectsLocationsModelsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsModelsOperationsRequest>;
 
@@ -49843,7 +49846,7 @@ export const ListProjectsLocationsModelsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsModelsOperationsRequest>;
 
@@ -49879,7 +49882,7 @@ export const DeleteProjectsLocationsModelsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsModelsOperationsRequest>;
 
@@ -49914,7 +49917,7 @@ export const WaitProjectsLocationsModelsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsModelsOperationsRequest>;
 
@@ -49958,7 +49961,7 @@ export const ListProjectsLocationsModelsEvaluationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/evaluations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/evaluations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsModelsEvaluationsRequest>;
 
@@ -49994,7 +49997,7 @@ export const GetProjectsLocationsModelsEvaluationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsModelsEvaluationsRequest>;
 
@@ -50033,7 +50036,7 @@ export const ImportProjectsLocationsModelsEvaluationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/evaluations:import",
+      path: "v1beta1/{+parent}/evaluations:import",
       hasBody: true,
     }),
     svc,
@@ -50081,7 +50084,7 @@ export const ListProjectsLocationsModelsEvaluationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsModelsEvaluationsOperationsRequest>;
 
@@ -50118,7 +50121,7 @@ export const GetProjectsLocationsModelsEvaluationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsModelsEvaluationsOperationsRequest>;
 
@@ -50151,7 +50154,7 @@ export const CancelProjectsLocationsModelsEvaluationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsModelsEvaluationsOperationsRequest>;
 
@@ -50184,7 +50187,7 @@ export const DeleteProjectsLocationsModelsEvaluationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsModelsEvaluationsOperationsRequest>;
 
@@ -50220,7 +50223,7 @@ export const WaitProjectsLocationsModelsEvaluationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsModelsEvaluationsOperationsRequest>;
 
@@ -50265,7 +50268,7 @@ export const ListProjectsLocationsModelsEvaluationsSlicesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/slices" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/slices" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsModelsEvaluationsSlicesRequest>;
 
@@ -50308,7 +50311,7 @@ export const BatchImportProjectsLocationsModelsEvaluationsSlicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:batchImport",
+      path: "v1beta1/{+parent}:batchImport",
       hasBody: true,
     }),
     svc,
@@ -50343,7 +50346,7 @@ export const GetProjectsLocationsModelsEvaluationsSlicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsModelsEvaluationsSlicesRequest>;
 
@@ -50375,7 +50378,7 @@ export const DeleteProjectsLocationsCustomJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCustomJobsRequest>;
 
@@ -50419,7 +50422,7 @@ export const ListProjectsLocationsCustomJobsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/customJobs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/customJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCustomJobsRequest>;
 
@@ -50462,7 +50465,7 @@ export const CreateProjectsLocationsCustomJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/customJobs",
+      path: "v1beta1/{+parent}/customJobs",
       hasBody: true,
     }),
     svc,
@@ -50496,7 +50499,7 @@ export const GetProjectsLocationsCustomJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCustomJobsRequest>;
 
@@ -50533,7 +50536,7 @@ export const CancelProjectsLocationsCustomJobsRequest =
       GoogleCloudAiplatformV1beta1CancelCustomJobRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsCustomJobsRequest>;
 
@@ -50578,7 +50581,7 @@ export const ListProjectsLocationsCustomJobsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCustomJobsOperationsRequest>;
 
@@ -50614,7 +50617,7 @@ export const GetProjectsLocationsCustomJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCustomJobsOperationsRequest>;
 
@@ -50646,7 +50649,7 @@ export const CancelProjectsLocationsCustomJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsCustomJobsOperationsRequest>;
 
@@ -50678,7 +50681,7 @@ export const DeleteProjectsLocationsCustomJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCustomJobsOperationsRequest>;
 
@@ -50713,7 +50716,7 @@ export const WaitProjectsLocationsCustomJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsCustomJobsOperationsRequest>;
 
@@ -50745,7 +50748,7 @@ export const GetProjectsLocationsSemanticGovernancePoliciesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSemanticGovernancePoliciesOperationsRequest>;
 
@@ -50778,7 +50781,7 @@ export const CancelProjectsLocationsSemanticGovernancePoliciesOperationsRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsSemanticGovernancePoliciesOperationsRequest>;
 
@@ -50825,7 +50828,7 @@ export const ListProjectsLocationsSemanticGovernancePoliciesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSemanticGovernancePoliciesOperationsRequest>;
 
@@ -50862,7 +50865,7 @@ export const DeleteProjectsLocationsSemanticGovernancePoliciesOperationsRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSemanticGovernancePoliciesOperationsRequest>;
 
@@ -50898,7 +50901,7 @@ export const WaitProjectsLocationsSemanticGovernancePoliciesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsSemanticGovernancePoliciesOperationsRequest>;
 
@@ -50931,7 +50934,7 @@ export const DeleteProjectsLocationsSolversOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSolversOperationsRequest>;
 
@@ -50977,7 +50980,7 @@ export const ListProjectsLocationsSolversOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSolversOperationsRequest>;
 
@@ -51013,7 +51016,7 @@ export const GetProjectsLocationsSolversOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSolversOperationsRequest>;
 
@@ -51045,7 +51048,7 @@ export const DeleteProjectsLocationsCachedContentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCachedContentsRequest>;
 
@@ -51084,7 +51087,7 @@ export const PatchProjectsLocationsCachedContentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCachedContentsRequest>;
 
@@ -51116,7 +51119,7 @@ export const GetProjectsLocationsCachedContentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCachedContentsRequest>;
 
@@ -51155,7 +51158,7 @@ export const CreateProjectsLocationsCachedContentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/cachedContents",
+      path: "v1beta1/{+parent}/cachedContents",
       hasBody: true,
     }),
     svc,
@@ -51195,7 +51198,7 @@ export const ListProjectsLocationsCachedContentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/cachedContents" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/cachedContents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCachedContentsRequest>;
 
@@ -51237,7 +51240,7 @@ export const PatchProjectsLocationsIndexesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudAiplatformV1beta1Index).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsIndexesRequest>;
 
@@ -51268,7 +51271,7 @@ export const DeleteProjectsLocationsIndexesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsIndexesRequest>;
 
@@ -51306,7 +51309,7 @@ export const RemoveDatapointsProjectsLocationsIndexesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{index}:removeDatapoints",
+      path: "v1beta1/{+index}:removeDatapoints",
       hasBody: true,
     }),
     svc,
@@ -51352,7 +51355,7 @@ export const ListProjectsLocationsIndexesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/indexes" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/indexes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIndexesRequest>;
 
@@ -51391,7 +51394,11 @@ export const CreateProjectsLocationsIndexesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudAiplatformV1beta1Index).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/indexes", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/indexes",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsIndexesRequest>;
 
@@ -51427,7 +51434,7 @@ export const ImportProjectsLocationsIndexesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:import", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:import", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsLocationsIndexesRequest>;
 
@@ -51465,7 +51472,7 @@ export const UpsertDatapointsProjectsLocationsIndexesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{index}:upsertDatapoints",
+      path: "v1beta1/{+index}:upsertDatapoints",
       hasBody: true,
     }),
     svc,
@@ -51499,7 +51506,7 @@ export const GetProjectsLocationsIndexesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIndexesRequest>;
 
@@ -51531,7 +51538,7 @@ export const DeleteProjectsLocationsIndexesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsIndexesOperationsRequest>;
 
@@ -51566,7 +51573,7 @@ export const WaitProjectsLocationsIndexesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsIndexesOperationsRequest>;
 
@@ -51598,7 +51605,7 @@ export const GetProjectsLocationsIndexesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIndexesOperationsRequest>;
 
@@ -51630,7 +51637,7 @@ export const CancelProjectsLocationsIndexesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsIndexesOperationsRequest>;
 
@@ -51676,7 +51683,7 @@ export const ListProjectsLocationsIndexesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIndexesOperationsRequest>;
 
@@ -51712,7 +51719,7 @@ export const DeleteProjectsLocationsNotebookRuntimeTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNotebookRuntimeTemplatesRequest>;
 
@@ -51753,7 +51760,7 @@ export const PatchProjectsLocationsNotebookRuntimeTemplatesRequest =
       GoogleCloudAiplatformV1beta1NotebookRuntimeTemplate,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsNotebookRuntimeTemplatesRequest>;
 
@@ -51792,7 +51799,7 @@ export const TestIamPermissionsProjectsLocationsNotebookRuntimeTemplatesRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -51839,7 +51846,7 @@ export const CreateProjectsLocationsNotebookRuntimeTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/notebookRuntimeTemplates",
+      path: "v1beta1/{+parent}/notebookRuntimeTemplates",
       hasBody: true,
     }),
     svc,
@@ -51879,7 +51886,7 @@ export const SetIamPolicyProjectsLocationsNotebookRuntimeTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -51931,7 +51938,7 @@ export const ListProjectsLocationsNotebookRuntimeTemplatesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/notebookRuntimeTemplates",
+      path: "v1beta1/{+parent}/notebookRuntimeTemplates",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNotebookRuntimeTemplatesRequest>;
@@ -51968,7 +51975,7 @@ export const GetProjectsLocationsNotebookRuntimeTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNotebookRuntimeTemplatesRequest>;
 
@@ -52007,7 +52014,7 @@ export const GetIamPolicyProjectsLocationsNotebookRuntimeTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -52042,7 +52049,7 @@ export const GetProjectsLocationsNotebookRuntimeTemplatesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -52075,7 +52082,7 @@ export const CancelProjectsLocationsNotebookRuntimeTemplatesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -52122,7 +52129,7 @@ export const ListProjectsLocationsNotebookRuntimeTemplatesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -52159,7 +52166,7 @@ export const DeleteProjectsLocationsNotebookRuntimeTemplatesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -52195,7 +52202,7 @@ export const WaitProjectsLocationsNotebookRuntimeTemplatesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -52228,7 +52235,7 @@ export const GetProjectsLocationsDeploymentResourcePoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeploymentResourcePoolsRequest>;
 
@@ -52266,7 +52273,10 @@ export const ListProjectsLocationsDeploymentResourcePoolsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/deploymentResourcePools" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/deploymentResourcePools",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeploymentResourcePoolsRequest>;
 
@@ -52309,7 +52319,7 @@ export const CreateProjectsLocationsDeploymentResourcePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/deploymentResourcePools",
+      path: "v1beta1/{+parent}/deploymentResourcePools",
       hasBody: true,
     }),
     svc,
@@ -52351,7 +52361,7 @@ export const PatchProjectsLocationsDeploymentResourcePoolsRequest =
       GoogleCloudAiplatformV1beta1DeploymentResourcePool,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDeploymentResourcePoolsRequest>;
 
@@ -52383,7 +52393,7 @@ export const DeleteProjectsLocationsDeploymentResourcePoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDeploymentResourcePoolsRequest>;
 
@@ -52425,7 +52435,7 @@ export const QueryDeployedModelsProjectsLocationsDeploymentResourcePoolsRequest 
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{deploymentResourcePool}:queryDeployedModels",
+      path: "v1beta1/{+deploymentResourcePool}:queryDeployedModels",
     }),
     svc,
   ) as unknown as Schema.Schema<QueryDeployedModelsProjectsLocationsDeploymentResourcePoolsRequest>;
@@ -52463,7 +52473,7 @@ export const GetProjectsLocationsDeploymentResourcePoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeploymentResourcePoolsOperationsRequest>;
 
@@ -52496,7 +52506,7 @@ export const CancelProjectsLocationsDeploymentResourcePoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDeploymentResourcePoolsOperationsRequest>;
 
@@ -52543,7 +52553,7 @@ export const ListProjectsLocationsDeploymentResourcePoolsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeploymentResourcePoolsOperationsRequest>;
 
@@ -52580,7 +52590,7 @@ export const DeleteProjectsLocationsDeploymentResourcePoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDeploymentResourcePoolsOperationsRequest>;
 
@@ -52616,7 +52626,7 @@ export const WaitProjectsLocationsDeploymentResourcePoolsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsDeploymentResourcePoolsOperationsRequest>;
 
@@ -52649,7 +52659,7 @@ export const DeleteProjectsLocationsRagEngineConfigOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRagEngineConfigOperationsRequest>;
 
@@ -52685,7 +52695,7 @@ export const WaitProjectsLocationsRagEngineConfigOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsRagEngineConfigOperationsRequest>;
 
@@ -52731,7 +52741,7 @@ export const ListProjectsLocationsRagEngineConfigOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRagEngineConfigOperationsRequest>;
 
@@ -52767,7 +52777,7 @@ export const GetProjectsLocationsRagEngineConfigOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRagEngineConfigOperationsRequest>;
 
@@ -52799,7 +52809,7 @@ export const CancelProjectsLocationsRagEngineConfigOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsRagEngineConfigOperationsRequest>;
 
@@ -52832,7 +52842,7 @@ export const DeleteProjectsLocationsNasJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNasJobsRequest>;
 
@@ -52863,7 +52873,7 @@ export const GetProjectsLocationsNasJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNasJobsRequest>;
 
@@ -52900,7 +52910,7 @@ export const CancelProjectsLocationsNasJobsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsNasJobsRequest>;
 
@@ -52943,7 +52953,7 @@ export const ListProjectsLocationsNasJobsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/nasJobs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/nasJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNasJobsRequest>;
 
@@ -52984,7 +52994,11 @@ export const CreateProjectsLocationsNasJobsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/nasJobs", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/nasJobs",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsNasJobsRequest>;
 
@@ -53016,7 +53030,7 @@ export const GetProjectsLocationsNasJobsNasTrialDetailsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNasJobsNasTrialDetailsRequest>;
 
@@ -53054,7 +53068,7 @@ export const ListProjectsLocationsNasJobsNasTrialDetailsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/nasTrialDetails" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/nasTrialDetails" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNasJobsNasTrialDetailsRequest>;
 
@@ -53097,7 +53111,7 @@ export const GetIamPolicyProjectsLocationsFeatureGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -53131,7 +53145,7 @@ export const GetProjectsLocationsFeatureGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureGroupsRequest>;
 
@@ -53168,7 +53182,7 @@ export const SetIamPolicyProjectsLocationsFeatureGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -53214,7 +53228,7 @@ export const ListProjectsLocationsFeatureGroupsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/featureGroups" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/featureGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeatureGroupsRequest>;
 
@@ -53257,7 +53271,7 @@ export const TestIamPermissionsProjectsLocationsFeatureGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -53304,7 +53318,7 @@ export const CreateProjectsLocationsFeatureGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/featureGroups",
+      path: "v1beta1/{+parent}/featureGroups",
       hasBody: true,
     }),
     svc,
@@ -53346,7 +53360,7 @@ export const PatchProjectsLocationsFeatureGroupsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFeatureGroupsRequest>;
 
@@ -53381,7 +53395,7 @@ export const DeleteProjectsLocationsFeatureGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeatureGroupsRequest>;
 
@@ -53421,7 +53435,7 @@ export const PatchProjectsLocationsFeatureGroupsFeatureMonitorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFeatureGroupsFeatureMonitorsRequest>;
 
@@ -53454,7 +53468,7 @@ export const DeleteProjectsLocationsFeatureGroupsFeatureMonitorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeatureGroupsFeatureMonitorsRequest>;
 
@@ -53499,7 +53513,7 @@ export const ListProjectsLocationsFeatureGroupsFeatureMonitorsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/featureMonitors" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/featureMonitors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeatureGroupsFeatureMonitorsRequest>;
 
@@ -53548,7 +53562,7 @@ export const CreateProjectsLocationsFeatureGroupsFeatureMonitorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/featureMonitors",
+      path: "v1beta1/{+parent}/featureMonitors",
       hasBody: true,
     }),
     svc,
@@ -53583,7 +53597,7 @@ export const GetProjectsLocationsFeatureGroupsFeatureMonitorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureGroupsFeatureMonitorsRequest>;
 
@@ -53630,7 +53644,7 @@ export const ListProjectsLocationsFeatureGroupsFeatureMonitorsOperationsRequest 
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeatureGroupsFeatureMonitorsOperationsRequest>;
 
@@ -53667,7 +53681,7 @@ export const DeleteProjectsLocationsFeatureGroupsFeatureMonitorsOperationsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeatureGroupsFeatureMonitorsOperationsRequest>;
 
@@ -53703,7 +53717,7 @@ export const WaitProjectsLocationsFeatureGroupsFeatureMonitorsOperationsRequest 
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsFeatureGroupsFeatureMonitorsOperationsRequest>;
 
@@ -53736,7 +53750,7 @@ export const GetProjectsLocationsFeatureGroupsFeatureMonitorsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureGroupsFeatureMonitorsOperationsRequest>;
 
@@ -53781,7 +53795,7 @@ export const CreateProjectsLocationsFeatureGroupsFeatureMonitorsFeatureMonitorJo
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/featureMonitorJobs",
+      path: "v1beta1/{+parent}/featureMonitorJobs",
       hasBody: true,
     }),
     svc,
@@ -53830,7 +53844,7 @@ export const ListProjectsLocationsFeatureGroupsFeatureMonitorsFeatureMonitorJobs
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/featureMonitorJobs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/featureMonitorJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeatureGroupsFeatureMonitorsFeatureMonitorJobsRequest>;
 
@@ -53869,7 +53883,7 @@ export const GetProjectsLocationsFeatureGroupsFeatureMonitorsFeatureMonitorJobsR
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureGroupsFeatureMonitorsFeatureMonitorJobsRequest>;
 
@@ -53904,7 +53918,7 @@ export const DeleteProjectsLocationsFeatureGroupsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeatureGroupsOperationsRequest>;
 
@@ -53939,7 +53953,7 @@ export const WaitProjectsLocationsFeatureGroupsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsFeatureGroupsOperationsRequest>;
 
@@ -53985,7 +53999,7 @@ export const ListProjectsLocationsFeatureGroupsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeatureGroupsOperationsRequest>;
 
@@ -54021,7 +54035,7 @@ export const GetProjectsLocationsFeatureGroupsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureGroupsOperationsRequest>;
 
@@ -54053,7 +54067,7 @@ export const DeleteProjectsLocationsFeatureGroupsFeaturesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeatureGroupsFeaturesRequest>;
 
@@ -54093,7 +54107,7 @@ export const PatchProjectsLocationsFeatureGroupsFeaturesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFeatureGroupsFeaturesRequest>;
 
@@ -54132,7 +54146,7 @@ export const BatchCreateProjectsLocationsFeatureGroupsFeaturesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/features:batchCreate",
+      path: "v1beta1/{+parent}/features:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -54182,7 +54196,7 @@ export const GetProjectsLocationsFeatureGroupsFeaturesRequest =
       Schema.Number,
     ).pipe(T.HttpQuery("featureStatsAndAnomalySpec.latestStatsCount")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureGroupsFeaturesRequest>;
 
@@ -54224,7 +54238,7 @@ export const CreateProjectsLocationsFeatureGroupsFeaturesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/features",
+      path: "v1beta1/{+parent}/features",
       hasBody: true,
     }),
     svc,
@@ -54278,7 +54292,7 @@ export const ListProjectsLocationsFeatureGroupsFeaturesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/features" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/features" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeatureGroupsFeaturesRequest>;
 
@@ -54328,7 +54342,7 @@ export const ListProjectsLocationsFeatureGroupsFeaturesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeatureGroupsFeaturesOperationsRequest>;
 
@@ -54365,7 +54379,7 @@ export const DeleteProjectsLocationsFeatureGroupsFeaturesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeatureGroupsFeaturesOperationsRequest>;
 
@@ -54401,7 +54415,7 @@ export const WaitProjectsLocationsFeatureGroupsFeaturesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsFeatureGroupsFeaturesOperationsRequest>;
 
@@ -54434,7 +54448,7 @@ export const GetProjectsLocationsFeatureGroupsFeaturesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeatureGroupsFeaturesOperationsRequest>;
 
@@ -54474,7 +54488,7 @@ export const CreateProjectsLocationsEvaluationSetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/evaluationSets",
+      path: "v1beta1/{+parent}/evaluationSets",
       hasBody: true,
     }),
     svc,
@@ -54520,7 +54534,7 @@ export const ListProjectsLocationsEvaluationSetsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/evaluationSets" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/evaluationSets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEvaluationSetsRequest>;
 
@@ -54556,7 +54570,7 @@ export const GetProjectsLocationsEvaluationSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEvaluationSetsRequest>;
 
@@ -54588,7 +54602,7 @@ export const DeleteProjectsLocationsEvaluationSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEvaluationSetsRequest>;
 
@@ -54628,7 +54642,7 @@ export const PatchProjectsLocationsEvaluationSetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEvaluationSetsRequest>;
 
@@ -54660,7 +54674,7 @@ export const GetProjectsLocationsEvaluationSetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEvaluationSetsOperationsRequest>;
 
@@ -54706,7 +54720,7 @@ export const ListProjectsLocationsEvaluationSetsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEvaluationSetsOperationsRequest>;
 
@@ -54742,7 +54756,7 @@ export const DeleteProjectsLocationsEvaluationSetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEvaluationSetsOperationsRequest>;
 
@@ -54778,7 +54792,7 @@ export const WaitProjectsLocationsEvaluationSetsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsEvaluationSetsOperationsRequest>;
 
@@ -54810,7 +54824,7 @@ export const DeleteProjectsLocationsStudiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsStudiesRequest>;
 
@@ -54848,7 +54862,7 @@ export const LookupProjectsLocationsStudiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/studies:lookup",
+      path: "v1beta1/{+parent}/studies:lookup",
       hasBody: true,
     }),
     svc,
@@ -54885,7 +54899,11 @@ export const CreateProjectsLocationsStudiesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudAiplatformV1beta1Study).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/studies", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/studies",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsStudiesRequest>;
 
@@ -54923,7 +54941,7 @@ export const ListProjectsLocationsStudiesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/studies" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/studies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsStudiesRequest>;
 
@@ -54959,7 +54977,7 @@ export const GetProjectsLocationsStudiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsStudiesRequest>;
 
@@ -54998,7 +55016,7 @@ export const ListOptimalTrialsProjectsLocationsStudiesTrialsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/trials:listOptimalTrials",
+      path: "v1beta1/{+parent}/trials:listOptimalTrials",
       hasBody: true,
     }),
     svc,
@@ -55038,7 +55056,7 @@ export const CompleteProjectsLocationsStudiesTrialsRequest =
       GoogleCloudAiplatformV1beta1CompleteTrialRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:complete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:complete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CompleteProjectsLocationsStudiesTrialsRequest>;
 
@@ -55075,7 +55093,7 @@ export const StopProjectsLocationsStudiesTrialsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsStudiesTrialsRequest>;
 
@@ -55107,7 +55125,7 @@ export const DeleteProjectsLocationsStudiesTrialsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsStudiesTrialsRequest>;
 
@@ -55145,7 +55163,7 @@ export const SuggestProjectsLocationsStudiesTrialsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/trials:suggest",
+      path: "v1beta1/{+parent}/trials:suggest",
       hasBody: true,
     }),
     svc,
@@ -55185,7 +55203,7 @@ export const ListProjectsLocationsStudiesTrialsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/trials" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/trials" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsStudiesTrialsRequest>;
 
@@ -55228,7 +55246,7 @@ export const AddTrialMeasurementProjectsLocationsStudiesTrialsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{trialName}:addTrialMeasurement",
+      path: "v1beta1/{+trialName}:addTrialMeasurement",
       hasBody: true,
     }),
     svc,
@@ -55266,7 +55284,7 @@ export const CreateProjectsLocationsStudiesTrialsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudAiplatformV1beta1Trial).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/trials", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+parent}/trials", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsStudiesTrialsRequest>;
 
@@ -55305,7 +55323,7 @@ export const CheckTrialEarlyStoppingStateProjectsLocationsStudiesTrialsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{trialName}:checkTrialEarlyStoppingState",
+      path: "v1beta1/{+trialName}:checkTrialEarlyStoppingState",
       hasBody: true,
     }),
     svc,
@@ -55340,7 +55358,7 @@ export const GetProjectsLocationsStudiesTrialsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsStudiesTrialsRequest>;
 
@@ -55372,7 +55390,7 @@ export const DeleteProjectsLocationsStudiesTrialsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsStudiesTrialsOperationsRequest>;
 
@@ -55407,7 +55425,7 @@ export const WaitProjectsLocationsStudiesTrialsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsStudiesTrialsOperationsRequest>;
 
@@ -55439,7 +55457,7 @@ export const GetProjectsLocationsStudiesTrialsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsStudiesTrialsOperationsRequest>;
 
@@ -55471,7 +55489,7 @@ export const CancelProjectsLocationsStudiesTrialsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsStudiesTrialsOperationsRequest>;
 
@@ -55517,7 +55535,7 @@ export const ListProjectsLocationsStudiesTrialsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsStudiesTrialsOperationsRequest>;
 
@@ -55567,7 +55585,7 @@ export const ListProjectsLocationsStudiesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsStudiesOperationsRequest>;
 
@@ -55603,7 +55621,7 @@ export const GetProjectsLocationsStudiesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsStudiesOperationsRequest>;
 
@@ -55635,7 +55653,7 @@ export const CancelProjectsLocationsStudiesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsStudiesOperationsRequest>;
 
@@ -55667,7 +55685,7 @@ export const DeleteProjectsLocationsStudiesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsStudiesOperationsRequest>;
 
@@ -55702,7 +55720,7 @@ export const WaitProjectsLocationsStudiesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsStudiesOperationsRequest>;
 
@@ -55746,7 +55764,7 @@ export const ListProjectsLocationsEvaluationItemsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/evaluationItems" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/evaluationItems" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEvaluationItemsRequest>;
 
@@ -55789,7 +55807,7 @@ export const CreateProjectsLocationsEvaluationItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/evaluationItems",
+      path: "v1beta1/{+parent}/evaluationItems",
       hasBody: true,
     }),
     svc,
@@ -55823,7 +55841,7 @@ export const DeleteProjectsLocationsEvaluationItemsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEvaluationItemsRequest>;
 
@@ -55855,7 +55873,7 @@ export const GetProjectsLocationsEvaluationItemsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEvaluationItemsRequest>;
 
@@ -55901,7 +55919,7 @@ export const ListProjectsLocationsEvaluationItemsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEvaluationItemsOperationsRequest>;
 
@@ -55937,7 +55955,7 @@ export const DeleteProjectsLocationsEvaluationItemsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEvaluationItemsOperationsRequest>;
 
@@ -55973,7 +55991,7 @@ export const WaitProjectsLocationsEvaluationItemsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsEvaluationItemsOperationsRequest>;
 
@@ -56005,7 +56023,7 @@ export const GetProjectsLocationsEvaluationItemsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEvaluationItemsOperationsRequest>;
 
@@ -56051,7 +56069,7 @@ export const ListProjectsLocationsExtensionControllersOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsExtensionControllersOperationsRequest>;
 
@@ -56088,7 +56106,7 @@ export const GetProjectsLocationsExtensionControllersOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsExtensionControllersOperationsRequest>;
 
@@ -56121,7 +56139,7 @@ export const CancelProjectsLocationsExtensionControllersOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsExtensionControllersOperationsRequest>;
 
@@ -56154,7 +56172,7 @@ export const DeleteProjectsLocationsExtensionControllersOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsExtensionControllersOperationsRequest>;
 
@@ -56190,7 +56208,7 @@ export const WaitProjectsLocationsExtensionControllersOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsExtensionControllersOperationsRequest>;
 
@@ -56230,7 +56248,7 @@ export const RebaseTunedModelProjectsLocationsTuningJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/tuningJobs:rebaseTunedModel",
+      path: "v1beta1/{+parent}/tuningJobs:rebaseTunedModel",
       hasBody: true,
     }),
     svc,
@@ -56271,7 +56289,7 @@ export const OptimizePromptProjectsLocationsTuningJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/tuningJobs:optimizePrompt",
+      path: "v1beta1/{+parent}/tuningJobs:optimizePrompt",
       hasBody: true,
     }),
     svc,
@@ -56305,7 +56323,7 @@ export const GetProjectsLocationsTuningJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTuningJobsRequest>;
 
@@ -56342,7 +56360,7 @@ export const CancelProjectsLocationsTuningJobsRequest =
       GoogleCloudAiplatformV1beta1CancelTuningJobRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsTuningJobsRequest>;
 
@@ -56382,7 +56400,7 @@ export const ListProjectsLocationsTuningJobsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/tuningJobs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/tuningJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTuningJobsRequest>;
 
@@ -56425,7 +56443,7 @@ export const CreateProjectsLocationsTuningJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/tuningJobs",
+      path: "v1beta1/{+parent}/tuningJobs",
       hasBody: true,
     }),
     svc,
@@ -56459,7 +56477,7 @@ export const DeleteProjectsLocationsTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTuningJobsOperationsRequest>;
 
@@ -56491,7 +56509,7 @@ export const GetProjectsLocationsNotebookRuntimesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNotebookRuntimesRequest>;
 
@@ -56528,7 +56546,7 @@ export const StartProjectsLocationsNotebookRuntimesRequest =
       GoogleCloudAiplatformV1beta1StartNotebookRuntimeRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsLocationsNotebookRuntimesRequest>;
 
@@ -56565,7 +56583,7 @@ export const UpgradeProjectsLocationsNotebookRuntimesRequest =
       GoogleCloudAiplatformV1beta1UpgradeNotebookRuntimeRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:upgrade", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:upgrade", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpgradeProjectsLocationsNotebookRuntimesRequest>;
 
@@ -56612,7 +56630,7 @@ export const ListProjectsLocationsNotebookRuntimesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/notebookRuntimes" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/notebookRuntimes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNotebookRuntimesRequest>;
 
@@ -56655,7 +56673,7 @@ export const AssignProjectsLocationsNotebookRuntimesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/notebookRuntimes:assign",
+      path: "v1beta1/{+parent}/notebookRuntimes:assign",
       hasBody: true,
     }),
     svc,
@@ -56689,7 +56707,7 @@ export const DeleteProjectsLocationsNotebookRuntimesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNotebookRuntimesRequest>;
 
@@ -56726,7 +56744,7 @@ export const StopProjectsLocationsNotebookRuntimesRequest =
       GoogleCloudAiplatformV1beta1StopNotebookRuntimeRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsNotebookRuntimesRequest>;
 
@@ -56765,7 +56783,7 @@ export const ReportEventProjectsLocationsNotebookRuntimesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:reportEvent",
+      path: "v1beta1/{+name}:reportEvent",
       hasBody: true,
     }),
     svc,
@@ -56805,7 +56823,7 @@ export const GenerateAccessTokenProjectsLocationsNotebookRuntimesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:generateAccessToken",
+      path: "v1beta1/{+name}:generateAccessToken",
       hasBody: true,
     }),
     svc,
@@ -56840,7 +56858,7 @@ export const GetProjectsLocationsNotebookRuntimesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNotebookRuntimesOperationsRequest>;
 
@@ -56872,7 +56890,7 @@ export const CancelProjectsLocationsNotebookRuntimesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsNotebookRuntimesOperationsRequest>;
 
@@ -56919,7 +56937,7 @@ export const ListProjectsLocationsNotebookRuntimesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNotebookRuntimesOperationsRequest>;
 
@@ -56956,7 +56974,7 @@ export const DeleteProjectsLocationsNotebookRuntimesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNotebookRuntimesOperationsRequest>;
 
@@ -56992,7 +57010,7 @@ export const WaitProjectsLocationsNotebookRuntimesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsNotebookRuntimesOperationsRequest>;
 
@@ -57032,7 +57050,7 @@ export const TestIamPermissionsProjectsLocationsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -57074,7 +57092,7 @@ export const PatchProjectsLocationsDatasetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsRequest>;
 
@@ -57111,7 +57129,7 @@ export const AssembleProjectsLocationsDatasetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:assemble", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:assemble", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AssembleProjectsLocationsDatasetsRequest>;
 
@@ -57148,7 +57166,7 @@ export const AssessProjectsLocationsDatasetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:assess", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:assess", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AssessProjectsLocationsDatasetsRequest>;
 
@@ -57187,7 +57205,7 @@ export const GetIamPolicyProjectsLocationsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -57225,7 +57243,7 @@ export const ImportProjectsLocationsDatasetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:import", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:import", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsLocationsDatasetsRequest>;
 
@@ -57257,7 +57275,7 @@ export const DeleteProjectsLocationsDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsRequest>;
 
@@ -57294,7 +57312,7 @@ export const ExportProjectsLocationsDatasetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsDatasetsRequest>;
 
@@ -57331,7 +57349,7 @@ export const SetIamPolicyProjectsLocationsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -57379,7 +57397,7 @@ export const ListProjectsLocationsDatasetsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/datasets" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/datasets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsRequest>;
 
@@ -57422,7 +57440,7 @@ export const CreateProjectsLocationsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/datasets",
+      path: "v1beta1/{+parent}/datasets",
       hasBody: true,
     }),
     svc,
@@ -57459,7 +57477,7 @@ export const GetProjectsLocationsDatasetsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsRequest>;
 
@@ -57546,7 +57564,7 @@ export const SearchDataItemsProjectsLocationsDatasetsRequest =
       T.HttpQuery("annotationFilters"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{dataset}:searchDataItems" }),
+    T.Http({ method: "GET", path: "v1beta1/{+dataset}:searchDataItems" }),
     svc,
   ) as unknown as Schema.Schema<SearchDataItemsProjectsLocationsDatasetsRequest>;
 
@@ -57590,7 +57608,7 @@ export const PatchProjectsLocationsDatasetsDatasetVersionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsDatasetVersionsRequest>;
 
@@ -57622,7 +57640,7 @@ export const DeleteProjectsLocationsDatasetsDatasetVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsDatasetVersionsRequest>;
 
@@ -57669,7 +57687,7 @@ export const ListProjectsLocationsDatasetsDatasetVersionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/datasetVersions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/datasetVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsDatasetVersionsRequest>;
 
@@ -57705,7 +57723,7 @@ export const RestoreProjectsLocationsDatasetsDatasetVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:restore" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:restore" }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsDatasetsDatasetVersionsRequest>;
 
@@ -57745,7 +57763,7 @@ export const CreateProjectsLocationsDatasetsDatasetVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/datasetVersions",
+      path: "v1beta1/{+parent}/datasetVersions",
       hasBody: true,
     }),
     svc,
@@ -57782,7 +57800,7 @@ export const GetProjectsLocationsDatasetsDatasetVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsDatasetVersionsRequest>;
 
@@ -57817,7 +57835,7 @@ export const GetProjectsLocationsDatasetsAnnotationSpecsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsAnnotationSpecsRequest>;
 
@@ -57849,7 +57867,7 @@ export const DeleteProjectsLocationsDatasetsAnnotationSpecsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -57885,7 +57903,7 @@ export const WaitProjectsLocationsDatasetsAnnotationSpecsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -57918,7 +57936,7 @@ export const GetProjectsLocationsDatasetsAnnotationSpecsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -57951,7 +57969,7 @@ export const CancelProjectsLocationsDatasetsAnnotationSpecsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -57998,7 +58016,7 @@ export const ListProjectsLocationsDatasetsAnnotationSpecsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -58035,7 +58053,7 @@ export const GetProjectsLocationsDatasetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsOperationsRequest>;
 
@@ -58067,7 +58085,7 @@ export const CancelProjectsLocationsDatasetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDatasetsOperationsRequest>;
 
@@ -58113,7 +58131,7 @@ export const ListProjectsLocationsDatasetsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsOperationsRequest>;
 
@@ -58149,7 +58167,7 @@ export const DeleteProjectsLocationsDatasetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsOperationsRequest>;
 
@@ -58184,7 +58202,7 @@ export const WaitProjectsLocationsDatasetsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsDatasetsOperationsRequest>;
 
@@ -58216,7 +58234,7 @@ export const DeleteProjectsLocationsDatasetsSavedQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsSavedQueriesRequest>;
 
@@ -58263,7 +58281,7 @@ export const ListProjectsLocationsDatasetsSavedQueriesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/savedQueries" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/savedQueries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsSavedQueriesRequest>;
 
@@ -58299,7 +58317,7 @@ export const DeleteProjectsLocationsDatasetsSavedQueriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsSavedQueriesOperationsRequest>;
 
@@ -58335,7 +58353,7 @@ export const WaitProjectsLocationsDatasetsSavedQueriesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsDatasetsSavedQueriesOperationsRequest>;
 
@@ -58382,7 +58400,7 @@ export const ListProjectsLocationsDatasetsSavedQueriesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsSavedQueriesOperationsRequest>;
 
@@ -58419,7 +58437,7 @@ export const GetProjectsLocationsDatasetsSavedQueriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsSavedQueriesOperationsRequest>;
 
@@ -58452,7 +58470,7 @@ export const CancelProjectsLocationsDatasetsSavedQueriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDatasetsSavedQueriesOperationsRequest>;
 
@@ -58500,7 +58518,7 @@ export const ListProjectsLocationsDatasetsDataItemsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dataItems" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/dataItems" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsDataItemsRequest>;
 
@@ -58536,7 +58554,7 @@ export const GetProjectsLocationsDatasetsDataItemsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsDataItemsOperationsRequest>;
 
@@ -58569,7 +58587,7 @@ export const CancelProjectsLocationsDatasetsDataItemsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDatasetsDataItemsOperationsRequest>;
 
@@ -58616,7 +58634,7 @@ export const ListProjectsLocationsDatasetsDataItemsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsDataItemsOperationsRequest>;
 
@@ -58653,7 +58671,7 @@ export const DeleteProjectsLocationsDatasetsDataItemsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsDataItemsOperationsRequest>;
 
@@ -58689,7 +58707,7 @@ export const WaitProjectsLocationsDatasetsDataItemsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsDatasetsDataItemsOperationsRequest>;
 
@@ -58737,7 +58755,7 @@ export const ListProjectsLocationsDatasetsDataItemsAnnotationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/annotations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/annotations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsDataItemsAnnotationsRequest>;
 
@@ -58788,7 +58806,7 @@ export const ListProjectsLocationsDatasetsDataItemsAnnotationsOperationsRequest 
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -58825,7 +58843,7 @@ export const GetProjectsLocationsDatasetsDataItemsAnnotationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -58858,7 +58876,7 @@ export const CancelProjectsLocationsDatasetsDataItemsAnnotationsOperationsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -58891,7 +58909,7 @@ export const DeleteProjectsLocationsDatasetsDataItemsAnnotationsOperationsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -58927,7 +58945,7 @@ export const WaitProjectsLocationsDatasetsDataItemsAnnotationsOperationsRequest 
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -58960,7 +58978,7 @@ export const GetProjectsLocationsPipelineJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPipelineJobsRequest>;
 
@@ -58997,7 +59015,7 @@ export const CancelProjectsLocationsPipelineJobsRequest =
       GoogleCloudAiplatformV1beta1CancelPipelineJobRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsPipelineJobsRequest>;
 
@@ -59035,7 +59053,7 @@ export const BatchCancelProjectsLocationsPipelineJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/pipelineJobs:batchCancel",
+      path: "v1beta1/{+parent}/pipelineJobs:batchCancel",
       hasBody: true,
     }),
     svc,
@@ -59084,7 +59102,7 @@ export const ListProjectsLocationsPipelineJobsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/pipelineJobs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/pipelineJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPipelineJobsRequest>;
 
@@ -59132,7 +59150,7 @@ export const CreateProjectsLocationsPipelineJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/pipelineJobs",
+      path: "v1beta1/{+parent}/pipelineJobs",
       hasBody: true,
     }),
     svc,
@@ -59166,7 +59184,7 @@ export const DeleteProjectsLocationsPipelineJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPipelineJobsRequest>;
 
@@ -59205,7 +59223,7 @@ export const BatchDeleteProjectsLocationsPipelineJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/pipelineJobs:batchDelete",
+      path: "v1beta1/{+parent}/pipelineJobs:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -59239,7 +59257,7 @@ export const DeleteProjectsLocationsPipelineJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPipelineJobsOperationsRequest>;
 
@@ -59274,7 +59292,7 @@ export const WaitProjectsLocationsPipelineJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsPipelineJobsOperationsRequest>;
 
@@ -59320,7 +59338,7 @@ export const ListProjectsLocationsPipelineJobsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPipelineJobsOperationsRequest>;
 
@@ -59356,7 +59374,7 @@ export const GetProjectsLocationsPipelineJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPipelineJobsOperationsRequest>;
 
@@ -59388,7 +59406,7 @@ export const CancelProjectsLocationsPipelineJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsPipelineJobsOperationsRequest>;
 
@@ -59431,7 +59449,7 @@ export const SearchFeaturesProjectsLocationsFeaturestoresRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{location}/featurestores:searchFeatures",
+      path: "v1beta1/{+location}/featurestores:searchFeatures",
     }),
     svc,
   ) as unknown as Schema.Schema<SearchFeaturesProjectsLocationsFeaturestoresRequest>;
@@ -59473,7 +59491,7 @@ export const SetIamPolicyProjectsLocationsFeaturestoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -59514,7 +59532,7 @@ export const TestIamPermissionsProjectsLocationsFeaturestoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -59556,7 +59574,7 @@ export const BatchReadFeatureValuesProjectsLocationsFeaturestoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{featurestore}:batchReadFeatureValues",
+      path: "v1beta1/{+featurestore}:batchReadFeatureValues",
       hasBody: true,
     }),
     svc,
@@ -59599,7 +59617,7 @@ export const PatchProjectsLocationsFeaturestoresRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFeaturestoresRequest>;
 
@@ -59636,7 +59654,7 @@ export const GetIamPolicyProjectsLocationsFeaturestoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -59670,7 +59688,7 @@ export const GetProjectsLocationsFeaturestoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeaturestoresRequest>;
 
@@ -59717,7 +59735,7 @@ export const ListProjectsLocationsFeaturestoresRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/featurestores" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/featurestores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeaturestoresRequest>;
 
@@ -59765,7 +59783,7 @@ export const CreateProjectsLocationsFeaturestoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/featurestores",
+      path: "v1beta1/{+parent}/featurestores",
       hasBody: true,
     }),
     svc,
@@ -59802,7 +59820,7 @@ export const DeleteProjectsLocationsFeaturestoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeaturestoresRequest>;
 
@@ -59841,7 +59859,7 @@ export const DeleteFeatureValuesProjectsLocationsFeaturestoresEntityTypesRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{entityType}:deleteFeatureValues",
+      path: "v1beta1/{+entityType}:deleteFeatureValues",
       hasBody: true,
     }),
     svc,
@@ -59883,7 +59901,7 @@ export const StreamingReadFeatureValuesProjectsLocationsFeaturestoresEntityTypes
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{entityType}:streamingReadFeatureValues",
+      path: "v1beta1/{+entityType}:streamingReadFeatureValues",
       hasBody: true,
     }),
     svc,
@@ -59925,7 +59943,7 @@ export const SetIamPolicyProjectsLocationsFeaturestoresEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -59967,7 +59985,7 @@ export const ReadFeatureValuesProjectsLocationsFeaturestoresEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{entityType}:readFeatureValues",
+      path: "v1beta1/{+entityType}:readFeatureValues",
       hasBody: true,
     }),
     svc,
@@ -60002,7 +60020,7 @@ export const GetProjectsLocationsFeaturestoresEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeaturestoresEntityTypesRequest>;
 
@@ -60046,7 +60064,7 @@ export const CreateProjectsLocationsFeaturestoresEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/entityTypes",
+      path: "v1beta1/{+parent}/entityTypes",
       hasBody: true,
     }),
     svc,
@@ -60096,7 +60114,7 @@ export const ListProjectsLocationsFeaturestoresEntityTypesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeaturestoresEntityTypesRequest>;
 
@@ -60140,7 +60158,7 @@ export const PatchProjectsLocationsFeaturestoresEntityTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFeaturestoresEntityTypesRequest>;
 
@@ -60179,7 +60197,7 @@ export const WriteFeatureValuesProjectsLocationsFeaturestoresEntityTypesRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{entityType}:writeFeatureValues",
+      path: "v1beta1/{+entityType}:writeFeatureValues",
       hasBody: true,
     }),
     svc,
@@ -60221,7 +60239,7 @@ export const ImportFeatureValuesProjectsLocationsFeaturestoresEntityTypesRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{entityType}:importFeatureValues",
+      path: "v1beta1/{+entityType}:importFeatureValues",
       hasBody: true,
     }),
     svc,
@@ -60263,7 +60281,7 @@ export const TestIamPermissionsProjectsLocationsFeaturestoresEntityTypesRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -60301,7 +60319,7 @@ export const DeleteProjectsLocationsFeaturestoresEntityTypesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeaturestoresEntityTypesRequest>;
 
@@ -60341,7 +60359,7 @@ export const ExportFeatureValuesProjectsLocationsFeaturestoresEntityTypesRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{entityType}:exportFeatureValues",
+      path: "v1beta1/{+entityType}:exportFeatureValues",
       hasBody: true,
     }),
     svc,
@@ -60383,7 +60401,7 @@ export const GetIamPolicyProjectsLocationsFeaturestoresEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -60418,7 +60436,7 @@ export const GetProjectsLocationsFeaturestoresEntityTypesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeaturestoresEntityTypesOperationsRequest>;
 
@@ -60451,7 +60469,7 @@ export const CancelProjectsLocationsFeaturestoresEntityTypesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsFeaturestoresEntityTypesOperationsRequest>;
 
@@ -60498,7 +60516,7 @@ export const ListProjectsLocationsFeaturestoresEntityTypesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeaturestoresEntityTypesOperationsRequest>;
 
@@ -60535,7 +60553,7 @@ export const DeleteProjectsLocationsFeaturestoresEntityTypesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeaturestoresEntityTypesOperationsRequest>;
 
@@ -60571,7 +60589,7 @@ export const WaitProjectsLocationsFeaturestoresEntityTypesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsFeaturestoresEntityTypesOperationsRequest>;
 
@@ -60624,7 +60642,7 @@ export const ListProjectsLocationsFeaturestoresEntityTypesFeaturesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/features" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/features" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeaturestoresEntityTypesFeaturesRequest>;
 
@@ -60671,7 +60689,7 @@ export const CreateProjectsLocationsFeaturestoresEntityTypesFeaturesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/features",
+      path: "v1beta1/{+parent}/features",
       hasBody: true,
     }),
     svc,
@@ -60713,7 +60731,7 @@ export const BatchCreateProjectsLocationsFeaturestoresEntityTypesFeaturesRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/features:batchCreate",
+      path: "v1beta1/{+parent}/features:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -60763,7 +60781,7 @@ export const GetProjectsLocationsFeaturestoresEntityTypesFeaturesRequest =
       Schema.String,
     ).pipe(T.HttpQuery("featureStatsAndAnomalySpec.statsTimeRange.endTime")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeaturestoresEntityTypesFeaturesRequest>;
 
@@ -60804,7 +60822,7 @@ export const PatchProjectsLocationsFeaturestoresEntityTypesFeaturesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFeaturestoresEntityTypesFeaturesRequest>;
 
@@ -60837,7 +60855,7 @@ export const DeleteProjectsLocationsFeaturestoresEntityTypesFeaturesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeaturestoresEntityTypesFeaturesRequest>;
 
@@ -60870,7 +60888,7 @@ export const DeleteProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsRe
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -60908,7 +60926,7 @@ export const WaitProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsRequ
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -60942,7 +60960,7 @@ export const GetProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsReque
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -60976,7 +60994,7 @@ export const CancelProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsRe
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -61025,7 +61043,7 @@ export const ListProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsRequ
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -61063,7 +61081,7 @@ export const GetProjectsLocationsFeaturestoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeaturestoresOperationsRequest>;
 
@@ -61095,7 +61113,7 @@ export const CancelProjectsLocationsFeaturestoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsFeaturestoresOperationsRequest>;
 
@@ -61141,7 +61159,7 @@ export const ListProjectsLocationsFeaturestoresOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeaturestoresOperationsRequest>;
 
@@ -61177,7 +61195,7 @@ export const DeleteProjectsLocationsFeaturestoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeaturestoresOperationsRequest>;
 
@@ -61212,7 +61230,7 @@ export const WaitProjectsLocationsFeaturestoresOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsFeaturestoresOperationsRequest>;
 
@@ -61276,7 +61294,7 @@ export const CreateProjectsLocationsExampleStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/exampleStores:create",
+      path: "v1beta1/{+parent}/exampleStores:create",
       hasBody: true,
     }),
     svc,
@@ -61319,7 +61337,7 @@ export const ListProjectsLocationsExampleStoresRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/exampleStores" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/exampleStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsExampleStoresRequest>;
 
@@ -61355,7 +61373,7 @@ export const GetProjectsLocationsExampleStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsExampleStoresRequest>;
 
@@ -61387,7 +61405,7 @@ export const DeleteProjectsLocationsExampleStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsExampleStoresRequest>;
 
@@ -61426,7 +61444,7 @@ export const FetchExamplesProjectsLocationsExampleStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{exampleStore}:fetchExamples",
+      path: "v1beta1/{+exampleStore}:fetchExamples",
       hasBody: true,
     }),
     svc,
@@ -61467,7 +61485,7 @@ export const RemoveExamplesProjectsLocationsExampleStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{exampleStore}:removeExamples",
+      path: "v1beta1/{+exampleStore}:removeExamples",
       hasBody: true,
     }),
     svc,
@@ -61508,7 +61526,7 @@ export const SearchExamplesProjectsLocationsExampleStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{exampleStore}:searchExamples",
+      path: "v1beta1/{+exampleStore}:searchExamples",
       hasBody: true,
     }),
     svc,
@@ -61550,7 +61568,7 @@ export const PatchProjectsLocationsExampleStoresRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsExampleStoresRequest>;
 
@@ -61589,7 +61607,7 @@ export const UpsertExamplesProjectsLocationsExampleStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{exampleStore}:upsertExamples",
+      path: "v1beta1/{+exampleStore}:upsertExamples",
       hasBody: true,
     }),
     svc,
@@ -61623,7 +61641,7 @@ export const DeleteProjectsLocationsExampleStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsExampleStoresOperationsRequest>;
 
@@ -61658,7 +61676,7 @@ export const WaitProjectsLocationsExampleStoresOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsExampleStoresOperationsRequest>;
 
@@ -61690,7 +61708,7 @@ export const GetProjectsLocationsExampleStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsExampleStoresOperationsRequest>;
 
@@ -61722,7 +61740,7 @@ export const CancelProjectsLocationsExampleStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsExampleStoresOperationsRequest>;
 
@@ -61768,7 +61786,7 @@ export const ListProjectsLocationsExampleStoresOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsExampleStoresOperationsRequest>;
 
@@ -61812,7 +61830,7 @@ export const DeleteProjectsLocationsRagCorporaRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRagCorporaRequest>;
 
@@ -61849,7 +61867,7 @@ export const PatchProjectsLocationsRagCorporaRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRagCorporaRequest>;
 
@@ -61881,7 +61899,7 @@ export const GetProjectsLocationsRagCorporaRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRagCorporaRequest>;
 
@@ -61920,7 +61938,7 @@ export const CreateProjectsLocationsRagCorporaRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/ragCorpora",
+      path: "v1beta1/{+parent}/ragCorpora",
       hasBody: true,
     }),
     svc,
@@ -61960,7 +61978,7 @@ export const ListProjectsLocationsRagCorporaRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/ragCorpora" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/ragCorpora" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRagCorporaRequest>;
 
@@ -62001,7 +62019,7 @@ export const DeleteProjectsLocationsRagCorporaRagFilesRequest =
       T.HttpQuery("forceDelete"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRagCorporaRagFilesRequest>;
 
@@ -62039,7 +62057,7 @@ export const ListProjectsLocationsRagCorporaRagFilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/ragFiles" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/ragFiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRagCorporaRagFilesRequest>;
 
@@ -62075,7 +62093,7 @@ export const GetProjectsLocationsRagCorporaRagFilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRagCorporaRagFilesRequest>;
 
@@ -62114,7 +62132,7 @@ export const ImportProjectsLocationsRagCorporaRagFilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/ragFiles:import",
+      path: "v1beta1/{+parent}/ragFiles:import",
       hasBody: true,
     }),
     svc,
@@ -62162,7 +62180,7 @@ export const ListProjectsLocationsRagCorporaRagFilesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRagCorporaRagFilesOperationsRequest>;
 
@@ -62199,7 +62217,7 @@ export const GetProjectsLocationsRagCorporaRagFilesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRagCorporaRagFilesOperationsRequest>;
 
@@ -62232,7 +62250,7 @@ export const CancelProjectsLocationsRagCorporaRagFilesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsRagCorporaRagFilesOperationsRequest>;
 
@@ -62265,7 +62283,7 @@ export const DeleteProjectsLocationsRagCorporaRagFilesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRagCorporaRagFilesOperationsRequest>;
 
@@ -62301,7 +62319,7 @@ export const WaitProjectsLocationsRagCorporaRagFilesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsRagCorporaRagFilesOperationsRequest>;
 
@@ -62346,7 +62364,7 @@ export const CreateProjectsLocationsRagCorporaRagFilesRagMetadataRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/ragMetadata",
+      path: "v1beta1/{+parent}/ragMetadata",
       hasBody: true,
     }),
     svc,
@@ -62387,7 +62405,7 @@ export const ListProjectsLocationsRagCorporaRagFilesRagMetadataRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/ragMetadata" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/ragMetadata" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRagCorporaRagFilesRagMetadataRequest>;
 
@@ -62431,7 +62449,7 @@ export const BatchCreateProjectsLocationsRagCorporaRagFilesRagMetadataRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/ragMetadata:batchCreate",
+      path: "v1beta1/{+parent}/ragMetadata:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -62466,7 +62484,7 @@ export const GetProjectsLocationsRagCorporaRagFilesRagMetadataRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRagCorporaRagFilesRagMetadataRequest>;
 
@@ -62499,7 +62517,7 @@ export const DeleteProjectsLocationsRagCorporaRagFilesRagMetadataRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRagCorporaRagFilesRagMetadataRequest>;
 
@@ -62539,7 +62557,7 @@ export const BatchDeleteProjectsLocationsRagCorporaRagFilesRagMetadataRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/ragMetadata:batchDelete",
+      path: "v1beta1/{+parent}/ragMetadata:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -62579,7 +62597,7 @@ export const PatchProjectsLocationsRagCorporaRagFilesRagMetadataRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRagCorporaRagFilesRagMetadataRequest>;
 
@@ -62612,7 +62630,7 @@ export const DeleteProjectsLocationsRagCorporaRagDataSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRagCorporaRagDataSchemasRequest>;
 
@@ -62652,7 +62670,7 @@ export const BatchDeleteProjectsLocationsRagCorporaRagDataSchemasRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/ragDataSchemas:batchDelete",
+      path: "v1beta1/{+parent}/ragDataSchemas:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -62693,7 +62711,7 @@ export const ListProjectsLocationsRagCorporaRagDataSchemasRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/ragDataSchemas" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/ragDataSchemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRagCorporaRagDataSchemasRequest>;
 
@@ -62741,7 +62759,7 @@ export const CreateProjectsLocationsRagCorporaRagDataSchemasRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/ragDataSchemas",
+      path: "v1beta1/{+parent}/ragDataSchemas",
       hasBody: true,
     }),
     svc,
@@ -62783,7 +62801,7 @@ export const BatchCreateProjectsLocationsRagCorporaRagDataSchemasRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/ragDataSchemas:batchCreate",
+      path: "v1beta1/{+parent}/ragDataSchemas:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -62818,7 +62836,7 @@ export const GetProjectsLocationsRagCorporaRagDataSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRagCorporaRagDataSchemasRequest>;
 
@@ -62864,7 +62882,7 @@ export const ListProjectsLocationsRagCorporaOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRagCorporaOperationsRequest>;
 
@@ -62900,7 +62918,7 @@ export const GetProjectsLocationsRagCorporaOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRagCorporaOperationsRequest>;
 
@@ -62932,7 +62950,7 @@ export const CancelProjectsLocationsRagCorporaOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsRagCorporaOperationsRequest>;
 
@@ -62964,7 +62982,7 @@ export const DeleteProjectsLocationsRagCorporaOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRagCorporaOperationsRequest>;
 
@@ -62999,7 +63017,7 @@ export const WaitProjectsLocationsRagCorporaOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsRagCorporaOperationsRequest>;
 
@@ -63039,7 +63057,7 @@ export const PatchProjectsLocationsModelMonitorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsModelMonitorsRequest>;
 
@@ -63078,7 +63096,7 @@ export const SearchModelMonitoringAlertsProjectsLocationsModelMonitorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{modelMonitor}:searchModelMonitoringAlerts",
+      path: "v1beta1/{+modelMonitor}:searchModelMonitoringAlerts",
       hasBody: true,
     }),
     svc,
@@ -63116,7 +63134,7 @@ export const DeleteProjectsLocationsModelMonitorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsModelMonitorsRequest>;
 
@@ -63160,7 +63178,7 @@ export const ListProjectsLocationsModelMonitorsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/modelMonitors" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/modelMonitors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsModelMonitorsRequest>;
 
@@ -63208,7 +63226,7 @@ export const CreateProjectsLocationsModelMonitorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/modelMonitors",
+      path: "v1beta1/{+parent}/modelMonitors",
       hasBody: true,
     }),
     svc,
@@ -63249,7 +63267,7 @@ export const SearchModelMonitoringStatsProjectsLocationsModelMonitorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{modelMonitor}:searchModelMonitoringStats",
+      path: "v1beta1/{+modelMonitor}:searchModelMonitoringStats",
       hasBody: true,
     }),
     svc,
@@ -63284,7 +63302,7 @@ export const GetProjectsLocationsModelMonitorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsModelMonitorsRequest>;
 
@@ -63316,7 +63334,7 @@ export const GetProjectsLocationsModelMonitorsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsModelMonitorsOperationsRequest>;
 
@@ -63348,7 +63366,7 @@ export const CancelProjectsLocationsModelMonitorsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsModelMonitorsOperationsRequest>;
 
@@ -63394,7 +63412,7 @@ export const ListProjectsLocationsModelMonitorsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsModelMonitorsOperationsRequest>;
 
@@ -63430,7 +63448,7 @@ export const DeleteProjectsLocationsModelMonitorsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsModelMonitorsOperationsRequest>;
 
@@ -63465,7 +63483,7 @@ export const WaitProjectsLocationsModelMonitorsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsModelMonitorsOperationsRequest>;
 
@@ -63497,7 +63515,7 @@ export const GetProjectsLocationsModelMonitorsModelMonitoringJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsModelMonitorsModelMonitoringJobsRequest>;
 
@@ -63542,7 +63560,7 @@ export const CreateProjectsLocationsModelMonitorsModelMonitoringJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/modelMonitoringJobs",
+      path: "v1beta1/{+parent}/modelMonitoringJobs",
       hasBody: true,
     }),
     svc,
@@ -63577,7 +63595,7 @@ export const DeleteProjectsLocationsModelMonitorsModelMonitoringJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsModelMonitorsModelMonitoringJobsRequest>;
 
@@ -63622,7 +63640,7 @@ export const ListProjectsLocationsModelMonitorsModelMonitoringJobsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/modelMonitoringJobs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/modelMonitoringJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsModelMonitorsModelMonitoringJobsRequest>;
 
@@ -63666,7 +63684,7 @@ export const CreateProjectsLocationsTensorboardsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/tensorboards",
+      path: "v1beta1/{+parent}/tensorboards",
       hasBody: true,
     }),
     svc,
@@ -63715,7 +63733,7 @@ export const ListProjectsLocationsTensorboardsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/tensorboards" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/tensorboards" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTensorboardsRequest>;
 
@@ -63751,7 +63769,7 @@ export const ReadSizeProjectsLocationsTensorboardsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     tensorboard: Schema.String.pipe(T.HttpPath("tensorboard")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{tensorboard}:readSize" }),
+    T.Http({ method: "GET", path: "v1beta1/{+tensorboard}:readSize" }),
     svc,
   ) as unknown as Schema.Schema<ReadSizeProjectsLocationsTensorboardsRequest>;
 
@@ -63788,7 +63806,7 @@ export const BatchReadProjectsLocationsTensorboardsRequest =
     ),
     tensorboard: Schema.String.pipe(T.HttpPath("tensorboard")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{tensorboard}:batchRead" }),
+    T.Http({ method: "GET", path: "v1beta1/{+tensorboard}:batchRead" }),
     svc,
   ) as unknown as Schema.Schema<BatchReadProjectsLocationsTensorboardsRequest>;
 
@@ -63820,7 +63838,7 @@ export const GetProjectsLocationsTensorboardsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTensorboardsRequest>;
 
@@ -63852,7 +63870,7 @@ export const DeleteProjectsLocationsTensorboardsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTensorboardsRequest>;
 
@@ -63884,7 +63902,7 @@ export const ReadUsageProjectsLocationsTensorboardsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     tensorboard: Schema.String.pipe(T.HttpPath("tensorboard")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{tensorboard}:readUsage" }),
+    T.Http({ method: "GET", path: "v1beta1/{+tensorboard}:readUsage" }),
     svc,
   ) as unknown as Schema.Schema<ReadUsageProjectsLocationsTensorboardsRequest>;
 
@@ -63924,7 +63942,7 @@ export const PatchProjectsLocationsTensorboardsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTensorboardsRequest>;
 
@@ -63956,7 +63974,7 @@ export const DeleteProjectsLocationsTensorboardsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTensorboardsOperationsRequest>;
 
@@ -63991,7 +64009,7 @@ export const WaitProjectsLocationsTensorboardsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsTensorboardsOperationsRequest>;
 
@@ -64037,7 +64055,7 @@ export const ListProjectsLocationsTensorboardsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTensorboardsOperationsRequest>;
 
@@ -64073,7 +64091,7 @@ export const GetProjectsLocationsTensorboardsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTensorboardsOperationsRequest>;
 
@@ -64105,7 +64123,7 @@ export const CancelProjectsLocationsTensorboardsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsTensorboardsOperationsRequest>;
 
@@ -64146,7 +64164,7 @@ export const WriteProjectsLocationsTensorboardsExperimentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{tensorboardExperiment}:write",
+      path: "v1beta1/{+tensorboardExperiment}:write",
       hasBody: true,
     }),
     svc,
@@ -64180,7 +64198,7 @@ export const DeleteProjectsLocationsTensorboardsExperimentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTensorboardsExperimentsRequest>;
 
@@ -64220,7 +64238,7 @@ export const PatchProjectsLocationsTensorboardsExperimentsRequest =
       GoogleCloudAiplatformV1beta1TensorboardExperiment,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTensorboardsExperimentsRequest>;
 
@@ -64252,7 +64270,7 @@ export const GetProjectsLocationsTensorboardsExperimentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTensorboardsExperimentsRequest>;
 
@@ -64291,7 +64309,7 @@ export const BatchCreateProjectsLocationsTensorboardsExperimentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:batchCreate",
+      path: "v1beta1/{+parent}:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -64338,7 +64356,7 @@ export const CreateProjectsLocationsTensorboardsExperimentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/experiments",
+      path: "v1beta1/{+parent}/experiments",
       hasBody: true,
     }),
     svc,
@@ -64387,7 +64405,7 @@ export const ListProjectsLocationsTensorboardsExperimentsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/experiments" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/experiments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTensorboardsExperimentsRequest>;
 
@@ -64423,7 +64441,7 @@ export const GetProjectsLocationsTensorboardsExperimentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTensorboardsExperimentsOperationsRequest>;
 
@@ -64456,7 +64474,7 @@ export const CancelProjectsLocationsTensorboardsExperimentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsTensorboardsExperimentsOperationsRequest>;
 
@@ -64503,7 +64521,7 @@ export const ListProjectsLocationsTensorboardsExperimentsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTensorboardsExperimentsOperationsRequest>;
 
@@ -64540,7 +64558,7 @@ export const DeleteProjectsLocationsTensorboardsExperimentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTensorboardsExperimentsOperationsRequest>;
 
@@ -64576,7 +64594,7 @@ export const WaitProjectsLocationsTensorboardsExperimentsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsTensorboardsExperimentsOperationsRequest>;
 
@@ -64617,7 +64635,7 @@ export const PatchProjectsLocationsTensorboardsExperimentsRunsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTensorboardsExperimentsRunsRequest>;
 
@@ -64650,7 +64668,7 @@ export const DeleteProjectsLocationsTensorboardsExperimentsRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTensorboardsExperimentsRunsRequest>;
 
@@ -64690,7 +64708,7 @@ export const WriteProjectsLocationsTensorboardsExperimentsRunsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{tensorboardRun}:write",
+      path: "v1beta1/{+tensorboardRun}:write",
       hasBody: true,
     }),
     svc,
@@ -64740,7 +64758,7 @@ export const ListProjectsLocationsTensorboardsExperimentsRunsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/runs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/runs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTensorboardsExperimentsRunsRequest>;
 
@@ -64787,7 +64805,7 @@ export const CreateProjectsLocationsTensorboardsExperimentsRunsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/runs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+parent}/runs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTensorboardsExperimentsRunsRequest>;
 
@@ -64827,7 +64845,7 @@ export const BatchCreateProjectsLocationsTensorboardsExperimentsRunsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/runs:batchCreate",
+      path: "v1beta1/{+parent}/runs:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -64862,7 +64880,7 @@ export const GetProjectsLocationsTensorboardsExperimentsRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTensorboardsExperimentsRunsRequest>;
 
@@ -64909,7 +64927,7 @@ export const ListProjectsLocationsTensorboardsExperimentsRunsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -64946,7 +64964,7 @@ export const GetProjectsLocationsTensorboardsExperimentsRunsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -64979,7 +64997,7 @@ export const CancelProjectsLocationsTensorboardsExperimentsRunsOperationsRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -65012,7 +65030,7 @@ export const DeleteProjectsLocationsTensorboardsExperimentsRunsOperationsRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -65048,7 +65066,7 @@ export const WaitProjectsLocationsTensorboardsExperimentsRunsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -65081,7 +65099,7 @@ export const GetProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest>;
 
@@ -65129,7 +65147,7 @@ export const ListProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/timeSeries" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/timeSeries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest>;
 
@@ -65178,7 +65196,7 @@ export const CreateProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/timeSeries",
+      path: "v1beta1/{+parent}/timeSeries",
       hasBody: true,
     }),
     svc,
@@ -65222,7 +65240,7 @@ export const ExportTensorboardTimeSeriesProjectsLocationsTensorboardsExperiments
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{tensorboardTimeSeries}:exportTensorboardTimeSeries",
+      path: "v1beta1/{+tensorboardTimeSeries}:exportTensorboardTimeSeries",
       hasBody: true,
     }),
     svc,
@@ -65269,7 +65287,7 @@ export const ReadProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{tensorboardTimeSeries}:read" }),
+    T.Http({ method: "GET", path: "v1beta1/{+tensorboardTimeSeries}:read" }),
     svc,
   ) as unknown as Schema.Schema<ReadProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest>;
 
@@ -65307,7 +65325,7 @@ export const ReadBlobDataProjectsLocationsTensorboardsExperimentsRunsTimeSeriesR
       T.HttpQuery("blobIds"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{timeSeries}:readBlobData" }),
+    T.Http({ method: "GET", path: "v1beta1/{+timeSeries}:readBlobData" }),
     svc,
   ) as unknown as Schema.Schema<ReadBlobDataProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest>;
 
@@ -65350,7 +65368,7 @@ export const PatchProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest 
       GoogleCloudAiplatformV1beta1TensorboardTimeSeries,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest>;
 
@@ -65383,7 +65401,7 @@ export const DeleteProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTensorboardsExperimentsRunsTimeSeriesRequest>;
 
@@ -65416,7 +65434,7 @@ export const DeleteProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperati
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -65454,7 +65472,7 @@ export const WaitProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperation
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -65489,7 +65507,7 @@ export const GetProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperations
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -65524,7 +65542,7 @@ export const CancelProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperati
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -65573,7 +65591,7 @@ export const ListProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperation
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -65612,7 +65630,7 @@ export const GetProjectsLocationsModelDeploymentMonitoringJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsModelDeploymentMonitoringJobsRequest>;
 
@@ -65654,7 +65672,7 @@ export const SearchModelDeploymentMonitoringStatsAnomaliesProjectsLocationsModel
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{modelDeploymentMonitoringJob}:searchModelDeploymentMonitoringStatsAnomalies",
+      path: "v1beta1/{+modelDeploymentMonitoringJob}:searchModelDeploymentMonitoringStatsAnomalies",
       hasBody: true,
     }),
     svc,
@@ -65698,7 +65716,7 @@ export const CreateProjectsLocationsModelDeploymentMonitoringJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/modelDeploymentMonitoringJobs",
+      path: "v1beta1/{+parent}/modelDeploymentMonitoringJobs",
       hasBody: true,
     }),
     svc,
@@ -65747,7 +65765,7 @@ export const ListProjectsLocationsModelDeploymentMonitoringJobsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/modelDeploymentMonitoringJobs",
+      path: "v1beta1/{+parent}/modelDeploymentMonitoringJobs",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsModelDeploymentMonitoringJobsRequest>;
@@ -65790,7 +65808,7 @@ export const ResumeProjectsLocationsModelDeploymentMonitoringJobsRequest =
       GoogleCloudAiplatformV1beta1ResumeModelDeploymentMonitoringJobRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsModelDeploymentMonitoringJobsRequest>;
 
@@ -65823,7 +65841,7 @@ export const DeleteProjectsLocationsModelDeploymentMonitoringJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsModelDeploymentMonitoringJobsRequest>;
 
@@ -65864,7 +65882,7 @@ export const PatchProjectsLocationsModelDeploymentMonitoringJobsRequest =
       GoogleCloudAiplatformV1beta1ModelDeploymentMonitoringJob,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsModelDeploymentMonitoringJobsRequest>;
 
@@ -65902,7 +65920,7 @@ export const PauseProjectsLocationsModelDeploymentMonitoringJobsRequest =
       GoogleCloudAiplatformV1beta1PauseModelDeploymentMonitoringJobRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsLocationsModelDeploymentMonitoringJobsRequest>;
 
@@ -65949,7 +65967,7 @@ export const ListProjectsLocationsModelDeploymentMonitoringJobsOperationsRequest
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -65986,7 +66004,7 @@ export const GetProjectsLocationsModelDeploymentMonitoringJobsOperationsRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -66019,7 +66037,7 @@ export const CancelProjectsLocationsModelDeploymentMonitoringJobsOperationsReque
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -66053,7 +66071,7 @@ export const DeleteProjectsLocationsModelDeploymentMonitoringJobsOperationsReque
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -66090,7 +66108,7 @@ export const WaitProjectsLocationsModelDeploymentMonitoringJobsOperationsRequest
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -66130,7 +66148,7 @@ export const CreateProjectsLocationsSchedulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/schedules",
+      path: "v1beta1/{+parent}/schedules",
       hasBody: true,
     }),
     svc,
@@ -66176,7 +66194,7 @@ export const ListProjectsLocationsSchedulesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/schedules" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/schedules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchedulesRequest>;
 
@@ -66217,7 +66235,7 @@ export const ResumeProjectsLocationsSchedulesRequest =
       GoogleCloudAiplatformV1beta1ResumeScheduleRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsSchedulesRequest>;
 
@@ -66248,7 +66266,7 @@ export const GetProjectsLocationsSchedulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchedulesRequest>;
 
@@ -66280,7 +66298,7 @@ export const DeleteProjectsLocationsSchedulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSchedulesRequest>;
 
@@ -66317,7 +66335,7 @@ export const PauseProjectsLocationsSchedulesRequest =
       GoogleCloudAiplatformV1beta1PauseScheduleRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsLocationsSchedulesRequest>;
 
@@ -66356,7 +66374,7 @@ export const PatchProjectsLocationsSchedulesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSchedulesRequest>;
 
@@ -66388,7 +66406,7 @@ export const DeleteProjectsLocationsSchedulesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSchedulesOperationsRequest>;
 
@@ -66423,7 +66441,7 @@ export const WaitProjectsLocationsSchedulesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsSchedulesOperationsRequest>;
 
@@ -66469,7 +66487,7 @@ export const ListProjectsLocationsSchedulesOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchedulesOperationsRequest>;
 
@@ -66505,7 +66523,7 @@ export const GetProjectsLocationsSchedulesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchedulesOperationsRequest>;
 
@@ -66537,7 +66555,7 @@ export const CancelProjectsLocationsSchedulesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsSchedulesOperationsRequest>;
 
@@ -66576,7 +66594,7 @@ export const GenerateContentProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{model}:generateContent",
+      path: "v1beta1/{+model}:generateContent",
       hasBody: true,
     }),
     svc,
@@ -66618,7 +66636,7 @@ export const StreamRawPredictProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:streamRawPredict",
+      path: "v1beta1/{+endpoint}:streamRawPredict",
       hasBody: true,
     }),
     svc,
@@ -66660,7 +66678,7 @@ export const FetchPredictOperationProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:fetchPredictOperation",
+      path: "v1beta1/{+endpoint}:fetchPredictOperation",
       hasBody: true,
     }),
     svc,
@@ -66702,7 +66720,7 @@ export const EmbedContentProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{model}:embedContent",
+      path: "v1beta1/{+model}:embedContent",
       hasBody: true,
     }),
     svc,
@@ -66743,7 +66761,7 @@ export const ServerStreamingPredictProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:serverStreamingPredict",
+      path: "v1beta1/{+endpoint}:serverStreamingPredict",
       hasBody: true,
     }),
     svc,
@@ -66785,7 +66803,7 @@ export const SetPublisherModelConfigProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:setPublisherModelConfig",
+      path: "v1beta1/{+name}:setPublisherModelConfig",
       hasBody: true,
     }),
     svc,
@@ -66820,7 +66838,10 @@ export const FetchPublisherModelConfigProjectsLocationsPublishersModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:fetchPublisherModelConfig" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+name}:fetchPublisherModelConfig",
+    }),
     svc,
   ) as unknown as Schema.Schema<FetchPublisherModelConfigProjectsLocationsPublishersModelsRequest>;
 
@@ -66860,7 +66881,7 @@ export const RawPredictProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:rawPredict",
+      path: "v1beta1/{+endpoint}:rawPredict",
       hasBody: true,
     }),
     svc,
@@ -66901,7 +66922,7 @@ export const StreamGenerateContentProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{model}:streamGenerateContent",
+      path: "v1beta1/{+model}:streamGenerateContent",
       hasBody: true,
     }),
     svc,
@@ -66943,7 +66964,7 @@ export const ComputeTokensProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:computeTokens",
+      path: "v1beta1/{+endpoint}:computeTokens",
       hasBody: true,
     }),
     svc,
@@ -66984,7 +67005,7 @@ export const PredictLongRunningProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:predictLongRunning",
+      path: "v1beta1/{+endpoint}:predictLongRunning",
       hasBody: true,
     }),
     svc,
@@ -67025,7 +67046,7 @@ export const PredictProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:predict",
+      path: "v1beta1/{+endpoint}:predict",
       hasBody: true,
     }),
     svc,
@@ -67065,7 +67086,7 @@ export const CountTokensProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:countTokens",
+      path: "v1beta1/{+endpoint}:countTokens",
       hasBody: true,
     }),
     svc,
@@ -67109,7 +67130,7 @@ export const ExportProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/{name}:export",
+      path: "v1beta1/{+parent}/{+name}:export",
       hasBody: true,
     }),
     svc,
@@ -67150,7 +67171,7 @@ export const GetIamPolicyProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -67193,7 +67214,7 @@ export const InvokeProjectsLocationsPublishersModelsInvokeRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}/invoke/{invokeId}",
+      path: "v1beta1/{+endpoint}/invoke/{+invokeId}",
       hasBody: true,
     }),
     svc,
@@ -67227,7 +67248,7 @@ export const GetProjectsLocationsMetadataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataStoresRequest>;
 
@@ -67265,7 +67286,7 @@ export const ListProjectsLocationsMetadataStoresRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/metadataStores" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/metadataStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataStoresRequest>;
 
@@ -67313,7 +67334,7 @@ export const CreateProjectsLocationsMetadataStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/metadataStores",
+      path: "v1beta1/{+parent}/metadataStores",
       hasBody: true,
     }),
     svc,
@@ -67350,7 +67371,7 @@ export const DeleteProjectsLocationsMetadataStoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMetadataStoresRequest>;
 
@@ -67382,7 +67403,7 @@ export const DeleteProjectsLocationsMetadataStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMetadataStoresOperationsRequest>;
 
@@ -67418,7 +67439,7 @@ export const WaitProjectsLocationsMetadataStoresOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsMetadataStoresOperationsRequest>;
 
@@ -67464,7 +67485,7 @@ export const ListProjectsLocationsMetadataStoresOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataStoresOperationsRequest>;
 
@@ -67500,7 +67521,7 @@ export const GetProjectsLocationsMetadataStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataStoresOperationsRequest>;
 
@@ -67532,7 +67553,7 @@ export const CancelProjectsLocationsMetadataStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsMetadataStoresOperationsRequest>;
 
@@ -67565,7 +67586,7 @@ export const GetProjectsLocationsMetadataStoresMetadataSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataStoresMetadataSchemasRequest>;
 
@@ -67610,7 +67631,7 @@ export const CreateProjectsLocationsMetadataStoresMetadataSchemasRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/metadataSchemas",
+      path: "v1beta1/{+parent}/metadataSchemas",
       hasBody: true,
     }),
     svc,
@@ -67654,7 +67675,7 @@ export const ListProjectsLocationsMetadataStoresMetadataSchemasRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/metadataSchemas" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/metadataSchemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataStoresMetadataSchemasRequest>;
 
@@ -67704,7 +67725,7 @@ export const PatchProjectsLocationsMetadataStoresContextsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMetadataStoresContextsRequest>;
 
@@ -67743,7 +67764,7 @@ export const PurgeProjectsLocationsMetadataStoresContextsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/contexts:purge",
+      path: "v1beta1/{+parent}/contexts:purge",
       hasBody: true,
     }),
     svc,
@@ -67779,7 +67800,7 @@ export const QueryContextLineageSubgraphProjectsLocationsMetadataStoresContextsR
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{context}:queryContextLineageSubgraph",
+      path: "v1beta1/{+context}:queryContextLineageSubgraph",
     }),
     svc,
   ) as unknown as Schema.Schema<QueryContextLineageSubgraphProjectsLocationsMetadataStoresContextsRequest>;
@@ -67822,7 +67843,7 @@ export const AddContextChildrenProjectsLocationsMetadataStoresContextsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{context}:addContextChildren",
+      path: "v1beta1/{+context}:addContextChildren",
       hasBody: true,
     }),
     svc,
@@ -67863,7 +67884,7 @@ export const DeleteProjectsLocationsMetadataStoresContextsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMetadataStoresContextsRequest>;
 
@@ -67902,7 +67923,7 @@ export const RemoveContextChildrenProjectsLocationsMetadataStoresContextsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{context}:removeContextChildren",
+      path: "v1beta1/{+context}:removeContextChildren",
       hasBody: true,
     }),
     svc,
@@ -67944,7 +67965,7 @@ export const AddContextArtifactsAndExecutionsProjectsLocationsMetadataStoresCont
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{context}:addContextArtifactsAndExecutions",
+      path: "v1beta1/{+context}:addContextArtifactsAndExecutions",
       hasBody: true,
     }),
     svc,
@@ -67993,7 +68014,7 @@ export const ListProjectsLocationsMetadataStoresContextsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/contexts" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataStoresContextsRequest>;
 
@@ -68039,7 +68060,7 @@ export const CreateProjectsLocationsMetadataStoresContextsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/contexts",
+      path: "v1beta1/{+parent}/contexts",
       hasBody: true,
     }),
     svc,
@@ -68073,7 +68094,7 @@ export const GetProjectsLocationsMetadataStoresContextsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataStoresContextsRequest>;
 
@@ -68105,7 +68126,7 @@ export const DeleteProjectsLocationsMetadataStoresContextsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMetadataStoresContextsOperationsRequest>;
 
@@ -68141,7 +68162,7 @@ export const WaitProjectsLocationsMetadataStoresContextsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsMetadataStoresContextsOperationsRequest>;
 
@@ -68174,7 +68195,7 @@ export const GetProjectsLocationsMetadataStoresContextsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataStoresContextsOperationsRequest>;
 
@@ -68207,7 +68228,7 @@ export const CancelProjectsLocationsMetadataStoresContextsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsMetadataStoresContextsOperationsRequest>;
 
@@ -68254,7 +68275,7 @@ export const ListProjectsLocationsMetadataStoresContextsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataStoresContextsOperationsRequest>;
 
@@ -68304,7 +68325,7 @@ export const PatchProjectsLocationsMetadataStoresArtifactsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMetadataStoresArtifactsRequest>;
 
@@ -68339,7 +68360,7 @@ export const DeleteProjectsLocationsMetadataStoresArtifactsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMetadataStoresArtifactsRequest>;
 
@@ -68378,7 +68399,7 @@ export const PurgeProjectsLocationsMetadataStoresArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/artifacts:purge",
+      path: "v1beta1/{+parent}/artifacts:purge",
       hasBody: true,
     }),
     svc,
@@ -68420,7 +68441,7 @@ export const QueryArtifactLineageSubgraphProjectsLocationsMetadataStoresArtifact
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{artifact}:queryArtifactLineageSubgraph",
+      path: "v1beta1/{+artifact}:queryArtifactLineageSubgraph",
     }),
     svc,
   ) as unknown as Schema.Schema<QueryArtifactLineageSubgraphProjectsLocationsMetadataStoresArtifactsRequest>;
@@ -68468,7 +68489,7 @@ export const ListProjectsLocationsMetadataStoresArtifactsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/artifacts" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/artifacts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataStoresArtifactsRequest>;
 
@@ -68514,7 +68535,7 @@ export const CreateProjectsLocationsMetadataStoresArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/artifacts",
+      path: "v1beta1/{+parent}/artifacts",
       hasBody: true,
     }),
     svc,
@@ -68548,7 +68569,7 @@ export const GetProjectsLocationsMetadataStoresArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataStoresArtifactsRequest>;
 
@@ -68580,7 +68601,7 @@ export const DeleteProjectsLocationsMetadataStoresArtifactsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMetadataStoresArtifactsOperationsRequest>;
 
@@ -68616,7 +68637,7 @@ export const WaitProjectsLocationsMetadataStoresArtifactsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsMetadataStoresArtifactsOperationsRequest>;
 
@@ -68649,7 +68670,7 @@ export const GetProjectsLocationsMetadataStoresArtifactsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataStoresArtifactsOperationsRequest>;
 
@@ -68682,7 +68703,7 @@ export const CancelProjectsLocationsMetadataStoresArtifactsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsMetadataStoresArtifactsOperationsRequest>;
 
@@ -68729,7 +68750,7 @@ export const ListProjectsLocationsMetadataStoresArtifactsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataStoresArtifactsOperationsRequest>;
 
@@ -68766,7 +68787,7 @@ export const GetProjectsLocationsMetadataStoresExecutionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataStoresExecutionsRequest>;
 
@@ -68805,7 +68826,7 @@ export const AddExecutionEventsProjectsLocationsMetadataStoresExecutionsRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{execution}:addExecutionEvents",
+      path: "v1beta1/{+execution}:addExecutionEvents",
       hasBody: true,
     }),
     svc,
@@ -68852,7 +68873,7 @@ export const CreateProjectsLocationsMetadataStoresExecutionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/executions",
+      path: "v1beta1/{+parent}/executions",
       hasBody: true,
     }),
     svc,
@@ -68889,7 +68910,7 @@ export const QueryExecutionInputsAndOutputsProjectsLocationsMetadataStoresExecut
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{execution}:queryExecutionInputsAndOutputs",
+      path: "v1beta1/{+execution}:queryExecutionInputsAndOutputs",
     }),
     svc,
   ) as unknown as Schema.Schema<QueryExecutionInputsAndOutputsProjectsLocationsMetadataStoresExecutionsRequest>;
@@ -68937,7 +68958,7 @@ export const ListProjectsLocationsMetadataStoresExecutionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/executions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/executions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataStoresExecutionsRequest>;
 
@@ -68976,7 +68997,7 @@ export const DeleteProjectsLocationsMetadataStoresExecutionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMetadataStoresExecutionsRequest>;
 
@@ -69016,7 +69037,7 @@ export const PurgeProjectsLocationsMetadataStoresExecutionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/executions:purge",
+      path: "v1beta1/{+parent}/executions:purge",
       hasBody: true,
     }),
     svc,
@@ -69063,7 +69084,7 @@ export const PatchProjectsLocationsMetadataStoresExecutionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMetadataStoresExecutionsRequest>;
 
@@ -69109,7 +69130,7 @@ export const ListProjectsLocationsMetadataStoresExecutionsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataStoresExecutionsOperationsRequest>;
 
@@ -69146,7 +69167,7 @@ export const GetProjectsLocationsMetadataStoresExecutionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataStoresExecutionsOperationsRequest>;
 
@@ -69179,7 +69200,7 @@ export const CancelProjectsLocationsMetadataStoresExecutionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsMetadataStoresExecutionsOperationsRequest>;
 
@@ -69212,7 +69233,7 @@ export const DeleteProjectsLocationsMetadataStoresExecutionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMetadataStoresExecutionsOperationsRequest>;
 
@@ -69248,7 +69269,7 @@ export const WaitProjectsLocationsMetadataStoresExecutionsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsMetadataStoresExecutionsOperationsRequest>;
 
@@ -69281,7 +69302,7 @@ export const DeleteProjectsLocationsEdgeDevicesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEdgeDevicesOperationsRequest>;
 
@@ -69316,7 +69337,7 @@ export const WaitProjectsLocationsEdgeDevicesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsEdgeDevicesOperationsRequest>;
 
@@ -69348,7 +69369,7 @@ export const GetProjectsLocationsEdgeDevicesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEdgeDevicesOperationsRequest>;
 
@@ -69380,7 +69401,7 @@ export const CancelProjectsLocationsEdgeDevicesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsEdgeDevicesOperationsRequest>;
 
@@ -69426,7 +69447,7 @@ export const ListProjectsLocationsEdgeDevicesOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEdgeDevicesOperationsRequest>;
 
@@ -69465,7 +69486,7 @@ export const DeleteProjectsLocationsSpecialistPoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSpecialistPoolsRequest>;
 
@@ -69505,7 +69526,7 @@ export const PatchProjectsLocationsSpecialistPoolsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSpecialistPoolsRequest>;
 
@@ -69537,7 +69558,7 @@ export const GetProjectsLocationsSpecialistPoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSpecialistPoolsRequest>;
 
@@ -69576,7 +69597,7 @@ export const CreateProjectsLocationsSpecialistPoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/specialistPools",
+      path: "v1beta1/{+parent}/specialistPools",
       hasBody: true,
     }),
     svc,
@@ -69619,7 +69640,7 @@ export const ListProjectsLocationsSpecialistPoolsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/specialistPools" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/specialistPools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSpecialistPoolsRequest>;
 
@@ -69669,7 +69690,7 @@ export const ListProjectsLocationsSpecialistPoolsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSpecialistPoolsOperationsRequest>;
 
@@ -69705,7 +69726,7 @@ export const GetProjectsLocationsSpecialistPoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSpecialistPoolsOperationsRequest>;
 
@@ -69737,7 +69758,7 @@ export const CancelProjectsLocationsSpecialistPoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsSpecialistPoolsOperationsRequest>;
 
@@ -69770,7 +69791,7 @@ export const DeleteProjectsLocationsSpecialistPoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSpecialistPoolsOperationsRequest>;
 
@@ -69806,7 +69827,7 @@ export const WaitProjectsLocationsSpecialistPoolsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsSpecialistPoolsOperationsRequest>;
 
@@ -69838,7 +69859,7 @@ export const GetProjectsLocationsBatchPredictionJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBatchPredictionJobsRequest>;
 
@@ -69875,7 +69896,7 @@ export const CancelProjectsLocationsBatchPredictionJobsRequest =
       GoogleCloudAiplatformV1beta1CancelBatchPredictionJobRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsBatchPredictionJobsRequest>;
 
@@ -69919,7 +69940,7 @@ export const ListProjectsLocationsBatchPredictionJobsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/batchPredictionJobs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/batchPredictionJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBatchPredictionJobsRequest>;
 
@@ -69962,7 +69983,7 @@ export const CreateProjectsLocationsBatchPredictionJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/batchPredictionJobs",
+      path: "v1beta1/{+parent}/batchPredictionJobs",
       hasBody: true,
     }),
     svc,
@@ -69996,7 +70017,7 @@ export const DeleteProjectsLocationsBatchPredictionJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBatchPredictionJobsRequest>;
 
@@ -70028,7 +70049,7 @@ export const DeleteProjectsLocationsTrainingPipelinesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTrainingPipelinesRequest>;
 
@@ -70060,7 +70081,7 @@ export const GetProjectsLocationsTrainingPipelinesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTrainingPipelinesRequest>;
 
@@ -70097,7 +70118,7 @@ export const CancelProjectsLocationsTrainingPipelinesRequest =
       GoogleCloudAiplatformV1beta1CancelTrainingPipelineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsTrainingPipelinesRequest>;
 
@@ -70141,7 +70162,7 @@ export const ListProjectsLocationsTrainingPipelinesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/trainingPipelines" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/trainingPipelines" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTrainingPipelinesRequest>;
 
@@ -70184,7 +70205,7 @@ export const CreateProjectsLocationsTrainingPipelinesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/trainingPipelines",
+      path: "v1beta1/{+parent}/trainingPipelines",
       hasBody: true,
     }),
     svc,
@@ -70232,7 +70253,7 @@ export const ListProjectsLocationsTrainingPipelinesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTrainingPipelinesOperationsRequest>;
 
@@ -70269,7 +70290,7 @@ export const GetProjectsLocationsTrainingPipelinesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTrainingPipelinesOperationsRequest>;
 
@@ -70302,7 +70323,7 @@ export const CancelProjectsLocationsTrainingPipelinesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsTrainingPipelinesOperationsRequest>;
 
@@ -70335,7 +70356,7 @@ export const DeleteProjectsLocationsTrainingPipelinesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTrainingPipelinesOperationsRequest>;
 
@@ -70371,7 +70392,7 @@ export const WaitProjectsLocationsTrainingPipelinesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsTrainingPipelinesOperationsRequest>;
 
@@ -70418,7 +70439,7 @@ export const ListProjectsLocationsHyperparameterTuningJobsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/hyperparameterTuningJobs",
+      path: "v1beta1/{+parent}/hyperparameterTuningJobs",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsHyperparameterTuningJobsRequest>;
@@ -70462,7 +70483,7 @@ export const CreateProjectsLocationsHyperparameterTuningJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/hyperparameterTuningJobs",
+      path: "v1beta1/{+parent}/hyperparameterTuningJobs",
       hasBody: true,
     }),
     svc,
@@ -70497,7 +70518,7 @@ export const GetProjectsLocationsHyperparameterTuningJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsHyperparameterTuningJobsRequest>;
 
@@ -70534,7 +70555,7 @@ export const CancelProjectsLocationsHyperparameterTuningJobsRequest =
       GoogleCloudAiplatformV1beta1CancelHyperparameterTuningJobRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsHyperparameterTuningJobsRequest>;
 
@@ -70567,7 +70588,7 @@ export const DeleteProjectsLocationsHyperparameterTuningJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsHyperparameterTuningJobsRequest>;
 
@@ -70600,7 +70621,7 @@ export const DeleteProjectsLocationsHyperparameterTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsHyperparameterTuningJobsOperationsRequest>;
 
@@ -70636,7 +70657,7 @@ export const WaitProjectsLocationsHyperparameterTuningJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsHyperparameterTuningJobsOperationsRequest>;
 
@@ -70683,7 +70704,7 @@ export const ListProjectsLocationsHyperparameterTuningJobsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsHyperparameterTuningJobsOperationsRequest>;
 
@@ -70720,7 +70741,7 @@ export const GetProjectsLocationsHyperparameterTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsHyperparameterTuningJobsOperationsRequest>;
 
@@ -70753,7 +70774,7 @@ export const CancelProjectsLocationsHyperparameterTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsHyperparameterTuningJobsOperationsRequest>;
 
@@ -70786,7 +70807,7 @@ export const DeleteNotebookRuntimeTemplatesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -70821,7 +70842,7 @@ export const WaitNotebookRuntimeTemplatesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -70853,7 +70874,7 @@ export const GetNotebookRuntimeTemplatesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -70885,7 +70906,7 @@ export const CancelNotebookRuntimeTemplatesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -70931,7 +70952,7 @@ export const ListNotebookRuntimeTemplatesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListNotebookRuntimeTemplatesOperationsRequest>;
 
@@ -70967,7 +70988,7 @@ export const DeleteIndexesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteIndexesOperationsRequest>;
 
@@ -71001,7 +71022,7 @@ export const WaitIndexesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitIndexesOperationsRequest>;
 
@@ -71046,7 +71067,7 @@ export const ListIndexesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListIndexesOperationsRequest>;
 
@@ -71082,7 +71103,7 @@ export const GetIndexesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetIndexesOperationsRequest>;
 
@@ -71113,7 +71134,7 @@ export const CancelIndexesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelIndexesOperationsRequest>;
 
@@ -71144,7 +71165,7 @@ export const DeleteEvaluationSetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteEvaluationSetsOperationsRequest>;
 
@@ -71178,7 +71199,7 @@ export const WaitEvaluationSetsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitEvaluationSetsOperationsRequest>;
 
@@ -71223,7 +71244,7 @@ export const ListEvaluationSetsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListEvaluationSetsOperationsRequest>;
 
@@ -71259,7 +71280,7 @@ export const GetEvaluationSetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEvaluationSetsOperationsRequest>;
 
@@ -71304,7 +71325,7 @@ export const ListFeatureGroupsFeatureMonitorsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListFeatureGroupsFeatureMonitorsOperationsRequest>;
 
@@ -71340,7 +71361,7 @@ export const DeleteFeatureGroupsFeatureMonitorsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFeatureGroupsFeatureMonitorsOperationsRequest>;
 
@@ -71375,7 +71396,7 @@ export const WaitFeatureGroupsFeatureMonitorsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitFeatureGroupsFeatureMonitorsOperationsRequest>;
 
@@ -71407,7 +71428,7 @@ export const GetFeatureGroupsFeatureMonitorsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFeatureGroupsFeatureMonitorsOperationsRequest>;
 
@@ -71453,7 +71474,7 @@ export const ListFeatureGroupsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListFeatureGroupsOperationsRequest>;
 
@@ -71489,7 +71510,7 @@ export const DeleteFeatureGroupsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFeatureGroupsOperationsRequest>;
 
@@ -71523,7 +71544,7 @@ export const WaitFeatureGroupsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitFeatureGroupsOperationsRequest>;
 
@@ -71554,7 +71575,7 @@ export const GetFeatureGroupsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFeatureGroupsOperationsRequest>;
 
@@ -71585,7 +71606,7 @@ export const DeleteFeatureGroupsFeaturesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFeatureGroupsFeaturesOperationsRequest>;
 
@@ -71619,7 +71640,7 @@ export const WaitFeatureGroupsFeaturesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitFeatureGroupsFeaturesOperationsRequest>;
 
@@ -71665,7 +71686,7 @@ export const ListFeatureGroupsFeaturesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListFeatureGroupsFeaturesOperationsRequest>;
 
@@ -71701,7 +71722,7 @@ export const GetFeatureGroupsFeaturesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFeatureGroupsFeaturesOperationsRequest>;
 
@@ -71747,7 +71768,7 @@ export const ListAppsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListAppsOperationsRequest>;
 
@@ -71783,7 +71804,7 @@ export const GetAppsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAppsOperationsRequest>;
 
@@ -71814,7 +71835,7 @@ export const CancelAppsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelAppsOperationsRequest>;
 
@@ -71845,7 +71866,7 @@ export const DeleteAppsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAppsOperationsRequest>;
 
@@ -71879,7 +71900,7 @@ export const WaitAppsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitAppsOperationsRequest>;
 
@@ -71910,7 +71931,7 @@ export const DeleteIndexEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteIndexEndpointsOperationsRequest>;
 
@@ -71944,7 +71965,7 @@ export const WaitIndexEndpointsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitIndexEndpointsOperationsRequest>;
 
@@ -71989,7 +72010,7 @@ export const ListIndexEndpointsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListIndexEndpointsOperationsRequest>;
 
@@ -72025,7 +72046,7 @@ export const GetIndexEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetIndexEndpointsOperationsRequest>;
 
@@ -72056,7 +72077,7 @@ export const CancelIndexEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelIndexEndpointsOperationsRequest>;
 
@@ -72086,7 +72107,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta1/{name}" }),
+  T.Http({ method: "GET", path: "v1beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -72117,7 +72138,7 @@ export const CancelOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOperationsRequest>;
 
@@ -72196,7 +72217,7 @@ export const DeleteOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOperationsRequest>;
 
@@ -72229,7 +72250,7 @@ export const WaitOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
 }).pipe(
-  T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+  T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<WaitOperationsRequest>;
 
@@ -72267,7 +72288,7 @@ export const PredictLongRunningEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:predictLongRunning",
+      path: "v1beta1/{+endpoint}:predictLongRunning",
       hasBody: true,
     }),
     svc,
@@ -72306,7 +72327,7 @@ export const StreamGenerateContentEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{model}:streamGenerateContent",
+      path: "v1beta1/{+model}:streamGenerateContent",
       hasBody: true,
     }),
     svc,
@@ -72347,7 +72368,7 @@ export const ComputeTokensEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:computeTokens",
+      path: "v1beta1/{+endpoint}:computeTokens",
       hasBody: true,
     }),
     svc,
@@ -72388,7 +72409,7 @@ export const FetchPredictOperationEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:fetchPredictOperation",
+      path: "v1beta1/{+endpoint}:fetchPredictOperation",
       hasBody: true,
     }),
     svc,
@@ -72428,7 +72449,7 @@ export const CountTokensEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:countTokens",
+      path: "v1beta1/{+endpoint}:countTokens",
       hasBody: true,
     }),
     svc,
@@ -72469,7 +72490,7 @@ export const GenerateContentEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{model}:generateContent",
+      path: "v1beta1/{+model}:generateContent",
       hasBody: true,
     }),
     svc,
@@ -72510,7 +72531,7 @@ export const PredictEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:predict",
+      path: "v1beta1/{+endpoint}:predict",
       hasBody: true,
     }),
     svc,
@@ -72543,7 +72564,7 @@ export const DeleteEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteEndpointsOperationsRequest>;
 
@@ -72577,7 +72598,7 @@ export const WaitEndpointsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitEndpointsOperationsRequest>;
 
@@ -72622,7 +72643,7 @@ export const ListEndpointsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListEndpointsOperationsRequest>;
 
@@ -72658,7 +72679,7 @@ export const GetEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEndpointsOperationsRequest>;
 
@@ -72689,7 +72710,7 @@ export const CancelEndpointsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelEndpointsOperationsRequest>;
 
@@ -72725,7 +72746,7 @@ export const CompletionsEndpointsChatRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}/chat/completions",
+      path: "v1beta1/{+endpoint}/chat/completions",
       hasBody: true,
     }),
     svc,
@@ -72758,7 +72779,7 @@ export const GetFeatureOnlineStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFeatureOnlineStoresOperationsRequest>;
 
@@ -72804,7 +72825,7 @@ export const ListFeatureOnlineStoresOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListFeatureOnlineStoresOperationsRequest>;
 
@@ -72840,7 +72861,7 @@ export const DeleteFeatureOnlineStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFeatureOnlineStoresOperationsRequest>;
 
@@ -72874,7 +72895,7 @@ export const WaitFeatureOnlineStoresOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitFeatureOnlineStoresOperationsRequest>;
 
@@ -72906,7 +72927,7 @@ export const GetFeatureOnlineStoresFeatureViewsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFeatureOnlineStoresFeatureViewsOperationsRequest>;
 
@@ -72952,7 +72973,7 @@ export const ListFeatureOnlineStoresFeatureViewsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListFeatureOnlineStoresFeatureViewsOperationsRequest>;
 
@@ -72988,7 +73009,7 @@ export const DeleteFeatureOnlineStoresFeatureViewsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFeatureOnlineStoresFeatureViewsOperationsRequest>;
 
@@ -73024,7 +73045,7 @@ export const WaitFeatureOnlineStoresFeatureViewsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitFeatureOnlineStoresFeatureViewsOperationsRequest>;
 
@@ -73059,7 +73080,7 @@ export const DeleteReasoningEnginesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesRequest>;
 
@@ -73097,7 +73118,7 @@ export const StreamQueryReasoningEnginesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:streamQuery",
+      path: "v1beta1/{+name}:streamQuery",
       hasBody: true,
     }),
     svc,
@@ -73138,7 +73159,7 @@ export const PatchReasoningEnginesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchReasoningEnginesRequest>;
 
@@ -73169,7 +73190,7 @@ export const GetReasoningEnginesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesRequest>;
 
@@ -73206,7 +73227,7 @@ export const QueryReasoningEnginesRequest =
       GoogleCloudAiplatformV1beta1QueryReasoningEngineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryReasoningEnginesRequest>;
 
@@ -73281,7 +73302,7 @@ export const ExecuteCodeReasoningEnginesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:executeCode",
+      path: "v1beta1/{+name}:executeCode",
       hasBody: true,
     }),
     svc,
@@ -73360,7 +73381,7 @@ export const DeleteReasoningEnginesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesOperationsRequest>;
 
@@ -73394,7 +73415,7 @@ export const WaitReasoningEnginesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitReasoningEnginesOperationsRequest>;
 
@@ -73425,7 +73446,7 @@ export const GetReasoningEnginesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesOperationsRequest>;
 
@@ -73456,7 +73477,7 @@ export const CancelReasoningEnginesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelReasoningEnginesOperationsRequest>;
 
@@ -73501,7 +73522,7 @@ export const ListReasoningEnginesOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesOperationsRequest>;
 
@@ -73537,7 +73558,7 @@ export const DeleteReasoningEnginesSandboxEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -73569,7 +73590,7 @@ export const GetReasoningEnginesSandboxEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -73606,7 +73627,7 @@ export const ExecuteReasoningEnginesSandboxEnvironmentsRequest =
       GoogleCloudAiplatformV1beta1ExecuteSandboxEnvironmentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:execute", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:execute", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -73647,7 +73668,7 @@ export const ListReasoningEnginesSandboxEnvironmentsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/sandboxEnvironments" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/sandboxEnvironments" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -73688,7 +73709,7 @@ export const SnapshotReasoningEnginesSandboxEnvironmentsRequest =
       GoogleCloudAiplatformV1beta1SandboxEnvironmentSnapshot,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:snapshot", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:snapshot", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SnapshotReasoningEnginesSandboxEnvironmentsRequest>;
 
@@ -73727,7 +73748,7 @@ export const CreateReasoningEnginesSandboxEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/sandboxEnvironments",
+      path: "v1beta1/{+parent}/sandboxEnvironments",
       hasBody: true,
     }),
     svc,
@@ -73761,7 +73782,7 @@ export const DeleteReasoningEnginesSandboxEnvironmentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesSandboxEnvironmentsOperationsRequest>;
 
@@ -73797,7 +73818,7 @@ export const WaitReasoningEnginesSandboxEnvironmentsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitReasoningEnginesSandboxEnvironmentsOperationsRequest>;
 
@@ -73844,7 +73865,7 @@ export const ListReasoningEnginesSandboxEnvironmentsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesSandboxEnvironmentsOperationsRequest>;
 
@@ -73881,7 +73902,7 @@ export const GetReasoningEnginesSandboxEnvironmentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesSandboxEnvironmentsOperationsRequest>;
 
@@ -73914,7 +73935,7 @@ export const CancelReasoningEnginesSandboxEnvironmentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelReasoningEnginesSandboxEnvironmentsOperationsRequest>;
 
@@ -73947,7 +73968,7 @@ export const DeleteReasoningEnginesExamplesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesExamplesOperationsRequest>;
 
@@ -73982,7 +74003,7 @@ export const WaitReasoningEnginesExamplesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitReasoningEnginesExamplesOperationsRequest>;
 
@@ -74014,7 +74035,7 @@ export const GetReasoningEnginesExamplesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesExamplesOperationsRequest>;
 
@@ -74046,7 +74067,7 @@ export const CancelReasoningEnginesExamplesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelReasoningEnginesExamplesOperationsRequest>;
 
@@ -74078,7 +74099,7 @@ export const DeleteReasoningEnginesSandboxEnvironmentSnapshotsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesSandboxEnvironmentSnapshotsRequest>;
 
@@ -74122,7 +74143,7 @@ export const ListReasoningEnginesSandboxEnvironmentSnapshotsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/sandboxEnvironmentSnapshots",
+      path: "v1beta1/{+parent}/sandboxEnvironmentSnapshots",
     }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesSandboxEnvironmentSnapshotsRequest>;
@@ -74160,7 +74181,7 @@ export const GetReasoningEnginesSandboxEnvironmentSnapshotsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesSandboxEnvironmentSnapshotsRequest>;
 
@@ -74192,7 +74213,7 @@ export const DeleteReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest>;
 
@@ -74228,7 +74249,7 @@ export const WaitReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest>;
 
@@ -74275,7 +74296,7 @@ export const ListReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest>;
 
@@ -74312,7 +74333,7 @@ export const GetReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest>;
 
@@ -74345,7 +74366,7 @@ export const CancelReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelReasoningEnginesSandboxEnvironmentSnapshotsOperationsRequest>;
 
@@ -74378,7 +74399,7 @@ export const GetReasoningEnginesSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesSessionsRequest>;
 
@@ -74422,7 +74443,7 @@ export const ListReasoningEnginesSessionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/sessions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/sessions" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesSessionsRequest>;
 
@@ -74468,7 +74489,7 @@ export const CreateReasoningEnginesSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/sessions",
+      path: "v1beta1/{+parent}/sessions",
       hasBody: true,
     }),
     svc,
@@ -74509,7 +74530,7 @@ export const PatchReasoningEnginesSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchReasoningEnginesSessionsRequest>;
 
@@ -74541,7 +74562,7 @@ export const DeleteReasoningEnginesSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesSessionsRequest>;
 
@@ -74579,7 +74600,7 @@ export const AppendEventReasoningEnginesSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:appendEvent",
+      path: "v1beta1/{+name}:appendEvent",
       hasBody: true,
     }),
     svc,
@@ -74625,7 +74646,7 @@ export const ListReasoningEnginesSessionsEventsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/events" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/events" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesSessionsEventsRequest>;
 
@@ -74675,7 +74696,7 @@ export const ListReasoningEnginesSessionsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesSessionsOperationsRequest>;
 
@@ -74711,7 +74732,7 @@ export const GetReasoningEnginesSessionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesSessionsOperationsRequest>;
 
@@ -74743,7 +74764,7 @@ export const CancelReasoningEnginesSessionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelReasoningEnginesSessionsOperationsRequest>;
 
@@ -74775,7 +74796,7 @@ export const DeleteReasoningEnginesSessionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesSessionsOperationsRequest>;
 
@@ -74810,7 +74831,7 @@ export const WaitReasoningEnginesSessionsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitReasoningEnginesSessionsOperationsRequest>;
 
@@ -74842,7 +74863,7 @@ export const GetReasoningEnginesFeedbackEntriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesFeedbackEntriesOperationsRequest>;
 
@@ -74874,7 +74895,7 @@ export const CancelReasoningEnginesFeedbackEntriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelReasoningEnginesFeedbackEntriesOperationsRequest>;
 
@@ -74921,7 +74942,7 @@ export const ListReasoningEnginesFeedbackEntriesOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesFeedbackEntriesOperationsRequest>;
 
@@ -74957,7 +74978,7 @@ export const DeleteReasoningEnginesFeedbackEntriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesFeedbackEntriesOperationsRequest>;
 
@@ -74993,7 +75014,7 @@ export const WaitReasoningEnginesFeedbackEntriesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitReasoningEnginesFeedbackEntriesOperationsRequest>;
 
@@ -75025,7 +75046,7 @@ export const GetReasoningEnginesSandboxEnvironmentTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesSandboxEnvironmentTemplatesRequest>;
 
@@ -75064,7 +75085,7 @@ export const CreateReasoningEnginesSandboxEnvironmentTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/sandboxEnvironmentTemplates",
+      path: "v1beta1/{+parent}/sandboxEnvironmentTemplates",
       hasBody: true,
     }),
     svc,
@@ -75099,7 +75120,7 @@ export const DeleteReasoningEnginesSandboxEnvironmentTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesSandboxEnvironmentTemplatesRequest>;
 
@@ -75143,7 +75164,7 @@ export const ListReasoningEnginesSandboxEnvironmentTemplatesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/sandboxEnvironmentTemplates",
+      path: "v1beta1/{+parent}/sandboxEnvironmentTemplates",
     }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesSandboxEnvironmentTemplatesRequest>;
@@ -75181,7 +75202,7 @@ export const GetReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest>;
 
@@ -75214,7 +75235,7 @@ export const CancelReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest>;
 
@@ -75261,7 +75282,7 @@ export const ListReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest>;
 
@@ -75298,7 +75319,7 @@ export const DeleteReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest>;
 
@@ -75334,7 +75355,7 @@ export const WaitReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitReasoningEnginesSandboxEnvironmentTemplatesOperationsRequest>;
 
@@ -75375,7 +75396,7 @@ export const TasksReasoningEnginesA2aRequest =
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<TasksReasoningEnginesA2aRequest>;
 
@@ -75416,7 +75437,7 @@ export const CardReasoningEnginesA2aRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<CardReasoningEnginesA2aRequest>;
 
@@ -75457,7 +75478,7 @@ export const ExtendedAgentCardReasoningEnginesA2aRequest =
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<ExtendedAgentCardReasoningEnginesA2aRequest>;
 
@@ -75495,7 +75516,7 @@ export const StreamReasoningEnginesA2aMessageRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:stream",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:stream",
       hasBody: true,
     }),
     svc,
@@ -75533,7 +75554,7 @@ export const SendReasoningEnginesA2aMessageRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:send",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:send",
       hasBody: true,
     }),
     svc,
@@ -75576,7 +75597,7 @@ export const TasksReasoningEnginesA2aV1Request =
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<TasksReasoningEnginesA2aV1Request>;
 
@@ -75617,7 +75638,7 @@ export const CardReasoningEnginesA2aV1Request =
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<CardReasoningEnginesA2aV1Request>;
 
@@ -75658,7 +75679,7 @@ export const ExtendedAgentCardReasoningEnginesA2aV1Request =
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<ExtendedAgentCardReasoningEnginesA2aV1Request>;
 
@@ -75696,7 +75717,7 @@ export const StreamReasoningEnginesA2aV1MessageRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:stream",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:stream",
       hasBody: true,
     }),
     svc,
@@ -75734,7 +75755,7 @@ export const SendReasoningEnginesA2aV1MessageRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:send",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:send",
       hasBody: true,
     }),
     svc,
@@ -75777,7 +75798,7 @@ export const PushNotificationConfigsReasoningEnginesA2aV1TasksRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<PushNotificationConfigsReasoningEnginesA2aV1TasksRequest>;
 
@@ -75819,7 +75840,7 @@ export const A2aGetReasoningEngineReasoningEnginesA2aV1TasksRequest =
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<A2aGetReasoningEngineReasoningEnginesA2aV1TasksRequest>;
 
@@ -75858,7 +75879,7 @@ export const CancelReasoningEnginesA2aV1TasksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:cancel",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:cancel",
       hasBody: true,
     }),
     svc,
@@ -75898,7 +75919,7 @@ export const SubscribeReasoningEnginesA2aV1TasksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:subscribe",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:subscribe",
     }),
     svc,
   ) as unknown as Schema.Schema<SubscribeReasoningEnginesA2aV1TasksRequest>;
@@ -75938,7 +75959,7 @@ export const A2aGetReasoningEngineReasoningEnginesA2aV1TasksPushNotificationConf
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<A2aGetReasoningEngineReasoningEnginesA2aV1TasksPushNotificationConfigsRequest>;
 
@@ -75979,7 +76000,7 @@ export const CancelReasoningEnginesA2aTasksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:cancel",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:cancel",
       hasBody: true,
     }),
     svc,
@@ -76022,7 +76043,7 @@ export const PushNotificationConfigsReasoningEnginesA2aTasksRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<PushNotificationConfigsReasoningEnginesA2aTasksRequest>;
 
@@ -76064,7 +76085,7 @@ export const A2aGetReasoningEngineReasoningEnginesA2aTasksRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<A2aGetReasoningEngineReasoningEnginesA2aTasksRequest>;
 
@@ -76102,7 +76123,7 @@ export const SubscribeReasoningEnginesA2aTasksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:subscribe",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:subscribe",
     }),
     svc,
   ) as unknown as Schema.Schema<SubscribeReasoningEnginesA2aTasksRequest>;
@@ -76142,7 +76163,7 @@ export const A2aGetReasoningEngineReasoningEnginesA2aTasksPushNotificationConfig
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<A2aGetReasoningEngineReasoningEnginesA2aTasksPushNotificationConfigsRequest>;
 
@@ -76178,7 +76199,7 @@ export const DeleteReasoningEnginesMemoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesMemoriesRequest>;
 
@@ -76209,7 +76230,7 @@ export const GetReasoningEnginesMemoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesMemoriesRequest>;
 
@@ -76248,7 +76269,7 @@ export const RetrieveReasoningEnginesMemoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/memories:retrieve",
+      path: "v1beta1/{+parent}/memories:retrieve",
       hasBody: true,
     }),
     svc,
@@ -76292,7 +76313,7 @@ export const CreateReasoningEnginesMemoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/memories",
+      path: "v1beta1/{+parent}/memories",
       hasBody: true,
     }),
     svc,
@@ -76332,7 +76353,7 @@ export const RetrieveProfilesReasoningEnginesMemoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/memories:retrieveProfiles",
+      path: "v1beta1/{+parent}/memories:retrieveProfiles",
       hasBody: true,
     }),
     svc,
@@ -76378,7 +76399,7 @@ export const ListReasoningEnginesMemoriesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/memories" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/memories" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesMemoriesRequest>;
 
@@ -76419,7 +76440,7 @@ export const RollbackReasoningEnginesMemoriesRequest =
       GoogleCloudAiplatformV1beta1RollbackMemoryRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:rollback", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:rollback", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RollbackReasoningEnginesMemoriesRequest>;
 
@@ -76458,7 +76479,7 @@ export const GenerateReasoningEnginesMemoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/memories:generate",
+      path: "v1beta1/{+parent}/memories:generate",
       hasBody: true,
     }),
     svc,
@@ -76499,7 +76520,7 @@ export const PurgeReasoningEnginesMemoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/memories:purge",
+      path: "v1beta1/{+parent}/memories:purge",
       hasBody: true,
     }),
     svc,
@@ -76540,7 +76561,7 @@ export const PatchReasoningEnginesMemoriesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchReasoningEnginesMemoriesRequest>;
 
@@ -76578,7 +76599,7 @@ export const IngestEventsReasoningEnginesMemoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/memories:ingestEvents",
+      path: "v1beta1/{+parent}/memories:ingestEvents",
       hasBody: true,
     }),
     svc,
@@ -76612,7 +76633,7 @@ export const DeleteReasoningEnginesMemoriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesMemoriesOperationsRequest>;
 
@@ -76647,7 +76668,7 @@ export const WaitReasoningEnginesMemoriesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitReasoningEnginesMemoriesOperationsRequest>;
 
@@ -76693,7 +76714,7 @@ export const ListReasoningEnginesMemoriesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesMemoriesOperationsRequest>;
 
@@ -76729,7 +76750,7 @@ export const GetReasoningEnginesMemoriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesMemoriesOperationsRequest>;
 
@@ -76761,7 +76782,7 @@ export const CancelReasoningEnginesMemoriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelReasoningEnginesMemoriesOperationsRequest>;
 
@@ -76802,7 +76823,7 @@ export const ListReasoningEnginesMemoriesRevisionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/revisions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/revisions" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesMemoriesRevisionsRequest>;
 
@@ -76838,7 +76859,7 @@ export const GetReasoningEnginesMemoriesRevisionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesMemoriesRevisionsRequest>;
 
@@ -76877,7 +76898,7 @@ export const StreamQueryReasoningEnginesRuntimeRevisionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:streamQuery",
+      path: "v1beta1/{+name}:streamQuery",
       hasBody: true,
     }),
     svc,
@@ -76916,7 +76937,7 @@ export const QueryReasoningEnginesRuntimeRevisionsRequest =
       GoogleCloudAiplatformV1beta1QueryReasoningEngineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryReasoningEnginesRuntimeRevisionsRequest>;
 
@@ -76956,7 +76977,7 @@ export const TasksReasoningEnginesRuntimeRevisionsA2aRequest =
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<TasksReasoningEnginesRuntimeRevisionsA2aRequest>;
 
@@ -76997,7 +77018,7 @@ export const CardReasoningEnginesRuntimeRevisionsA2aRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<CardReasoningEnginesRuntimeRevisionsA2aRequest>;
 
@@ -77038,7 +77059,7 @@ export const ExtendedAgentCardReasoningEnginesRuntimeRevisionsA2aRequest =
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<ExtendedAgentCardReasoningEnginesRuntimeRevisionsA2aRequest>;
 
@@ -77077,7 +77098,7 @@ export const CancelReasoningEnginesRuntimeRevisionsA2aTasksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:cancel",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:cancel",
       hasBody: true,
     }),
     svc,
@@ -77120,7 +77141,7 @@ export const PushNotificationConfigsReasoningEnginesRuntimeRevisionsA2aTasksRequ
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<PushNotificationConfigsReasoningEnginesRuntimeRevisionsA2aTasksRequest>;
 
@@ -77163,7 +77184,7 @@ export const A2aGetReasoningEngineReasoningEnginesRuntimeRevisionsA2aTasksReques
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<A2aGetReasoningEngineReasoningEnginesRuntimeRevisionsA2aTasksRequest>;
 
@@ -77202,7 +77223,7 @@ export const SubscribeReasoningEnginesRuntimeRevisionsA2aTasksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:subscribe",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:subscribe",
     }),
     svc,
   ) as unknown as Schema.Schema<SubscribeReasoningEnginesRuntimeRevisionsA2aTasksRequest>;
@@ -77244,7 +77265,7 @@ export const A2aGetReasoningEngineReasoningEnginesRuntimeRevisionsA2aTasksPushNo
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<A2aGetReasoningEngineReasoningEnginesRuntimeRevisionsA2aTasksPushNotificationConfigsRequest>;
 
@@ -77285,7 +77306,7 @@ export const SendReasoningEnginesRuntimeRevisionsA2aMessageRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:send",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:send",
       hasBody: true,
     }),
     svc,
@@ -77325,7 +77346,7 @@ export const StreamReasoningEnginesRuntimeRevisionsA2aMessageRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:stream",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:stream",
       hasBody: true,
     }),
     svc,
@@ -77368,7 +77389,7 @@ export const TasksReasoningEnginesRuntimeRevisionsA2aV1Request =
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<TasksReasoningEnginesRuntimeRevisionsA2aV1Request>;
 
@@ -77409,7 +77430,7 @@ export const CardReasoningEnginesRuntimeRevisionsA2aV1Request =
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<CardReasoningEnginesRuntimeRevisionsA2aV1Request>;
 
@@ -77450,7 +77471,7 @@ export const ExtendedAgentCardReasoningEnginesRuntimeRevisionsA2aV1Request =
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<ExtendedAgentCardReasoningEnginesRuntimeRevisionsA2aV1Request>;
 
@@ -77489,7 +77510,7 @@ export const StreamReasoningEnginesRuntimeRevisionsA2aV1MessageRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:stream",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:stream",
       hasBody: true,
     }),
     svc,
@@ -77529,7 +77550,7 @@ export const SendReasoningEnginesRuntimeRevisionsA2aV1MessageRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:send",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:send",
       hasBody: true,
     }),
     svc,
@@ -77570,7 +77591,7 @@ export const CancelReasoningEnginesRuntimeRevisionsA2aV1TasksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:cancel",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:cancel",
       hasBody: true,
     }),
     svc,
@@ -77614,7 +77635,7 @@ export const PushNotificationConfigsReasoningEnginesRuntimeRevisionsA2aV1TasksRe
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<PushNotificationConfigsReasoningEnginesRuntimeRevisionsA2aV1TasksRequest>;
 
@@ -77658,7 +77679,7 @@ export const A2aGetReasoningEngineReasoningEnginesRuntimeRevisionsA2aV1TasksRequ
     name: Schema.String.pipe(T.HttpPath("name")),
     a2aEndpoint: Schema.String.pipe(T.HttpPath("a2aEndpoint")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<A2aGetReasoningEngineReasoningEnginesRuntimeRevisionsA2aV1TasksRequest>;
 
@@ -77698,7 +77719,7 @@ export const SubscribeReasoningEnginesRuntimeRevisionsA2aV1TasksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{name}/a2a/{a2aEndpoint}:subscribe",
+      path: "v1beta1/{+name}/a2a/{+a2aEndpoint}:subscribe",
     }),
     svc,
   ) as unknown as Schema.Schema<SubscribeReasoningEnginesRuntimeRevisionsA2aV1TasksRequest>;
@@ -77740,7 +77761,7 @@ export const A2aGetReasoningEngineReasoningEnginesRuntimeRevisionsA2aV1TasksPush
       T.HttpQuery("historyLength"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/a2a/{a2aEndpoint}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/a2a/{+a2aEndpoint}" }),
     svc,
   ) as unknown as Schema.Schema<A2aGetReasoningEngineReasoningEnginesRuntimeRevisionsA2aV1TasksPushNotificationConfigsRequest>;
 
@@ -77776,7 +77797,7 @@ export const GetReasoningEnginesRuntimeRevisionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReasoningEnginesRuntimeRevisionsOperationsRequest>;
 
@@ -77808,7 +77829,7 @@ export const CancelReasoningEnginesRuntimeRevisionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelReasoningEnginesRuntimeRevisionsOperationsRequest>;
 
@@ -77855,7 +77876,7 @@ export const ListReasoningEnginesRuntimeRevisionsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListReasoningEnginesRuntimeRevisionsOperationsRequest>;
 
@@ -77891,7 +77912,7 @@ export const DeleteReasoningEnginesRuntimeRevisionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteReasoningEnginesRuntimeRevisionsOperationsRequest>;
 
@@ -77927,7 +77948,7 @@ export const WaitReasoningEnginesRuntimeRevisionsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitReasoningEnginesRuntimeRevisionsOperationsRequest>;
 
@@ -77959,7 +77980,7 @@ export const DeleteNotebookExecutionJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNotebookExecutionJobsOperationsRequest>;
 
@@ -77993,7 +78014,7 @@ export const WaitNotebookExecutionJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitNotebookExecutionJobsOperationsRequest>;
 
@@ -78039,7 +78060,7 @@ export const ListNotebookExecutionJobsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListNotebookExecutionJobsOperationsRequest>;
 
@@ -78075,7 +78096,7 @@ export const GetNotebookExecutionJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNotebookExecutionJobsOperationsRequest>;
 
@@ -78107,7 +78128,7 @@ export const CancelNotebookExecutionJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelNotebookExecutionJobsOperationsRequest>;
 
@@ -78138,7 +78159,7 @@ export const DeletePersistentResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePersistentResourcesOperationsRequest>;
 
@@ -78172,7 +78193,7 @@ export const WaitPersistentResourcesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitPersistentResourcesOperationsRequest>;
 
@@ -78218,7 +78239,7 @@ export const ListPersistentResourcesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListPersistentResourcesOperationsRequest>;
 
@@ -78254,7 +78275,7 @@ export const GetPersistentResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPersistentResourcesOperationsRequest>;
 
@@ -78286,7 +78307,7 @@ export const CancelPersistentResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelPersistentResourcesOperationsRequest>;
 
@@ -78317,7 +78338,7 @@ export const GetEvaluationRunsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEvaluationRunsOperationsRequest>;
 
@@ -78348,7 +78369,7 @@ export const DeleteEvaluationRunsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteEvaluationRunsOperationsRequest>;
 
@@ -78382,7 +78403,7 @@ export const WaitEvaluationRunsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitEvaluationRunsOperationsRequest>;
 
@@ -78427,7 +78448,7 @@ export const ListEvaluationRunsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListEvaluationRunsOperationsRequest>;
 
@@ -78463,7 +78484,7 @@ export const DeleteEvaluationTasksOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteEvaluationTasksOperationsRequest>;
 
@@ -78497,7 +78518,7 @@ export const WaitEvaluationTasksOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitEvaluationTasksOperationsRequest>;
 
@@ -78542,7 +78563,7 @@ export const ListEvaluationTasksOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListEvaluationTasksOperationsRequest>;
 
@@ -78578,7 +78599,7 @@ export const GetEvaluationTasksOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEvaluationTasksOperationsRequest>;
 
@@ -78609,7 +78630,7 @@ export const DeleteMigratableResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteMigratableResourcesOperationsRequest>;
 
@@ -78643,7 +78664,7 @@ export const WaitMigratableResourcesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitMigratableResourcesOperationsRequest>;
 
@@ -78689,7 +78710,7 @@ export const ListMigratableResourcesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListMigratableResourcesOperationsRequest>;
 
@@ -78725,7 +78746,7 @@ export const GetMigratableResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetMigratableResourcesOperationsRequest>;
 
@@ -78757,7 +78778,7 @@ export const CancelMigratableResourcesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelMigratableResourcesOperationsRequest>;
 
@@ -78788,7 +78809,7 @@ export const GetEvaluationMetricsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEvaluationMetricsOperationsRequest>;
 
@@ -78819,7 +78840,7 @@ export const DeleteEvaluationMetricsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteEvaluationMetricsOperationsRequest>;
 
@@ -78864,7 +78885,7 @@ export const ListEvaluationMetricsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListEvaluationMetricsOperationsRequest>;
 
@@ -78900,7 +78921,7 @@ export const DeleteExtensionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteExtensionsOperationsRequest>;
 
@@ -78934,7 +78955,7 @@ export const WaitExtensionsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitExtensionsOperationsRequest>;
 
@@ -78979,7 +79000,7 @@ export const ListExtensionsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListExtensionsOperationsRequest>;
 
@@ -79015,7 +79036,7 @@ export const GetExtensionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetExtensionsOperationsRequest>;
 
@@ -79046,7 +79067,7 @@ export const CancelExtensionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelExtensionsOperationsRequest>;
 
@@ -79077,7 +79098,7 @@ export const GetDataLabelingJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDataLabelingJobsOperationsRequest>;
 
@@ -79108,7 +79129,7 @@ export const CancelDataLabelingJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelDataLabelingJobsOperationsRequest>;
 
@@ -79153,7 +79174,7 @@ export const ListDataLabelingJobsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListDataLabelingJobsOperationsRequest>;
 
@@ -79189,7 +79210,7 @@ export const DeleteDataLabelingJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDataLabelingJobsOperationsRequest>;
 
@@ -79223,7 +79244,7 @@ export const WaitDataLabelingJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitDataLabelingJobsOperationsRequest>;
 
@@ -79254,7 +79275,7 @@ export const DeleteOnlineEvaluatorsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOnlineEvaluatorsOperationsRequest>;
 
@@ -79288,7 +79309,7 @@ export const WaitOnlineEvaluatorsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitOnlineEvaluatorsOperationsRequest>;
 
@@ -79333,7 +79354,7 @@ export const ListOnlineEvaluatorsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListOnlineEvaluatorsOperationsRequest>;
 
@@ -79369,7 +79390,7 @@ export const GetOnlineEvaluatorsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOnlineEvaluatorsOperationsRequest>;
 
@@ -79400,7 +79421,7 @@ export const CancelOnlineEvaluatorsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOnlineEvaluatorsOperationsRequest>;
 
@@ -79431,7 +79452,7 @@ export const GetRagCorporaOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetRagCorporaOperationsRequest>;
 
@@ -79462,7 +79483,7 @@ export const CancelRagCorporaOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelRagCorporaOperationsRequest>;
 
@@ -79507,7 +79528,7 @@ export const ListRagCorporaOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListRagCorporaOperationsRequest>;
 
@@ -79543,7 +79564,7 @@ export const DeleteRagCorporaOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteRagCorporaOperationsRequest>;
 
@@ -79577,7 +79598,7 @@ export const WaitRagCorporaOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitRagCorporaOperationsRequest>;
 
@@ -79622,7 +79643,7 @@ export const ListRagCorporaRagFilesOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListRagCorporaRagFilesOperationsRequest>;
 
@@ -79658,7 +79679,7 @@ export const GetRagCorporaRagFilesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetRagCorporaRagFilesOperationsRequest>;
 
@@ -79690,7 +79711,7 @@ export const CancelRagCorporaRagFilesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelRagCorporaRagFilesOperationsRequest>;
 
@@ -79721,7 +79742,7 @@ export const DeleteRagCorporaRagFilesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteRagCorporaRagFilesOperationsRequest>;
 
@@ -79755,7 +79776,7 @@ export const WaitRagCorporaRagFilesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitRagCorporaRagFilesOperationsRequest>;
 
@@ -79787,7 +79808,7 @@ export const DeleteExampleStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteExampleStoresOperationsRequest>;
 
@@ -79821,7 +79842,7 @@ export const WaitExampleStoresOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitExampleStoresOperationsRequest>;
 
@@ -79852,7 +79873,7 @@ export const GetExampleStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetExampleStoresOperationsRequest>;
 
@@ -79883,7 +79904,7 @@ export const CancelExampleStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelExampleStoresOperationsRequest>;
 
@@ -79928,7 +79949,7 @@ export const ListExampleStoresOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListExampleStoresOperationsRequest>;
 
@@ -79978,7 +79999,7 @@ export const ListFeaturestoresEntityTypesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListFeaturestoresEntityTypesOperationsRequest>;
 
@@ -80014,7 +80035,7 @@ export const GetFeaturestoresEntityTypesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFeaturestoresEntityTypesOperationsRequest>;
 
@@ -80046,7 +80067,7 @@ export const CancelFeaturestoresEntityTypesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelFeaturestoresEntityTypesOperationsRequest>;
 
@@ -80078,7 +80099,7 @@ export const DeleteFeaturestoresEntityTypesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFeaturestoresEntityTypesOperationsRequest>;
 
@@ -80113,7 +80134,7 @@ export const WaitFeaturestoresEntityTypesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitFeaturestoresEntityTypesOperationsRequest>;
 
@@ -80159,7 +80180,7 @@ export const ListFeaturestoresEntityTypesFeaturesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -80195,7 +80216,7 @@ export const GetFeaturestoresEntityTypesFeaturesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -80227,7 +80248,7 @@ export const CancelFeaturestoresEntityTypesFeaturesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -80260,7 +80281,7 @@ export const DeleteFeaturestoresEntityTypesFeaturesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -80296,7 +80317,7 @@ export const WaitFeaturestoresEntityTypesFeaturesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitFeaturestoresEntityTypesFeaturesOperationsRequest>;
 
@@ -80342,7 +80363,7 @@ export const ListFeaturestoresOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListFeaturestoresOperationsRequest>;
 
@@ -80378,7 +80399,7 @@ export const GetFeaturestoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFeaturestoresOperationsRequest>;
 
@@ -80409,7 +80430,7 @@ export const CancelFeaturestoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelFeaturestoresOperationsRequest>;
 
@@ -80440,7 +80461,7 @@ export const DeleteFeaturestoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFeaturestoresOperationsRequest>;
 
@@ -80474,7 +80495,7 @@ export const WaitFeaturestoresOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitFeaturestoresOperationsRequest>;
 
@@ -80505,7 +80526,7 @@ export const DeleteModelDeploymentMonitoringJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -80540,7 +80561,7 @@ export const WaitModelDeploymentMonitoringJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -80572,7 +80593,7 @@ export const GetModelDeploymentMonitoringJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -80604,7 +80625,7 @@ export const CancelModelDeploymentMonitoringJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -80650,7 +80671,7 @@ export const ListModelDeploymentMonitoringJobsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListModelDeploymentMonitoringJobsOperationsRequest>;
 
@@ -80686,7 +80707,7 @@ export const DeleteTensorboardsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteTensorboardsOperationsRequest>;
 
@@ -80720,7 +80741,7 @@ export const WaitTensorboardsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitTensorboardsOperationsRequest>;
 
@@ -80765,7 +80786,7 @@ export const ListTensorboardsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListTensorboardsOperationsRequest>;
 
@@ -80801,7 +80822,7 @@ export const GetTensorboardsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTensorboardsOperationsRequest>;
 
@@ -80832,7 +80853,7 @@ export const CancelTensorboardsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelTensorboardsOperationsRequest>;
 
@@ -80877,7 +80898,7 @@ export const ListTensorboardsExperimentsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListTensorboardsExperimentsOperationsRequest>;
 
@@ -80913,7 +80934,7 @@ export const GetTensorboardsExperimentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTensorboardsExperimentsOperationsRequest>;
 
@@ -80945,7 +80966,7 @@ export const CancelTensorboardsExperimentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelTensorboardsExperimentsOperationsRequest>;
 
@@ -80977,7 +80998,7 @@ export const DeleteTensorboardsExperimentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteTensorboardsExperimentsOperationsRequest>;
 
@@ -81012,7 +81033,7 @@ export const WaitTensorboardsExperimentsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitTensorboardsExperimentsOperationsRequest>;
 
@@ -81044,7 +81065,7 @@ export const DeleteTensorboardsExperimentsRunsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -81079,7 +81100,7 @@ export const WaitTensorboardsExperimentsRunsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -81125,7 +81146,7 @@ export const ListTensorboardsExperimentsRunsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -81161,7 +81182,7 @@ export const GetTensorboardsExperimentsRunsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -81193,7 +81214,7 @@ export const CancelTensorboardsExperimentsRunsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelTensorboardsExperimentsRunsOperationsRequest>;
 
@@ -81239,7 +81260,7 @@ export const ListTensorboardsExperimentsRunsTimeSeriesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -81276,7 +81297,7 @@ export const GetTensorboardsExperimentsRunsTimeSeriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -81309,7 +81330,7 @@ export const CancelTensorboardsExperimentsRunsTimeSeriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -81342,7 +81363,7 @@ export const DeleteTensorboardsExperimentsRunsTimeSeriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -81378,7 +81399,7 @@ export const WaitTensorboardsExperimentsRunsTimeSeriesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitTensorboardsExperimentsRunsTimeSeriesOperationsRequest>;
 
@@ -81411,7 +81432,7 @@ export const DeleteModelMonitorsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteModelMonitorsOperationsRequest>;
 
@@ -81445,7 +81466,7 @@ export const WaitModelMonitorsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitModelMonitorsOperationsRequest>;
 
@@ -81490,7 +81511,7 @@ export const ListModelMonitorsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListModelMonitorsOperationsRequest>;
 
@@ -81526,7 +81547,7 @@ export const GetModelMonitorsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetModelMonitorsOperationsRequest>;
 
@@ -81557,7 +81578,7 @@ export const CancelModelMonitorsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelModelMonitorsOperationsRequest>;
 
@@ -81588,7 +81609,7 @@ export const DeleteSpecialistPoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteSpecialistPoolsOperationsRequest>;
 
@@ -81622,7 +81643,7 @@ export const WaitSpecialistPoolsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitSpecialistPoolsOperationsRequest>;
 
@@ -81667,7 +81688,7 @@ export const ListSpecialistPoolsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListSpecialistPoolsOperationsRequest>;
 
@@ -81703,7 +81724,7 @@ export const GetSpecialistPoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSpecialistPoolsOperationsRequest>;
 
@@ -81734,7 +81755,7 @@ export const CancelSpecialistPoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelSpecialistPoolsOperationsRequest>;
 
@@ -81765,7 +81786,7 @@ export const DeleteEdgeDevicesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteEdgeDevicesOperationsRequest>;
 
@@ -81799,7 +81820,7 @@ export const WaitEdgeDevicesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitEdgeDevicesOperationsRequest>;
 
@@ -81844,7 +81865,7 @@ export const ListEdgeDevicesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListEdgeDevicesOperationsRequest>;
 
@@ -81880,7 +81901,7 @@ export const GetEdgeDevicesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEdgeDevicesOperationsRequest>;
 
@@ -81911,7 +81932,7 @@ export const CancelEdgeDevicesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelEdgeDevicesOperationsRequest>;
 
@@ -81942,7 +81963,7 @@ export const DeleteMetadataStoresContextsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteMetadataStoresContextsOperationsRequest>;
 
@@ -81977,7 +81998,7 @@ export const WaitMetadataStoresContextsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitMetadataStoresContextsOperationsRequest>;
 
@@ -82009,7 +82030,7 @@ export const GetMetadataStoresContextsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetMetadataStoresContextsOperationsRequest>;
 
@@ -82041,7 +82062,7 @@ export const CancelMetadataStoresContextsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelMetadataStoresContextsOperationsRequest>;
 
@@ -82087,7 +82108,7 @@ export const ListMetadataStoresContextsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListMetadataStoresContextsOperationsRequest>;
 
@@ -82123,7 +82144,7 @@ export const DeleteMetadataStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteMetadataStoresOperationsRequest>;
 
@@ -82157,7 +82178,7 @@ export const WaitMetadataStoresOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitMetadataStoresOperationsRequest>;
 
@@ -82188,7 +82209,7 @@ export const GetMetadataStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetMetadataStoresOperationsRequest>;
 
@@ -82219,7 +82240,7 @@ export const CancelMetadataStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelMetadataStoresOperationsRequest>;
 
@@ -82264,7 +82285,7 @@ export const ListMetadataStoresOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListMetadataStoresOperationsRequest>;
 
@@ -82314,7 +82335,7 @@ export const ListMetadataStoresExecutionsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListMetadataStoresExecutionsOperationsRequest>;
 
@@ -82350,7 +82371,7 @@ export const GetMetadataStoresExecutionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetMetadataStoresExecutionsOperationsRequest>;
 
@@ -82382,7 +82403,7 @@ export const CancelMetadataStoresExecutionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelMetadataStoresExecutionsOperationsRequest>;
 
@@ -82414,7 +82435,7 @@ export const DeleteMetadataStoresExecutionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteMetadataStoresExecutionsOperationsRequest>;
 
@@ -82449,7 +82470,7 @@ export const WaitMetadataStoresExecutionsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitMetadataStoresExecutionsOperationsRequest>;
 
@@ -82481,7 +82502,7 @@ export const GetMetadataStoresArtifactsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetMetadataStoresArtifactsOperationsRequest>;
 
@@ -82513,7 +82534,7 @@ export const CancelMetadataStoresArtifactsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelMetadataStoresArtifactsOperationsRequest>;
 
@@ -82559,7 +82580,7 @@ export const ListMetadataStoresArtifactsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListMetadataStoresArtifactsOperationsRequest>;
 
@@ -82595,7 +82616,7 @@ export const DeleteMetadataStoresArtifactsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteMetadataStoresArtifactsOperationsRequest>;
 
@@ -82630,7 +82651,7 @@ export const WaitMetadataStoresArtifactsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitMetadataStoresArtifactsOperationsRequest>;
 
@@ -82692,7 +82713,7 @@ export const ListPublishersModelsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/models" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/models" }),
     svc,
   ) as unknown as Schema.Schema<ListPublishersModelsRequest>;
 
@@ -82756,7 +82777,7 @@ export const GetPublishersModelsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPublishersModelsRequest>;
 
@@ -82795,7 +82816,7 @@ export const PredictPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:predict",
+      path: "v1beta1/{+endpoint}:predict",
       hasBody: true,
     }),
     svc,
@@ -82835,7 +82856,7 @@ export const CountTokensPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:countTokens",
+      path: "v1beta1/{+endpoint}:countTokens",
       hasBody: true,
     }),
     svc,
@@ -82876,7 +82897,7 @@ export const FetchPredictOperationPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:fetchPredictOperation",
+      path: "v1beta1/{+endpoint}:fetchPredictOperation",
       hasBody: true,
     }),
     svc,
@@ -82917,7 +82938,7 @@ export const PredictLongRunningPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:predictLongRunning",
+      path: "v1beta1/{+endpoint}:predictLongRunning",
       hasBody: true,
     }),
     svc,
@@ -82957,7 +82978,7 @@ export const StreamGenerateContentPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{model}:streamGenerateContent",
+      path: "v1beta1/{+model}:streamGenerateContent",
       hasBody: true,
     }),
     svc,
@@ -82998,7 +83019,7 @@ export const ComputeTokensPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{endpoint}:computeTokens",
+      path: "v1beta1/{+endpoint}:computeTokens",
       hasBody: true,
     }),
     svc,
@@ -83039,7 +83060,7 @@ export const GenerateContentPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{model}:generateContent",
+      path: "v1beta1/{+model}:generateContent",
       hasBody: true,
     }),
     svc,
@@ -83073,7 +83094,7 @@ export const GetSchedulesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSchedulesOperationsRequest>;
 
@@ -83104,7 +83125,7 @@ export const CancelSchedulesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelSchedulesOperationsRequest>;
 
@@ -83149,7 +83170,7 @@ export const ListSchedulesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListSchedulesOperationsRequest>;
 
@@ -83185,7 +83206,7 @@ export const DeleteSchedulesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteSchedulesOperationsRequest>;
 
@@ -83219,7 +83240,7 @@ export const WaitSchedulesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitSchedulesOperationsRequest>;
 
@@ -83250,7 +83271,7 @@ export const DeleteHyperparameterTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteHyperparameterTuningJobsOperationsRequest>;
 
@@ -83285,7 +83306,7 @@ export const WaitHyperparameterTuningJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitHyperparameterTuningJobsOperationsRequest>;
 
@@ -83331,7 +83352,7 @@ export const ListHyperparameterTuningJobsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListHyperparameterTuningJobsOperationsRequest>;
 
@@ -83367,7 +83388,7 @@ export const GetHyperparameterTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetHyperparameterTuningJobsOperationsRequest>;
 
@@ -83399,7 +83420,7 @@ export const CancelHyperparameterTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelHyperparameterTuningJobsOperationsRequest>;
 
@@ -83445,7 +83466,7 @@ export const ListTrainingPipelinesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListTrainingPipelinesOperationsRequest>;
 
@@ -83481,7 +83502,7 @@ export const GetTrainingPipelinesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTrainingPipelinesOperationsRequest>;
 
@@ -83512,7 +83533,7 @@ export const CancelTrainingPipelinesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelTrainingPipelinesOperationsRequest>;
 
@@ -83543,7 +83564,7 @@ export const DeleteTrainingPipelinesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteTrainingPipelinesOperationsRequest>;
 
@@ -83577,7 +83598,7 @@ export const WaitTrainingPipelinesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitTrainingPipelinesOperationsRequest>;
 
@@ -83698,7 +83719,7 @@ export const GetBatchPredictionJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBatchPredictionJobsRequest>;
 
@@ -83744,7 +83765,7 @@ export const ListStudiesTrialsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListStudiesTrialsOperationsRequest>;
 
@@ -83780,7 +83801,7 @@ export const GetStudiesTrialsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetStudiesTrialsOperationsRequest>;
 
@@ -83811,7 +83832,7 @@ export const CancelStudiesTrialsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelStudiesTrialsOperationsRequest>;
 
@@ -83842,7 +83863,7 @@ export const DeleteStudiesTrialsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteStudiesTrialsOperationsRequest>;
 
@@ -83876,7 +83897,7 @@ export const WaitStudiesTrialsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitStudiesTrialsOperationsRequest>;
 
@@ -83921,7 +83942,7 @@ export const ListStudiesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListStudiesOperationsRequest>;
 
@@ -83957,7 +83978,7 @@ export const GetStudiesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetStudiesOperationsRequest>;
 
@@ -83988,7 +84009,7 @@ export const CancelStudiesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelStudiesOperationsRequest>;
 
@@ -84019,7 +84040,7 @@ export const DeleteStudiesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteStudiesOperationsRequest>;
 
@@ -84053,7 +84074,7 @@ export const WaitStudiesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitStudiesOperationsRequest>;
 
@@ -84084,7 +84105,7 @@ export const GetExtensionControllersOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetExtensionControllersOperationsRequest>;
 
@@ -84116,7 +84137,7 @@ export const CancelExtensionControllersOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelExtensionControllersOperationsRequest>;
 
@@ -84161,7 +84182,7 @@ export const ListExtensionControllersOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListExtensionControllersOperationsRequest>;
 
@@ -84197,7 +84218,7 @@ export const DeleteExtensionControllersOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteExtensionControllersOperationsRequest>;
 
@@ -84231,7 +84252,7 @@ export const WaitExtensionControllersOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitExtensionControllersOperationsRequest>;
 
@@ -84263,7 +84284,7 @@ export const DeleteEvaluationItemsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteEvaluationItemsOperationsRequest>;
 
@@ -84297,7 +84318,7 @@ export const WaitEvaluationItemsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitEvaluationItemsOperationsRequest>;
 
@@ -84342,7 +84363,7 @@ export const ListEvaluationItemsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListEvaluationItemsOperationsRequest>;
 
@@ -84378,7 +84399,7 @@ export const GetEvaluationItemsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEvaluationItemsOperationsRequest>;
 
@@ -84411,7 +84432,7 @@ export const GetDatasetsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta1/{name}" }),
+  T.Http({ method: "GET", path: "v1beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetDatasetsRequest>;
 
@@ -84524,7 +84545,7 @@ export interface DeleteDatasetsRequest {
 export const DeleteDatasetsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+  T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteDatasetsRequest>;
 
@@ -84560,7 +84581,7 @@ export const PatchDatasetsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(GoogleCloudAiplatformV1beta1Dataset).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchDatasetsRequest>;
 
@@ -84594,7 +84615,7 @@ export const GetDatasetsDatasetVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDatasetsDatasetVersionsRequest>;
 
@@ -84633,7 +84654,7 @@ export const CreateDatasetsDatasetVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/datasetVersions",
+      path: "v1beta1/{+parent}/datasetVersions",
       hasBody: true,
     }),
     svc,
@@ -84681,7 +84702,7 @@ export const ListDatasetsDatasetVersionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/datasetVersions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/datasetVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListDatasetsDatasetVersionsRequest>;
 
@@ -84717,7 +84738,7 @@ export const RestoreDatasetsDatasetVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:restore" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:restore" }),
     svc,
   ) as unknown as Schema.Schema<RestoreDatasetsDatasetVersionsRequest>;
 
@@ -84748,7 +84769,7 @@ export const DeleteDatasetsDatasetVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDatasetsDatasetVersionsRequest>;
 
@@ -84787,7 +84808,7 @@ export const PatchDatasetsDatasetVersionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchDatasetsDatasetVersionsRequest>;
 
@@ -84819,7 +84840,7 @@ export const GetDatasetsAnnotationSpecsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -84851,7 +84872,7 @@ export const CancelDatasetsAnnotationSpecsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -84897,7 +84918,7 @@ export const ListDatasetsAnnotationSpecsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -84933,7 +84954,7 @@ export const DeleteDatasetsAnnotationSpecsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -84968,7 +84989,7 @@ export const WaitDatasetsAnnotationSpecsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitDatasetsAnnotationSpecsOperationsRequest>;
 
@@ -85014,7 +85035,7 @@ export const ListDatasetsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListDatasetsOperationsRequest>;
 
@@ -85050,7 +85071,7 @@ export const GetDatasetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDatasetsOperationsRequest>;
 
@@ -85081,7 +85102,7 @@ export const CancelDatasetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelDatasetsOperationsRequest>;
 
@@ -85112,7 +85133,7 @@ export const DeleteDatasetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDatasetsOperationsRequest>;
 
@@ -85146,7 +85167,7 @@ export const WaitDatasetsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitDatasetsOperationsRequest>;
 
@@ -85177,7 +85198,7 @@ export const DeleteDatasetsSavedQueriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDatasetsSavedQueriesOperationsRequest>;
 
@@ -85211,7 +85232,7 @@ export const WaitDatasetsSavedQueriesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitDatasetsSavedQueriesOperationsRequest>;
 
@@ -85243,7 +85264,7 @@ export const GetDatasetsSavedQueriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDatasetsSavedQueriesOperationsRequest>;
 
@@ -85275,7 +85296,7 @@ export const CancelDatasetsSavedQueriesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelDatasetsSavedQueriesOperationsRequest>;
 
@@ -85320,7 +85341,7 @@ export const ListDatasetsSavedQueriesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListDatasetsSavedQueriesOperationsRequest>;
 
@@ -85370,7 +85391,7 @@ export const ListDatasetsDataItemsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListDatasetsDataItemsOperationsRequest>;
 
@@ -85406,7 +85427,7 @@ export const GetDatasetsDataItemsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDatasetsDataItemsOperationsRequest>;
 
@@ -85437,7 +85458,7 @@ export const CancelDatasetsDataItemsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelDatasetsDataItemsOperationsRequest>;
 
@@ -85468,7 +85489,7 @@ export const DeleteDatasetsDataItemsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDatasetsDataItemsOperationsRequest>;
 
@@ -85502,7 +85523,7 @@ export const WaitDatasetsDataItemsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitDatasetsDataItemsOperationsRequest>;
 
@@ -85548,7 +85569,7 @@ export const ListDatasetsDataItemsAnnotationsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -85584,7 +85605,7 @@ export const GetDatasetsDataItemsAnnotationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -85616,7 +85637,7 @@ export const CancelDatasetsDataItemsAnnotationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -85648,7 +85669,7 @@ export const DeleteDatasetsDataItemsAnnotationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -85683,7 +85704,7 @@ export const WaitDatasetsDataItemsAnnotationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitDatasetsDataItemsAnnotationsOperationsRequest>;
 
@@ -85715,7 +85736,7 @@ export const DeleteNotebookRuntimesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNotebookRuntimesOperationsRequest>;
 
@@ -85749,7 +85770,7 @@ export const WaitNotebookRuntimesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitNotebookRuntimesOperationsRequest>;
 
@@ -85794,7 +85815,7 @@ export const ListNotebookRuntimesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListNotebookRuntimesOperationsRequest>;
 
@@ -85830,7 +85851,7 @@ export const GetNotebookRuntimesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNotebookRuntimesOperationsRequest>;
 
@@ -85861,7 +85882,7 @@ export const CancelNotebookRuntimesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelNotebookRuntimesOperationsRequest>;
 
@@ -85892,7 +85913,7 @@ export const DeleteTuningJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteTuningJobsOperationsRequest>;
 
@@ -86032,7 +86053,7 @@ export const GetPipelineJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPipelineJobsOperationsRequest>;
 
@@ -86063,7 +86084,7 @@ export const CancelPipelineJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelPipelineJobsOperationsRequest>;
 
@@ -86108,7 +86129,7 @@ export const ListPipelineJobsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListPipelineJobsOperationsRequest>;
 
@@ -86144,7 +86165,7 @@ export const DeletePipelineJobsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePipelineJobsOperationsRequest>;
 
@@ -86178,7 +86199,7 @@ export const WaitPipelineJobsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitPipelineJobsOperationsRequest>;
 

--- a/packages/gcp/src/services/alloydb-v1.ts
+++ b/packages/gcp/src/services/alloydb-v1.ts
@@ -3226,7 +3226,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -3262,7 +3262,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -3307,7 +3307,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -3342,7 +3342,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -3373,7 +3373,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -3407,7 +3407,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -3443,7 +3443,7 @@ export const RestoreFromCloudSQLProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/clusters:restoreFromCloudSQL",
+      path: "v1/{+parent}/clusters:restoreFromCloudSQL",
       hasBody: true,
     }),
     svc,
@@ -3488,7 +3488,7 @@ export const ListProjectsLocationsClustersRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/clusters" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/clusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersRequest>;
 
@@ -3530,7 +3530,7 @@ export const GetProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersRequest>;
 
@@ -3575,7 +3575,7 @@ export const CreateProjectsLocationsClustersRequest =
     ),
     body: Schema.optional(Cluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/clusters", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/clusters", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsClustersRequest>;
 
@@ -3625,7 +3625,7 @@ export const PatchProjectsLocationsClustersRequest =
     ),
     body: Schema.optional(Cluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsClustersRequest>;
 
@@ -3659,7 +3659,7 @@ export const ExportProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsClustersRequest>;
 
@@ -3693,7 +3693,7 @@ export const ImportProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ImportClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:import", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:import", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsLocationsClustersRequest>;
 
@@ -3727,7 +3727,7 @@ export const UpgradeProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpgradeClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}:upgrade", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}:upgrade", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpgradeProjectsLocationsClustersRequest>;
 
@@ -3772,7 +3772,7 @@ export const DeleteProjectsLocationsClustersRequest =
     ),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersRequest>;
 
@@ -3806,7 +3806,7 @@ export const PromoteProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PromoteClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:promote", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:promote", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PromoteProjectsLocationsClustersRequest>;
 
@@ -3840,7 +3840,7 @@ export const SwitchoverProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SwitchoverClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:switchover", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:switchover", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SwitchoverProjectsLocationsClustersRequest>;
 
@@ -3876,7 +3876,7 @@ export const RestoreProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/clusters:restore",
+      path: "v1/{+parent}/clusters:restore",
       hasBody: true,
     }),
     svc,
@@ -3925,7 +3925,7 @@ export const CreatesecondaryProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/clusters:createsecondary",
+      path: "v1/{+parent}/clusters:createsecondary",
       hasBody: true,
     }),
     svc,
@@ -3970,7 +3970,7 @@ export const ListProjectsLocationsClustersInstancesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersInstancesRequest>;
 
@@ -4013,7 +4013,7 @@ export const GetProjectsLocationsClustersInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersInstancesRequest>;
 
@@ -4058,7 +4058,7 @@ export const CreateProjectsLocationsClustersInstancesRequest =
     ),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/instances", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/instances", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsClustersInstancesRequest>;
 
@@ -4105,7 +4105,7 @@ export const CreatesecondaryProjectsLocationsClustersInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/instances:createsecondary",
+      path: "v1/{+parent}/instances:createsecondary",
       hasBody: true,
     }),
     svc,
@@ -4159,7 +4159,7 @@ export const PatchProjectsLocationsClustersInstancesRequest =
     ),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsClustersInstancesRequest>;
 
@@ -4201,7 +4201,7 @@ export const DeleteProjectsLocationsClustersInstancesRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersInstancesRequest>;
 
@@ -4235,7 +4235,7 @@ export const FailoverProjectsLocationsClustersInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(FailoverInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:failover", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:failover", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<FailoverProjectsLocationsClustersInstancesRequest>;
 
@@ -4269,7 +4269,7 @@ export const InjectFaultProjectsLocationsClustersInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(InjectFaultRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:injectFault", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:injectFault", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<InjectFaultProjectsLocationsClustersInstancesRequest>;
 
@@ -4303,7 +4303,7 @@ export const RestartProjectsLocationsClustersInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestartInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:restart", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:restart", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestartProjectsLocationsClustersInstancesRequest>;
 
@@ -4337,7 +4337,7 @@ export const GetConnectionInfoProjectsLocationsClustersInstancesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/connectionInfo" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/connectionInfo" }),
     svc,
   ) as unknown as Schema.Schema<GetConnectionInfoProjectsLocationsClustersInstancesRequest>;
 
@@ -4382,7 +4382,7 @@ export const ListProjectsLocationsClustersUsersRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/users" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/users" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersUsersRequest>;
 
@@ -4417,7 +4417,7 @@ export const GetProjectsLocationsClustersUsersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersUsersRequest>;
 
@@ -4462,7 +4462,7 @@ export const CreateProjectsLocationsClustersUsersRequest =
     ),
     body: Schema.optional(User).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/users", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/users", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsClustersUsersRequest>;
 
@@ -4512,7 +4512,7 @@ export const PatchProjectsLocationsClustersUsersRequest =
     ),
     body: Schema.optional(User).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsClustersUsersRequest>;
 
@@ -4551,7 +4551,7 @@ export const DeleteProjectsLocationsClustersUsersRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersUsersRequest>;
 
@@ -4601,7 +4601,7 @@ export const ListProjectsLocationsBackupsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupsRequest>;
 
@@ -4643,7 +4643,7 @@ export const GetProjectsLocationsBackupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupsRequest>;
 
@@ -4688,7 +4688,7 @@ export const CreateProjectsLocationsBackupsRequest =
     ),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/backups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/backups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackupsRequest>;
 
@@ -4738,7 +4738,7 @@ export const PatchProjectsLocationsBackupsRequest =
     ),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupsRequest>;
 
@@ -4780,7 +4780,7 @@ export const DeleteProjectsLocationsBackupsRequest =
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupsRequest>;
 
@@ -4820,7 +4820,7 @@ export const ListProjectsLocationsSupportedDatabaseFlagsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     scope: Schema.optional(Schema.String).pipe(T.HttpQuery("scope")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/supportedDatabaseFlags" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/supportedDatabaseFlags" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSupportedDatabaseFlagsRequest>;
 

--- a/packages/gcp/src/services/alloydb-v1alpha.ts
+++ b/packages/gcp/src/services/alloydb-v1alpha.ts
@@ -3447,7 +3447,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -3483,7 +3483,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -3528,7 +3528,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -3563,7 +3563,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -3594,7 +3594,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -3628,7 +3628,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -3664,7 +3664,7 @@ export const RestoreFromCloudSQLProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/clusters:restoreFromCloudSQL",
+      path: "v1alpha/{+parent}/clusters:restoreFromCloudSQL",
       hasBody: true,
     }),
     svc,
@@ -3709,7 +3709,7 @@ export const ListProjectsLocationsClustersRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/clusters" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/clusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersRequest>;
 
@@ -3751,7 +3751,7 @@ export const GetProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersRequest>;
 
@@ -3798,7 +3798,7 @@ export const CreateProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/clusters",
+      path: "v1alpha/{+parent}/clusters",
       hasBody: true,
     }),
     svc,
@@ -3850,7 +3850,7 @@ export const PatchProjectsLocationsClustersRequest =
     ),
     body: Schema.optional(Cluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsClustersRequest>;
 
@@ -3884,7 +3884,7 @@ export const ExportProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsClustersRequest>;
 
@@ -3918,7 +3918,7 @@ export const ImportProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ImportClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:import", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:import", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsLocationsClustersRequest>;
 
@@ -3952,7 +3952,7 @@ export const UpgradeProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpgradeClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}:upgrade", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}:upgrade", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpgradeProjectsLocationsClustersRequest>;
 
@@ -3997,7 +3997,7 @@ export const DeleteProjectsLocationsClustersRequest =
     ),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersRequest>;
 
@@ -4031,7 +4031,7 @@ export const PromoteProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PromoteClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:promote", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:promote", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PromoteProjectsLocationsClustersRequest>;
 
@@ -4067,7 +4067,7 @@ export const SwitchoverProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{name}:switchover",
+      path: "v1alpha/{+name}:switchover",
       hasBody: true,
     }),
     svc,
@@ -4105,7 +4105,7 @@ export const RestoreProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/clusters:restore",
+      path: "v1alpha/{+parent}/clusters:restore",
       hasBody: true,
     }),
     svc,
@@ -4154,7 +4154,7 @@ export const CreatesecondaryProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/clusters:createsecondary",
+      path: "v1alpha/{+parent}/clusters:createsecondary",
       hasBody: true,
     }),
     svc,
@@ -4199,7 +4199,7 @@ export const ListProjectsLocationsClustersInstancesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersInstancesRequest>;
 
@@ -4242,7 +4242,7 @@ export const GetProjectsLocationsClustersInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersInstancesRequest>;
 
@@ -4289,7 +4289,7 @@ export const CreateProjectsLocationsClustersInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/instances",
+      path: "v1alpha/{+parent}/instances",
       hasBody: true,
     }),
     svc,
@@ -4338,7 +4338,7 @@ export const CreatesecondaryProjectsLocationsClustersInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/instances:createsecondary",
+      path: "v1alpha/{+parent}/instances:createsecondary",
       hasBody: true,
     }),
     svc,
@@ -4392,7 +4392,7 @@ export const PatchProjectsLocationsClustersInstancesRequest =
     ),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsClustersInstancesRequest>;
 
@@ -4434,7 +4434,7 @@ export const DeleteProjectsLocationsClustersInstancesRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersInstancesRequest>;
 
@@ -4468,7 +4468,7 @@ export const FailoverProjectsLocationsClustersInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(FailoverInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:failover", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:failover", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<FailoverProjectsLocationsClustersInstancesRequest>;
 
@@ -4504,7 +4504,7 @@ export const InjectFaultProjectsLocationsClustersInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{name}:injectFault",
+      path: "v1alpha/{+name}:injectFault",
       hasBody: true,
     }),
     svc,
@@ -4540,7 +4540,7 @@ export const RestartProjectsLocationsClustersInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestartInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:restart", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:restart", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestartProjectsLocationsClustersInstancesRequest>;
 
@@ -4574,7 +4574,7 @@ export const GetConnectionInfoProjectsLocationsClustersInstancesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/connectionInfo" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/connectionInfo" }),
     svc,
   ) as unknown as Schema.Schema<GetConnectionInfoProjectsLocationsClustersInstancesRequest>;
 
@@ -4619,7 +4619,7 @@ export const ListProjectsLocationsClustersUsersRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/users" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/users" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersUsersRequest>;
 
@@ -4654,7 +4654,7 @@ export const GetProjectsLocationsClustersUsersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersUsersRequest>;
 
@@ -4699,7 +4699,7 @@ export const CreateProjectsLocationsClustersUsersRequest =
     ),
     body: Schema.optional(User).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{parent}/users", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+parent}/users", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsClustersUsersRequest>;
 
@@ -4749,7 +4749,7 @@ export const PatchProjectsLocationsClustersUsersRequest =
     ),
     body: Schema.optional(User).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsClustersUsersRequest>;
 
@@ -4788,7 +4788,7 @@ export const DeleteProjectsLocationsClustersUsersRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersUsersRequest>;
 
@@ -4819,7 +4819,7 @@ export const GetProjectsLocationsEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEndpointsRequest>;
 
@@ -4862,7 +4862,7 @@ export const ListProjectsLocationsEndpointsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/endpoints" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/endpoints" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEndpointsRequest>;
 
@@ -4913,7 +4913,7 @@ export const CreateProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/endpoints",
+      path: "v1alpha/{+parent}/endpoints",
       hasBody: true,
     }),
     svc,
@@ -4965,7 +4965,7 @@ export const PatchProjectsLocationsEndpointsRequest =
     ),
     body: Schema.optional(Endpoint).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEndpointsRequest>;
 
@@ -5007,7 +5007,7 @@ export const DeleteProjectsLocationsEndpointsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEndpointsRequest>;
 
@@ -5057,7 +5057,7 @@ export const ListProjectsLocationsBackupsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupsRequest>;
 
@@ -5099,7 +5099,7 @@ export const GetProjectsLocationsBackupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupsRequest>;
 
@@ -5144,7 +5144,11 @@ export const CreateProjectsLocationsBackupsRequest =
     ),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{parent}/backups", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1alpha/{+parent}/backups",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackupsRequest>;
 
@@ -5194,7 +5198,7 @@ export const PatchProjectsLocationsBackupsRequest =
     ),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupsRequest>;
 
@@ -5236,7 +5240,7 @@ export const DeleteProjectsLocationsBackupsRequest =
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupsRequest>;
 
@@ -5276,7 +5280,7 @@ export const ListProjectsLocationsSupportedDatabaseFlagsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     scope: Schema.optional(Schema.String).pipe(T.HttpQuery("scope")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/supportedDatabaseFlags" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/supportedDatabaseFlags" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSupportedDatabaseFlagsRequest>;
 

--- a/packages/gcp/src/services/alloydb-v1beta.ts
+++ b/packages/gcp/src/services/alloydb-v1beta.ts
@@ -3432,7 +3432,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -3468,7 +3468,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -3513,7 +3513,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -3548,7 +3548,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -3579,7 +3579,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -3610,7 +3610,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -3646,7 +3646,7 @@ export const RestoreFromCloudSQLProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/clusters:restoreFromCloudSQL",
+      path: "v1beta/{+parent}/clusters:restoreFromCloudSQL",
       hasBody: true,
     }),
     svc,
@@ -3691,7 +3691,7 @@ export const ListProjectsLocationsClustersRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/clusters" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/clusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersRequest>;
 
@@ -3733,7 +3733,7 @@ export const GetProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersRequest>;
 
@@ -3778,7 +3778,11 @@ export const CreateProjectsLocationsClustersRequest =
     ),
     body: Schema.optional(Cluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/clusters", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/clusters",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsClustersRequest>;
 
@@ -3828,7 +3832,7 @@ export const PatchProjectsLocationsClustersRequest =
     ),
     body: Schema.optional(Cluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsClustersRequest>;
 
@@ -3862,7 +3866,7 @@ export const ExportProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsClustersRequest>;
 
@@ -3896,7 +3900,7 @@ export const ImportProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ImportClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:import", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:import", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsLocationsClustersRequest>;
 
@@ -3930,7 +3934,7 @@ export const UpgradeProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpgradeClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}:upgrade", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}:upgrade", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpgradeProjectsLocationsClustersRequest>;
 
@@ -3975,7 +3979,7 @@ export const DeleteProjectsLocationsClustersRequest =
     ),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersRequest>;
 
@@ -4009,7 +4013,7 @@ export const PromoteProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PromoteClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:promote", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:promote", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PromoteProjectsLocationsClustersRequest>;
 
@@ -4043,7 +4047,11 @@ export const SwitchoverProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SwitchoverClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:switchover", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+name}:switchover",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<SwitchoverProjectsLocationsClustersRequest>;
 
@@ -4079,7 +4087,7 @@ export const RestoreProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/clusters:restore",
+      path: "v1beta/{+parent}/clusters:restore",
       hasBody: true,
     }),
     svc,
@@ -4128,7 +4136,7 @@ export const CreatesecondaryProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/clusters:createsecondary",
+      path: "v1beta/{+parent}/clusters:createsecondary",
       hasBody: true,
     }),
     svc,
@@ -4173,7 +4181,7 @@ export const ListProjectsLocationsClustersInstancesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersInstancesRequest>;
 
@@ -4216,7 +4224,7 @@ export const GetProjectsLocationsClustersInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersInstancesRequest>;
 
@@ -4263,7 +4271,7 @@ export const CreateProjectsLocationsClustersInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/instances",
+      path: "v1beta/{+parent}/instances",
       hasBody: true,
     }),
     svc,
@@ -4312,7 +4320,7 @@ export const CreatesecondaryProjectsLocationsClustersInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/instances:createsecondary",
+      path: "v1beta/{+parent}/instances:createsecondary",
       hasBody: true,
     }),
     svc,
@@ -4366,7 +4374,7 @@ export const PatchProjectsLocationsClustersInstancesRequest =
     ),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsClustersInstancesRequest>;
 
@@ -4408,7 +4416,7 @@ export const DeleteProjectsLocationsClustersInstancesRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersInstancesRequest>;
 
@@ -4442,7 +4450,7 @@ export const FailoverProjectsLocationsClustersInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(FailoverInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:failover", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:failover", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<FailoverProjectsLocationsClustersInstancesRequest>;
 
@@ -4478,7 +4486,7 @@ export const InjectFaultProjectsLocationsClustersInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{name}:injectFault",
+      path: "v1beta/{+name}:injectFault",
       hasBody: true,
     }),
     svc,
@@ -4514,7 +4522,7 @@ export const RestartProjectsLocationsClustersInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestartInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:restart", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:restart", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestartProjectsLocationsClustersInstancesRequest>;
 
@@ -4548,7 +4556,7 @@ export const GetConnectionInfoProjectsLocationsClustersInstancesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/connectionInfo" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/connectionInfo" }),
     svc,
   ) as unknown as Schema.Schema<GetConnectionInfoProjectsLocationsClustersInstancesRequest>;
 
@@ -4593,7 +4601,7 @@ export const ListProjectsLocationsClustersUsersRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/users" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/users" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersUsersRequest>;
 
@@ -4628,7 +4636,7 @@ export const GetProjectsLocationsClustersUsersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersUsersRequest>;
 
@@ -4673,7 +4681,7 @@ export const CreateProjectsLocationsClustersUsersRequest =
     ),
     body: Schema.optional(User).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/users", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/users", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsClustersUsersRequest>;
 
@@ -4723,7 +4731,7 @@ export const PatchProjectsLocationsClustersUsersRequest =
     ),
     body: Schema.optional(User).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsClustersUsersRequest>;
 
@@ -4762,7 +4770,7 @@ export const DeleteProjectsLocationsClustersUsersRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersUsersRequest>;
 
@@ -4793,7 +4801,7 @@ export const GetProjectsLocationsEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEndpointsRequest>;
 
@@ -4836,7 +4844,7 @@ export const ListProjectsLocationsEndpointsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/endpoints" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/endpoints" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEndpointsRequest>;
 
@@ -4887,7 +4895,7 @@ export const CreateProjectsLocationsEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/endpoints",
+      path: "v1beta/{+parent}/endpoints",
       hasBody: true,
     }),
     svc,
@@ -4939,7 +4947,7 @@ export const PatchProjectsLocationsEndpointsRequest =
     ),
     body: Schema.optional(Endpoint).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEndpointsRequest>;
 
@@ -4981,7 +4989,7 @@ export const DeleteProjectsLocationsEndpointsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEndpointsRequest>;
 
@@ -5031,7 +5039,7 @@ export const ListProjectsLocationsBackupsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupsRequest>;
 
@@ -5073,7 +5081,7 @@ export const GetProjectsLocationsBackupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupsRequest>;
 
@@ -5118,7 +5126,7 @@ export const CreateProjectsLocationsBackupsRequest =
     ),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/backups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/backups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackupsRequest>;
 
@@ -5168,7 +5176,7 @@ export const PatchProjectsLocationsBackupsRequest =
     ),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupsRequest>;
 
@@ -5210,7 +5218,7 @@ export const DeleteProjectsLocationsBackupsRequest =
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupsRequest>;
 
@@ -5250,7 +5258,7 @@ export const ListProjectsLocationsSupportedDatabaseFlagsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     scope: Schema.optional(Schema.String).pipe(T.HttpQuery("scope")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/supportedDatabaseFlags" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/supportedDatabaseFlags" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSupportedDatabaseFlagsRequest>;
 

--- a/packages/gcp/src/services/analyticsadmin-v1alpha.ts
+++ b/packages/gcp/src/services/analyticsadmin-v1alpha.ts
@@ -3600,7 +3600,7 @@ export const GetDataSharingSettingsAccountsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDataSharingSettingsAccountsRequest>;
 
@@ -3639,7 +3639,7 @@ export const RunAccessReportAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{entity}:runAccessReport",
+      path: "v1alpha/{+entity}:runAccessReport",
       hasBody: true,
     }),
     svc,
@@ -3672,7 +3672,7 @@ export interface GetAccountsRequest {
 export const GetAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1alpha/{name}" }),
+  T.Http({ method: "GET", path: "v1alpha/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetAccountsRequest>;
 
@@ -3710,7 +3710,7 @@ export const SearchChangeHistoryEventsAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{account}:searchChangeHistoryEvents",
+      path: "v1alpha/{+account}:searchChangeHistoryEvents",
       hasBody: true,
     }),
     svc,
@@ -3784,7 +3784,7 @@ export interface DeleteAccountsRequest {
 export const DeleteAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+  T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteAccountsRequest>;
 
@@ -3820,7 +3820,7 @@ export const PatchAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(GoogleAnalyticsAdminV1alphaAccount).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchAccountsRequest>;
 
@@ -3889,7 +3889,7 @@ export const DeleteAccountsAccessBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsAccessBindingsRequest>;
 
@@ -3925,7 +3925,10 @@ export const BatchGetAccountsAccessBindingsRequest =
       T.HttpQuery("names"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/accessBindings:batchGet" }),
+    T.Http({
+      method: "GET",
+      path: "v1alpha/{+parent}/accessBindings:batchGet",
+    }),
     svc,
   ) as unknown as Schema.Schema<BatchGetAccountsAccessBindingsRequest>;
 
@@ -3964,7 +3967,7 @@ export const CreateAccountsAccessBindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/accessBindings",
+      path: "v1alpha/{+parent}/accessBindings",
       hasBody: true,
     }),
     svc,
@@ -4005,7 +4008,7 @@ export const BatchUpdateAccountsAccessBindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/accessBindings:batchUpdate",
+      path: "v1alpha/{+parent}/accessBindings:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -4046,7 +4049,7 @@ export const BatchDeleteAccountsAccessBindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/accessBindings:batchDelete",
+      path: "v1alpha/{+parent}/accessBindings:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -4085,7 +4088,7 @@ export const ListAccountsAccessBindingsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/accessBindings" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/accessBindings" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAccessBindingsRequest>;
 
@@ -4126,7 +4129,7 @@ export const PatchAccountsAccessBindingsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsAccessBindingsRequest>;
 
@@ -4165,7 +4168,7 @@ export const BatchCreateAccountsAccessBindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/accessBindings:batchCreate",
+      path: "v1alpha/{+parent}/accessBindings:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -4199,7 +4202,7 @@ export const GetAccountsAccessBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsAccessBindingsRequest>;
 
@@ -4278,7 +4281,7 @@ export const UpdateDataRetentionSettingsPropertiesRequest =
       GoogleAnalyticsAdminV1alphaDataRetentionSettings,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateDataRetentionSettingsPropertiesRequest>;
 
@@ -4363,7 +4366,7 @@ export const PatchPropertiesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     ),
   },
 ).pipe(
-  T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchPropertiesRequest>;
 
@@ -4402,7 +4405,7 @@ export const UpdateGoogleSignalsSettingsPropertiesRequest =
       GoogleAnalyticsAdminV1alphaGoogleSignalsSettings,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateGoogleSignalsSettingsPropertiesRequest>;
 
@@ -4441,7 +4444,7 @@ export const RunAccessReportPropertiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{entity}:runAccessReport",
+      path: "v1alpha/{+entity}:runAccessReport",
       hasBody: true,
     }),
     svc,
@@ -4474,7 +4477,7 @@ export interface GetPropertiesRequest {
 export const GetPropertiesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1alpha/{name}" }),
+  T.Http({ method: "GET", path: "v1alpha/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetPropertiesRequest>;
 
@@ -4505,7 +4508,7 @@ export const GetAttributionSettingsPropertiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAttributionSettingsPropertiesRequest>;
 
@@ -4583,7 +4586,7 @@ export const UpdateAttributionSettingsPropertiesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAttributionSettingsPropertiesRequest>;
 
@@ -4615,7 +4618,7 @@ export const GetDataRetentionSettingsPropertiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDataRetentionSettingsPropertiesRequest>;
 
@@ -4647,7 +4650,7 @@ export const DeletePropertiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesRequest>;
 
@@ -4685,7 +4688,7 @@ export const AcknowledgeUserDataCollectionPropertiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{property}:acknowledgeUserDataCollection",
+      path: "v1alpha/{+property}:acknowledgeUserDataCollection",
       hasBody: true,
     }),
     svc,
@@ -4757,7 +4760,7 @@ export const GetGoogleSignalsSettingsPropertiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetGoogleSignalsSettingsPropertiesRequest>;
 
@@ -4796,7 +4799,7 @@ export const SubmitUserDeletionPropertiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{name}:submitUserDeletion",
+      path: "v1alpha/{+name}:submitUserDeletion",
       hasBody: true,
     }),
     svc,
@@ -4863,7 +4866,7 @@ export const GetReportingIdentitySettingsPropertiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetReportingIdentitySettingsPropertiesRequest>;
 
@@ -4903,7 +4906,7 @@ export const ListPropertiesDisplayVideo360AdvertiserLinkProposalsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}/displayVideo360AdvertiserLinkProposals",
+      path: "v1alpha/{+parent}/displayVideo360AdvertiserLinkProposals",
     }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesDisplayVideo360AdvertiserLinkProposalsRequest>;
@@ -4941,7 +4944,7 @@ export const DeletePropertiesDisplayVideo360AdvertiserLinkProposalsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesDisplayVideo360AdvertiserLinkProposalsRequest>;
 
@@ -4979,7 +4982,7 @@ export const CancelPropertiesDisplayVideo360AdvertiserLinkProposalsRequest =
       GoogleAnalyticsAdminV1alphaCancelDisplayVideo360AdvertiserLinkProposalRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelPropertiesDisplayVideo360AdvertiserLinkProposalsRequest>;
 
@@ -5019,7 +5022,7 @@ export const CreatePropertiesDisplayVideo360AdvertiserLinkProposalsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/displayVideo360AdvertiserLinkProposals",
+      path: "v1alpha/{+parent}/displayVideo360AdvertiserLinkProposals",
       hasBody: true,
     }),
     svc,
@@ -5059,7 +5062,7 @@ export const ApprovePropertiesDisplayVideo360AdvertiserLinkProposalsRequest =
       GoogleAnalyticsAdminV1alphaApproveDisplayVideo360AdvertiserLinkProposalRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:approve", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:approve", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ApprovePropertiesDisplayVideo360AdvertiserLinkProposalsRequest>;
 
@@ -5092,7 +5095,7 @@ export const GetPropertiesDisplayVideo360AdvertiserLinkProposalsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesDisplayVideo360AdvertiserLinkProposalsRequest>;
 
@@ -5125,7 +5128,7 @@ export const GetEnhancedMeasurementSettingsPropertiesDataStreamsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEnhancedMeasurementSettingsPropertiesDataStreamsRequest>;
 
@@ -5164,7 +5167,7 @@ export const ListPropertiesDataStreamsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/dataStreams" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/dataStreams" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesDataStreamsRequest>;
 
@@ -5208,7 +5211,7 @@ export const PatchPropertiesDataStreamsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesDataStreamsRequest>;
 
@@ -5240,7 +5243,7 @@ export const GetDataRedactionSettingsPropertiesDataStreamsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDataRedactionSettingsPropertiesDataStreamsRequest>;
 
@@ -5272,7 +5275,7 @@ export const GetPropertiesDataStreamsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesDataStreamsRequest>;
 
@@ -5311,7 +5314,7 @@ export const CreatePropertiesDataStreamsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/dataStreams",
+      path: "v1alpha/{+parent}/dataStreams",
       hasBody: true,
     }),
     svc,
@@ -5353,7 +5356,7 @@ export const UpdateDataRedactionSettingsPropertiesDataStreamsRequest =
       GoogleAnalyticsAdminV1alphaDataRedactionSettings,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateDataRedactionSettingsPropertiesDataStreamsRequest>;
 
@@ -5386,7 +5389,7 @@ export const DeletePropertiesDataStreamsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesDataStreamsRequest>;
 
@@ -5425,7 +5428,7 @@ export const UpdateEnhancedMeasurementSettingsPropertiesDataStreamsRequest =
       GoogleAnalyticsAdminV1alphaEnhancedMeasurementSettings,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateEnhancedMeasurementSettingsPropertiesDataStreamsRequest>;
 
@@ -5458,7 +5461,7 @@ export const GetGlobalSiteTagPropertiesDataStreamsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetGlobalSiteTagPropertiesDataStreamsRequest>;
 
@@ -5490,7 +5493,7 @@ export const GetPropertiesDataStreamsEventEditRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesDataStreamsEventEditRulesRequest>;
 
@@ -5529,7 +5532,7 @@ export const ReorderPropertiesDataStreamsEventEditRulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/eventEditRules:reorder",
+      path: "v1alpha/{+parent}/eventEditRules:reorder",
       hasBody: true,
     }),
     svc,
@@ -5570,7 +5573,7 @@ export const CreatePropertiesDataStreamsEventEditRulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/eventEditRules",
+      path: "v1alpha/{+parent}/eventEditRules",
       hasBody: true,
     }),
     svc,
@@ -5610,7 +5613,7 @@ export const ListPropertiesDataStreamsEventEditRulesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/eventEditRules" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/eventEditRules" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesDataStreamsEventEditRulesRequest>;
 
@@ -5654,7 +5657,7 @@ export const PatchPropertiesDataStreamsEventEditRulesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesDataStreamsEventEditRulesRequest>;
 
@@ -5686,7 +5689,7 @@ export const DeletePropertiesDataStreamsEventEditRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesDataStreamsEventEditRulesRequest>;
 
@@ -5718,7 +5721,7 @@ export const GetPropertiesDataStreamsSKAdNetworkConversionValueSchemaRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesDataStreamsSKAdNetworkConversionValueSchemaRequest>;
 
@@ -5758,7 +5761,7 @@ export const CreatePropertiesDataStreamsSKAdNetworkConversionValueSchemaRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/sKAdNetworkConversionValueSchema",
+      path: "v1alpha/{+parent}/sKAdNetworkConversionValueSchema",
       hasBody: true,
     }),
     svc,
@@ -5793,7 +5796,7 @@ export const DeletePropertiesDataStreamsSKAdNetworkConversionValueSchemaRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesDataStreamsSKAdNetworkConversionValueSchemaRequest>;
 
@@ -5834,7 +5837,7 @@ export const PatchPropertiesDataStreamsSKAdNetworkConversionValueSchemaRequest =
       GoogleAnalyticsAdminV1alphaSKAdNetworkConversionValueSchema,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesDataStreamsSKAdNetworkConversionValueSchemaRequest>;
 
@@ -5875,7 +5878,7 @@ export const ListPropertiesDataStreamsSKAdNetworkConversionValueSchemaRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}/sKAdNetworkConversionValueSchema",
+      path: "v1alpha/{+parent}/sKAdNetworkConversionValueSchema",
     }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesDataStreamsSKAdNetworkConversionValueSchemaRequest>;
@@ -5913,7 +5916,7 @@ export const GetPropertiesDataStreamsEventCreateRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesDataStreamsEventCreateRulesRequest>;
 
@@ -5951,7 +5954,7 @@ export const ListPropertiesDataStreamsEventCreateRulesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/eventCreateRules" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/eventCreateRules" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesDataStreamsEventCreateRulesRequest>;
 
@@ -5995,7 +5998,7 @@ export const PatchPropertiesDataStreamsEventCreateRulesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesDataStreamsEventCreateRulesRequest>;
 
@@ -6027,7 +6030,7 @@ export const DeletePropertiesDataStreamsEventCreateRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesDataStreamsEventCreateRulesRequest>;
 
@@ -6066,7 +6069,7 @@ export const CreatePropertiesDataStreamsEventCreateRulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/eventCreateRules",
+      path: "v1alpha/{+parent}/eventCreateRules",
       hasBody: true,
     }),
     svc,
@@ -6100,7 +6103,7 @@ export const GetPropertiesDataStreamsMeasurementProtocolSecretsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesDataStreamsMeasurementProtocolSecretsRequest>;
 
@@ -6141,7 +6144,7 @@ export const ListPropertiesDataStreamsMeasurementProtocolSecretsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}/measurementProtocolSecrets",
+      path: "v1alpha/{+parent}/measurementProtocolSecrets",
     }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesDataStreamsMeasurementProtocolSecretsRequest>;
@@ -6179,7 +6182,7 @@ export const DeletePropertiesDataStreamsMeasurementProtocolSecretsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesDataStreamsMeasurementProtocolSecretsRequest>;
 
@@ -6220,7 +6223,7 @@ export const PatchPropertiesDataStreamsMeasurementProtocolSecretsRequest =
       GoogleAnalyticsAdminV1alphaMeasurementProtocolSecret,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesDataStreamsMeasurementProtocolSecretsRequest>;
 
@@ -6260,7 +6263,7 @@ export const CreatePropertiesDataStreamsMeasurementProtocolSecretsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/measurementProtocolSecrets",
+      path: "v1alpha/{+parent}/measurementProtocolSecrets",
       hasBody: true,
     }),
     svc,
@@ -6301,7 +6304,7 @@ export const ListPropertiesAccessBindingsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/accessBindings" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/accessBindings" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesAccessBindingsRequest>;
 
@@ -6342,7 +6345,7 @@ export const PatchPropertiesAccessBindingsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesAccessBindingsRequest>;
 
@@ -6381,7 +6384,7 @@ export const BatchCreatePropertiesAccessBindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/accessBindings:batchCreate",
+      path: "v1alpha/{+parent}/accessBindings:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -6415,7 +6418,7 @@ export const GetPropertiesAccessBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesAccessBindingsRequest>;
 
@@ -6447,7 +6450,7 @@ export const DeletePropertiesAccessBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesAccessBindingsRequest>;
 
@@ -6483,7 +6486,10 @@ export const BatchGetPropertiesAccessBindingsRequest =
       T.HttpQuery("names"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/accessBindings:batchGet" }),
+    T.Http({
+      method: "GET",
+      path: "v1alpha/{+parent}/accessBindings:batchGet",
+    }),
     svc,
   ) as unknown as Schema.Schema<BatchGetPropertiesAccessBindingsRequest>;
 
@@ -6522,7 +6528,7 @@ export const CreatePropertiesAccessBindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/accessBindings",
+      path: "v1alpha/{+parent}/accessBindings",
       hasBody: true,
     }),
     svc,
@@ -6563,7 +6569,7 @@ export const BatchUpdatePropertiesAccessBindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/accessBindings:batchUpdate",
+      path: "v1alpha/{+parent}/accessBindings:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -6604,7 +6610,7 @@ export const BatchDeletePropertiesAccessBindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/accessBindings:batchDelete",
+      path: "v1alpha/{+parent}/accessBindings:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -6644,7 +6650,7 @@ export const CreatePropertiesGoogleAdsLinksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/googleAdsLinks",
+      path: "v1alpha/{+parent}/googleAdsLinks",
       hasBody: true,
     }),
     svc,
@@ -6684,7 +6690,7 @@ export const ListPropertiesGoogleAdsLinksRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/googleAdsLinks" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/googleAdsLinks" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesGoogleAdsLinksRequest>;
 
@@ -6728,7 +6734,7 @@ export const PatchPropertiesGoogleAdsLinksRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesGoogleAdsLinksRequest>;
 
@@ -6760,7 +6766,7 @@ export const DeletePropertiesGoogleAdsLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesGoogleAdsLinksRequest>;
 
@@ -6798,7 +6804,7 @@ export const CreatePropertiesFirebaseLinksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/firebaseLinks",
+      path: "v1alpha/{+parent}/firebaseLinks",
       hasBody: true,
     }),
     svc,
@@ -6832,7 +6838,7 @@ export const DeletePropertiesFirebaseLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesFirebaseLinksRequest>;
 
@@ -6869,7 +6875,7 @@ export const ListPropertiesFirebaseLinksRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/firebaseLinks" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/firebaseLinks" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesFirebaseLinksRequest>;
 
@@ -6905,7 +6911,7 @@ export const GetPropertiesCustomMetricsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesCustomMetricsRequest>;
 
@@ -6944,7 +6950,7 @@ export const CreatePropertiesCustomMetricsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/customMetrics",
+      path: "v1alpha/{+parent}/customMetrics",
       hasBody: true,
     }),
     svc,
@@ -6983,7 +6989,7 @@ export const ArchivePropertiesCustomMetricsRequest =
       GoogleAnalyticsAdminV1alphaArchiveCustomMetricRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:archive", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:archive", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ArchivePropertiesCustomMetricsRequest>;
 
@@ -7020,7 +7026,7 @@ export const ListPropertiesCustomMetricsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/customMetrics" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/customMetrics" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesCustomMetricsRequest>;
 
@@ -7064,7 +7070,7 @@ export const PatchPropertiesCustomMetricsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesCustomMetricsRequest>;
 
@@ -7108,7 +7114,7 @@ export const CreatePropertiesCalculatedMetricsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/calculatedMetrics",
+      path: "v1alpha/{+parent}/calculatedMetrics",
       hasBody: true,
     }),
     svc,
@@ -7148,7 +7154,7 @@ export const ListPropertiesCalculatedMetricsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/calculatedMetrics" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/calculatedMetrics" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesCalculatedMetricsRequest>;
 
@@ -7192,7 +7198,7 @@ export const PatchPropertiesCalculatedMetricsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesCalculatedMetricsRequest>;
 
@@ -7224,7 +7230,7 @@ export const DeletePropertiesCalculatedMetricsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesCalculatedMetricsRequest>;
 
@@ -7255,7 +7261,7 @@ export const GetPropertiesCalculatedMetricsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesCalculatedMetricsRequest>;
 
@@ -7294,7 +7300,7 @@ export const CreatePropertiesReportingDataAnnotationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/reportingDataAnnotations",
+      path: "v1alpha/{+parent}/reportingDataAnnotations",
       hasBody: true,
     }),
     svc,
@@ -7336,7 +7342,7 @@ export const PatchPropertiesReportingDataAnnotationsRequest =
       GoogleAnalyticsAdminV1alphaReportingDataAnnotation,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesReportingDataAnnotationsRequest>;
 
@@ -7368,7 +7374,7 @@ export const DeletePropertiesReportingDataAnnotationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesReportingDataAnnotationsRequest>;
 
@@ -7411,7 +7417,7 @@ export const ListPropertiesReportingDataAnnotationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}/reportingDataAnnotations",
+      path: "v1alpha/{+parent}/reportingDataAnnotations",
     }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesReportingDataAnnotationsRequest>;
@@ -7448,7 +7454,7 @@ export const GetPropertiesReportingDataAnnotationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesReportingDataAnnotationsRequest>;
 
@@ -7480,7 +7486,7 @@ export const GetPropertiesSearchAds360LinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesSearchAds360LinksRequest>;
 
@@ -7519,7 +7525,7 @@ export const CreatePropertiesSearchAds360LinksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/searchAds360Links",
+      path: "v1alpha/{+parent}/searchAds360Links",
       hasBody: true,
     }),
     svc,
@@ -7559,7 +7565,7 @@ export const ListPropertiesSearchAds360LinksRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/searchAds360Links" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/searchAds360Links" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesSearchAds360LinksRequest>;
 
@@ -7595,7 +7601,7 @@ export const DeletePropertiesSearchAds360LinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesSearchAds360LinksRequest>;
 
@@ -7634,7 +7640,7 @@ export const PatchPropertiesSearchAds360LinksRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesSearchAds360LinksRequest>;
 
@@ -7673,7 +7679,7 @@ export const CreatePropertiesSubpropertyEventFiltersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/subpropertyEventFilters",
+      path: "v1alpha/{+parent}/subpropertyEventFilters",
       hasBody: true,
     }),
     svc,
@@ -7715,7 +7721,7 @@ export const PatchPropertiesSubpropertyEventFiltersRequest =
       GoogleAnalyticsAdminV1alphaSubpropertyEventFilter,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesSubpropertyEventFiltersRequest>;
 
@@ -7747,7 +7753,7 @@ export const DeletePropertiesSubpropertyEventFiltersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesSubpropertyEventFiltersRequest>;
 
@@ -7785,7 +7791,10 @@ export const ListPropertiesSubpropertyEventFiltersRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/subpropertyEventFilters" }),
+    T.Http({
+      method: "GET",
+      path: "v1alpha/{+parent}/subpropertyEventFilters",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesSubpropertyEventFiltersRequest>;
 
@@ -7821,7 +7830,7 @@ export const GetPropertiesSubpropertyEventFiltersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesSubpropertyEventFiltersRequest>;
 
@@ -7860,7 +7869,7 @@ export const CreatePropertiesChannelGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/channelGroups",
+      path: "v1alpha/{+parent}/channelGroups",
       hasBody: true,
     }),
     svc,
@@ -7900,7 +7909,7 @@ export const ListPropertiesChannelGroupsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/channelGroups" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/channelGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesChannelGroupsRequest>;
 
@@ -7944,7 +7953,7 @@ export const PatchPropertiesChannelGroupsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesChannelGroupsRequest>;
 
@@ -7976,7 +7985,7 @@ export const DeletePropertiesChannelGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesChannelGroupsRequest>;
 
@@ -8007,7 +8016,7 @@ export const GetPropertiesChannelGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesChannelGroupsRequest>;
 
@@ -8039,7 +8048,7 @@ export const GetPropertiesBigQueryLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesBigQueryLinksRequest>;
 
@@ -8071,7 +8080,7 @@ export const DeletePropertiesBigQueryLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesBigQueryLinksRequest>;
 
@@ -8110,7 +8119,7 @@ export const PatchPropertiesBigQueryLinksRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesBigQueryLinksRequest>;
 
@@ -8148,7 +8157,7 @@ export const ListPropertiesBigQueryLinksRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/bigQueryLinks" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/bigQueryLinks" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesBigQueryLinksRequest>;
 
@@ -8191,7 +8200,7 @@ export const CreatePropertiesBigQueryLinksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/bigQueryLinks",
+      path: "v1alpha/{+parent}/bigQueryLinks",
       hasBody: true,
     }),
     svc,
@@ -8225,7 +8234,7 @@ export const GetPropertiesAdSenseLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesAdSenseLinksRequest>;
 
@@ -8264,7 +8273,7 @@ export const CreatePropertiesAdSenseLinksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/adSenseLinks",
+      path: "v1alpha/{+parent}/adSenseLinks",
       hasBody: true,
     }),
     svc,
@@ -8304,7 +8313,7 @@ export const ListPropertiesAdSenseLinksRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/adSenseLinks" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/adSenseLinks" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesAdSenseLinksRequest>;
 
@@ -8340,7 +8349,7 @@ export const DeletePropertiesAdSenseLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesAdSenseLinksRequest>;
 
@@ -8378,7 +8387,7 @@ export const CreatePropertiesAudiencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/audiences",
+      path: "v1alpha/{+parent}/audiences",
       hasBody: true,
     }),
     svc,
@@ -8417,7 +8426,7 @@ export const ArchivePropertiesAudiencesRequest =
       GoogleAnalyticsAdminV1alphaArchiveAudienceRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:archive", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:archive", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ArchivePropertiesAudiencesRequest>;
 
@@ -8456,7 +8465,7 @@ export const PatchPropertiesAudiencesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesAudiencesRequest>;
 
@@ -8494,7 +8503,7 @@ export const ListPropertiesAudiencesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/audiences" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/audiences" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesAudiencesRequest>;
 
@@ -8530,7 +8539,7 @@ export const GetPropertiesAudiencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesAudiencesRequest>;
 
@@ -8570,7 +8579,7 @@ export const PatchPropertiesCustomDimensionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesCustomDimensionsRequest>;
 
@@ -8608,7 +8617,7 @@ export const ListPropertiesCustomDimensionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/customDimensions" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/customDimensions" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesCustomDimensionsRequest>;
 
@@ -8651,7 +8660,7 @@ export const CreatePropertiesCustomDimensionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/customDimensions",
+      path: "v1alpha/{+parent}/customDimensions",
       hasBody: true,
     }),
     svc,
@@ -8690,7 +8699,7 @@ export const ArchivePropertiesCustomDimensionsRequest =
       GoogleAnalyticsAdminV1alphaArchiveCustomDimensionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:archive", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:archive", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ArchivePropertiesCustomDimensionsRequest>;
 
@@ -8721,7 +8730,7 @@ export const GetPropertiesCustomDimensionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesCustomDimensionsRequest>;
 
@@ -8753,7 +8762,7 @@ export const DeletePropertiesRollupPropertySourceLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesRollupPropertySourceLinksRequest>;
 
@@ -8793,7 +8802,7 @@ export const ListPropertiesRollupPropertySourceLinksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}/rollupPropertySourceLinks",
+      path: "v1alpha/{+parent}/rollupPropertySourceLinks",
     }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesRollupPropertySourceLinksRequest>;
@@ -8830,7 +8839,7 @@ export const GetPropertiesRollupPropertySourceLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesRollupPropertySourceLinksRequest>;
 
@@ -8869,7 +8878,7 @@ export const CreatePropertiesRollupPropertySourceLinksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/rollupPropertySourceLinks",
+      path: "v1alpha/{+parent}/rollupPropertySourceLinks",
       hasBody: true,
     }),
     svc,
@@ -8910,7 +8919,7 @@ export const CreatePropertiesConversionEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/conversionEvents",
+      path: "v1alpha/{+parent}/conversionEvents",
       hasBody: true,
     }),
     svc,
@@ -8952,7 +8961,7 @@ export const PatchPropertiesConversionEventsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesConversionEventsRequest>;
 
@@ -8984,7 +8993,7 @@ export const DeletePropertiesConversionEventsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesConversionEventsRequest>;
 
@@ -9021,7 +9030,7 @@ export const ListPropertiesConversionEventsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/conversionEvents" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/conversionEvents" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesConversionEventsRequest>;
 
@@ -9057,7 +9066,7 @@ export const GetPropertiesConversionEventsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesConversionEventsRequest>;
 
@@ -9089,7 +9098,7 @@ export const GetPropertiesKeyEventsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesKeyEventsRequest>;
 
@@ -9127,7 +9136,7 @@ export const ListPropertiesKeyEventsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/keyEvents" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/keyEvents" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesKeyEventsRequest>;
 
@@ -9171,7 +9180,7 @@ export const PatchPropertiesKeyEventsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesKeyEventsRequest>;
 
@@ -9203,7 +9212,7 @@ export const DeletePropertiesKeyEventsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesKeyEventsRequest>;
 
@@ -9241,7 +9250,7 @@ export const CreatePropertiesKeyEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/keyEvents",
+      path: "v1alpha/{+parent}/keyEvents",
       hasBody: true,
     }),
     svc,
@@ -9282,7 +9291,7 @@ export const CreatePropertiesDisplayVideo360AdvertiserLinksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/displayVideo360AdvertiserLinks",
+      path: "v1alpha/{+parent}/displayVideo360AdvertiserLinks",
       hasBody: true,
     }),
     svc,
@@ -9324,7 +9333,7 @@ export const ListPropertiesDisplayVideo360AdvertiserLinksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}/displayVideo360AdvertiserLinks",
+      path: "v1alpha/{+parent}/displayVideo360AdvertiserLinks",
     }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesDisplayVideo360AdvertiserLinksRequest>;
@@ -9361,7 +9370,7 @@ export const DeletePropertiesDisplayVideo360AdvertiserLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesDisplayVideo360AdvertiserLinksRequest>;
 
@@ -9401,7 +9410,7 @@ export const PatchPropertiesDisplayVideo360AdvertiserLinksRequest =
       GoogleAnalyticsAdminV1alphaDisplayVideo360AdvertiserLink,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesDisplayVideo360AdvertiserLinksRequest>;
 
@@ -9433,7 +9442,7 @@ export const GetPropertiesDisplayVideo360AdvertiserLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesDisplayVideo360AdvertiserLinksRequest>;
 
@@ -9472,7 +9481,7 @@ export const CreatePropertiesExpandedDataSetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/expandedDataSets",
+      path: "v1alpha/{+parent}/expandedDataSets",
       hasBody: true,
     }),
     svc,
@@ -9512,7 +9521,7 @@ export const ListPropertiesExpandedDataSetsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/expandedDataSets" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/expandedDataSets" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesExpandedDataSetsRequest>;
 
@@ -9556,7 +9565,7 @@ export const PatchPropertiesExpandedDataSetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesExpandedDataSetsRequest>;
 
@@ -9588,7 +9597,7 @@ export const DeletePropertiesExpandedDataSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesExpandedDataSetsRequest>;
 
@@ -9619,7 +9628,7 @@ export const GetPropertiesExpandedDataSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesExpandedDataSetsRequest>;
 
@@ -9651,7 +9660,7 @@ export const GetPropertiesSubpropertySyncConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesSubpropertySyncConfigsRequest>;
 
@@ -9689,7 +9698,7 @@ export const ListPropertiesSubpropertySyncConfigsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/subpropertySyncConfigs" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/subpropertySyncConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesSubpropertySyncConfigsRequest>;
 
@@ -9733,7 +9742,7 @@ export const PatchPropertiesSubpropertySyncConfigsRequest =
       GoogleAnalyticsAdminV1alphaSubpropertySyncConfig,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesSubpropertySyncConfigsRequest>;
 

--- a/packages/gcp/src/services/analyticsadmin-v1beta.ts
+++ b/packages/gcp/src/services/analyticsadmin-v1beta.ts
@@ -1463,7 +1463,7 @@ export const GetDataSharingSettingsAccountsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDataSharingSettingsAccountsRequest>;
 
@@ -1494,7 +1494,7 @@ export interface GetAccountsRequest {
 export const GetAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta/{name}" }),
+  T.Http({ method: "GET", path: "v1beta/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetAccountsRequest>;
 
@@ -1530,7 +1530,7 @@ export const PatchAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(GoogleAnalyticsAdminV1betaAccount).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchAccountsRequest>;
 
@@ -1560,7 +1560,7 @@ export interface DeleteAccountsRequest {
 export const DeleteAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+  T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteAccountsRequest>;
 
@@ -1636,7 +1636,7 @@ export const SearchChangeHistoryEventsAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{account}:searchChangeHistoryEvents",
+      path: "v1beta/{+account}:searchChangeHistoryEvents",
       hasBody: true,
     }),
     svc,
@@ -1677,7 +1677,7 @@ export const RunAccessReportAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{entity}:runAccessReport",
+      path: "v1beta/{+entity}:runAccessReport",
       hasBody: true,
     }),
     svc,
@@ -1758,7 +1758,7 @@ export const UpdateDataRetentionSettingsPropertiesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateDataRetentionSettingsPropertiesRequest>;
 
@@ -1823,7 +1823,7 @@ export const GetDataRetentionSettingsPropertiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDataRetentionSettingsPropertiesRequest>;
 
@@ -1854,7 +1854,7 @@ export interface GetPropertiesRequest {
 export const GetPropertiesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta/{name}" }),
+  T.Http({ method: "GET", path: "v1beta/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetPropertiesRequest>;
 
@@ -1892,7 +1892,7 @@ export const AcknowledgeUserDataCollectionPropertiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{property}:acknowledgeUserDataCollection",
+      path: "v1beta/{+property}:acknowledgeUserDataCollection",
       hasBody: true,
     }),
     svc,
@@ -1933,7 +1933,7 @@ export const RunAccessReportPropertiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{entity}:runAccessReport",
+      path: "v1beta/{+entity}:runAccessReport",
       hasBody: true,
     }),
     svc,
@@ -2020,7 +2020,7 @@ export const PatchPropertiesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     ),
   },
 ).pipe(
-  T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchPropertiesRequest>;
 
@@ -2051,7 +2051,7 @@ export const DeletePropertiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesRequest>;
 
@@ -2088,7 +2088,7 @@ export const ListPropertiesCustomDimensionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/customDimensions" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/customDimensions" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesCustomDimensionsRequest>;
 
@@ -2129,7 +2129,7 @@ export const ArchivePropertiesCustomDimensionsRequest =
       GoogleAnalyticsAdminV1betaArchiveCustomDimensionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:archive", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:archive", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ArchivePropertiesCustomDimensionsRequest>;
 
@@ -2168,7 +2168,7 @@ export const PatchPropertiesCustomDimensionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesCustomDimensionsRequest>;
 
@@ -2200,7 +2200,7 @@ export const GetPropertiesCustomDimensionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesCustomDimensionsRequest>;
 
@@ -2239,7 +2239,7 @@ export const CreatePropertiesCustomDimensionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/customDimensions",
+      path: "v1beta/{+parent}/customDimensions",
       hasBody: true,
     }),
     svc,
@@ -2279,7 +2279,7 @@ export const ListPropertiesGoogleAdsLinksRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/googleAdsLinks" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/googleAdsLinks" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesGoogleAdsLinksRequest>;
 
@@ -2322,7 +2322,7 @@ export const CreatePropertiesGoogleAdsLinksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/googleAdsLinks",
+      path: "v1beta/{+parent}/googleAdsLinks",
       hasBody: true,
     }),
     svc,
@@ -2364,7 +2364,7 @@ export const PatchPropertiesGoogleAdsLinksRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesGoogleAdsLinksRequest>;
 
@@ -2396,7 +2396,7 @@ export const DeletePropertiesGoogleAdsLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesGoogleAdsLinksRequest>;
 
@@ -2435,7 +2435,7 @@ export const PatchPropertiesConversionEventsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesConversionEventsRequest>;
 
@@ -2467,7 +2467,7 @@ export const GetPropertiesConversionEventsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesConversionEventsRequest>;
 
@@ -2499,7 +2499,7 @@ export const DeletePropertiesConversionEventsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesConversionEventsRequest>;
 
@@ -2536,7 +2536,7 @@ export const ListPropertiesConversionEventsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/conversionEvents" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/conversionEvents" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesConversionEventsRequest>;
 
@@ -2579,7 +2579,7 @@ export const CreatePropertiesConversionEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/conversionEvents",
+      path: "v1beta/{+parent}/conversionEvents",
       hasBody: true,
     }),
     svc,
@@ -2619,7 +2619,7 @@ export const ListPropertiesFirebaseLinksRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/firebaseLinks" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/firebaseLinks" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesFirebaseLinksRequest>;
 
@@ -2662,7 +2662,7 @@ export const CreatePropertiesFirebaseLinksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/firebaseLinks",
+      path: "v1beta/{+parent}/firebaseLinks",
       hasBody: true,
     }),
     svc,
@@ -2696,7 +2696,7 @@ export const DeletePropertiesFirebaseLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesFirebaseLinksRequest>;
 
@@ -2734,7 +2734,7 @@ export const CreatePropertiesCustomMetricsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/customMetrics",
+      path: "v1beta/{+parent}/customMetrics",
       hasBody: true,
     }),
     svc,
@@ -2776,7 +2776,7 @@ export const PatchPropertiesCustomMetricsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesCustomMetricsRequest>;
 
@@ -2808,7 +2808,7 @@ export const GetPropertiesCustomMetricsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesCustomMetricsRequest>;
 
@@ -2846,7 +2846,7 @@ export const ListPropertiesCustomMetricsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/customMetrics" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/customMetrics" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesCustomMetricsRequest>;
 
@@ -2887,7 +2887,7 @@ export const ArchivePropertiesCustomMetricsRequest =
       GoogleAnalyticsAdminV1betaArchiveCustomMetricRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:archive", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:archive", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ArchivePropertiesCustomMetricsRequest>;
 
@@ -2926,7 +2926,7 @@ export const PatchPropertiesDataStreamsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesDataStreamsRequest>;
 
@@ -2958,7 +2958,7 @@ export const GetPropertiesDataStreamsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesDataStreamsRequest>;
 
@@ -2990,7 +2990,7 @@ export const DeletePropertiesDataStreamsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesDataStreamsRequest>;
 
@@ -3027,7 +3027,7 @@ export const ListPropertiesDataStreamsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/dataStreams" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/dataStreams" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesDataStreamsRequest>;
 
@@ -3070,7 +3070,7 @@ export const CreatePropertiesDataStreamsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/dataStreams",
+      path: "v1beta/{+parent}/dataStreams",
       hasBody: true,
     }),
     svc,
@@ -3111,7 +3111,7 @@ export const CreatePropertiesDataStreamsMeasurementProtocolSecretsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/measurementProtocolSecrets",
+      path: "v1beta/{+parent}/measurementProtocolSecrets",
       hasBody: true,
     }),
     svc,
@@ -3154,7 +3154,7 @@ export const ListPropertiesDataStreamsMeasurementProtocolSecretsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta/{parent}/measurementProtocolSecrets",
+      path: "v1beta/{+parent}/measurementProtocolSecrets",
     }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesDataStreamsMeasurementProtocolSecretsRequest>;
@@ -3192,7 +3192,7 @@ export const GetPropertiesDataStreamsMeasurementProtocolSecretsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesDataStreamsMeasurementProtocolSecretsRequest>;
 
@@ -3233,7 +3233,7 @@ export const PatchPropertiesDataStreamsMeasurementProtocolSecretsRequest =
       GoogleAnalyticsAdminV1betaMeasurementProtocolSecret,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesDataStreamsMeasurementProtocolSecretsRequest>;
 
@@ -3266,7 +3266,7 @@ export const DeletePropertiesDataStreamsMeasurementProtocolSecretsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesDataStreamsMeasurementProtocolSecretsRequest>;
 
@@ -3307,7 +3307,7 @@ export const PatchPropertiesKeyEventsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPropertiesKeyEventsRequest>;
 
@@ -3339,7 +3339,7 @@ export const GetPropertiesKeyEventsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesKeyEventsRequest>;
 
@@ -3370,7 +3370,7 @@ export const DeletePropertiesKeyEventsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePropertiesKeyEventsRequest>;
 
@@ -3407,7 +3407,7 @@ export const ListPropertiesKeyEventsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/keyEvents" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/keyEvents" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesKeyEventsRequest>;
 
@@ -3450,7 +3450,7 @@ export const CreatePropertiesKeyEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/keyEvents",
+      path: "v1beta/{+parent}/keyEvents",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/analyticsdata-v1beta.ts
+++ b/packages/gcp/src/services/analyticsdata-v1beta.ts
@@ -1269,7 +1269,7 @@ export const CheckCompatibilityPropertiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{property}:checkCompatibility",
+      path: "v1beta/{+property}:checkCompatibility",
       hasBody: true,
     }),
     svc,
@@ -1307,7 +1307,7 @@ export const RunPivotReportPropertiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{property}:runPivotReport",
+      path: "v1beta/{+property}:runPivotReport",
       hasBody: true,
     }),
     svc,
@@ -1345,7 +1345,7 @@ export const BatchRunPivotReportsPropertiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{property}:batchRunPivotReports",
+      path: "v1beta/{+property}:batchRunPivotReports",
       hasBody: true,
     }),
     svc,
@@ -1384,7 +1384,7 @@ export const RunReportPropertiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{property}:runReport",
+      path: "v1beta/{+property}:runReport",
       hasBody: true,
     }),
     svc,
@@ -1417,7 +1417,7 @@ export const GetMetadataPropertiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetMetadataPropertiesRequest>;
 
@@ -1453,7 +1453,7 @@ export const BatchRunReportsPropertiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{property}:batchRunReports",
+      path: "v1beta/{+property}:batchRunReports",
       hasBody: true,
     }),
     svc,
@@ -1491,7 +1491,7 @@ export const RunRealtimeReportPropertiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{property}:runRealtimeReport",
+      path: "v1beta/{+property}:runRealtimeReport",
       hasBody: true,
     }),
     svc,
@@ -1524,7 +1524,7 @@ export const GetPropertiesAudienceExportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPropertiesAudienceExportsRequest>;
 
@@ -1560,7 +1560,7 @@ export const CreatePropertiesAudienceExportsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/audienceExports",
+      path: "v1beta/{+parent}/audienceExports",
       hasBody: true,
     }),
     svc,
@@ -1596,7 +1596,7 @@ export const QueryPropertiesAudienceExportsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(QueryAudienceExportRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryPropertiesAudienceExportsRequest>;
 
@@ -1634,7 +1634,7 @@ export const ListPropertiesAudienceExportsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/audienceExports" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/audienceExports" }),
     svc,
   ) as unknown as Schema.Schema<ListPropertiesAudienceExportsRequest>;
 

--- a/packages/gcp/src/services/analyticshub-v1.ts
+++ b/packages/gcp/src/services/analyticshub-v1.ts
@@ -1265,7 +1265,7 @@ export const GetIamPolicyProjectsLocationsDataExchangesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1308,7 +1308,7 @@ export const CreateProjectsLocationsDataExchangesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/dataExchanges",
+      path: "v1/{+parent}/dataExchanges",
       hasBody: true,
     }),
     svc,
@@ -1347,7 +1347,7 @@ export const PatchProjectsLocationsDataExchangesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DataExchange).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataExchangesRequest>;
 
@@ -1378,7 +1378,7 @@ export const GetProjectsLocationsDataExchangesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataExchangesRequest>;
 
@@ -1415,7 +1415,7 @@ export const ListProjectsLocationsDataExchangesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dataExchanges" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dataExchanges" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataExchangesRequest>;
 
@@ -1462,7 +1462,7 @@ export const ListSubscriptionsProjectsLocationsDataExchangesRequest =
     resource: Schema.String.pipe(T.HttpPath("resource")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:listSubscriptions" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:listSubscriptions" }),
     svc,
   ) as unknown as Schema.Schema<ListSubscriptionsProjectsLocationsDataExchangesRequest>;
 
@@ -1502,7 +1502,7 @@ export const SubscribeProjectsLocationsDataExchangesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SubscribeDataExchangeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:subscribe", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:subscribe", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SubscribeProjectsLocationsDataExchangesRequest>;
 
@@ -1538,7 +1538,7 @@ export const SetIamPolicyProjectsLocationsDataExchangesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1571,7 +1571,7 @@ export const DeleteProjectsLocationsDataExchangesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataExchangesRequest>;
 
@@ -1607,7 +1607,7 @@ export const TestIamPermissionsProjectsLocationsDataExchangesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1648,7 +1648,7 @@ export const CreateProjectsLocationsDataExchangesListingsRequest =
     listingId: Schema.optional(Schema.String).pipe(T.HttpQuery("listingId")),
     body: Schema.optional(Listing).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/listings", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/listings", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataExchangesListingsRequest>;
 
@@ -1685,7 +1685,7 @@ export const PatchProjectsLocationsDataExchangesListingsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Listing).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataExchangesListingsRequest>;
 
@@ -1721,7 +1721,7 @@ export const GetIamPolicyProjectsLocationsDataExchangesListingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1755,7 +1755,7 @@ export const GetProjectsLocationsDataExchangesListingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataExchangesListingsRequest>;
 
@@ -1792,7 +1792,7 @@ export const ListProjectsLocationsDataExchangesListingsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/listings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/listings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataExchangesListingsRequest>;
 
@@ -1839,7 +1839,7 @@ export const ListSubscriptionsProjectsLocationsDataExchangesListingsRequest =
     resource: Schema.String.pipe(T.HttpPath("resource")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:listSubscriptions" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:listSubscriptions" }),
     svc,
   ) as unknown as Schema.Schema<ListSubscriptionsProjectsLocationsDataExchangesListingsRequest>;
 
@@ -1879,7 +1879,7 @@ export const SubscribeProjectsLocationsDataExchangesListingsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SubscribeListingRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:subscribe", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:subscribe", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SubscribeProjectsLocationsDataExchangesListingsRequest>;
 
@@ -1917,7 +1917,7 @@ export const SetIamPolicyProjectsLocationsDataExchangesListingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1956,7 +1956,7 @@ export const DeleteProjectsLocationsDataExchangesListingsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataExchangesListingsRequest>;
 
@@ -1992,7 +1992,7 @@ export const TestIamPermissionsProjectsLocationsDataExchangesListingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2033,7 +2033,7 @@ export const ListProjectsLocationsDataExchangesQueryTemplatesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/queryTemplates" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/queryTemplates" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataExchangesQueryTemplatesRequest>;
 
@@ -2073,7 +2073,7 @@ export const ApproveProjectsLocationsDataExchangesQueryTemplatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ApproveQueryTemplateRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:approve", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:approve", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ApproveProjectsLocationsDataExchangesQueryTemplatesRequest>;
 
@@ -2106,7 +2106,7 @@ export const GetProjectsLocationsDataExchangesQueryTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataExchangesQueryTemplatesRequest>;
 
@@ -2139,7 +2139,7 @@ export const DeleteProjectsLocationsDataExchangesQueryTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataExchangesQueryTemplatesRequest>;
 
@@ -2181,7 +2181,7 @@ export const CreateProjectsLocationsDataExchangesQueryTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/queryTemplates",
+      path: "v1/{+parent}/queryTemplates",
       hasBody: true,
     }),
     svc,
@@ -2222,7 +2222,7 @@ export const PatchProjectsLocationsDataExchangesQueryTemplatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(QueryTemplate).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataExchangesQueryTemplatesRequest>;
 
@@ -2258,7 +2258,7 @@ export const SubmitProjectsLocationsDataExchangesQueryTemplatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SubmitQueryTemplateRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:submit", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:submit", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SubmitProjectsLocationsDataExchangesQueryTemplatesRequest>;
 
@@ -2300,7 +2300,7 @@ export const ListProjectsLocationsSubscriptionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/subscriptions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/subscriptions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSubscriptionsRequest>;
 
@@ -2339,7 +2339,7 @@ export const RefreshProjectsLocationsSubscriptionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RefreshSubscriptionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:refresh", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:refresh", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RefreshProjectsLocationsSubscriptionsRequest>;
 
@@ -2373,7 +2373,7 @@ export const RevokeProjectsLocationsSubscriptionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RevokeSubscriptionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:revoke", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:revoke", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RevokeProjectsLocationsSubscriptionsRequest>;
 
@@ -2405,7 +2405,7 @@ export const DeleteProjectsLocationsSubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSubscriptionsRequest>;
 
@@ -2436,7 +2436,7 @@ export const GetProjectsLocationsSubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSubscriptionsRequest>;
 
@@ -2472,7 +2472,7 @@ export const GetIamPolicyProjectsLocationsSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2510,7 +2510,7 @@ export const SetIamPolicyProjectsLocationsSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2549,7 +2549,7 @@ export const ListOrganizationsLocationsDataExchangesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{organization}/dataExchanges" }),
+    T.Http({ method: "GET", path: "v1/{+organization}/dataExchanges" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsDataExchangesRequest>;
 

--- a/packages/gcp/src/services/analyticshub-v1beta1.ts
+++ b/packages/gcp/src/services/analyticshub-v1beta1.ts
@@ -604,7 +604,7 @@ export const ListProjectsLocationsDataExchangesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dataExchanges" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/dataExchanges" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataExchangesRequest>;
 
@@ -650,7 +650,7 @@ export const CreateProjectsLocationsDataExchangesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/dataExchanges",
+      path: "v1beta1/{+parent}/dataExchanges",
       hasBody: true,
     }),
     svc,
@@ -689,7 +689,7 @@ export const PatchProjectsLocationsDataExchangesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(DataExchange).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataExchangesRequest>;
 
@@ -725,7 +725,7 @@ export const TestIamPermissionsProjectsLocationsDataExchangesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -760,7 +760,7 @@ export const GetProjectsLocationsDataExchangesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataExchangesRequest>;
 
@@ -791,7 +791,7 @@ export const DeleteProjectsLocationsDataExchangesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataExchangesRequest>;
 
@@ -827,7 +827,7 @@ export const GetIamPolicyProjectsLocationsDataExchangesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -865,7 +865,7 @@ export const SetIamPolicyProjectsLocationsDataExchangesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -898,7 +898,7 @@ export const DeleteProjectsLocationsDataExchangesListingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataExchangesListingsRequest>;
 
@@ -934,7 +934,7 @@ export const TestIamPermissionsProjectsLocationsDataExchangesListingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -972,7 +972,11 @@ export const SubscribeProjectsLocationsDataExchangesListingsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SubscribeListingRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:subscribe", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+name}:subscribe",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<SubscribeProjectsLocationsDataExchangesListingsRequest>;
 
@@ -1010,7 +1014,7 @@ export const SetIamPolicyProjectsLocationsDataExchangesListingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1044,7 +1048,7 @@ export const GetProjectsLocationsDataExchangesListingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataExchangesListingsRequest>;
 
@@ -1080,7 +1084,7 @@ export const GetIamPolicyProjectsLocationsDataExchangesListingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1122,7 +1126,7 @@ export const CreateProjectsLocationsDataExchangesListingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/listings",
+      path: "v1beta1/{+parent}/listings",
       hasBody: true,
     }),
     svc,
@@ -1161,7 +1165,7 @@ export const PatchProjectsLocationsDataExchangesListingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Listing).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataExchangesListingsRequest>;
 
@@ -1198,7 +1202,7 @@ export const ListProjectsLocationsDataExchangesListingsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/listings" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/listings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataExchangesListingsRequest>;
 
@@ -1240,7 +1244,7 @@ export const ListOrganizationsLocationsDataExchangesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{organization}/dataExchanges" }),
+    T.Http({ method: "GET", path: "v1beta1/{+organization}/dataExchanges" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsDataExchangesRequest>;
 

--- a/packages/gcp/src/services/androiddeviceprovisioning-v1.ts
+++ b/packages/gcp/src/services/androiddeviceprovisioning-v1.ts
@@ -843,7 +843,7 @@ export const ApplyConfigurationCustomersDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/devices:applyConfiguration",
+      path: "v1/{+parent}/devices:applyConfiguration",
       hasBody: true,
     }),
     svc,
@@ -883,7 +883,7 @@ export const RemoveConfigurationCustomersDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/devices:removeConfiguration",
+      path: "v1/{+parent}/devices:removeConfiguration",
       hasBody: true,
     }),
     svc,
@@ -922,7 +922,7 @@ export const ListCustomersDevicesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.String).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/devices" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/devices" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersDevicesRequest>;
 
@@ -957,7 +957,7 @@ export const GetCustomersDevicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersDevicesRequest>;
 
@@ -992,7 +992,7 @@ export const UnclaimCustomersDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/devices:unclaim",
+      path: "v1/{+parent}/devices:unclaim",
       hasBody: true,
     }),
     svc,
@@ -1025,7 +1025,7 @@ export const ListCustomersDpcsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dpcs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dpcs" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersDpcsRequest>;
 
@@ -1061,7 +1061,7 @@ export const CreateCustomersConfigurationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/configurations",
+      path: "v1/{+parent}/configurations",
       hasBody: true,
     }),
     svc,
@@ -1094,7 +1094,7 @@ export const GetCustomersConfigurationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersConfigurationsRequest>;
 
@@ -1125,7 +1125,7 @@ export const DeleteCustomersConfigurationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteCustomersConfigurationsRequest>;
 
@@ -1156,7 +1156,7 @@ export const ListCustomersConfigurationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/configurations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/configurations" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersConfigurationsRequest>;
 
@@ -1194,7 +1194,7 @@ export const PatchCustomersConfigurationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Configuration).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchCustomersConfigurationsRequest>;
 
@@ -1224,7 +1224,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -1260,7 +1260,7 @@ export const ListPartnersVendorsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/vendors" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/vendors" }),
     svc,
   ) as unknown as Schema.Schema<ListPartnersVendorsRequest>;
 
@@ -1301,7 +1301,7 @@ export const ListPartnersVendorsCustomersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/customers" }),
     svc,
   ) as unknown as Schema.Schema<ListPartnersVendorsCustomersRequest>;
 
@@ -1339,7 +1339,7 @@ export const CreatePartnersCustomersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateCustomerRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/customers", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/customers", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreatePartnersCustomersRequest>;
 
@@ -1376,7 +1376,7 @@ export const ListPartnersCustomersRequest =
     partnerId: Schema.String.pipe(T.HttpPath("partnerId")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/partners/{partnerId}/customers" }),
+    T.Http({ method: "GET", path: "v1/partners/{+partnerId}/customers" }),
     svc,
   ) as unknown as Schema.Schema<ListPartnersCustomersRequest>;
 
@@ -1416,7 +1416,7 @@ export const UnclaimAsyncPartnersDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/partners/{partnerId}/devices:unclaimAsync",
+      path: "v1/partners/{+partnerId}/devices:unclaimAsync",
       hasBody: true,
     }),
     svc,
@@ -1454,7 +1454,7 @@ export const FindByOwnerPartnersDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/partners/{partnerId}/devices:findByOwner",
+      path: "v1/partners/{+partnerId}/devices:findByOwner",
       hasBody: true,
     }),
     svc,
@@ -1492,7 +1492,7 @@ export const GetSimLockStatePartnersDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/partners/{partnerId}/devices:getSimLockState",
+      path: "v1/partners/{+partnerId}/devices:getSimLockState",
       hasBody: true,
     }),
     svc,
@@ -1534,7 +1534,7 @@ export const MetadataPartnersDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/partners/{metadataOwnerId}/devices/{deviceId}/metadata",
+      path: "v1/partners/{+metadataOwnerId}/devices/{+deviceId}/metadata",
       hasBody: true,
     }),
     svc,
@@ -1572,7 +1572,7 @@ export const ClaimAsyncPartnersDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/partners/{partnerId}/devices:claimAsync",
+      path: "v1/partners/{+partnerId}/devices:claimAsync",
       hasBody: true,
     }),
     svc,
@@ -1612,7 +1612,7 @@ export const UpdateMetadataAsyncPartnersDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/partners/{partnerId}/devices:updateMetadataAsync",
+      path: "v1/partners/{+partnerId}/devices:updateMetadataAsync",
       hasBody: true,
     }),
     svc,
@@ -1650,7 +1650,7 @@ export const ClaimPartnersDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/partners/{partnerId}/devices:claim",
+      path: "v1/partners/{+partnerId}/devices:claim",
       hasBody: true,
     }),
     svc,
@@ -1690,7 +1690,7 @@ export const FindByIdentifierPartnersDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/partners/{partnerId}/devices:findByIdentifier",
+      path: "v1/partners/{+partnerId}/devices:findByIdentifier",
       hasBody: true,
     }),
     svc,
@@ -1724,7 +1724,7 @@ export const GetPartnersDevicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPartnersDevicesRequest>;
 
@@ -1759,7 +1759,7 @@ export const UnclaimPartnersDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/partners/{partnerId}/devices:unclaim",
+      path: "v1/partners/{+partnerId}/devices:unclaim",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/androidmanagement-v1.ts
+++ b/packages/gcp/src/services/androidmanagement-v1.ts
@@ -4418,7 +4418,7 @@ export interface GetEnterprisesRequest {
 export const GetEnterprisesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetEnterprisesRequest>;
 
@@ -4499,7 +4499,7 @@ export const PatchEnterprisesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Enterprise).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchEnterprisesRequest>;
 
@@ -4577,7 +4577,7 @@ export const DeleteEnterprisesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteEnterprisesRequest>;
 
@@ -4614,7 +4614,7 @@ export const GenerateEnterpriseUpgradeUrlEnterprisesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:generateEnterpriseUpgradeUrl",
+      path: "v1/{+name}:generateEnterpriseUpgradeUrl",
       hasBody: true,
     }),
     svc,
@@ -4653,7 +4653,7 @@ export const CreateEnterprisesMigrationTokensRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/migrationTokens",
+      path: "v1/{+parent}/migrationTokens",
       hasBody: true,
     }),
     svc,
@@ -4686,7 +4686,7 @@ export const GetEnterprisesMigrationTokensRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEnterprisesMigrationTokensRequest>;
 
@@ -4723,7 +4723,7 @@ export const ListEnterprisesMigrationTokensRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/migrationTokens" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/migrationTokens" }),
     svc,
   ) as unknown as Schema.Schema<ListEnterprisesMigrationTokensRequest>;
 
@@ -4764,7 +4764,7 @@ export const CreateEnterprisesEnrollmentTokensRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/enrollmentTokens",
+      path: "v1/{+parent}/enrollmentTokens",
       hasBody: true,
     }),
     svc,
@@ -4797,7 +4797,7 @@ export const GetEnterprisesEnrollmentTokensRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEnterprisesEnrollmentTokensRequest>;
 
@@ -4834,7 +4834,7 @@ export const ListEnterprisesEnrollmentTokensRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/enrollmentTokens" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/enrollmentTokens" }),
     svc,
   ) as unknown as Schema.Schema<ListEnterprisesEnrollmentTokensRequest>;
 
@@ -4870,7 +4870,7 @@ export const DeleteEnterprisesEnrollmentTokensRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteEnterprisesEnrollmentTokensRequest>;
 
@@ -4904,7 +4904,7 @@ export const CreateEnterprisesWebTokensRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(WebToken).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/webTokens", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/webTokens", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateEnterprisesWebTokensRequest>;
 
@@ -4941,7 +4941,7 @@ export const PatchEnterprisesWebAppsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(WebApp).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchEnterprisesWebAppsRequest>;
 
@@ -4972,7 +4972,7 @@ export const GetEnterprisesWebAppsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEnterprisesWebAppsRequest>;
 
@@ -5008,7 +5008,7 @@ export const ListEnterprisesWebAppsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/webApps" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/webApps" }),
     svc,
   ) as unknown as Schema.Schema<ListEnterprisesWebAppsRequest>;
 
@@ -5043,7 +5043,7 @@ export const DeleteEnterprisesWebAppsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteEnterprisesWebAppsRequest>;
 
@@ -5077,7 +5077,7 @@ export const CreateEnterprisesWebAppsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(WebApp).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/webApps", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/webApps", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateEnterprisesWebAppsRequest>;
 
@@ -5114,7 +5114,7 @@ export const PatchEnterprisesDevicesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Device).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchEnterprisesDevicesRequest>;
 
@@ -5145,7 +5145,7 @@ export const GetEnterprisesDevicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEnterprisesDevicesRequest>;
 
@@ -5181,7 +5181,7 @@ export const ListEnterprisesDevicesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/devices" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/devices" }),
     svc,
   ) as unknown as Schema.Schema<ListEnterprisesDevicesRequest>;
 
@@ -5219,7 +5219,7 @@ export const IssueCommandEnterprisesDevicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Command).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:issueCommand", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:issueCommand", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<IssueCommandEnterprisesDevicesRequest>;
 
@@ -5265,7 +5265,7 @@ export const DeleteEnterprisesDevicesRequest =
       T.HttpQuery("wipeReasonMessage"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteEnterprisesDevicesRequest>;
 
@@ -5310,7 +5310,7 @@ export const ListEnterprisesDevicesOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListEnterprisesDevicesOperationsRequest>;
 
@@ -5345,7 +5345,7 @@ export const GetEnterprisesDevicesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEnterprisesDevicesOperationsRequest>;
 
@@ -5376,7 +5376,7 @@ export const CancelEnterprisesDevicesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelEnterprisesDevicesOperationsRequest>;
 
@@ -5407,7 +5407,7 @@ export const GetEnterprisesPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEnterprisesPoliciesRequest>;
 
@@ -5444,7 +5444,7 @@ export const ListEnterprisesPoliciesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/policies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/policies" }),
     svc,
   ) as unknown as Schema.Schema<ListEnterprisesPoliciesRequest>;
 
@@ -5484,7 +5484,7 @@ export const ModifyPolicyApplicationsEnterprisesPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:modifyPolicyApplications",
+      path: "v1/{+name}:modifyPolicyApplications",
       hasBody: true,
     }),
     svc,
@@ -5523,7 +5523,7 @@ export const RemovePolicyApplicationsEnterprisesPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:removePolicyApplications",
+      path: "v1/{+name}:removePolicyApplications",
       hasBody: true,
     }),
     svc,
@@ -5563,7 +5563,7 @@ export const PatchEnterprisesPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Policy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchEnterprisesPoliciesRequest>;
 
@@ -5594,7 +5594,7 @@ export const DeleteEnterprisesPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteEnterprisesPoliciesRequest>;
 
@@ -5630,7 +5630,7 @@ export const GetEnterprisesApplicationsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEnterprisesApplicationsRequest>;
 
@@ -5661,7 +5661,7 @@ export const GetProvisioningInfoRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProvisioningInfoRequest>;
 

--- a/packages/gcp/src/services/androidpublisher-v3.ts
+++ b/packages/gcp/src/services/androidpublisher-v3.ts
@@ -5470,7 +5470,7 @@ export const CreateUsersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "androidpublisher/v3/{parent}/users",
+    path: "androidpublisher/v3/{+parent}/users",
     hasBody: true,
   }),
   svc,
@@ -5507,7 +5507,7 @@ export const ListUsersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
 }).pipe(
-  T.Http({ method: "GET", path: "androidpublisher/v3/{parent}/users" }),
+  T.Http({ method: "GET", path: "androidpublisher/v3/{+parent}/users" }),
   svc,
 ) as unknown as Schema.Schema<ListUsersRequest>;
 
@@ -5549,7 +5549,7 @@ export const PatchUsersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "androidpublisher/v3/{name}",
+    path: "androidpublisher/v3/{+name}",
     hasBody: true,
   }),
   svc,
@@ -5580,7 +5580,7 @@ export interface DeleteUsersRequest {
 export const DeleteUsersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "androidpublisher/v3/{name}" }),
+  T.Http({ method: "DELETE", path: "androidpublisher/v3/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteUsersRequest>;
 
@@ -5617,7 +5617,7 @@ export const CreateGrantsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "androidpublisher/v3/{parent}/grants",
+    path: "androidpublisher/v3/{+parent}/grants",
     hasBody: true,
   }),
   svc,
@@ -5656,7 +5656,7 @@ export const PatchGrantsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "androidpublisher/v3/{name}",
+    path: "androidpublisher/v3/{+name}",
     hasBody: true,
   }),
   svc,
@@ -5687,7 +5687,7 @@ export interface DeleteGrantsRequest {
 export const DeleteGrantsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "androidpublisher/v3/{name}" }),
+  T.Http({ method: "DELETE", path: "androidpublisher/v3/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteGrantsRequest>;
 
@@ -8172,7 +8172,7 @@ export const CreateexternaltransactionExternaltransactionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "androidpublisher/v3/{parent}/externalTransactions",
+      path: "androidpublisher/v3/{+parent}/externalTransactions",
       hasBody: true,
     }),
     svc,
@@ -8211,7 +8211,7 @@ export const RefundexternaltransactionExternaltransactionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "androidpublisher/v3/{name}:refund",
+      path: "androidpublisher/v3/{+name}:refund",
       hasBody: true,
     }),
     svc,
@@ -8245,7 +8245,7 @@ export const GetexternaltransactionExternaltransactionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "androidpublisher/v3/{name}" }),
+    T.Http({ method: "GET", path: "androidpublisher/v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetexternaltransactionExternaltransactionsRequest>;
 
@@ -9107,7 +9107,7 @@ export const ListApplicationsTracksReleasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "androidpublisher/v3/{parent}/releases" }),
+    T.Http({ method: "GET", path: "androidpublisher/v3/{+parent}/releases" }),
     svc,
   ) as unknown as Schema.Schema<ListApplicationsTracksReleasesRequest>;
 

--- a/packages/gcp/src/services/apigateway-v1.ts
+++ b/packages/gcp/src/services/apigateway-v1.ts
@@ -516,7 +516,7 @@ export const ListProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -551,7 +551,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -587,7 +587,7 @@ export const GetIamPolicyProjectsLocationsApisRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsApisRequest>;
 
@@ -623,7 +623,7 @@ export const SetIamPolicyProjectsLocationsApisRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -663,7 +663,7 @@ export const TestIamPermissionsProjectsLocationsApisRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -709,7 +709,7 @@ export const ListProjectsLocationsApisRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/apis" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/apis" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApisRequest>;
 
@@ -744,7 +744,7 @@ export const GetProjectsLocationsApisRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApisRequest>;
 
@@ -781,7 +781,7 @@ export const PatchProjectsLocationsApisRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ApigatewayApi).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApisRequest>;
 
@@ -812,7 +812,7 @@ export const DeleteProjectsLocationsApisRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApisRequest>;
 
@@ -849,7 +849,7 @@ export const CreateProjectsLocationsApisRequest =
     apiId: Schema.optional(Schema.String).pipe(T.HttpQuery("apiId")),
     body: Schema.optional(ApigatewayApi).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/apis", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/apis", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApisRequest>;
 
@@ -883,7 +883,7 @@ export const GetProjectsLocationsApisConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApisConfigsRequest>;
 
@@ -920,7 +920,7 @@ export const PatchProjectsLocationsApisConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ApigatewayApiConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApisConfigsRequest>;
 
@@ -951,7 +951,7 @@ export const DeleteProjectsLocationsApisConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApisConfigsRequest>;
 
@@ -990,7 +990,7 @@ export const CreateProjectsLocationsApisConfigsRequest =
     ),
     body: Schema.optional(ApigatewayApiConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/configs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/configs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApisConfigsRequest>;
 
@@ -1033,7 +1033,7 @@ export const ListProjectsLocationsApisConfigsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/configs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/configs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApisConfigsRequest>;
 
@@ -1074,7 +1074,7 @@ export const SetIamPolicyProjectsLocationsApisConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1114,7 +1114,7 @@ export const TestIamPermissionsProjectsLocationsApisConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1153,7 +1153,7 @@ export const GetIamPolicyProjectsLocationsApisConfigsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsApisConfigsRequest>;
 
@@ -1198,7 +1198,7 @@ export const ListProjectsLocationsOperationsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1237,7 +1237,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ApigatewayCancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1268,7 +1268,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1299,7 +1299,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1335,7 +1335,7 @@ export const GetIamPolicyProjectsLocationsGatewaysRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGatewaysRequest>;
 
@@ -1371,7 +1371,7 @@ export const SetIamPolicyProjectsLocationsGatewaysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1411,7 +1411,7 @@ export const TestIamPermissionsProjectsLocationsGatewaysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1457,7 +1457,7 @@ export const ListProjectsLocationsGatewaysRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/gateways" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/gateways" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGatewaysRequest>;
 
@@ -1493,7 +1493,7 @@ export const GetProjectsLocationsGatewaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGatewaysRequest>;
 
@@ -1530,7 +1530,7 @@ export const PatchProjectsLocationsGatewaysRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ApigatewayGateway).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGatewaysRequest>;
 
@@ -1561,7 +1561,7 @@ export const DeleteProjectsLocationsGatewaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGatewaysRequest>;
 
@@ -1598,7 +1598,7 @@ export const CreateProjectsLocationsGatewaysRequest =
     gatewayId: Schema.optional(Schema.String).pipe(T.HttpQuery("gatewayId")),
     body: Schema.optional(ApigatewayGateway).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/gateways", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/gateways", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGatewaysRequest>;
 

--- a/packages/gcp/src/services/apigateway-v1beta.ts
+++ b/packages/gcp/src/services/apigateway-v1beta.ts
@@ -539,7 +539,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -574,7 +574,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -605,7 +605,7 @@ export const GetProjectsLocationsGatewaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGatewaysRequest>;
 
@@ -642,7 +642,7 @@ export const PatchProjectsLocationsGatewaysRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ApigatewayGateway).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGatewaysRequest>;
 
@@ -685,7 +685,7 @@ export const ListProjectsLocationsGatewaysRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/gateways" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/gateways" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGatewaysRequest>;
 
@@ -728,7 +728,7 @@ export const TestIamPermissionsProjectsLocationsGatewaysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:testIamPermissions",
+      path: "v1beta/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -762,7 +762,7 @@ export const DeleteProjectsLocationsGatewaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGatewaysRequest>;
 
@@ -798,7 +798,7 @@ export const GetIamPolicyProjectsLocationsGatewaysRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGatewaysRequest>;
 
@@ -835,7 +835,11 @@ export const CreateProjectsLocationsGatewaysRequest =
     gatewayId: Schema.optional(Schema.String).pipe(T.HttpQuery("gatewayId")),
     body: Schema.optional(ApigatewayGateway).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/gateways", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/gateways",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGatewaysRequest>;
 
@@ -871,7 +875,7 @@ export const SetIamPolicyProjectsLocationsGatewaysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:setIamPolicy",
+      path: "v1beta/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -910,7 +914,7 @@ export const CreateProjectsLocationsApisRequest =
     apiId: Schema.optional(Schema.String).pipe(T.HttpQuery("apiId")),
     body: Schema.optional(ApigatewayApi).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/apis", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/apis", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApisRequest>;
 
@@ -946,7 +950,7 @@ export const SetIamPolicyProjectsLocationsApisRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:setIamPolicy",
+      path: "v1beta/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -984,7 +988,7 @@ export const GetIamPolicyProjectsLocationsApisRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsApisRequest>;
 
@@ -1015,7 +1019,7 @@ export const DeleteProjectsLocationsApisRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApisRequest>;
 
@@ -1058,7 +1062,7 @@ export const ListProjectsLocationsApisRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/apis" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/apis" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApisRequest>;
 
@@ -1100,7 +1104,7 @@ export const TestIamPermissionsProjectsLocationsApisRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:testIamPermissions",
+      path: "v1beta/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1140,7 +1144,7 @@ export const PatchProjectsLocationsApisRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ApigatewayApi).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApisRequest>;
 
@@ -1171,7 +1175,7 @@ export const GetProjectsLocationsApisRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApisRequest>;
 
@@ -1214,7 +1218,7 @@ export const ListProjectsLocationsApisConfigsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/configs" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/configs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApisConfigsRequest>;
 
@@ -1257,7 +1261,7 @@ export const TestIamPermissionsProjectsLocationsApisConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:testIamPermissions",
+      path: "v1beta/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1291,7 +1295,7 @@ export const DeleteProjectsLocationsApisConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApisConfigsRequest>;
 
@@ -1327,7 +1331,7 @@ export const GetIamPolicyProjectsLocationsApisConfigsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsApisConfigsRequest>;
 
@@ -1366,7 +1370,7 @@ export const CreateProjectsLocationsApisConfigsRequest =
     ),
     body: Schema.optional(ApigatewayApiConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/configs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/configs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApisConfigsRequest>;
 
@@ -1402,7 +1406,7 @@ export const SetIamPolicyProjectsLocationsApisConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:setIamPolicy",
+      path: "v1beta/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1438,7 +1442,7 @@ export const GetProjectsLocationsApisConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApisConfigsRequest>;
 
@@ -1475,7 +1479,7 @@ export const PatchProjectsLocationsApisConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ApigatewayApiConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApisConfigsRequest>;
 
@@ -1520,7 +1524,7 @@ export const ListProjectsLocationsOperationsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1556,7 +1560,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1587,7 +1591,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1621,7 +1625,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ApigatewayCancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/apigee-v1.ts
+++ b/packages/gcp/src/services/apigee-v1.ts
@@ -7134,7 +7134,7 @@ export const SetAddonsOrganizationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{org}:setAddons", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+org}:setAddons", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetAddonsOrganizationsRequest>;
 
@@ -7172,7 +7172,7 @@ export const GetSyncAuthorizationOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:getSyncAuthorization",
+      path: "v1/{+name}:getSyncAuthorization",
       hasBody: true,
     }),
     svc,
@@ -7206,7 +7206,7 @@ export const GetRuntimeConfigOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetRuntimeConfigOrganizationsRequest>;
 
@@ -7238,7 +7238,7 @@ export const ListOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsRequest>;
 
@@ -7304,7 +7304,7 @@ export const GetProjectMappingOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getProjectMapping" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getProjectMapping" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectMappingOrganizationsRequest>;
 
@@ -7339,7 +7339,7 @@ export const UpdateOrganizationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1Organization).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsRequest>;
 
@@ -7373,7 +7373,7 @@ export const DeleteOrganizationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     retention: Schema.optional(Schema.String).pipe(T.HttpQuery("retention")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsRequest>;
 
@@ -7404,7 +7404,7 @@ export const GetControlPlaneAccessOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetControlPlaneAccessOrganizationsRequest>;
 
@@ -7444,7 +7444,7 @@ export const UpdateControlPlaneAccessOrganizationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateControlPlaneAccessOrganizationsRequest>;
 
@@ -7476,7 +7476,7 @@ export const GetOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsRequest>;
 
@@ -7514,7 +7514,7 @@ export const SetSyncAuthorizationOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:setSyncAuthorization",
+      path: "v1/{+name}:setSyncAuthorization",
       hasBody: true,
     }),
     svc,
@@ -7551,7 +7551,7 @@ export const GetDeployedIngressConfigOrganizationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDeployedIngressConfigOrganizationsRequest>;
 
@@ -7583,7 +7583,7 @@ export const GetSecuritySettingsOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSecuritySettingsOrganizationsRequest>;
 
@@ -7623,7 +7623,7 @@ export const UpdateSecuritySettingsOrganizationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSecuritySettingsOrganizationsRequest>;
 
@@ -7661,7 +7661,7 @@ export const CreateOrganizationsDnsZonesRequest =
     dnsZoneId: Schema.optional(Schema.String).pipe(T.HttpQuery("dnsZoneId")),
     body: Schema.optional(GoogleCloudApigeeV1DnsZone).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/dnsZones", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/dnsZones", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsDnsZonesRequest>;
 
@@ -7692,7 +7692,7 @@ export const GetOrganizationsDnsZonesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsDnsZonesRequest>;
 
@@ -7729,7 +7729,7 @@ export const ListOrganizationsDnsZonesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dnsZones" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dnsZones" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsDnsZonesRequest>;
 
@@ -7765,7 +7765,7 @@ export const DeleteOrganizationsDnsZonesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsDnsZonesRequest>;
 
@@ -7799,7 +7799,7 @@ export const PatchOrganizationsSitesApicategoriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1ApiCategory).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsSitesApicategoriesRequest>;
 
@@ -7831,7 +7831,7 @@ export const DeleteOrganizationsSitesApicategoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsSitesApicategoriesRequest>;
 
@@ -7868,7 +7868,7 @@ export const CreateOrganizationsSitesApicategoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/apicategories",
+      path: "v1/{+parent}/apicategories",
       hasBody: true,
     }),
     svc,
@@ -7902,7 +7902,7 @@ export const GetOrganizationsSitesApicategoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsSitesApicategoriesRequest>;
 
@@ -7934,7 +7934,7 @@ export const ListOrganizationsSitesApicategoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/apicategories" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/apicategories" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSitesApicategoriesRequest>;
 
@@ -7971,7 +7971,7 @@ export const UpdateDocumentationOrganizationsSitesApidocsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateDocumentationOrganizationsSitesApidocsRequest>;
 
@@ -8006,7 +8006,7 @@ export const UpdateOrganizationsSitesApidocsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1ApiDoc).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsSitesApidocsRequest>;
 
@@ -8038,7 +8038,7 @@ export const DeleteOrganizationsSitesApidocsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsSitesApidocsRequest>;
 
@@ -8070,7 +8070,7 @@ export const GetDocumentationOrganizationsSitesApidocsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDocumentationOrganizationsSitesApidocsRequest>;
 
@@ -8102,7 +8102,7 @@ export const GetOrganizationsSitesApidocsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsSitesApidocsRequest>;
 
@@ -8137,7 +8137,7 @@ export const CreateOrganizationsSitesApidocsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1ApiDoc).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/apidocs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/apidocs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsSitesApidocsRequest>;
 
@@ -8175,7 +8175,7 @@ export const ListOrganizationsSitesApidocsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/apidocs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/apidocs" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSitesApidocsRequest>;
 
@@ -8257,7 +8257,7 @@ export const GetOrganizationsHostStatsRequest =
     timeRange: Schema.optional(Schema.String).pipe(T.HttpQuery("timeRange")),
     tzo: Schema.optional(Schema.String).pipe(T.HttpQuery("tzo")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsHostStatsRequest>;
 
@@ -8288,7 +8288,7 @@ export const GetResultOrganizationsHostQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetResultOrganizationsHostQueriesRequest>;
 
@@ -8322,7 +8322,7 @@ export const CreateOrganizationsHostQueriesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1Query).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/hostQueries", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/hostQueries", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsHostQueriesRequest>;
 
@@ -8354,7 +8354,7 @@ export const GetOrganizationsHostQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsHostQueriesRequest>;
 
@@ -8385,7 +8385,7 @@ export const GetResultViewOrganizationsHostQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetResultViewOrganizationsHostQueriesRequest>;
 
@@ -8443,7 +8443,7 @@ export const ListOrganizationsHostQueriesRequest =
     dataset: Schema.optional(Schema.String).pipe(T.HttpQuery("dataset")),
     from: Schema.optional(Schema.String).pipe(T.HttpQuery("from")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/hostQueries" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/hostQueries" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsHostQueriesRequest>;
 
@@ -8478,7 +8478,11 @@ export const CreateOrganizationsKeyvaluemapsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1KeyValueMap).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/keyvaluemaps", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/keyvaluemaps",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsKeyvaluemapsRequest>;
 
@@ -8510,7 +8514,7 @@ export const DeleteOrganizationsKeyvaluemapsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsKeyvaluemapsRequest>;
 
@@ -8542,7 +8546,7 @@ export const GetOrganizationsKeyvaluemapsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsKeyvaluemapsRequest>;
 
@@ -8577,7 +8581,7 @@ export const UpdateOrganizationsKeyvaluemapsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1KeyValueMap).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsKeyvaluemapsRequest>;
 
@@ -8609,7 +8613,7 @@ export const DeleteOrganizationsKeyvaluemapsEntriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsKeyvaluemapsEntriesRequest>;
 
@@ -8644,7 +8648,7 @@ export const UpdateOrganizationsKeyvaluemapsEntriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1KeyValueEntry).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsKeyvaluemapsEntriesRequest>;
 
@@ -8676,7 +8680,7 @@ export const GetOrganizationsKeyvaluemapsEntriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsKeyvaluemapsEntriesRequest>;
 
@@ -8711,7 +8715,7 @@ export const CreateOrganizationsKeyvaluemapsEntriesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1KeyValueEntry).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/entries", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/entries", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsKeyvaluemapsEntriesRequest>;
 
@@ -8749,7 +8753,7 @@ export const ListOrganizationsKeyvaluemapsEntriesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/entries" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/entries" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsKeyvaluemapsEntriesRequest>;
 
@@ -8794,7 +8798,7 @@ export const DeleteOrganizationsSecurityMonitoringConditionsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsSecurityMonitoringConditionsRequest>;
 
@@ -8835,7 +8839,7 @@ export const PatchOrganizationsSecurityMonitoringConditionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsSecurityMonitoringConditionsRequest>;
 
@@ -8879,7 +8883,7 @@ export const CreateOrganizationsSecurityMonitoringConditionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/securityMonitoringConditions",
+      path: "v1/{+parent}/securityMonitoringConditions",
       hasBody: true,
     }),
     svc,
@@ -8923,7 +8927,7 @@ export const GetOrganizationsSecurityMonitoringConditionsRequest =
       T.HttpQuery("riskAssessmentType"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsSecurityMonitoringConditionsRequest>;
 
@@ -8973,7 +8977,10 @@ export const ListOrganizationsSecurityMonitoringConditionsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/securityMonitoringConditions" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+parent}/securityMonitoringConditions",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSecurityMonitoringConditionsRequest>;
 
@@ -9015,7 +9022,7 @@ export const PatchOrganizationsApisRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudApigeeV1ApiProxy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsApisRequest>;
 
@@ -9051,7 +9058,7 @@ export const MoveOrganizationsApisRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveOrganizationsApisRequest>;
 
@@ -9082,7 +9089,7 @@ export const DeleteOrganizationsApisRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsApisRequest>;
 
@@ -9126,7 +9133,7 @@ export const ListOrganizationsApisRequest =
       T.HttpQuery("includeRevisions"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/apis" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/apis" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsApisRequest>;
 
@@ -9158,7 +9165,7 @@ export const GetOrganizationsApisRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsApisRequest>;
 
@@ -9204,7 +9211,7 @@ export const CreateOrganizationsApisRequest =
     validate: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("validate")),
     body: Schema.optional(GoogleApiHttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/apis", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/apis", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsApisRequest>;
 
@@ -9242,7 +9249,7 @@ export const ListOrganizationsApisDebugsessionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/debugsessions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/debugsessions" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsApisDebugsessionsRequest>;
 
@@ -9284,7 +9291,7 @@ export const UpdateApiProxyRevisionOrganizationsApisRevisionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleApiHttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateApiProxyRevisionOrganizationsApisRevisionsRequest>;
 
@@ -9320,7 +9327,7 @@ export const GetOrganizationsApisRevisionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     format: Schema.optional(Schema.String).pipe(T.HttpQuery("format")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsApisRevisionsRequest>;
 
@@ -9351,7 +9358,7 @@ export const DeleteOrganizationsApisRevisionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsApisRevisionsRequest>;
 
@@ -9383,7 +9390,7 @@ export const ListOrganizationsApisRevisionsDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsApisRevisionsDeploymentsRequest>;
 
@@ -9415,7 +9422,7 @@ export const ListOrganizationsApisDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsApisDeploymentsRequest>;
 
@@ -9447,7 +9454,7 @@ export const GetOrganizationsApisKeyvaluemapsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsApisKeyvaluemapsRequest>;
 
@@ -9482,7 +9489,7 @@ export const UpdateOrganizationsApisKeyvaluemapsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1KeyValueMap).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsApisKeyvaluemapsRequest>;
 
@@ -9517,7 +9524,11 @@ export const CreateOrganizationsApisKeyvaluemapsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1KeyValueMap).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/keyvaluemaps", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/keyvaluemaps",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsApisKeyvaluemapsRequest>;
 
@@ -9549,7 +9560,7 @@ export const DeleteOrganizationsApisKeyvaluemapsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsApisKeyvaluemapsRequest>;
 
@@ -9581,7 +9592,7 @@ export const GetOrganizationsApisKeyvaluemapsEntriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsApisKeyvaluemapsEntriesRequest>;
 
@@ -9616,7 +9627,7 @@ export const CreateOrganizationsApisKeyvaluemapsEntriesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1KeyValueEntry).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/entries", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/entries", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsApisKeyvaluemapsEntriesRequest>;
 
@@ -9654,7 +9665,7 @@ export const ListOrganizationsApisKeyvaluemapsEntriesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/entries" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/entries" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsApisKeyvaluemapsEntriesRequest>;
 
@@ -9690,7 +9701,7 @@ export const DeleteOrganizationsApisKeyvaluemapsEntriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsApisKeyvaluemapsEntriesRequest>;
 
@@ -9725,7 +9736,7 @@ export const UpdateOrganizationsApisKeyvaluemapsEntriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1KeyValueEntry).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsApisKeyvaluemapsEntriesRequest>;
 
@@ -9757,7 +9768,7 @@ export const DeleteOrganizationsAnalyticsDatastoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsAnalyticsDatastoresRequest>;
 
@@ -9792,7 +9803,7 @@ export const UpdateOrganizationsAnalyticsDatastoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1Datastore).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsAnalyticsDatastoresRequest>;
 
@@ -9829,7 +9840,7 @@ export const TestOrganizationsAnalyticsDatastoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/analytics/datastores:test",
+      path: "v1/{+parent}/analytics/datastores:test",
       hasBody: true,
     }),
     svc,
@@ -9868,7 +9879,7 @@ export const CreateOrganizationsAnalyticsDatastoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/analytics/datastores",
+      path: "v1/{+parent}/analytics/datastores",
       hasBody: true,
     }),
     svc,
@@ -9902,7 +9913,7 @@ export const GetOrganizationsAnalyticsDatastoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsAnalyticsDatastoresRequest>;
 
@@ -9937,7 +9948,7 @@ export const ListOrganizationsAnalyticsDatastoresRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     targetType: Schema.optional(Schema.String).pipe(T.HttpQuery("targetType")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/analytics/datastores" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/analytics/datastores" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsAnalyticsDatastoresRequest>;
 
@@ -9974,7 +9985,7 @@ export const UpdateMonetizationConfigOrganizationsDevelopersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateMonetizationConfigOrganizationsDevelopersRequest>;
 
@@ -10010,7 +10021,7 @@ export const CreateOrganizationsDevelopersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1Developer).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/developers", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/developers", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsDevelopersRequest>;
 
@@ -10062,7 +10073,7 @@ export const ListOrganizationsDevelopersRequest =
       T.HttpQuery("includeCompany"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/developers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/developers" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsDevelopersRequest>;
 
@@ -10097,7 +10108,7 @@ export const SetDeveloperStatusOrganizationsDevelopersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     action: Schema.optional(Schema.String).pipe(T.HttpQuery("action")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetDeveloperStatusOrganizationsDevelopersRequest>;
 
@@ -10129,7 +10140,7 @@ export const GetBalanceOrganizationsDevelopersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBalanceOrganizationsDevelopersRequest>;
 
@@ -10164,7 +10175,7 @@ export const UpdateOrganizationsDevelopersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1Developer).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsDevelopersRequest>;
 
@@ -10196,7 +10207,7 @@ export const DeleteOrganizationsDevelopersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsDevelopersRequest>;
 
@@ -10231,7 +10242,7 @@ export const AttributesOrganizationsDevelopersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1Attributes).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/attributes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/attributes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AttributesOrganizationsDevelopersRequest>;
 
@@ -10266,7 +10277,7 @@ export const GetOrganizationsDevelopersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     action: Schema.optional(Schema.String).pipe(T.HttpQuery("action")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsDevelopersRequest>;
 
@@ -10297,7 +10308,7 @@ export const GetMonetizationConfigOrganizationsDevelopersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetMonetizationConfigOrganizationsDevelopersRequest>;
 
@@ -10329,7 +10340,7 @@ export const GetOrganizationsDevelopersAttributesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsDevelopersAttributesRequest>;
 
@@ -10361,7 +10372,7 @@ export const DeleteOrganizationsDevelopersAttributesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsDevelopersAttributesRequest>;
 
@@ -10396,7 +10407,7 @@ export const UpdateDeveloperAttributeOrganizationsDevelopersAttributesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1Attribute).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateDeveloperAttributeOrganizationsDevelopersAttributesRequest>;
 
@@ -10429,7 +10440,7 @@ export const ListOrganizationsDevelopersAttributesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/attributes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/attributes" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsDevelopersAttributesRequest>;
 
@@ -10466,7 +10477,7 @@ export const AdjustOrganizationsDevelopersBalanceRequest =
       GoogleCloudApigeeV1AdjustDeveloperBalanceRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:adjust", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:adjust", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AdjustOrganizationsDevelopersBalanceRequest>;
 
@@ -10503,7 +10514,7 @@ export const CreditOrganizationsDevelopersBalanceRequest =
       GoogleCloudApigeeV1CreditDeveloperBalanceRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:credit", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:credit", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreditOrganizationsDevelopersBalanceRequest>;
 
@@ -10541,7 +10552,7 @@ export const GenerateKeyPairOrUpdateDeveloperAppStatusOrganizationsDevelopersApp
     action: Schema.optional(Schema.String).pipe(T.HttpQuery("action")),
     body: Schema.optional(GoogleCloudApigeeV1DeveloperApp).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<GenerateKeyPairOrUpdateDeveloperAppStatusOrganizationsDevelopersAppsRequest>;
 
@@ -10579,7 +10590,7 @@ export const CreateOrganizationsDevelopersAppsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1DeveloperApp).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/apps", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/apps", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsDevelopersAppsRequest>;
 
@@ -10617,7 +10628,7 @@ export const GetOrganizationsDevelopersAppsRequest =
     query: Schema.optional(Schema.String).pipe(T.HttpQuery("query")),
     entity: Schema.optional(Schema.String).pipe(T.HttpQuery("entity")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsDevelopersAppsRequest>;
 
@@ -10663,7 +10674,7 @@ export const ListOrganizationsDevelopersAppsRequest =
     startKey: Schema.optional(Schema.String).pipe(T.HttpQuery("startKey")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/apps" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/apps" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsDevelopersAppsRequest>;
 
@@ -10698,7 +10709,7 @@ export const AttributesOrganizationsDevelopersAppsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1Attributes).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}/attributes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}/attributes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AttributesOrganizationsDevelopersAppsRequest>;
 
@@ -10730,7 +10741,7 @@ export const DeleteOrganizationsDevelopersAppsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsDevelopersAppsRequest>;
 
@@ -10765,7 +10776,7 @@ export const UpdateOrganizationsDevelopersAppsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1DeveloperApp).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsDevelopersAppsRequest>;
 
@@ -10802,7 +10813,7 @@ export const CreateOrganizationsDevelopersAppsKeysRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/keys", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/keys", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsDevelopersAppsKeysRequest>;
 
@@ -10834,7 +10845,7 @@ export const GetOrganizationsDevelopersAppsKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsDevelopersAppsKeysRequest>;
 
@@ -10874,7 +10885,7 @@ export const UpdateDeveloperAppKeyOrganizationsDevelopersAppsKeysRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateDeveloperAppKeyOrganizationsDevelopersAppsKeysRequest>;
 
@@ -10912,7 +10923,7 @@ export const ReplaceDeveloperAppKeyOrganizationsDevelopersAppsKeysRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReplaceDeveloperAppKeyOrganizationsDevelopersAppsKeysRequest>;
 
@@ -10945,7 +10956,7 @@ export const DeleteOrganizationsDevelopersAppsKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsDevelopersAppsKeysRequest>;
 
@@ -10977,7 +10988,7 @@ export const DeleteOrganizationsDevelopersAppsKeysApiproductsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsDevelopersAppsKeysApiproductsRequest>;
 
@@ -11013,7 +11024,7 @@ export const UpdateDeveloperAppKeyApiProductOrganizationsDevelopersAppsKeysApipr
     name: Schema.String.pipe(T.HttpPath("name")),
     action: Schema.optional(Schema.String).pipe(T.HttpQuery("action")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateDeveloperAppKeyApiProductOrganizationsDevelopersAppsKeysApiproductsRequest>;
 
@@ -11053,7 +11064,7 @@ export const CreateOrganizationsDevelopersAppsKeysCreateRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/keys/create", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/keys/create", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsDevelopersAppsKeysCreateRequest>;
 
@@ -11088,7 +11099,7 @@ export const UpdateDeveloperAppAttributeOrganizationsDevelopersAppsAttributesReq
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1Attribute).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateDeveloperAppAttributeOrganizationsDevelopersAppsAttributesRequest>;
 
@@ -11123,7 +11134,7 @@ export const GetOrganizationsDevelopersAppsAttributesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsDevelopersAppsAttributesRequest>;
 
@@ -11155,7 +11166,7 @@ export const DeleteOrganizationsDevelopersAppsAttributesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsDevelopersAppsAttributesRequest>;
 
@@ -11187,7 +11198,7 @@ export const ListOrganizationsDevelopersAppsAttributesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/attributes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/attributes" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsDevelopersAppsAttributesRequest>;
 
@@ -11226,7 +11237,7 @@ export const CreateOrganizationsDevelopersSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/subscriptions",
+      path: "v1/{+parent}/subscriptions",
       hasBody: true,
     }),
     svc,
@@ -11260,7 +11271,7 @@ export const GetOrganizationsDevelopersSubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsDevelopersSubscriptionsRequest>;
 
@@ -11298,7 +11309,7 @@ export const ListOrganizationsDevelopersSubscriptionsRequest =
     startKey: Schema.optional(Schema.String).pipe(T.HttpQuery("startKey")),
     count: Schema.optional(Schema.Number).pipe(T.HttpQuery("count")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/subscriptions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/subscriptions" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsDevelopersSubscriptionsRequest>;
 
@@ -11335,7 +11346,7 @@ export const ExpireOrganizationsDevelopersSubscriptionsRequest =
       GoogleCloudApigeeV1ExpireDeveloperSubscriptionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:expire", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:expire", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExpireOrganizationsDevelopersSubscriptionsRequest>;
 
@@ -11376,7 +11387,7 @@ export const DeleteOrganizationsSecurityProfilesV2Request =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsSecurityProfilesV2Request>;
 
@@ -11415,7 +11426,7 @@ export const PatchOrganizationsSecurityProfilesV2Request =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsSecurityProfilesV2Request>;
 
@@ -11459,7 +11470,7 @@ export const CreateOrganizationsSecurityProfilesV2Request =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/securityProfilesV2",
+      path: "v1/{+parent}/securityProfilesV2",
       hasBody: true,
     }),
     svc,
@@ -11502,7 +11513,7 @@ export const GetOrganizationsSecurityProfilesV2Request =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsSecurityProfilesV2Request>;
 
@@ -11549,7 +11560,7 @@ export const ListOrganizationsSecurityProfilesV2Request =
       T.HttpQuery("riskAssessmentType"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/securityProfilesV2" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/securityProfilesV2" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSecurityProfilesV2Request>;
 
@@ -11598,7 +11609,7 @@ export const ListOrganizationsSharedflowsRequest =
       T.HttpQuery("includeMetaData"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sharedflows" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sharedflows" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSharedflowsRequest>;
 
@@ -11630,7 +11641,7 @@ export const GetOrganizationsSharedflowsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsSharedflowsRequest>;
 
@@ -11673,7 +11684,7 @@ export const CreateOrganizationsSharedflowsRequest =
     action: Schema.optional(Schema.String).pipe(T.HttpQuery("action")),
     body: Schema.optional(GoogleApiHttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/sharedflows", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/sharedflows", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsSharedflowsRequest>;
 
@@ -11705,7 +11716,7 @@ export const DeleteOrganizationsSharedflowsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsSharedflowsRequest>;
 
@@ -11742,7 +11753,7 @@ export const MoveOrganizationsSharedflowsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveOrganizationsSharedflowsRequest>;
 
@@ -11774,7 +11785,7 @@ export const ListOrganizationsSharedflowsDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSharedflowsDeploymentsRequest>;
 
@@ -11809,7 +11820,7 @@ export const GetOrganizationsSharedflowsRevisionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     format: Schema.optional(Schema.String).pipe(T.HttpQuery("format")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsSharedflowsRevisionsRequest>;
 
@@ -11840,7 +11851,7 @@ export const DeleteOrganizationsSharedflowsRevisionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsSharedflowsRevisionsRequest>;
 
@@ -11878,7 +11889,7 @@ export const UpdateSharedFlowRevisionOrganizationsSharedflowsRevisionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleApiHttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSharedFlowRevisionOrganizationsSharedflowsRevisionsRequest>;
 
@@ -11911,7 +11922,7 @@ export const ListOrganizationsSharedflowsRevisionsDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSharedflowsRevisionsDeploymentsRequest>;
 
@@ -11944,7 +11955,7 @@ export const DeleteOrganizationsSecurityProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsSecurityProfilesRequest>;
 
@@ -11983,7 +11994,7 @@ export const PatchOrganizationsSecurityProfilesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsSecurityProfilesRequest>;
 
@@ -12021,7 +12032,7 @@ export const ListRevisionsOrganizationsSecurityProfilesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:listRevisions" }),
+    T.Http({ method: "GET", path: "v1/{+name}:listRevisions" }),
     svc,
   ) as unknown as Schema.Schema<ListRevisionsOrganizationsSecurityProfilesRequest>;
 
@@ -12069,7 +12080,7 @@ export const CreateOrganizationsSecurityProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/securityProfiles",
+      path: "v1/{+parent}/securityProfiles",
       hasBody: true,
     }),
     svc,
@@ -12103,7 +12114,7 @@ export const GetOrganizationsSecurityProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsSecurityProfilesRequest>;
 
@@ -12141,7 +12152,7 @@ export const ListOrganizationsSecurityProfilesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/securityProfiles" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/securityProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSecurityProfilesRequest>;
 
@@ -12182,7 +12193,11 @@ export const CreateOrganizationsSecurityProfilesEnvironmentsRequest =
       GoogleCloudApigeeV1SecurityProfileEnvironmentAssociation,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/environments", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/environments",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsSecurityProfilesEnvironmentsRequest>;
 
@@ -12215,7 +12230,7 @@ export const DeleteOrganizationsSecurityProfilesEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsSecurityProfilesEnvironmentsRequest>;
 
@@ -12255,7 +12270,7 @@ export const ComputeEnvironmentScoresOrganizationsSecurityProfilesEnvironmentsRe
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{profileEnvironment}:computeEnvironmentScores",
+      path: "v1/{+profileEnvironment}:computeEnvironmentScores",
       hasBody: true,
     }),
     svc,
@@ -12304,7 +12319,7 @@ export const CreateOrganizationsApimServiceExtensionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/apimServiceExtensions",
+      path: "v1/{+parent}/apimServiceExtensions",
       hasBody: true,
     }),
     svc,
@@ -12338,7 +12353,7 @@ export const GetOrganizationsApimServiceExtensionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsApimServiceExtensionsRequest>;
 
@@ -12376,7 +12391,7 @@ export const ListOrganizationsApimServiceExtensionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/apimServiceExtensions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/apimServiceExtensions" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsApimServiceExtensionsRequest>;
 
@@ -12425,7 +12440,7 @@ export const PatchOrganizationsApimServiceExtensionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsApimServiceExtensionsRequest>;
 
@@ -12457,7 +12472,7 @@ export const DeleteOrganizationsApimServiceExtensionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsApimServiceExtensionsRequest>;
 
@@ -12496,7 +12511,7 @@ export const CreateOrganizationsHostSecurityReportsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/hostSecurityReports",
+      path: "v1/{+parent}/hostSecurityReports",
       hasBody: true,
     }),
     svc,
@@ -12530,7 +12545,7 @@ export const GetOrganizationsHostSecurityReportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsHostSecurityReportsRequest>;
 
@@ -12562,7 +12577,7 @@ export const GetResultViewOrganizationsHostSecurityReportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetResultViewOrganizationsHostSecurityReportsRequest>;
 
@@ -12622,7 +12637,7 @@ export const ListOrganizationsHostSecurityReportsRequest =
     from: Schema.optional(Schema.String).pipe(T.HttpQuery("from")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/hostSecurityReports" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/hostSecurityReports" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsHostSecurityReportsRequest>;
 
@@ -12658,7 +12673,7 @@ export const GetResultOrganizationsHostSecurityReportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetResultOrganizationsHostSecurityReportsRequest>;
 
@@ -12693,7 +12708,7 @@ export const UpdateOrganizationsReportsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1CustomReport).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsReportsRequest>;
 
@@ -12725,7 +12740,7 @@ export const DeleteOrganizationsReportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsReportsRequest>;
 
@@ -12760,7 +12775,7 @@ export const CreateOrganizationsReportsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1CustomReport).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/reports", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/reports", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsReportsRequest>;
 
@@ -12792,7 +12807,7 @@ export const GetOrganizationsReportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsReportsRequest>;
 
@@ -12826,7 +12841,7 @@ export const ListOrganizationsReportsRequest =
     expand: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("expand")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/reports" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/reports" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsReportsRequest>;
 
@@ -12870,7 +12885,7 @@ export const CreateOrganizationsEndpointAttachmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/endpointAttachments",
+      path: "v1/{+parent}/endpointAttachments",
       hasBody: true,
     }),
     svc,
@@ -12904,7 +12919,7 @@ export const GetOrganizationsEndpointAttachmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEndpointAttachmentsRequest>;
 
@@ -12942,7 +12957,7 @@ export const ListOrganizationsEndpointAttachmentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/endpointAttachments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/endpointAttachments" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsEndpointAttachmentsRequest>;
 
@@ -12978,7 +12993,7 @@ export const DeleteOrganizationsEndpointAttachmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsEndpointAttachmentsRequest>;
 
@@ -13010,7 +13025,7 @@ export const DeleteOrganizationsSecurityFeedbackRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsSecurityFeedbackRequest>;
 
@@ -13049,7 +13064,7 @@ export const PatchOrganizationsSecurityFeedbackRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsSecurityFeedbackRequest>;
 
@@ -13093,7 +13108,7 @@ export const CreateOrganizationsSecurityFeedbackRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/securityFeedback",
+      path: "v1/{+parent}/securityFeedback",
       hasBody: true,
     }),
     svc,
@@ -13127,7 +13142,7 @@ export const GetOrganizationsSecurityFeedbackRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsSecurityFeedbackRequest>;
 
@@ -13165,7 +13180,7 @@ export const ListOrganizationsSecurityFeedbackRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/securityFeedback" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/securityFeedback" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSecurityFeedbackRequest>;
 
@@ -13247,7 +13262,7 @@ export const GetOrganizationsOptimizedHostStatsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     accuracy: Schema.optional(Schema.String).pipe(T.HttpQuery("accuracy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsOptimizedHostStatsRequest>;
 
@@ -13284,7 +13299,7 @@ export const BatchComputeOrganizationsSecurityAssessmentResultsRequest =
       GoogleCloudApigeeV1BatchComputeSecurityAssessmentResultsRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:batchCompute", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:batchCompute", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<BatchComputeOrganizationsSecurityAssessmentResultsRequest>;
 
@@ -13327,7 +13342,7 @@ export const CreateOrganizationsDatacollectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/datacollectors",
+      path: "v1/{+parent}/datacollectors",
       hasBody: true,
     }),
     svc,
@@ -13367,7 +13382,7 @@ export const ListOrganizationsDatacollectorsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/datacollectors" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/datacollectors" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsDatacollectorsRequest>;
 
@@ -13403,7 +13418,7 @@ export const GetOrganizationsDatacollectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsDatacollectorsRequest>;
 
@@ -13435,7 +13450,7 @@ export const DeleteOrganizationsDatacollectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsDatacollectorsRequest>;
 
@@ -13472,7 +13487,7 @@ export const PatchOrganizationsDatacollectorsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudApigeeV1DataCollector).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsDatacollectorsRequest>;
 
@@ -13504,7 +13519,7 @@ export const GetOrganizationsAppsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsAppsRequest>;
 
@@ -13573,7 +13588,7 @@ export const ListOrganizationsAppsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     apiProduct: Schema.optional(Schema.String).pipe(T.HttpQuery("apiProduct")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/apps" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/apps" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsAppsRequest>;
 
@@ -13622,7 +13637,7 @@ export const ListOrganizationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsOperationsRequest>;
 
@@ -13658,7 +13673,7 @@ export const GetOrganizationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsOperationsRequest>;
 
@@ -13700,7 +13715,7 @@ export const UpdateDebugmaskOrganizationsEnvironmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1DebugMask).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateDebugmaskOrganizationsEnvironmentsRequest>;
 
@@ -13732,7 +13747,7 @@ export const GetApiSecurityRuntimeConfigOrganizationsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetApiSecurityRuntimeConfigOrganizationsEnvironmentsRequest>;
 
@@ -13770,7 +13785,7 @@ export const SetIamPolicyOrganizationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -13803,7 +13818,7 @@ export const SubscribeOrganizationsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:subscribe", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}:subscribe", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SubscribeOrganizationsEnvironmentsRequest>;
 
@@ -13841,7 +13856,11 @@ export const CreateOrganizationsEnvironmentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1Environment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/environments", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/environments",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsEnvironmentsRequest>;
 
@@ -13876,7 +13895,7 @@ export const UpdateEnvironmentOrganizationsEnvironmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1Environment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateEnvironmentOrganizationsEnvironmentsRequest>;
 
@@ -13915,7 +13934,7 @@ export const TestIamPermissionsOrganizationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -13955,7 +13974,7 @@ export const ModifyEnvironmentOrganizationsEnvironmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1Environment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ModifyEnvironmentOrganizationsEnvironmentsRequest>;
 
@@ -13987,7 +14006,7 @@ export const GetSecurityActionsConfigOrganizationsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSecurityActionsConfigOrganizationsEnvironmentsRequest>;
 
@@ -14026,7 +14045,7 @@ export const UpdateTraceConfigOrganizationsEnvironmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1TraceConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateTraceConfigOrganizationsEnvironmentsRequest>;
 
@@ -14061,7 +14080,7 @@ export const UnsubscribeOrganizationsEnvironmentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1Subscription).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:unsubscribe", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}:unsubscribe", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UnsubscribeOrganizationsEnvironmentsRequest>;
 
@@ -14092,7 +14111,7 @@ export const GetTraceConfigOrganizationsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTraceConfigOrganizationsEnvironmentsRequest>;
 
@@ -14129,7 +14148,7 @@ export const GetIamPolicyOrganizationsEnvironmentsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyOrganizationsEnvironmentsRequest>;
 
@@ -14160,7 +14179,7 @@ export const GetDeployedConfigOrganizationsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDeployedConfigOrganizationsEnvironmentsRequest>;
 
@@ -14200,7 +14219,7 @@ export const UpdateSecurityActionsConfigOrganizationsEnvironmentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSecurityActionsConfigOrganizationsEnvironmentsRequest>;
 
@@ -14233,7 +14252,7 @@ export const GetDebugmaskOrganizationsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDebugmaskOrganizationsEnvironmentsRequest>;
 
@@ -14265,7 +14284,7 @@ export const DeleteOrganizationsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsEnvironmentsRequest>;
 
@@ -14300,7 +14319,7 @@ export const UpdateOrganizationsEnvironmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1Environment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsEnvironmentsRequest>;
 
@@ -14332,7 +14351,7 @@ export const GetAddonsConfigOrganizationsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAddonsConfigOrganizationsEnvironmentsRequest>;
 
@@ -14364,7 +14383,7 @@ export const GetOrganizationsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsRequest>;
 
@@ -14409,7 +14428,7 @@ export const DeployOrganizationsEnvironmentsApisRevisionsRequest =
       T.HttpQuery("serviceAccount"),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}/deployments", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}/deployments", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeployOrganizationsEnvironmentsApisRevisionsRequest>;
 
@@ -14441,7 +14460,7 @@ export const GetDeploymentsOrganizationsEnvironmentsApisRevisionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/deployments" }),
+    T.Http({ method: "GET", path: "v1/{+name}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<GetDeploymentsOrganizationsEnvironmentsApisRevisionsRequest>;
 
@@ -14479,7 +14498,7 @@ export const UndeployOrganizationsEnvironmentsApisRevisionsRequest =
       T.HttpQuery("sequencedRollout"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}/deployments" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<UndeployOrganizationsEnvironmentsApisRevisionsRequest>;
 
@@ -14513,7 +14532,7 @@ export const GenerateUndeployChangeReportOrganizationsEnvironmentsApisRevisionsD
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}/deployments:generateUndeployChangeReport",
+      path: "v1/{+name}/deployments:generateUndeployChangeReport",
       hasBody: true,
     }),
     svc,
@@ -14555,7 +14574,7 @@ export const GenerateDeployChangeReportOrganizationsEnvironmentsApisRevisionsDep
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}/deployments:generateDeployChangeReport",
+      path: "v1/{+name}/deployments:generateDeployChangeReport",
       hasBody: true,
     }),
     svc,
@@ -14592,7 +14611,7 @@ export const DeleteDataOrganizationsEnvironmentsApisRevisionsDebugsessionsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}/data" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}/data" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDataOrganizationsEnvironmentsApisRevisionsDebugsessionsRequest>;
 
@@ -14633,7 +14652,7 @@ export const CreateOrganizationsEnvironmentsApisRevisionsDebugsessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/debugsessions",
+      path: "v1/{+parent}/debugsessions",
       hasBody: true,
     }),
     svc,
@@ -14668,7 +14687,7 @@ export const GetOrganizationsEnvironmentsApisRevisionsDebugsessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsApisRevisionsDebugsessionsRequest>;
 
@@ -14707,7 +14726,7 @@ export const ListOrganizationsEnvironmentsApisRevisionsDebugsessionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/debugsessions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/debugsessions" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsEnvironmentsApisRevisionsDebugsessionsRequest>;
 
@@ -14744,7 +14763,7 @@ export const GetOrganizationsEnvironmentsApisRevisionsDebugsessionsDataRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsApisRevisionsDebugsessionsDataRequest>;
 
@@ -14777,7 +14796,7 @@ export const ListOrganizationsEnvironmentsApisDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsEnvironmentsApisDeploymentsRequest>;
 
@@ -14814,7 +14833,7 @@ export const CreateOrganizationsEnvironmentsAnalyticsExportsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/analytics/exports",
+      path: "v1/{+parent}/analytics/exports",
       hasBody: true,
     }),
     svc,
@@ -14849,7 +14868,7 @@ export const GetOrganizationsEnvironmentsAnalyticsExportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsAnalyticsExportsRequest>;
 
@@ -14881,7 +14900,7 @@ export const ListOrganizationsEnvironmentsAnalyticsExportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/analytics/exports" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/analytics/exports" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsEnvironmentsAnalyticsExportsRequest>;
 
@@ -14921,7 +14940,7 @@ export const GetSchemav2OrganizationsEnvironmentsAnalyticsAdminRequest =
       T.HttpQuery("disableCache"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSchemav2OrganizationsEnvironmentsAnalyticsAdminRequest>;
 
@@ -14962,7 +14981,7 @@ export const DeployOrganizationsEnvironmentsSharedflowsRevisionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     override: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("override")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}/deployments", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}/deployments", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeployOrganizationsEnvironmentsSharedflowsRevisionsRequest>;
 
@@ -14995,7 +15014,7 @@ export const GetDeploymentsOrganizationsEnvironmentsSharedflowsRevisionsRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/deployments" }),
+    T.Http({ method: "GET", path: "v1/{+name}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<GetDeploymentsOrganizationsEnvironmentsSharedflowsRevisionsRequest>;
 
@@ -15028,7 +15047,7 @@ export const UndeployOrganizationsEnvironmentsSharedflowsRevisionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}/deployments" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<UndeployOrganizationsEnvironmentsSharedflowsRevisionsRequest>;
 
@@ -15061,7 +15080,7 @@ export const ListOrganizationsEnvironmentsSharedflowsDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsEnvironmentsSharedflowsDeploymentsRequest>;
 
@@ -15094,7 +15113,7 @@ export const DeleteOrganizationsEnvironmentsTraceConfigOverridesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsEnvironmentsTraceConfigOverridesRequest>;
 
@@ -15135,7 +15154,7 @@ export const PatchOrganizationsEnvironmentsTraceConfigOverridesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsEnvironmentsTraceConfigOverridesRequest>;
 
@@ -15173,7 +15192,7 @@ export const CreateOrganizationsEnvironmentsTraceConfigOverridesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/overrides", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/overrides", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsEnvironmentsTraceConfigOverridesRequest>;
 
@@ -15212,7 +15231,7 @@ export const ListOrganizationsEnvironmentsTraceConfigOverridesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/overrides" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/overrides" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsEnvironmentsTraceConfigOverridesRequest>;
 
@@ -15249,7 +15268,7 @@ export const GetOrganizationsEnvironmentsTraceConfigOverridesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsTraceConfigOverridesRequest>;
 
@@ -15290,7 +15309,7 @@ export const PatchOrganizationsEnvironmentsArchiveDeploymentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsEnvironmentsArchiveDeploymentsRequest>;
 
@@ -15323,7 +15342,7 @@ export const DeleteOrganizationsEnvironmentsArchiveDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsEnvironmentsArchiveDeploymentsRequest>;
 
@@ -15356,7 +15375,7 @@ export const GetOrganizationsEnvironmentsArchiveDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsArchiveDeploymentsRequest>;
 
@@ -15397,7 +15416,7 @@ export const ListOrganizationsEnvironmentsArchiveDeploymentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/archiveDeployments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/archiveDeployments" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsEnvironmentsArchiveDeploymentsRequest>;
 
@@ -15441,7 +15460,7 @@ export const CreateOrganizationsEnvironmentsArchiveDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/archiveDeployments",
+      path: "v1/{+parent}/archiveDeployments",
       hasBody: true,
     }),
     svc,
@@ -15483,7 +15502,7 @@ export const GenerateUploadUrlOrganizationsEnvironmentsArchiveDeploymentsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/archiveDeployments:generateUploadUrl",
+      path: "v1/{+parent}/archiveDeployments:generateUploadUrl",
       hasBody: true,
     }),
     svc,
@@ -15525,7 +15544,7 @@ export const GenerateDownloadUrlOrganizationsEnvironmentsArchiveDeploymentsReque
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:generateDownloadUrl",
+      path: "v1/{+name}:generateDownloadUrl",
       hasBody: true,
     }),
     svc,
@@ -15568,7 +15587,7 @@ export const CreateOrganizationsEnvironmentsSecurityReportsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/securityReports",
+      path: "v1/{+parent}/securityReports",
       hasBody: true,
     }),
     svc,
@@ -15602,7 +15621,7 @@ export const GetOrganizationsEnvironmentsSecurityReportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsSecurityReportsRequest>;
 
@@ -15634,7 +15653,7 @@ export const GetResultViewOrganizationsEnvironmentsSecurityReportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetResultViewOrganizationsEnvironmentsSecurityReportsRequest>;
 
@@ -15690,7 +15709,7 @@ export const ListOrganizationsEnvironmentsSecurityReportsRequest =
     from: Schema.optional(Schema.String).pipe(T.HttpQuery("from")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/securityReports" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/securityReports" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsEnvironmentsSecurityReportsRequest>;
 
@@ -15726,7 +15745,7 @@ export const GetResultOrganizationsEnvironmentsSecurityReportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetResultOrganizationsEnvironmentsSecurityReportsRequest>;
 
@@ -15762,7 +15781,7 @@ export const CreateOrganizationsEnvironmentsReferencesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1Reference).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/references", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/references", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsEnvironmentsReferencesRequest>;
 
@@ -15794,7 +15813,7 @@ export const DeleteOrganizationsEnvironmentsReferencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsEnvironmentsReferencesRequest>;
 
@@ -15826,7 +15845,7 @@ export const GetOrganizationsEnvironmentsReferencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsReferencesRequest>;
 
@@ -15861,7 +15880,7 @@ export const UpdateOrganizationsEnvironmentsReferencesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1Reference).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsEnvironmentsReferencesRequest>;
 
@@ -15898,7 +15917,7 @@ export const GetIamPolicyOrganizationsEnvironmentsDeploymentsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyOrganizationsEnvironmentsDeploymentsRequest>;
 
@@ -15936,7 +15955,7 @@ export const ListOrganizationsEnvironmentsDeploymentsRequest =
       T.HttpQuery("sharedFlows"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsEnvironmentsDeploymentsRequest>;
 
@@ -15968,7 +15987,7 @@ export const GetOrganizationsEnvironmentsDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsDeploymentsRequest>;
 
@@ -16007,7 +16026,7 @@ export const TestIamPermissionsOrganizationsEnvironmentsDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -16047,7 +16066,7 @@ export const SetIamPolicyOrganizationsEnvironmentsDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -16092,7 +16111,7 @@ export const CreateOrganizationsEnvironmentsSecurityActionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/securityActions",
+      path: "v1/{+parent}/securityActions",
       hasBody: true,
     }),
     svc,
@@ -16126,7 +16145,7 @@ export const GetOrganizationsEnvironmentsSecurityActionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsSecurityActionsRequest>;
 
@@ -16167,7 +16186,7 @@ export const ListOrganizationsEnvironmentsSecurityActionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/securityActions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/securityActions" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsEnvironmentsSecurityActionsRequest>;
 
@@ -16209,7 +16228,7 @@ export const PatchOrganizationsEnvironmentsSecurityActionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudApigeeV1SecurityAction).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsEnvironmentsSecurityActionsRequest>;
 
@@ -16246,7 +16265,7 @@ export const EnableOrganizationsEnvironmentsSecurityActionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:enable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:enable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EnableOrganizationsEnvironmentsSecurityActionsRequest>;
 
@@ -16278,7 +16297,7 @@ export const DeleteOrganizationsEnvironmentsSecurityActionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsEnvironmentsSecurityActionsRequest>;
 
@@ -16315,7 +16334,7 @@ export const DisableOrganizationsEnvironmentsSecurityActionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:disable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:disable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DisableOrganizationsEnvironmentsSecurityActionsRequest>;
 
@@ -16348,7 +16367,7 @@ export const GetOrganizationsEnvironmentsFlowhooksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsFlowhooksRequest>;
 
@@ -16380,7 +16399,7 @@ export const DetachSharedFlowFromFlowHookOrganizationsEnvironmentsFlowhooksReque
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DetachSharedFlowFromFlowHookOrganizationsEnvironmentsFlowhooksRequest>;
 
@@ -16417,7 +16436,7 @@ export const AttachSharedFlowToFlowHookOrganizationsEnvironmentsFlowhooksRequest
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1FlowHook).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AttachSharedFlowToFlowHookOrganizationsEnvironmentsFlowhooksRequest>;
 
@@ -16457,7 +16476,7 @@ export const SetAddonEnablementOrganizationsEnvironmentsAddonsConfigRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:setAddonEnablement",
+      path: "v1/{+name}:setAddonEnablement",
       hasBody: true,
     }),
     svc,
@@ -16539,7 +16558,7 @@ export const GetOrganizationsEnvironmentsOptimizedStatsRequest =
     limit: Schema.optional(Schema.String).pipe(T.HttpQuery("limit")),
     aggTable: Schema.optional(Schema.String).pipe(T.HttpQuery("aggTable")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsOptimizedStatsRequest>;
 
@@ -16582,7 +16601,7 @@ export const UpdateOrganizationsEnvironmentsResourcefilesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "v1/{parent}/resourcefiles/{type}/{name}",
+      path: "v1/{+parent}/resourcefiles/{type}/{name}",
       hasBody: true,
     }),
     svc,
@@ -16624,7 +16643,7 @@ export const DeleteOrganizationsEnvironmentsResourcefilesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v1/{parent}/resourcefiles/{type}/{name}",
+      path: "v1/{+parent}/resourcefiles/{type}/{name}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsEnvironmentsResourcefilesRequest>;
@@ -16668,7 +16687,7 @@ export const CreateOrganizationsEnvironmentsResourcefilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/resourcefiles",
+      path: "v1/{+parent}/resourcefiles",
       hasBody: true,
     }),
     svc,
@@ -16708,7 +16727,7 @@ export const GetOrganizationsEnvironmentsResourcefilesRequest =
     type: Schema.String.pipe(T.HttpPath("type")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/resourcefiles/{type}/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/resourcefiles/{type}/{name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsResourcefilesRequest>;
 
@@ -16743,7 +16762,7 @@ export const ListOrganizationsEnvironmentsResourcefilesRequest =
     type: Schema.optional(Schema.String).pipe(T.HttpQuery("type")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/resourcefiles" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/resourcefiles" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsEnvironmentsResourcefilesRequest>;
 
@@ -16778,7 +16797,7 @@ export const ListEnvironmentResourcesOrganizationsEnvironmentsResourcefilesReque
     type: Schema.String.pipe(T.HttpPath("type")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/resourcefiles/{type}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/resourcefiles/{type}" }),
     svc,
   ) as unknown as Schema.Schema<ListEnvironmentResourcesOrganizationsEnvironmentsResourcefilesRequest>;
 
@@ -16818,7 +16837,7 @@ export const CreateOrganizationsEnvironmentsKeystoresRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1Keystore).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/keystores", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/keystores", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsEnvironmentsKeystoresRequest>;
 
@@ -16850,7 +16869,7 @@ export const DeleteOrganizationsEnvironmentsKeystoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsEnvironmentsKeystoresRequest>;
 
@@ -16882,7 +16901,7 @@ export const GetOrganizationsEnvironmentsKeystoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsKeystoresRequest>;
 
@@ -16936,7 +16955,7 @@ export const CreateOrganizationsEnvironmentsKeystoresAliasesRequest =
     _password: Schema.optional(Schema.String).pipe(T.HttpQuery("_password")),
     body: Schema.optional(GoogleApiHttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/aliases", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/aliases", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsEnvironmentsKeystoresAliasesRequest>;
 
@@ -16969,7 +16988,7 @@ export const GetOrganizationsEnvironmentsKeystoresAliasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsKeystoresAliasesRequest>;
 
@@ -17001,7 +17020,7 @@ export const DeleteOrganizationsEnvironmentsKeystoresAliasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsEnvironmentsKeystoresAliasesRequest>;
 
@@ -17047,7 +17066,7 @@ export const UpdateOrganizationsEnvironmentsKeystoresAliasesRequest =
     ),
     body: Schema.optional(GoogleApiHttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsEnvironmentsKeystoresAliasesRequest>;
 
@@ -17080,7 +17099,7 @@ export const GetCertificateOrganizationsEnvironmentsKeystoresAliasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/certificate" }),
+    T.Http({ method: "GET", path: "v1/{+name}/certificate" }),
     svc,
   ) as unknown as Schema.Schema<GetCertificateOrganizationsEnvironmentsKeystoresAliasesRequest>;
 
@@ -17113,7 +17132,7 @@ export const CsrOrganizationsEnvironmentsKeystoresAliasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/csr" }),
+    T.Http({ method: "GET", path: "v1/{+name}/csr" }),
     svc,
   ) as unknown as Schema.Schema<CsrOrganizationsEnvironmentsKeystoresAliasesRequest>;
 
@@ -17148,7 +17167,11 @@ export const CreateOrganizationsEnvironmentsKeyvaluemapsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1KeyValueMap).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/keyvaluemaps", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/keyvaluemaps",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsEnvironmentsKeyvaluemapsRequest>;
 
@@ -17180,7 +17203,7 @@ export const GetOrganizationsEnvironmentsKeyvaluemapsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsKeyvaluemapsRequest>;
 
@@ -17215,7 +17238,7 @@ export const UpdateOrganizationsEnvironmentsKeyvaluemapsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1KeyValueMap).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsEnvironmentsKeyvaluemapsRequest>;
 
@@ -17247,7 +17270,7 @@ export const DeleteOrganizationsEnvironmentsKeyvaluemapsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsEnvironmentsKeyvaluemapsRequest>;
 
@@ -17279,7 +17302,7 @@ export const GetOrganizationsEnvironmentsKeyvaluemapsEntriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsKeyvaluemapsEntriesRequest>;
 
@@ -17315,7 +17338,7 @@ export const CreateOrganizationsEnvironmentsKeyvaluemapsEntriesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1KeyValueEntry).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/entries", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/entries", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsEnvironmentsKeyvaluemapsEntriesRequest>;
 
@@ -17354,7 +17377,7 @@ export const ListOrganizationsEnvironmentsKeyvaluemapsEntriesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/entries" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/entries" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsEnvironmentsKeyvaluemapsEntriesRequest>;
 
@@ -17391,7 +17414,7 @@ export const DeleteOrganizationsEnvironmentsKeyvaluemapsEntriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsEnvironmentsKeyvaluemapsEntriesRequest>;
 
@@ -17427,7 +17450,7 @@ export const UpdateOrganizationsEnvironmentsKeyvaluemapsEntriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1KeyValueEntry).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsEnvironmentsKeyvaluemapsEntriesRequest>;
 
@@ -17460,7 +17483,7 @@ export const DeleteOrganizationsEnvironmentsCachesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsEnvironmentsCachesRequest>;
 
@@ -17498,7 +17521,7 @@ export const QueryTabularStatsOrganizationsEnvironmentsSecurityStatsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{orgenv}/securityStats:queryTabularStats",
+      path: "v1/{+orgenv}/securityStats:queryTabularStats",
       hasBody: true,
     }),
     svc,
@@ -17540,7 +17563,7 @@ export const QueryTimeSeriesStatsOrganizationsEnvironmentsSecurityStatsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{orgenv}/securityStats:queryTimeSeriesStats",
+      path: "v1/{+orgenv}/securityStats:queryTimeSeriesStats",
       hasBody: true,
     }),
     svc,
@@ -17575,7 +17598,7 @@ export const GetOrganizationsEnvironmentsSecurityIncidentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsSecurityIncidentsRequest>;
 
@@ -17616,7 +17639,7 @@ export const ListOrganizationsEnvironmentsSecurityIncidentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/securityIncidents" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/securityIncidents" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsEnvironmentsSecurityIncidentsRequest>;
 
@@ -17660,7 +17683,7 @@ export const PatchOrganizationsEnvironmentsSecurityIncidentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsEnvironmentsSecurityIncidentsRequest>;
 
@@ -17700,7 +17723,7 @@ export const BatchUpdateOrganizationsEnvironmentsSecurityIncidentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/securityIncidents:batchUpdate",
+      path: "v1/{+parent}/securityIncidents:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -17743,7 +17766,7 @@ export const CreateOrganizationsEnvironmentsTargetserversRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/targetservers",
+      path: "v1/{+parent}/targetservers",
       hasBody: true,
     }),
     svc,
@@ -17777,7 +17800,7 @@ export const DeleteOrganizationsEnvironmentsTargetserversRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsEnvironmentsTargetserversRequest>;
 
@@ -17809,7 +17832,7 @@ export const GetOrganizationsEnvironmentsTargetserversRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsTargetserversRequest>;
 
@@ -17844,7 +17867,7 @@ export const UpdateOrganizationsEnvironmentsTargetserversRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1TargetServer).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsEnvironmentsTargetserversRequest>;
 
@@ -17923,7 +17946,7 @@ export const GetOrganizationsEnvironmentsStatsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     accuracy: Schema.optional(Schema.String).pipe(T.HttpQuery("accuracy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsStatsRequest>;
 
@@ -17958,7 +17981,7 @@ export const CreateOrganizationsEnvironmentsQueriesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1Query).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/queries", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/queries", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsEnvironmentsQueriesRequest>;
 
@@ -17990,7 +18013,7 @@ export const GetOrganizationsEnvironmentsQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvironmentsQueriesRequest>;
 
@@ -18044,7 +18067,7 @@ export const ListOrganizationsEnvironmentsQueriesRequest =
     to: Schema.optional(Schema.String).pipe(T.HttpQuery("to")),
     dataset: Schema.optional(Schema.String).pipe(T.HttpQuery("dataset")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/queries" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/queries" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsEnvironmentsQueriesRequest>;
 
@@ -18076,7 +18099,7 @@ export const GetResulturlOrganizationsEnvironmentsQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetResulturlOrganizationsEnvironmentsQueriesRequest>;
 
@@ -18108,7 +18131,7 @@ export const GetResultOrganizationsEnvironmentsQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetResultOrganizationsEnvironmentsQueriesRequest>;
 
@@ -18145,7 +18168,7 @@ export const UpdateMonetizationConfigOrganizationsAppgroupsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateMonetizationConfigOrganizationsAppgroupsRequest>;
 
@@ -18177,7 +18200,7 @@ export const DeleteOrganizationsAppgroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsAppgroupsRequest>;
 
@@ -18214,7 +18237,7 @@ export const UpdateOrganizationsAppgroupsRequest =
     action: Schema.optional(Schema.String).pipe(T.HttpQuery("action")),
     body: Schema.optional(GoogleCloudApigeeV1AppGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsAppgroupsRequest>;
 
@@ -18245,7 +18268,7 @@ export const GetMonetizationConfigOrganizationsAppgroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetMonetizationConfigOrganizationsAppgroupsRequest>;
 
@@ -18280,7 +18303,7 @@ export const CreateOrganizationsAppgroupsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1AppGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/appgroups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/appgroups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsAppgroupsRequest>;
 
@@ -18311,7 +18334,7 @@ export const GetOrganizationsAppgroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsAppgroupsRequest>;
 
@@ -18351,7 +18374,7 @@ export const ListOrganizationsAppgroupsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/appgroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/appgroups" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsAppgroupsRequest>;
 
@@ -18387,7 +18410,7 @@ export const GetBalanceOrganizationsAppgroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBalanceOrganizationsAppgroupsRequest>;
 
@@ -18422,7 +18445,7 @@ export const CreateOrganizationsAppgroupsAppsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1AppGroupApp).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/apps", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/apps", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsAppgroupsAppsRequest>;
 
@@ -18454,7 +18477,7 @@ export const GetOrganizationsAppgroupsAppsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsAppgroupsAppsRequest>;
 
@@ -18492,7 +18515,7 @@ export const ListOrganizationsAppgroupsAppsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/apps" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/apps" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsAppgroupsAppsRequest>;
 
@@ -18528,7 +18551,7 @@ export const DeleteOrganizationsAppgroupsAppsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsAppgroupsAppsRequest>;
 
@@ -18566,7 +18589,7 @@ export const UpdateOrganizationsAppgroupsAppsRequest =
     action: Schema.optional(Schema.String).pipe(T.HttpQuery("action")),
     body: Schema.optional(GoogleCloudApigeeV1AppGroupApp).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsAppgroupsAppsRequest>;
 
@@ -18601,7 +18624,7 @@ export const CreateOrganizationsAppgroupsAppsKeysRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1AppGroupAppKey).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/keys", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/keys", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsAppgroupsAppsKeysRequest>;
 
@@ -18633,7 +18656,7 @@ export const DeleteOrganizationsAppgroupsAppsKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsAppgroupsAppsKeysRequest>;
 
@@ -18665,7 +18688,7 @@ export const GetOrganizationsAppgroupsAppsKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsAppgroupsAppsKeysRequest>;
 
@@ -18702,7 +18725,7 @@ export const UpdateAppGroupAppKeyOrganizationsAppgroupsAppsKeysRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAppGroupAppKeyOrganizationsAppgroupsAppsKeysRequest>;
 
@@ -18738,7 +18761,7 @@ export const UpdateAppGroupAppKeyApiProductOrganizationsAppgroupsAppsKeysApiprod
     name: Schema.String.pipe(T.HttpPath("name")),
     action: Schema.optional(Schema.String).pipe(T.HttpQuery("action")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAppGroupAppKeyApiProductOrganizationsAppgroupsAppsKeysApiproductsRequest>;
 
@@ -18773,7 +18796,7 @@ export const DeleteOrganizationsAppgroupsAppsKeysApiproductsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsAppgroupsAppsKeysApiproductsRequest>;
 
@@ -18811,7 +18834,7 @@ export const ExpireOrganizationsAppgroupsSubscriptionsRequest =
       GoogleCloudApigeeV1ExpireAppGroupSubscriptionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:expire", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:expire", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExpireOrganizationsAppgroupsSubscriptionsRequest>;
 
@@ -18850,7 +18873,7 @@ export const CreateOrganizationsAppgroupsSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/subscriptions",
+      path: "v1/{+parent}/subscriptions",
       hasBody: true,
     }),
     svc,
@@ -18884,7 +18907,7 @@ export const GetOrganizationsAppgroupsSubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsAppgroupsSubscriptionsRequest>;
 
@@ -18922,7 +18945,7 @@ export const ListOrganizationsAppgroupsSubscriptionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/subscriptions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/subscriptions" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsAppgroupsSubscriptionsRequest>;
 
@@ -18963,7 +18986,7 @@ export const AdjustOrganizationsAppgroupsBalanceRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:adjust", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:adjust", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AdjustOrganizationsAppgroupsBalanceRequest>;
 
@@ -19000,7 +19023,7 @@ export const CreditOrganizationsAppgroupsBalanceRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:credit", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:credit", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreditOrganizationsAppgroupsBalanceRequest>;
 
@@ -19039,7 +19062,7 @@ export const ReportStatusOrganizationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{instance}:reportStatus",
+      path: "v1/{+instance}:reportStatus",
       hasBody: true,
     }),
     svc,
@@ -19076,7 +19099,7 @@ export const CreateOrganizationsInstancesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/instances", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/instances", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsInstancesRequest>;
 
@@ -19107,7 +19130,7 @@ export const GetOrganizationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsInstancesRequest>;
 
@@ -19144,7 +19167,7 @@ export const ListOrganizationsInstancesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsInstancesRequest>;
 
@@ -19186,7 +19209,7 @@ export const PatchOrganizationsInstancesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudApigeeV1Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsInstancesRequest>;
 
@@ -19217,7 +19240,7 @@ export const DeleteOrganizationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsInstancesRequest>;
 
@@ -19254,7 +19277,7 @@ export const ListOrganizationsInstancesNatAddressesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/natAddresses" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/natAddresses" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsInstancesNatAddressesRequest>;
 
@@ -19290,7 +19313,7 @@ export const GetOrganizationsInstancesNatAddressesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsInstancesNatAddressesRequest>;
 
@@ -19325,7 +19348,11 @@ export const CreateOrganizationsInstancesNatAddressesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1NatAddress).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/natAddresses", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/natAddresses",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsInstancesNatAddressesRequest>;
 
@@ -19362,7 +19389,7 @@ export const ActivateOrganizationsInstancesNatAddressesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:activate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:activate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ActivateOrganizationsInstancesNatAddressesRequest>;
 
@@ -19394,7 +19421,7 @@ export const DeleteOrganizationsInstancesNatAddressesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsInstancesNatAddressesRequest>;
 
@@ -19433,7 +19460,7 @@ export const CreateOrganizationsInstancesCanaryevaluationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/canaryevaluations",
+      path: "v1/{+parent}/canaryevaluations",
       hasBody: true,
     }),
     svc,
@@ -19467,7 +19494,7 @@ export const GetOrganizationsInstancesCanaryevaluationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsInstancesCanaryevaluationsRequest>;
 
@@ -19504,7 +19531,7 @@ export const CreateOrganizationsInstancesAttachmentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/attachments", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/attachments", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsInstancesAttachmentsRequest>;
 
@@ -19542,7 +19569,7 @@ export const ListOrganizationsInstancesAttachmentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/attachments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/attachments" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsInstancesAttachmentsRequest>;
 
@@ -19578,7 +19605,7 @@ export const GetOrganizationsInstancesAttachmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsInstancesAttachmentsRequest>;
 
@@ -19610,7 +19637,7 @@ export const DeleteOrganizationsInstancesAttachmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsInstancesAttachmentsRequest>;
 
@@ -19650,7 +19677,7 @@ export const CreateOrganizationsEnvgroupsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/envgroups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/envgroups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsEnvgroupsRequest>;
 
@@ -19687,7 +19714,7 @@ export const ListOrganizationsEnvgroupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/envgroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/envgroups" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsEnvgroupsRequest>;
 
@@ -19723,7 +19750,7 @@ export const GetOrganizationsEnvgroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvgroupsRequest>;
 
@@ -19763,7 +19790,7 @@ export const PatchOrganizationsEnvgroupsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsEnvgroupsRequest>;
 
@@ -19797,7 +19824,7 @@ export const GetDeployedIngressConfigOrganizationsEnvgroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDeployedIngressConfigOrganizationsEnvgroupsRequest>;
 
@@ -19829,7 +19856,7 @@ export const DeleteOrganizationsEnvgroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsEnvgroupsRequest>;
 
@@ -19865,7 +19892,7 @@ export const CreateOrganizationsEnvgroupsAttachmentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/attachments", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/attachments", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsEnvgroupsAttachmentsRequest>;
 
@@ -19903,7 +19930,7 @@ export const ListOrganizationsEnvgroupsAttachmentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/attachments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/attachments" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsEnvgroupsAttachmentsRequest>;
 
@@ -19939,7 +19966,7 @@ export const GetOrganizationsEnvgroupsAttachmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEnvgroupsAttachmentsRequest>;
 
@@ -19971,7 +19998,7 @@ export const DeleteOrganizationsEnvgroupsAttachmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsEnvgroupsAttachmentsRequest>;
 
@@ -20008,7 +20035,7 @@ export const ListOrganizationsDeploymentsRequest =
       T.HttpQuery("sharedFlows"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsDeploymentsRequest>;
 
@@ -20045,7 +20072,7 @@ export const GetIamPolicyOrganizationsSpacesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyOrganizationsSpacesRequest>;
 
@@ -20082,7 +20109,7 @@ export const CreateOrganizationsSpacesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1Space).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/spaces", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/spaces", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsSpacesRequest>;
 
@@ -20113,7 +20140,7 @@ export const GetOrganizationsSpacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsSpacesRequest>;
 
@@ -20150,7 +20177,7 @@ export const ListOrganizationsSpacesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/spaces" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/spaces" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSpacesRequest>;
 
@@ -20193,7 +20220,7 @@ export const TestIamPermissionsOrganizationsSpacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -20227,7 +20254,7 @@ export const DeleteOrganizationsSpacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsSpacesRequest>;
 
@@ -20263,7 +20290,7 @@ export const SetIamPolicyOrganizationsSpacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -20302,7 +20329,7 @@ export const PatchOrganizationsSpacesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1Space).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsSpacesRequest>;
 
@@ -20338,7 +20365,7 @@ export const MoveOrganizationsApiproductsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveOrganizationsApiproductsRequest>;
 
@@ -20370,7 +20397,7 @@ export const DeleteOrganizationsApiproductsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsApiproductsRequest>;
 
@@ -20405,7 +20432,7 @@ export const UpdateOrganizationsApiproductsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1ApiProduct).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsApiproductsRequest>;
 
@@ -20440,7 +20467,7 @@ export const AttributesOrganizationsApiproductsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1Attributes).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}/attributes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}/attributes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AttributesOrganizationsApiproductsRequest>;
 
@@ -20475,7 +20502,7 @@ export const CreateOrganizationsApiproductsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1ApiProduct).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/apiproducts", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/apiproducts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsApiproductsRequest>;
 
@@ -20507,7 +20534,7 @@ export const GetOrganizationsApiproductsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsApiproductsRequest>;
 
@@ -20560,7 +20587,7 @@ export const ListOrganizationsApiproductsRequest =
     count: Schema.optional(Schema.String).pipe(T.HttpQuery("count")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/apiproducts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/apiproducts" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsApiproductsRequest>;
 
@@ -20595,7 +20622,7 @@ export const UpdateApiProductAttributeOrganizationsApiproductsAttributesRequest 
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1Attribute).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateApiProductAttributeOrganizationsApiproductsAttributesRequest>;
 
@@ -20628,7 +20655,7 @@ export const GetOrganizationsApiproductsAttributesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsApiproductsAttributesRequest>;
 
@@ -20660,7 +20687,7 @@ export const DeleteOrganizationsApiproductsAttributesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsApiproductsAttributesRequest>;
 
@@ -20692,7 +20719,7 @@ export const ListOrganizationsApiproductsAttributesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/attributes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/attributes" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsApiproductsAttributesRequest>;
 
@@ -20727,7 +20754,7 @@ export const CreateOrganizationsApiproductsRateplansRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudApigeeV1RatePlan).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/rateplans", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/rateplans", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsApiproductsRateplansRequest>;
 
@@ -20759,7 +20786,7 @@ export const GetOrganizationsApiproductsRateplansRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsApiproductsRateplansRequest>;
 
@@ -20806,7 +20833,7 @@ export const ListOrganizationsApiproductsRateplansRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     state: Schema.optional(Schema.String).pipe(T.HttpQuery("state")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/rateplans" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/rateplans" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsApiproductsRateplansRequest>;
 
@@ -20841,7 +20868,7 @@ export const UpdateOrganizationsApiproductsRateplansRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudApigeeV1RatePlan).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsApiproductsRateplansRequest>;
 
@@ -20873,7 +20900,7 @@ export const DeleteOrganizationsApiproductsRateplansRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsApiproductsRateplansRequest>;
 
@@ -20905,7 +20932,7 @@ export const ListHybridIssuersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListHybridIssuersRequest>;
 
@@ -20944,7 +20971,7 @@ export const ProvisionOrganizationProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{project}:provisionOrganization",
+      path: "v1/{+project}:provisionOrganization",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/apigeeregistry-v1.ts
+++ b/packages/gcp/src/services/apigeeregistry-v1.ts
@@ -651,7 +651,7 @@ export const ListProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -686,7 +686,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -723,7 +723,7 @@ export const CreateProjectsLocationsArtifactsRequest =
     artifactId: Schema.optional(Schema.String).pipe(T.HttpQuery("artifactId")),
     body: Schema.optional(Artifact).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/artifacts", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/artifacts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsArtifactsRequest>;
 
@@ -759,7 +759,7 @@ export const TestIamPermissionsProjectsLocationsArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -793,7 +793,7 @@ export const GetProjectsLocationsArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsArtifactsRequest>;
 
@@ -824,7 +824,7 @@ export const GetContentsProjectsLocationsArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getContents" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getContents" }),
     svc,
   ) as unknown as Schema.Schema<GetContentsProjectsLocationsArtifactsRequest>;
 
@@ -858,7 +858,7 @@ export const ReplaceArtifactProjectsLocationsArtifactsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Artifact).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReplaceArtifactProjectsLocationsArtifactsRequest>;
 
@@ -894,7 +894,7 @@ export const GetIamPolicyProjectsLocationsArtifactsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsArtifactsRequest>;
 
@@ -937,7 +937,7 @@ export const ListProjectsLocationsArtifactsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/artifacts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/artifacts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsArtifactsRequest>;
 
@@ -977,7 +977,7 @@ export const SetIamPolicyProjectsLocationsArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1010,7 +1010,7 @@ export const DeleteProjectsLocationsArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsArtifactsRequest>;
 
@@ -1050,7 +1050,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1085,7 +1085,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1119,7 +1119,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1150,7 +1150,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1186,7 +1186,7 @@ export const SetIamPolicyProjectsLocationsRuntimeRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1224,7 +1224,7 @@ export const GetIamPolicyProjectsLocationsRuntimeRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsRuntimeRequest>;
 
@@ -1260,7 +1260,7 @@ export const TestIamPermissionsProjectsLocationsRuntimeRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1299,7 +1299,7 @@ export const SetIamPolicyProjectsLocationsDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1337,7 +1337,7 @@ export const GetIamPolicyProjectsLocationsDocumentsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDocumentsRequest>;
 
@@ -1373,7 +1373,7 @@ export const TestIamPermissionsProjectsLocationsDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1412,7 +1412,7 @@ export const SetIamPolicyProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1445,7 +1445,7 @@ export const DeleteProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesRequest>;
 
@@ -1482,7 +1482,7 @@ export const CreateProjectsLocationsInstancesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/instances", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/instances", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsInstancesRequest>;
 
@@ -1518,7 +1518,7 @@ export const GetIamPolicyProjectsLocationsInstancesRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsInstancesRequest>;
 
@@ -1554,7 +1554,7 @@ export const TestIamPermissionsProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1588,7 +1588,7 @@ export const GetProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesRequest>;
 
@@ -1624,7 +1624,7 @@ export const SetIamPolicyProjectsLocationsApisRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1660,7 +1660,7 @@ export const DeleteProjectsLocationsApisRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApisRequest>;
 
@@ -1697,7 +1697,7 @@ export const CreateProjectsLocationsApisRequest =
     apiId: Schema.optional(Schema.String).pipe(T.HttpQuery("apiId")),
     body: Schema.optional(Api).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/apis", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/apis", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApisRequest>;
 
@@ -1733,7 +1733,7 @@ export const GetIamPolicyProjectsLocationsApisRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsApisRequest>;
 
@@ -1769,7 +1769,7 @@ export const TestIamPermissionsProjectsLocationsApisRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1815,7 +1815,7 @@ export const ListProjectsLocationsApisRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/apis" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/apis" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApisRequest>;
 
@@ -1850,7 +1850,7 @@ export const GetProjectsLocationsApisRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApisRequest>;
 
@@ -1891,7 +1891,7 @@ export const PatchProjectsLocationsApisRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Api).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApisRequest>;
 
@@ -1927,7 +1927,7 @@ export const SetIamPolicyProjectsLocationsApisVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1963,7 +1963,7 @@ export const DeleteProjectsLocationsApisVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApisVersionsRequest>;
 
@@ -2006,7 +2006,7 @@ export const ListProjectsLocationsApisVersionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApisVersionsRequest>;
 
@@ -2041,7 +2041,7 @@ export const GetProjectsLocationsApisVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApisVersionsRequest>;
 
@@ -2080,7 +2080,7 @@ export const CreateProjectsLocationsApisVersionsRequest =
     ),
     body: Schema.optional(ApiVersion).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/versions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/versions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApisVersionsRequest>;
 
@@ -2116,7 +2116,7 @@ export const GetIamPolicyProjectsLocationsApisVersionsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsApisVersionsRequest>;
 
@@ -2152,7 +2152,7 @@ export const TestIamPermissionsProjectsLocationsApisVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2198,7 +2198,7 @@ export const PatchProjectsLocationsApisVersionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ApiVersion).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApisVersionsRequest>;
 
@@ -2234,7 +2234,7 @@ export const SetIamPolicyProjectsLocationsApisVersionsSpecsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2270,7 +2270,7 @@ export const DeleteProjectsLocationsApisVersionsSpecsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -2304,7 +2304,7 @@ export const RollbackProjectsLocationsApisVersionsSpecsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RollbackApiSpecRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:rollback", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:rollback", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RollbackProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -2335,7 +2335,7 @@ export const GetContentsProjectsLocationsApisVersionsSpecsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getContents" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getContents" }),
     svc,
   ) as unknown as Schema.Schema<GetContentsProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -2375,7 +2375,7 @@ export const ListRevisionsProjectsLocationsApisVersionsSpecsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:listRevisions" }),
+    T.Http({ method: "GET", path: "v1/{+name}:listRevisions" }),
     svc,
   ) as unknown as Schema.Schema<ListRevisionsProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -2415,7 +2415,7 @@ export const TagRevisionProjectsLocationsApisVersionsSpecsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(TagApiSpecRevisionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:tagRevision", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:tagRevision", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TagRevisionProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -2458,7 +2458,7 @@ export const ListProjectsLocationsApisVersionsSpecsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/specs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/specs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -2499,7 +2499,7 @@ export const GetIamPolicyProjectsLocationsApisVersionsSpecsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -2530,7 +2530,7 @@ export const DeleteRevisionProjectsLocationsApisVersionsSpecsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}:deleteRevision" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}:deleteRevision" }),
     svc,
   ) as unknown as Schema.Schema<DeleteRevisionProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -2562,7 +2562,7 @@ export const GetProjectsLocationsApisVersionsSpecsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -2599,7 +2599,7 @@ export const CreateProjectsLocationsApisVersionsSpecsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(ApiSpec).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/specs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/specs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -2635,7 +2635,7 @@ export const TestIamPermissionsProjectsLocationsApisVersionsSpecsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2681,7 +2681,7 @@ export const PatchProjectsLocationsApisVersionsSpecsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ApiSpec).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -2718,7 +2718,7 @@ export const CreateProjectsLocationsApisVersionsSpecsArtifactsRequest =
     artifactId: Schema.optional(Schema.String).pipe(T.HttpQuery("artifactId")),
     body: Schema.optional(Artifact).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/artifacts", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/artifacts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApisVersionsSpecsArtifactsRequest>;
 
@@ -2756,7 +2756,7 @@ export const TestIamPermissionsProjectsLocationsApisVersionsSpecsArtifactsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2791,7 +2791,7 @@ export const GetProjectsLocationsApisVersionsSpecsArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApisVersionsSpecsArtifactsRequest>;
 
@@ -2822,7 +2822,7 @@ export const GetContentsProjectsLocationsApisVersionsSpecsArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getContents" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getContents" }),
     svc,
   ) as unknown as Schema.Schema<GetContentsProjectsLocationsApisVersionsSpecsArtifactsRequest>;
 
@@ -2858,7 +2858,7 @@ export const ReplaceArtifactProjectsLocationsApisVersionsSpecsArtifactsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Artifact).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReplaceArtifactProjectsLocationsApisVersionsSpecsArtifactsRequest>;
 
@@ -2896,7 +2896,7 @@ export const GetIamPolicyProjectsLocationsApisVersionsSpecsArtifactsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsApisVersionsSpecsArtifactsRequest>;
 
@@ -2941,7 +2941,7 @@ export const ListProjectsLocationsApisVersionsSpecsArtifactsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/artifacts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/artifacts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApisVersionsSpecsArtifactsRequest>;
 
@@ -2983,7 +2983,7 @@ export const SetIamPolicyProjectsLocationsApisVersionsSpecsArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3018,7 +3018,7 @@ export const DeleteProjectsLocationsApisVersionsSpecsArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApisVersionsSpecsArtifactsRequest>;
 
@@ -3053,7 +3053,7 @@ export const ReplaceArtifactProjectsLocationsApisVersionsArtifactsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Artifact).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReplaceArtifactProjectsLocationsApisVersionsArtifactsRequest>;
 
@@ -3091,7 +3091,7 @@ export const GetIamPolicyProjectsLocationsApisVersionsArtifactsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsApisVersionsArtifactsRequest>;
 
@@ -3135,7 +3135,7 @@ export const ListProjectsLocationsApisVersionsArtifactsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/artifacts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/artifacts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApisVersionsArtifactsRequest>;
 
@@ -3171,7 +3171,7 @@ export const DeleteProjectsLocationsApisVersionsArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApisVersionsArtifactsRequest>;
 
@@ -3207,7 +3207,7 @@ export const SetIamPolicyProjectsLocationsApisVersionsArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3247,7 +3247,7 @@ export const CreateProjectsLocationsApisVersionsArtifactsRequest =
     artifactId: Schema.optional(Schema.String).pipe(T.HttpQuery("artifactId")),
     body: Schema.optional(Artifact).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/artifacts", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/artifacts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApisVersionsArtifactsRequest>;
 
@@ -3283,7 +3283,7 @@ export const TestIamPermissionsProjectsLocationsApisVersionsArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3318,7 +3318,7 @@ export const GetProjectsLocationsApisVersionsArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApisVersionsArtifactsRequest>;
 
@@ -3349,7 +3349,7 @@ export const GetContentsProjectsLocationsApisVersionsArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getContents" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getContents" }),
     svc,
   ) as unknown as Schema.Schema<GetContentsProjectsLocationsApisVersionsArtifactsRequest>;
 
@@ -3382,7 +3382,7 @@ export const DeleteProjectsLocationsApisArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApisArtifactsRequest>;
 
@@ -3418,7 +3418,7 @@ export const SetIamPolicyProjectsLocationsApisArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3454,7 +3454,7 @@ export const ReplaceArtifactProjectsLocationsApisArtifactsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Artifact).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReplaceArtifactProjectsLocationsApisArtifactsRequest>;
 
@@ -3490,7 +3490,7 @@ export const GetIamPolicyProjectsLocationsApisArtifactsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsApisArtifactsRequest>;
 
@@ -3533,7 +3533,7 @@ export const ListProjectsLocationsApisArtifactsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/artifacts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/artifacts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApisArtifactsRequest>;
 
@@ -3568,7 +3568,7 @@ export const GetContentsProjectsLocationsApisArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getContents" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getContents" }),
     svc,
   ) as unknown as Schema.Schema<GetContentsProjectsLocationsApisArtifactsRequest>;
 
@@ -3605,7 +3605,7 @@ export const CreateProjectsLocationsApisArtifactsRequest =
     artifactId: Schema.optional(Schema.String).pipe(T.HttpQuery("artifactId")),
     body: Schema.optional(Artifact).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/artifacts", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/artifacts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApisArtifactsRequest>;
 
@@ -3641,7 +3641,7 @@ export const TestIamPermissionsProjectsLocationsApisArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3676,7 +3676,7 @@ export const GetProjectsLocationsApisArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApisArtifactsRequest>;
 
@@ -3710,7 +3710,7 @@ export const TagRevisionProjectsLocationsApisDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(TagApiDeploymentRevisionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:tagRevision", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:tagRevision", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TagRevisionProjectsLocationsApisDeploymentsRequest>;
 
@@ -3744,7 +3744,7 @@ export const DeleteProjectsLocationsApisDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApisDeploymentsRequest>;
 
@@ -3784,7 +3784,7 @@ export const ListRevisionsProjectsLocationsApisDeploymentsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:listRevisions" }),
+    T.Http({ method: "GET", path: "v1/{+name}:listRevisions" }),
     svc,
   ) as unknown as Schema.Schema<ListRevisionsProjectsLocationsApisDeploymentsRequest>;
 
@@ -3825,7 +3825,7 @@ export const SetIamPolicyProjectsLocationsApisDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3861,7 +3861,7 @@ export const RollbackProjectsLocationsApisDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RollbackApiDeploymentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:rollback", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:rollback", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RollbackProjectsLocationsApisDeploymentsRequest>;
 
@@ -3897,7 +3897,7 @@ export const GetIamPolicyProjectsLocationsApisDeploymentsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsApisDeploymentsRequest>;
 
@@ -3940,7 +3940,7 @@ export const ListProjectsLocationsApisDeploymentsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApisDeploymentsRequest>;
 
@@ -3976,7 +3976,7 @@ export const DeleteRevisionProjectsLocationsApisDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}:deleteRevision" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}:deleteRevision" }),
     svc,
   ) as unknown as Schema.Schema<DeleteRevisionProjectsLocationsApisDeploymentsRequest>;
 
@@ -4019,7 +4019,7 @@ export const PatchProjectsLocationsApisDeploymentsRequest =
     ),
     body: Schema.optional(ApiDeployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApisDeploymentsRequest>;
 
@@ -4058,7 +4058,7 @@ export const CreateProjectsLocationsApisDeploymentsRequest =
     ),
     body: Schema.optional(ApiDeployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/deployments", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/deployments", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApisDeploymentsRequest>;
 
@@ -4094,7 +4094,7 @@ export const TestIamPermissionsProjectsLocationsApisDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4129,7 +4129,7 @@ export const GetProjectsLocationsApisDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApisDeploymentsRequest>;
 
@@ -4160,7 +4160,7 @@ export const GetContentsProjectsLocationsApisDeploymentsArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getContents" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getContents" }),
     svc,
   ) as unknown as Schema.Schema<GetContentsProjectsLocationsApisDeploymentsArtifactsRequest>;
 
@@ -4193,7 +4193,7 @@ export const DeleteProjectsLocationsApisDeploymentsArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApisDeploymentsArtifactsRequest>;
 
@@ -4231,7 +4231,7 @@ export const CreateProjectsLocationsApisDeploymentsArtifactsRequest =
     artifactId: Schema.optional(Schema.String).pipe(T.HttpQuery("artifactId")),
     body: Schema.optional(Artifact).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/artifacts", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/artifacts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApisDeploymentsArtifactsRequest>;
 
@@ -4266,7 +4266,7 @@ export const ReplaceArtifactProjectsLocationsApisDeploymentsArtifactsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Artifact).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReplaceArtifactProjectsLocationsApisDeploymentsArtifactsRequest>;
 
@@ -4311,7 +4311,7 @@ export const ListProjectsLocationsApisDeploymentsArtifactsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/artifacts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/artifacts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApisDeploymentsArtifactsRequest>;
 
@@ -4347,7 +4347,7 @@ export const GetProjectsLocationsApisDeploymentsArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApisDeploymentsArtifactsRequest>;
 

--- a/packages/gcp/src/services/apihub-v1.ts
+++ b/packages/gcp/src/services/apihub-v1.ts
@@ -2920,7 +2920,7 @@ export const SearchResourcesProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{location}:searchResources",
+      path: "v1/{+location}:searchResources",
       hasBody: true,
     }),
     svc,
@@ -2970,7 +2970,7 @@ export const RetrieveApiViewsProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}:retrieveApiViews" }),
+    T.Http({ method: "GET", path: "v1/{+parent}:retrieveApiViews" }),
     svc,
   ) as unknown as Schema.Schema<RetrieveApiViewsProjectsLocationsRequest>;
 
@@ -3013,7 +3013,7 @@ export const CollectApiDataProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{location}:collectApiData",
+      path: "v1/{+location}:collectApiData",
       hasBody: true,
     }),
     svc,
@@ -3047,7 +3047,10 @@ export const LookupRuntimeProjectAttachmentProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:lookupRuntimeProjectAttachment" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+name}:lookupRuntimeProjectAttachment",
+    }),
     svc,
   ) as unknown as Schema.Schema<LookupRuntimeProjectAttachmentProjectsLocationsRequest>;
 
@@ -3094,7 +3097,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -3130,7 +3133,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -3175,7 +3178,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -3211,7 +3214,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -3242,7 +3245,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -3278,7 +3281,7 @@ export const CancelProjectsLocationsOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -3309,7 +3312,7 @@ export const GetProjectsLocationsAddonsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAddonsRequest>;
 
@@ -3345,7 +3348,7 @@ export const ManageConfigProjectsLocationsAddonsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:manageConfig", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:manageConfig", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ManageConfigProjectsLocationsAddonsRequest>;
 
@@ -3386,7 +3389,7 @@ export const ListProjectsLocationsAddonsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/addons" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/addons" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAddonsRequest>;
 
@@ -3422,7 +3425,7 @@ export const GetProjectsLocationsPluginsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPluginsRequest>;
 
@@ -3458,7 +3461,7 @@ export const EnableProjectsLocationsPluginsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:enable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:enable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EnableProjectsLocationsPluginsRequest>;
 
@@ -3494,7 +3497,7 @@ export const DisableProjectsLocationsPluginsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:disable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:disable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DisableProjectsLocationsPluginsRequest>;
 
@@ -3531,7 +3534,7 @@ export const CreateProjectsLocationsPluginsRequest =
     pluginId: Schema.optional(Schema.String).pipe(T.HttpQuery("pluginId")),
     body: Schema.optional(GoogleCloudApihubV1Plugin).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/plugins", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/plugins", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsPluginsRequest>;
 
@@ -3571,7 +3574,7 @@ export const ListProjectsLocationsPluginsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/plugins" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/plugins" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPluginsRequest>;
 
@@ -3607,7 +3610,7 @@ export const DeleteProjectsLocationsPluginsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPluginsRequest>;
 
@@ -3638,7 +3641,7 @@ export const GetStyleGuideProjectsLocationsPluginsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetStyleGuideProjectsLocationsPluginsRequest>;
 
@@ -3676,7 +3679,7 @@ export const UpdateStyleGuideProjectsLocationsPluginsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudApihubV1StyleGuide).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateStyleGuideProjectsLocationsPluginsRequest>;
 
@@ -3716,7 +3719,7 @@ export const CreateProjectsLocationsPluginsInstancesRequest =
     ),
     body: Schema.optional(GoogleCloudApihubV1PluginInstance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/instances", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/instances", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsPluginsInstancesRequest>;
 
@@ -3753,7 +3756,7 @@ export const ExecuteActionProjectsLocationsPluginsInstancesRequest =
       GoogleCloudApihubV1ExecutePluginInstanceActionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:executeAction", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:executeAction", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteActionProjectsLocationsPluginsInstancesRequest>;
 
@@ -3785,7 +3788,7 @@ export const GetProjectsLocationsPluginsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPluginsInstancesRequest>;
 
@@ -3826,7 +3829,7 @@ export const ListProjectsLocationsPluginsInstancesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPluginsInstancesRequest>;
 
@@ -3867,7 +3870,7 @@ export const EnableActionProjectsLocationsPluginsInstancesRequest =
       GoogleCloudApihubV1EnablePluginInstanceActionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:enableAction", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:enableAction", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EnableActionProjectsLocationsPluginsInstancesRequest>;
 
@@ -3904,7 +3907,7 @@ export const DisableActionProjectsLocationsPluginsInstancesRequest =
       GoogleCloudApihubV1DisablePluginInstanceActionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:disableAction", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:disableAction", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DisableActionProjectsLocationsPluginsInstancesRequest>;
 
@@ -3942,7 +3945,7 @@ export const PatchProjectsLocationsPluginsInstancesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudApihubV1PluginInstance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPluginsInstancesRequest>;
 
@@ -3974,7 +3977,7 @@ export const DeleteProjectsLocationsPluginsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPluginsInstancesRequest>;
 
@@ -4013,7 +4016,7 @@ export const ManageSourceDataProjectsLocationsPluginsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:manageSourceData",
+      path: "v1/{+name}:manageSourceData",
       hasBody: true,
     }),
     svc,
@@ -4048,7 +4051,7 @@ export const GetContentsProjectsLocationsPluginsStyleGuideRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:contents" }),
+    T.Http({ method: "GET", path: "v1/{+name}:contents" }),
     svc,
   ) as unknown as Schema.Schema<GetContentsProjectsLocationsPluginsStyleGuideRequest>;
 
@@ -4086,7 +4089,7 @@ export const CreateProjectsLocationsApisRequest =
     apiId: Schema.optional(Schema.String).pipe(T.HttpQuery("apiId")),
     body: Schema.optional(GoogleCloudApihubV1Api).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/apis", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/apis", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApisRequest>;
 
@@ -4117,7 +4120,7 @@ export const GetProjectsLocationsApisRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApisRequest>;
 
@@ -4157,7 +4160,7 @@ export const ListProjectsLocationsApisRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/apis" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/apis" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApisRequest>;
 
@@ -4199,7 +4202,7 @@ export const PatchProjectsLocationsApisRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudApihubV1Api).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApisRequest>;
 
@@ -4233,7 +4236,7 @@ export const DeleteProjectsLocationsApisRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApisRequest>;
 
@@ -4270,7 +4273,7 @@ export const CreateProjectsLocationsApisVersionsRequest =
     versionId: Schema.optional(Schema.String).pipe(T.HttpQuery("versionId")),
     body: Schema.optional(GoogleCloudApihubV1Version).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/versions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/versions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApisVersionsRequest>;
 
@@ -4302,7 +4305,7 @@ export const GetProjectsLocationsApisVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApisVersionsRequest>;
 
@@ -4343,7 +4346,7 @@ export const ListProjectsLocationsApisVersionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApisVersionsRequest>;
 
@@ -4385,7 +4388,7 @@ export const PatchProjectsLocationsApisVersionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudApihubV1Version).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApisVersionsRequest>;
 
@@ -4420,7 +4423,7 @@ export const DeleteProjectsLocationsApisVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApisVersionsRequest>;
 
@@ -4457,7 +4460,7 @@ export const CreateProjectsLocationsApisVersionsSpecsRequest =
     specId: Schema.optional(Schema.String).pipe(T.HttpQuery("specId")),
     body: Schema.optional(GoogleCloudApihubV1Spec).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/specs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/specs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -4489,7 +4492,7 @@ export const GetProjectsLocationsApisVersionsSpecsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -4521,7 +4524,7 @@ export const GetContentsProjectsLocationsApisVersionsSpecsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:contents" }),
+    T.Http({ method: "GET", path: "v1/{+name}:contents" }),
     svc,
   ) as unknown as Schema.Schema<GetContentsProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -4562,7 +4565,7 @@ export const FetchAdditionalSpecContentProjectsLocationsApisVersionsSpecsRequest
       T.HttpQuery("specContentType"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:fetchAdditionalSpecContent" }),
+    T.Http({ method: "GET", path: "v1/{+name}:fetchAdditionalSpecContent" }),
     svc,
   ) as unknown as Schema.Schema<FetchAdditionalSpecContentProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -4604,7 +4607,7 @@ export const ListProjectsLocationsApisVersionsSpecsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/specs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/specs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -4646,7 +4649,7 @@ export const PatchProjectsLocationsApisVersionsSpecsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudApihubV1Spec).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -4678,7 +4681,7 @@ export const DeleteProjectsLocationsApisVersionsSpecsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -4714,7 +4717,7 @@ export const LintProjectsLocationsApisVersionsSpecsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:lint", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:lint", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<LintProjectsLocationsApisVersionsSpecsRequest>;
 
@@ -4753,7 +4756,7 @@ export const CreateProjectsLocationsApisVersionsOperationsRequest =
     ),
     body: Schema.optional(GoogleCloudApihubV1ApiOperation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/operations", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/operations", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApisVersionsOperationsRequest>;
 
@@ -4785,7 +4788,7 @@ export const GetProjectsLocationsApisVersionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApisVersionsOperationsRequest>;
 
@@ -4826,7 +4829,7 @@ export const ListProjectsLocationsApisVersionsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApisVersionsOperationsRequest>;
 
@@ -4868,7 +4871,7 @@ export const PatchProjectsLocationsApisVersionsOperationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudApihubV1ApiOperation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApisVersionsOperationsRequest>;
 
@@ -4900,7 +4903,7 @@ export const DeleteProjectsLocationsApisVersionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApisVersionsOperationsRequest>;
 
@@ -4931,7 +4934,7 @@ export const GetProjectsLocationsApisVersionsDefinitionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApisVersionsDefinitionsRequest>;
 
@@ -4971,7 +4974,7 @@ export const CreateProjectsLocationsDeploymentsRequest =
     ),
     body: Schema.optional(GoogleCloudApihubV1Deployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/deployments", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/deployments", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDeploymentsRequest>;
 
@@ -5003,7 +5006,7 @@ export const GetProjectsLocationsDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeploymentsRequest>;
 
@@ -5044,7 +5047,7 @@ export const ListProjectsLocationsDeploymentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeploymentsRequest>;
 
@@ -5086,7 +5089,7 @@ export const PatchProjectsLocationsDeploymentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudApihubV1Deployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDeploymentsRequest>;
 
@@ -5118,7 +5121,7 @@ export const DeleteProjectsLocationsDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDeploymentsRequest>;
 
@@ -5157,7 +5160,7 @@ export const CreateProjectsLocationsAttributesRequest =
     ),
     body: Schema.optional(GoogleCloudApihubV1Attribute).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/attributes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/attributes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAttributesRequest>;
 
@@ -5189,7 +5192,7 @@ export const GetProjectsLocationsAttributesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAttributesRequest>;
 
@@ -5227,7 +5230,7 @@ export const PatchProjectsLocationsAttributesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudApihubV1Attribute).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAttributesRequest>;
 
@@ -5259,7 +5262,7 @@ export const DeleteProjectsLocationsAttributesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAttributesRequest>;
 
@@ -5299,7 +5302,7 @@ export const ListProjectsLocationsAttributesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/attributes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/attributes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAttributesRequest>;
 
@@ -5343,7 +5346,11 @@ export const CreateProjectsLocationsExternalApisRequest =
     ),
     body: Schema.optional(GoogleCloudApihubV1ExternalApi).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/externalApis", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/externalApis",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsExternalApisRequest>;
 
@@ -5375,7 +5382,7 @@ export const GetProjectsLocationsExternalApisRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsExternalApisRequest>;
 
@@ -5413,7 +5420,7 @@ export const PatchProjectsLocationsExternalApisRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudApihubV1ExternalApi).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsExternalApisRequest>;
 
@@ -5445,7 +5452,7 @@ export const DeleteProjectsLocationsExternalApisRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsExternalApisRequest>;
 
@@ -5482,7 +5489,7 @@ export const ListProjectsLocationsExternalApisRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/externalApis" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/externalApis" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsExternalApisRequest>;
 
@@ -5526,7 +5533,11 @@ export const CreateProjectsLocationsDependenciesRequest =
     ),
     body: Schema.optional(GoogleCloudApihubV1Dependency).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/dependencies", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/dependencies",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDependenciesRequest>;
 
@@ -5558,7 +5569,7 @@ export const GetProjectsLocationsDependenciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDependenciesRequest>;
 
@@ -5596,7 +5607,7 @@ export const PatchProjectsLocationsDependenciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudApihubV1Dependency).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDependenciesRequest>;
 
@@ -5628,7 +5639,7 @@ export const DeleteProjectsLocationsDependenciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDependenciesRequest>;
 
@@ -5668,7 +5679,7 @@ export const ListProjectsLocationsDependenciesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dependencies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dependencies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDependenciesRequest>;
 
@@ -5710,7 +5721,7 @@ export const CreateProjectsLocationsCurationsRequest =
     curationId: Schema.optional(Schema.String).pipe(T.HttpQuery("curationId")),
     body: Schema.optional(GoogleCloudApihubV1Curation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/curations", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/curations", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCurationsRequest>;
 
@@ -5742,7 +5753,7 @@ export const GetProjectsLocationsCurationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCurationsRequest>;
 
@@ -5782,7 +5793,7 @@ export const ListProjectsLocationsCurationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/curations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/curations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCurationsRequest>;
 
@@ -5824,7 +5835,7 @@ export const PatchProjectsLocationsCurationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudApihubV1Curation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCurationsRequest>;
 
@@ -5856,7 +5867,7 @@ export const DeleteProjectsLocationsCurationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCurationsRequest>;
 
@@ -5893,7 +5904,7 @@ export const ListProjectsLocationsDiscoveredApiObservationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/discoveredApiObservations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/discoveredApiObservations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDiscoveredApiObservationsRequest>;
 
@@ -5929,7 +5940,7 @@ export const GetProjectsLocationsDiscoveredApiObservationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDiscoveredApiObservationsRequest>;
 
@@ -5967,7 +5978,7 @@ export const ListProjectsLocationsDiscoveredApiObservationsDiscoveredApiOperatio
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/discoveredApiOperations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/discoveredApiOperations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDiscoveredApiObservationsDiscoveredApiOperationsRequest>;
 
@@ -6006,7 +6017,7 @@ export const GetProjectsLocationsDiscoveredApiObservationsDiscoveredApiOperation
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDiscoveredApiObservationsDiscoveredApiOperationsRequest>;
 
@@ -6053,7 +6064,7 @@ export const CreateProjectsLocationsHostProjectRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/hostProjectRegistrations",
+      path: "v1/{+parent}/hostProjectRegistrations",
       hasBody: true,
     }),
     svc,
@@ -6088,7 +6099,7 @@ export const GetProjectsLocationsHostProjectRegistrationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsHostProjectRegistrationsRequest>;
 
@@ -6132,7 +6143,7 @@ export const ListProjectsLocationsHostProjectRegistrationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/hostProjectRegistrations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/hostProjectRegistrations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsHostProjectRegistrationsRequest>;
 
@@ -6178,7 +6189,7 @@ export const CreateProjectsLocationsApiHubInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/apiHubInstances",
+      path: "v1/{+parent}/apiHubInstances",
       hasBody: true,
     }),
     svc,
@@ -6212,7 +6223,7 @@ export const DeleteProjectsLocationsApiHubInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApiHubInstancesRequest>;
 
@@ -6244,7 +6255,7 @@ export const GetProjectsLocationsApiHubInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApiHubInstancesRequest>;
 
@@ -6282,7 +6293,7 @@ export const PatchProjectsLocationsApiHubInstancesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudApihubV1ApiHubInstance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApiHubInstancesRequest>;
 
@@ -6314,7 +6325,7 @@ export const LookupProjectsLocationsApiHubInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/apiHubInstances:lookup" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/apiHubInstances:lookup" }),
     svc,
   ) as unknown as Schema.Schema<LookupProjectsLocationsApiHubInstancesRequest>;
 
@@ -6358,7 +6369,7 @@ export const CreateProjectsLocationsRuntimeProjectAttachmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/runtimeProjectAttachments",
+      path: "v1/{+parent}/runtimeProjectAttachments",
       hasBody: true,
     }),
     svc,
@@ -6393,7 +6404,7 @@ export const GetProjectsLocationsRuntimeProjectAttachmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRuntimeProjectAttachmentsRequest>;
 
@@ -6437,7 +6448,7 @@ export const ListProjectsLocationsRuntimeProjectAttachmentsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/runtimeProjectAttachments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/runtimeProjectAttachments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRuntimeProjectAttachmentsRequest>;
 
@@ -6473,7 +6484,7 @@ export const DeleteProjectsLocationsRuntimeProjectAttachmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRuntimeProjectAttachmentsRequest>;
 

--- a/packages/gcp/src/services/apikeys-v2.ts
+++ b/packages/gcp/src/services/apikeys-v2.ts
@@ -267,7 +267,7 @@ export const GetKeyStringProjectsLocationsKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/keyString" }),
+    T.Http({ method: "GET", path: "v2/{+name}/keyString" }),
     svc,
   ) as unknown as Schema.Schema<GetKeyStringProjectsLocationsKeysRequest>;
 
@@ -304,7 +304,7 @@ export const CreateProjectsLocationsKeysRequest =
     keyId: Schema.optional(Schema.String).pipe(T.HttpQuery("keyId")),
     body: Schema.optional(V2Key).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/keys", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/keys", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsKeysRequest>;
 
@@ -335,7 +335,7 @@ export const GetProjectsLocationsKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsKeysRequest>;
 
@@ -369,7 +369,7 @@ export const UndeleteProjectsLocationsKeysRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(V2UndeleteKeyRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsLocationsKeysRequest>;
 
@@ -411,7 +411,7 @@ export const ListProjectsLocationsKeysRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/keys" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/keys" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsKeysRequest>;
 
@@ -452,7 +452,7 @@ export const PatchProjectsLocationsKeysRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(V2Key).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsKeysRequest>;
 
@@ -486,7 +486,7 @@ export const DeleteProjectsLocationsKeysRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsKeysRequest>;
 
@@ -516,7 +516,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{name}" }),
+  T.Http({ method: "GET", path: "v2/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 

--- a/packages/gcp/src/services/apim-v1alpha.ts
+++ b/packages/gcp/src/services/apim-v1alpha.ts
@@ -577,7 +577,7 @@ export const GetEntitlementProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEntitlementProjectsLocationsRequest>;
 
@@ -608,7 +608,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -645,7 +645,7 @@ export const ListApiObservationTagsProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}:listApiObservationTags" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}:listApiObservationTags" }),
     svc,
   ) as unknown as Schema.Schema<ListApiObservationTagsProjectsLocationsRequest>;
 
@@ -695,7 +695,7 @@ export const ListProjectsLocationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -730,7 +730,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -761,7 +761,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -795,7 +795,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -840,7 +840,7 @@ export const ListProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -881,7 +881,7 @@ export const ListProjectsLocationsObservationJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/observationJobs" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/observationJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsObservationJobsRequest>;
 
@@ -920,7 +920,7 @@ export const DisableProjectsLocationsObservationJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DisableObservationJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:disable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:disable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DisableProjectsLocationsObservationJobsRequest>;
 
@@ -951,7 +951,7 @@ export const GetProjectsLocationsObservationJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsObservationJobsRequest>;
 
@@ -995,7 +995,7 @@ export const CreateProjectsLocationsObservationJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/observationJobs",
+      path: "v1alpha/{+parent}/observationJobs",
       hasBody: true,
     }),
     svc,
@@ -1028,7 +1028,7 @@ export const DeleteProjectsLocationsObservationJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsObservationJobsRequest>;
 
@@ -1062,7 +1062,7 @@ export const EnableProjectsLocationsObservationJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EnableObservationJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:enable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:enable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EnableProjectsLocationsObservationJobsRequest>;
 
@@ -1093,7 +1093,7 @@ export const GetProjectsLocationsObservationJobsApiObservationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsObservationJobsApiObservationsRequest>;
 
@@ -1132,7 +1132,7 @@ export const ListProjectsLocationsObservationJobsApiObservationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/apiObservations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/apiObservations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsObservationJobsApiObservationsRequest>;
 
@@ -1176,7 +1176,7 @@ export const BatchEditTagsProjectsLocationsObservationJobsApiObservationsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/apiObservations:batchEditTags",
+      path: "v1alpha/{+parent}/apiObservations:batchEditTags",
       hasBody: true,
     }),
     svc,
@@ -1211,7 +1211,7 @@ export const GetProjectsLocationsObservationJobsApiObservationsApiOperationsRequ
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsObservationJobsApiObservationsApiOperationsRequest>;
 
@@ -1251,7 +1251,7 @@ export const ListProjectsLocationsObservationJobsApiObservationsApiOperationsReq
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/apiOperations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/apiOperations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsObservationJobsApiObservationsApiOperationsRequest>;
 
@@ -1303,7 +1303,7 @@ export const CreateProjectsLocationsObservationSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/observationSources",
+      path: "v1alpha/{+parent}/observationSources",
       hasBody: true,
     }),
     svc,
@@ -1336,7 +1336,7 @@ export const DeleteProjectsLocationsObservationSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsObservationSourcesRequest>;
 
@@ -1367,7 +1367,7 @@ export const GetProjectsLocationsObservationSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsObservationSourcesRequest>;
 
@@ -1404,7 +1404,7 @@ export const ListProjectsLocationsObservationSourcesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/observationSources" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/observationSources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsObservationSourcesRequest>;
 

--- a/packages/gcp/src/services/apphub-v1.ts
+++ b/packages/gcp/src/services/apphub-v1.ts
@@ -867,7 +867,7 @@ export const DetachServiceProjectAttachmentProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:detachServiceProjectAttachment",
+      path: "v1/{+name}:detachServiceProjectAttachment",
       hasBody: true,
     }),
     svc,
@@ -902,7 +902,10 @@ export const LookupServiceProjectAttachmentProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:lookupServiceProjectAttachment" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+name}:lookupServiceProjectAttachment",
+    }),
     svc,
   ) as unknown as Schema.Schema<LookupServiceProjectAttachmentProjectsLocationsRequest>;
 
@@ -935,7 +938,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -966,7 +969,7 @@ export const GetBoundaryProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBoundaryProjectsLocationsRequest>;
 
@@ -1011,7 +1014,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1055,7 +1058,7 @@ export const UpdateBoundaryProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Boundary).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateBoundaryProjectsLocationsRequest>;
 
@@ -1098,7 +1101,7 @@ export const ListProjectsLocationsServiceProjectAttachmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/serviceProjectAttachments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/serviceProjectAttachments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServiceProjectAttachmentsRequest>;
 
@@ -1137,7 +1140,7 @@ export const DeleteProjectsLocationsServiceProjectAttachmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServiceProjectAttachmentsRequest>;
 
@@ -1183,7 +1186,7 @@ export const CreateProjectsLocationsServiceProjectAttachmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/serviceProjectAttachments",
+      path: "v1/{+parent}/serviceProjectAttachments",
       hasBody: true,
     }),
     svc,
@@ -1218,7 +1221,7 @@ export const GetProjectsLocationsServiceProjectAttachmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServiceProjectAttachmentsRequest>;
 
@@ -1255,7 +1258,7 @@ export const GetIamPolicyProjectsLocationsApplicationsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsApplicationsRequest>;
 
@@ -1289,7 +1292,7 @@ export const DeleteProjectsLocationsApplicationsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApplicationsRequest>;
 
@@ -1331,7 +1334,11 @@ export const CreateProjectsLocationsApplicationsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Application).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/applications", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/applications",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApplicationsRequest>;
 
@@ -1362,7 +1369,7 @@ export const GetProjectsLocationsApplicationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApplicationsRequest>;
 
@@ -1398,7 +1405,7 @@ export const TestIamPermissionsProjectsLocationsApplicationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1445,7 +1452,7 @@ export const ListProjectsLocationsApplicationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/applications" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/applications" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApplicationsRequest>;
 
@@ -1490,7 +1497,7 @@ export const PatchProjectsLocationsApplicationsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Application).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApplicationsRequest>;
 
@@ -1526,7 +1533,7 @@ export const SetIamPolicyProjectsLocationsApplicationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1571,7 +1578,7 @@ export const ListProjectsLocationsApplicationsServicesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/services" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/services" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApplicationsServicesRequest>;
 
@@ -1616,7 +1623,7 @@ export const PatchProjectsLocationsApplicationsServicesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApplicationsServicesRequest>;
 
@@ -1650,7 +1657,7 @@ export const DeleteProjectsLocationsApplicationsServicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApplicationsServicesRequest>;
 
@@ -1690,7 +1697,7 @@ export const CreateProjectsLocationsApplicationsServicesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/services", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/services", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApplicationsServicesRequest>;
 
@@ -1721,7 +1728,7 @@ export const GetProjectsLocationsApplicationsServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApplicationsServicesRequest>;
 
@@ -1761,7 +1768,7 @@ export const CreateProjectsLocationsApplicationsWorkloadsRequest =
     workloadId: Schema.optional(Schema.String).pipe(T.HttpQuery("workloadId")),
     body: Schema.optional(Workload).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/workloads", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/workloads", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsApplicationsWorkloadsRequest>;
 
@@ -1792,7 +1799,7 @@ export const GetProjectsLocationsApplicationsWorkloadsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApplicationsWorkloadsRequest>;
 
@@ -1826,7 +1833,7 @@ export const DeleteProjectsLocationsApplicationsWorkloadsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApplicationsWorkloadsRequest>;
 
@@ -1869,7 +1876,7 @@ export const ListProjectsLocationsApplicationsWorkloadsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/workloads" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/workloads" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApplicationsWorkloadsRequest>;
 
@@ -1914,7 +1921,7 @@ export const PatchProjectsLocationsApplicationsWorkloadsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Workload).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApplicationsWorkloadsRequest>;
 
@@ -1945,7 +1952,7 @@ export const GetProjectsLocationsExtendedMetadataSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsExtendedMetadataSchemasRequest>;
 
@@ -1983,7 +1990,7 @@ export const ListProjectsLocationsExtendedMetadataSchemasRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/extendedMetadataSchemas" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/extendedMetadataSchemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsExtendedMetadataSchemasRequest>;
 
@@ -2033,7 +2040,7 @@ export const ListProjectsLocationsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2068,7 +2075,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2102,7 +2109,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2133,7 +2140,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2164,7 +2171,7 @@ export const GetProjectsLocationsDiscoveredServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDiscoveredServicesRequest>;
 
@@ -2198,7 +2205,7 @@ export const LookupProjectsLocationsDiscoveredServicesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     uri: Schema.optional(Schema.String).pipe(T.HttpQuery("uri")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/discoveredServices:lookup" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/discoveredServices:lookup" }),
     svc,
   ) as unknown as Schema.Schema<LookupProjectsLocationsDiscoveredServicesRequest>;
 
@@ -2242,7 +2249,7 @@ export const ListProjectsLocationsDiscoveredServicesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/discoveredServices" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/discoveredServices" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDiscoveredServicesRequest>;
 
@@ -2281,7 +2288,7 @@ export const LookupProjectsLocationsDiscoveredWorkloadsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     uri: Schema.optional(Schema.String).pipe(T.HttpQuery("uri")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/discoveredWorkloads:lookup" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/discoveredWorkloads:lookup" }),
     svc,
   ) as unknown as Schema.Schema<LookupProjectsLocationsDiscoveredWorkloadsRequest>;
 
@@ -2325,7 +2332,7 @@ export const ListProjectsLocationsDiscoveredWorkloadsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/discoveredWorkloads" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/discoveredWorkloads" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDiscoveredWorkloadsRequest>;
 
@@ -2361,7 +2368,7 @@ export const GetProjectsLocationsDiscoveredWorkloadsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDiscoveredWorkloadsRequest>;
 

--- a/packages/gcp/src/services/apphub-v1alpha.ts
+++ b/packages/gcp/src/services/apphub-v1alpha.ts
@@ -901,7 +901,7 @@ export const LookupServiceProjectAttachmentProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{name}:lookupServiceProjectAttachment",
+      path: "v1alpha/{+name}:lookupServiceProjectAttachment",
     }),
     svc,
   ) as unknown as Schema.Schema<LookupServiceProjectAttachmentProjectsLocationsRequest>;
@@ -944,7 +944,7 @@ export const UpdateBoundaryProjectsLocationsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Boundary).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateBoundaryProjectsLocationsRequest>;
 
@@ -975,7 +975,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1013,7 +1013,7 @@ export const DetachServiceProjectAttachmentProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{name}:detachServiceProjectAttachment",
+      path: "v1alpha/{+name}:detachServiceProjectAttachment",
       hasBody: true,
     }),
     svc,
@@ -1048,7 +1048,7 @@ export const GetBoundaryProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBoundaryProjectsLocationsRequest>;
 
@@ -1093,7 +1093,7 @@ export const ListProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1128,7 +1128,7 @@ export const GetProjectsLocationsDiscoveredWorkloadsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDiscoveredWorkloadsRequest>;
 
@@ -1172,7 +1172,7 @@ export const ListProjectsLocationsDiscoveredWorkloadsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/discoveredWorkloads" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/discoveredWorkloads" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDiscoveredWorkloadsRequest>;
 
@@ -1213,7 +1213,7 @@ export const LookupProjectsLocationsDiscoveredWorkloadsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}/discoveredWorkloads:lookup",
+      path: "v1alpha/{+parent}/discoveredWorkloads:lookup",
     }),
     svc,
   ) as unknown as Schema.Schema<LookupProjectsLocationsDiscoveredWorkloadsRequest>;
@@ -1260,7 +1260,7 @@ export const FindUnregisteredProjectsLocationsDiscoveredWorkloadsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}/discoveredWorkloads:findUnregistered",
+      path: "v1alpha/{+parent}/discoveredWorkloads:findUnregistered",
     }),
     svc,
   ) as unknown as Schema.Schema<FindUnregisteredProjectsLocationsDiscoveredWorkloadsRequest>;
@@ -1298,7 +1298,7 @@ export const GetProjectsLocationsApplicationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApplicationsRequest>;
 
@@ -1332,7 +1332,7 @@ export const DeleteProjectsLocationsApplicationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApplicationsRequest>;
 
@@ -1368,7 +1368,7 @@ export const TestIamPermissionsProjectsLocationsApplicationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:testIamPermissions",
+      path: "v1alpha/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1416,7 +1416,7 @@ export const CreateProjectsLocationsApplicationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/applications",
+      path: "v1alpha/{+parent}/applications",
       hasBody: true,
     }),
     svc,
@@ -1458,7 +1458,7 @@ export const PatchProjectsLocationsApplicationsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Application).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApplicationsRequest>;
 
@@ -1494,7 +1494,7 @@ export const GetIamPolicyProjectsLocationsApplicationsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsApplicationsRequest>;
 
@@ -1530,7 +1530,7 @@ export const SetIamPolicyProjectsLocationsApplicationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1575,7 +1575,7 @@ export const ListProjectsLocationsApplicationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/applications" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/applications" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApplicationsRequest>;
 
@@ -1614,7 +1614,7 @@ export const DeleteProjectsLocationsApplicationsServicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApplicationsServicesRequest>;
 
@@ -1645,7 +1645,7 @@ export const GetProjectsLocationsApplicationsServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApplicationsServicesRequest>;
 
@@ -1687,7 +1687,7 @@ export const CreateProjectsLocationsApplicationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/services",
+      path: "v1alpha/{+parent}/services",
       hasBody: true,
     }),
     svc,
@@ -1729,7 +1729,7 @@ export const PatchProjectsLocationsApplicationsServicesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApplicationsServicesRequest>;
 
@@ -1772,7 +1772,7 @@ export const ListProjectsLocationsApplicationsServicesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/services" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/services" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApplicationsServicesRequest>;
 
@@ -1820,7 +1820,7 @@ export const ListProjectsLocationsApplicationsWorkloadsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/workloads" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/workloads" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsApplicationsWorkloadsRequest>;
 
@@ -1867,7 +1867,7 @@ export const CreateProjectsLocationsApplicationsWorkloadsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/workloads",
+      path: "v1alpha/{+parent}/workloads",
       hasBody: true,
     }),
     svc,
@@ -1909,7 +1909,7 @@ export const PatchProjectsLocationsApplicationsWorkloadsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Workload).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsApplicationsWorkloadsRequest>;
 
@@ -1943,7 +1943,7 @@ export const DeleteProjectsLocationsApplicationsWorkloadsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsApplicationsWorkloadsRequest>;
 
@@ -1974,7 +1974,7 @@ export const GetProjectsLocationsApplicationsWorkloadsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsApplicationsWorkloadsRequest>;
 
@@ -2011,7 +2011,10 @@ export const ListProjectsLocationsExtendedMetadataSchemasRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/extendedMetadataSchemas" }),
+    T.Http({
+      method: "GET",
+      path: "v1alpha/{+parent}/extendedMetadataSchemas",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsExtendedMetadataSchemasRequest>;
 
@@ -2047,7 +2050,7 @@ export const GetProjectsLocationsExtendedMetadataSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsExtendedMetadataSchemasRequest>;
 
@@ -2079,7 +2082,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2110,7 +2113,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2155,7 +2158,7 @@ export const ListProjectsLocationsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2193,7 +2196,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2224,7 +2227,7 @@ export const GetProjectsLocationsDiscoveredServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDiscoveredServicesRequest>;
 
@@ -2269,7 +2272,7 @@ export const FindUnregisteredProjectsLocationsDiscoveredServicesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}/discoveredServices:findUnregistered",
+      path: "v1alpha/{+parent}/discoveredServices:findUnregistered",
     }),
     svc,
   ) as unknown as Schema.Schema<FindUnregisteredProjectsLocationsDiscoveredServicesRequest>;
@@ -2319,7 +2322,7 @@ export const ListProjectsLocationsDiscoveredServicesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/discoveredServices" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/discoveredServices" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDiscoveredServicesRequest>;
 
@@ -2360,7 +2363,7 @@ export const LookupProjectsLocationsDiscoveredServicesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}/discoveredServices:lookup",
+      path: "v1alpha/{+parent}/discoveredServices:lookup",
     }),
     svc,
   ) as unknown as Schema.Schema<LookupProjectsLocationsDiscoveredServicesRequest>;
@@ -2393,7 +2396,7 @@ export const GetProjectsLocationsServiceProjectAttachmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServiceProjectAttachmentsRequest>;
 
@@ -2428,7 +2431,7 @@ export const DeleteProjectsLocationsServiceProjectAttachmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServiceProjectAttachmentsRequest>;
 
@@ -2475,7 +2478,7 @@ export const ListProjectsLocationsServiceProjectAttachmentsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}/serviceProjectAttachments",
+      path: "v1alpha/{+parent}/serviceProjectAttachments",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServiceProjectAttachmentsRequest>;
@@ -2525,7 +2528,7 @@ export const CreateProjectsLocationsServiceProjectAttachmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/serviceProjectAttachments",
+      path: "v1alpha/{+parent}/serviceProjectAttachments",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/artifactregistry-v1.ts
+++ b/packages/gcp/src/services/artifactregistry-v1.ts
@@ -1807,7 +1807,7 @@ export const UpdateProjectSettingsProjectsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ProjectSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectSettingsProjectsRequest>;
 
@@ -1838,7 +1838,7 @@ export const GetProjectSettingsProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectSettingsProjectsRequest>;
 
@@ -1875,7 +1875,7 @@ export const UpdateProjectConfigProjectsLocationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ProjectConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectConfigProjectsLocationsRequest>;
 
@@ -1906,7 +1906,7 @@ export const GetProjectConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectConfigProjectsLocationsRequest>;
 
@@ -1943,7 +1943,7 @@ export const UpdateVpcscConfigProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(VPCSCConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateVpcscConfigProjectsLocationsRequest>;
 
@@ -1988,7 +1988,7 @@ export const ListProjectsLocationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2023,7 +2023,7 @@ export const GetVpcscConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVpcscConfigProjectsLocationsRequest>;
 
@@ -2054,7 +2054,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2088,7 +2088,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2119,7 +2119,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2155,7 +2155,7 @@ export const GetIamPolicyProjectsLocationsRepositoriesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsRepositoriesRequest>;
 
@@ -2198,7 +2198,7 @@ export const ListProjectsLocationsRepositoriesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/repositories" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/repositories" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesRequest>;
 
@@ -2239,7 +2239,7 @@ export const SetIamPolicyProjectsLocationsRepositoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2280,7 +2280,11 @@ export const CreateProjectsLocationsRepositoriesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Repository).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/repositories", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/repositories",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRepositoriesRequest>;
 
@@ -2311,7 +2315,7 @@ export const DeleteProjectsLocationsRepositoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesRequest>;
 
@@ -2348,7 +2352,7 @@ export const PatchProjectsLocationsRepositoriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Repository).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesRequest>;
 
@@ -2384,7 +2388,7 @@ export const TestIamPermissionsProjectsLocationsRepositoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2424,7 +2428,7 @@ export const ExportArtifactProjectsLocationsRepositoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{repository}:exportArtifact",
+      path: "v1/{+repository}:exportArtifact",
       hasBody: true,
     }),
     svc,
@@ -2457,7 +2461,7 @@ export const GetProjectsLocationsRepositoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesRequest>;
 
@@ -2493,7 +2497,7 @@ export const UploadProjectsLocationsRepositoriesGenericArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/genericArtifacts:create",
+      path: "v1/{+parent}/genericArtifacts:create",
       hasBody: true,
     }),
     svc,
@@ -2533,7 +2537,7 @@ export const ImportProjectsLocationsRepositoriesYumArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/yumArtifacts:import",
+      path: "v1/{+parent}/yumArtifacts:import",
       hasBody: true,
     }),
     svc,
@@ -2572,7 +2576,7 @@ export const UploadProjectsLocationsRepositoriesYumArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/yumArtifacts:create",
+      path: "v1/{+parent}/yumArtifacts:create",
       hasBody: true,
     }),
     svc,
@@ -2612,7 +2616,7 @@ export const ImportProjectsLocationsRepositoriesGoogetArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/googetArtifacts:import",
+      path: "v1/{+parent}/googetArtifacts:import",
       hasBody: true,
     }),
     svc,
@@ -2652,7 +2656,7 @@ export const UploadProjectsLocationsRepositoriesGoogetArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/googetArtifacts:create",
+      path: "v1/{+parent}/googetArtifacts:create",
       hasBody: true,
     }),
     svc,
@@ -2693,7 +2697,7 @@ export const ListProjectsLocationsRepositoriesMavenArtifactsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/mavenArtifacts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/mavenArtifacts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesMavenArtifactsRequest>;
 
@@ -2730,7 +2734,7 @@ export const GetProjectsLocationsRepositoriesMavenArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesMavenArtifactsRequest>;
 
@@ -2762,7 +2766,7 @@ export const GetProjectsLocationsRepositoriesPackagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesPackagesRequest>;
 
@@ -2799,7 +2803,7 @@ export const PatchProjectsLocationsRepositoriesPackagesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Package).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesPackagesRequest>;
 
@@ -2842,7 +2846,7 @@ export const ListProjectsLocationsRepositoriesPackagesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/packages" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/packages" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesPackagesRequest>;
 
@@ -2878,7 +2882,7 @@ export const DeleteProjectsLocationsRepositoriesPackagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesPackagesRequest>;
 
@@ -2914,7 +2918,7 @@ export const BatchDeleteProjectsLocationsRepositoriesPackagesVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/versions:batchDelete",
+      path: "v1/{+parent}/versions:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -2952,7 +2956,7 @@ export const GetProjectsLocationsRepositoriesPackagesVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesPackagesVersionsRequest>;
 
@@ -2990,7 +2994,7 @@ export const PatchProjectsLocationsRepositoriesPackagesVersionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Version).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesPackagesVersionsRequest>;
 
@@ -3038,7 +3042,7 @@ export const ListProjectsLocationsRepositoriesPackagesVersionsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesPackagesVersionsRequest>;
 
@@ -3078,7 +3082,7 @@ export const DeleteProjectsLocationsRepositoriesPackagesVersionsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesPackagesVersionsRequest>;
 
@@ -3111,7 +3115,7 @@ export const GetProjectsLocationsRepositoriesPackagesTagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesPackagesTagsRequest>;
 
@@ -3148,7 +3152,7 @@ export const PatchProjectsLocationsRepositoriesPackagesTagsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Tag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesPackagesTagsRequest>;
 
@@ -3188,7 +3192,7 @@ export const ListProjectsLocationsRepositoriesPackagesTagsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/tags" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/tags" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesPackagesTagsRequest>;
 
@@ -3230,7 +3234,7 @@ export const CreateProjectsLocationsRepositoriesPackagesTagsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Tag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/tags", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/tags", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRepositoriesPackagesTagsRequest>;
 
@@ -3262,7 +3266,7 @@ export const DeleteProjectsLocationsRepositoriesPackagesTagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesPackagesTagsRequest>;
 
@@ -3299,7 +3303,7 @@ export const UploadProjectsLocationsRepositoriesKfpArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/kfpArtifacts:create",
+      path: "v1/{+parent}/kfpArtifacts:create",
       hasBody: true,
     }),
     svc,
@@ -3339,7 +3343,7 @@ export const ImportProjectsLocationsRepositoriesAptArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/aptArtifacts:import",
+      path: "v1/{+parent}/aptArtifacts:import",
       hasBody: true,
     }),
     svc,
@@ -3378,7 +3382,7 @@ export const UploadProjectsLocationsRepositoriesAptArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/aptArtifacts:create",
+      path: "v1/{+parent}/aptArtifacts:create",
       hasBody: true,
     }),
     svc,
@@ -3418,7 +3422,7 @@ export const UploadProjectsLocationsRepositoriesGoModulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/goModules:create",
+      path: "v1/{+parent}/goModules:create",
       hasBody: true,
     }),
     svc,
@@ -3452,7 +3456,7 @@ export const GetProjectsLocationsRepositoriesNpmPackagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesNpmPackagesRequest>;
 
@@ -3489,7 +3493,7 @@ export const ListProjectsLocationsRepositoriesNpmPackagesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/npmPackages" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/npmPackages" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesNpmPackagesRequest>;
 
@@ -3534,7 +3538,7 @@ export const ListProjectsLocationsRepositoriesDockerImagesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dockerImages" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dockerImages" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesDockerImagesRequest>;
 
@@ -3570,7 +3574,7 @@ export const GetProjectsLocationsRepositoriesDockerImagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesDockerImagesRequest>;
 
@@ -3610,7 +3614,7 @@ export const ListProjectsLocationsRepositoriesAttachmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/attachments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/attachments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesAttachmentsRequest>;
 
@@ -3654,7 +3658,7 @@ export const CreateProjectsLocationsRepositoriesAttachmentsRequest =
     ),
     body: Schema.optional(Attachment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/attachments", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/attachments", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRepositoriesAttachmentsRequest>;
 
@@ -3685,7 +3689,7 @@ export const DeleteProjectsLocationsRepositoriesAttachmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesAttachmentsRequest>;
 
@@ -3716,7 +3720,7 @@ export const GetProjectsLocationsRepositoriesAttachmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesAttachmentsRequest>;
 
@@ -3753,7 +3757,7 @@ export const ListProjectsLocationsRepositoriesRulesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/rules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/rules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesRulesRequest>;
 
@@ -3796,7 +3800,7 @@ export const CreateProjectsLocationsRepositoriesRulesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/rules", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/rules", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRepositoriesRulesRequest>;
 
@@ -3828,7 +3832,7 @@ export const DeleteProjectsLocationsRepositoriesRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesRulesRequest>;
 
@@ -3859,7 +3863,7 @@ export const GetProjectsLocationsRepositoriesRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesRulesRequest>;
 
@@ -3899,7 +3903,7 @@ export const PatchProjectsLocationsRepositoriesRulesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesRulesRequest>;
 
@@ -3937,7 +3941,7 @@ export const ListProjectsLocationsRepositoriesPythonPackagesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/pythonPackages" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/pythonPackages" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesPythonPackagesRequest>;
 
@@ -3974,7 +3978,7 @@ export const GetProjectsLocationsRepositoriesPythonPackagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesPythonPackagesRequest>;
 
@@ -4018,7 +4022,7 @@ export const ListProjectsLocationsRepositoriesFilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/files" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/files" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesFilesRequest>;
 
@@ -4053,7 +4057,7 @@ export const DeleteProjectsLocationsRepositoriesFilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesFilesRequest>;
 
@@ -4087,7 +4091,11 @@ export const UploadProjectsLocationsRepositoriesFilesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(UploadFileRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/files:upload", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/files:upload",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<UploadProjectsLocationsRepositoriesFilesRequest>;
 
@@ -4119,7 +4127,7 @@ export const GetProjectsLocationsRepositoriesFilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesFilesRequest>;
 
@@ -4159,7 +4167,7 @@ export const PatchProjectsLocationsRepositoriesFilesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesFilesRequest>;
 
@@ -4191,7 +4199,7 @@ export const DownloadProjectsLocationsRepositoriesFilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:download" }),
+    T.Http({ method: "GET", path: "v1/{+name}:download" }),
     svc,
   ) as unknown as Schema.Schema<DownloadProjectsLocationsRepositoriesFilesRequest>;
 

--- a/packages/gcp/src/services/artifactregistry-v1beta1.ts
+++ b/packages/gcp/src/services/artifactregistry-v1beta1.ts
@@ -387,7 +387,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -432,7 +432,7 @@ export const ListProjectsLocationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -467,7 +467,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -503,7 +503,7 @@ export const TestIamPermissionsProjectsLocationsRepositoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -543,7 +543,7 @@ export const GetIamPolicyProjectsLocationsRepositoriesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsRepositoriesRequest>;
 
@@ -584,7 +584,7 @@ export const CreateProjectsLocationsRepositoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/repositories",
+      path: "v1beta1/{+parent}/repositories",
       hasBody: true,
     }),
     svc,
@@ -623,7 +623,7 @@ export const PatchProjectsLocationsRepositoriesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Repository).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesRequest>;
 
@@ -659,7 +659,7 @@ export const SetIamPolicyProjectsLocationsRepositoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -692,7 +692,7 @@ export const DeleteProjectsLocationsRepositoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesRequest>;
 
@@ -723,7 +723,7 @@ export const GetProjectsLocationsRepositoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesRequest>;
 
@@ -763,7 +763,7 @@ export const ListProjectsLocationsRepositoriesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/repositories" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/repositories" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesRequest>;
 
@@ -799,7 +799,7 @@ export const DeleteProjectsLocationsRepositoriesPackagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesPackagesRequest>;
 
@@ -839,7 +839,7 @@ export const ListProjectsLocationsRepositoriesPackagesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/packages" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/packages" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesPackagesRequest>;
 
@@ -875,7 +875,7 @@ export const GetProjectsLocationsRepositoriesPackagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesPackagesRequest>;
 
@@ -918,7 +918,7 @@ export const ListProjectsLocationsRepositoriesPackagesVersionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesPackagesVersionsRequest>;
 
@@ -958,7 +958,7 @@ export const GetProjectsLocationsRepositoriesPackagesVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesPackagesVersionsRequest>;
 
@@ -993,7 +993,7 @@ export const DeleteProjectsLocationsRepositoriesPackagesVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesPackagesVersionsRequest>;
 
@@ -1026,7 +1026,7 @@ export const DeleteProjectsLocationsRepositoriesPackagesTagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesPackagesTagsRequest>;
 
@@ -1058,7 +1058,7 @@ export const GetProjectsLocationsRepositoriesPackagesTagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesPackagesTagsRequest>;
 
@@ -1098,7 +1098,7 @@ export const ListProjectsLocationsRepositoriesPackagesTagsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/tags" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/tags" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesPackagesTagsRequest>;
 
@@ -1140,7 +1140,7 @@ export const CreateProjectsLocationsRepositoriesPackagesTagsRequest =
     tagId: Schema.optional(Schema.String).pipe(T.HttpQuery("tagId")),
     body: Schema.optional(Tag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/tags", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+parent}/tags", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRepositoriesPackagesTagsRequest>;
 
@@ -1178,7 +1178,7 @@ export const PatchProjectsLocationsRepositoriesPackagesTagsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Tag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesPackagesTagsRequest>;
 
@@ -1218,7 +1218,7 @@ export const ListProjectsLocationsRepositoriesFilesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/files" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/files" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesFilesRequest>;
 
@@ -1253,7 +1253,7 @@ export const GetProjectsLocationsRepositoriesFilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesFilesRequest>;
 

--- a/packages/gcp/src/services/artifactregistry-v1beta2.ts
+++ b/packages/gcp/src/services/artifactregistry-v1beta2.ts
@@ -679,7 +679,7 @@ export const GetProjectSettingsProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectSettingsProjectsRequest>;
 
@@ -716,7 +716,7 @@ export const UpdateProjectSettingsProjectsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ProjectSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectSettingsProjectsRequest>;
 
@@ -761,7 +761,7 @@ export const ListProjectsLocationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -796,7 +796,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -827,7 +827,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -858,7 +858,7 @@ export const DeleteProjectsLocationsRepositoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta2/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesRequest>;
 
@@ -894,7 +894,7 @@ export const SetIamPolicyProjectsLocationsRepositoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{resource}:setIamPolicy",
+      path: "v1beta2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -936,7 +936,7 @@ export const ListProjectsLocationsRepositoriesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{parent}/repositories" }),
+    T.Http({ method: "GET", path: "v1beta2/{+parent}/repositories" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesRequest>;
 
@@ -977,7 +977,7 @@ export const TestIamPermissionsProjectsLocationsRepositoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{resource}:testIamPermissions",
+      path: "v1beta2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1022,7 +1022,7 @@ export const CreateProjectsLocationsRepositoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{parent}/repositories",
+      path: "v1beta2/{+parent}/repositories",
       hasBody: true,
     }),
     svc,
@@ -1060,7 +1060,7 @@ export const GetIamPolicyProjectsLocationsRepositoriesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta2/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsRepositoriesRequest>;
 
@@ -1091,7 +1091,7 @@ export const GetProjectsLocationsRepositoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesRequest>;
 
@@ -1128,7 +1128,7 @@ export const PatchProjectsLocationsRepositoriesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Repository).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesRequest>;
 
@@ -1164,7 +1164,7 @@ export const ImportProjectsLocationsRepositoriesAptArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{parent}/aptArtifacts:import",
+      path: "v1beta2/{+parent}/aptArtifacts:import",
       hasBody: true,
     }),
     svc,
@@ -1203,7 +1203,7 @@ export const UploadProjectsLocationsRepositoriesAptArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{parent}/aptArtifacts:create",
+      path: "v1beta2/{+parent}/aptArtifacts:create",
       hasBody: true,
     }),
     svc,
@@ -1243,7 +1243,7 @@ export const ImportProjectsLocationsRepositoriesYumArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{parent}/yumArtifacts:import",
+      path: "v1beta2/{+parent}/yumArtifacts:import",
       hasBody: true,
     }),
     svc,
@@ -1282,7 +1282,7 @@ export const UploadProjectsLocationsRepositoriesYumArtifactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{parent}/yumArtifacts:create",
+      path: "v1beta2/{+parent}/yumArtifacts:create",
       hasBody: true,
     }),
     svc,
@@ -1317,7 +1317,7 @@ export const GetProjectsLocationsRepositoriesFilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesFilesRequest>;
 
@@ -1358,7 +1358,7 @@ export const ListProjectsLocationsRepositoriesFilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{parent}/files" }),
+    T.Http({ method: "GET", path: "v1beta2/{+parent}/files" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesFilesRequest>;
 
@@ -1393,7 +1393,7 @@ export const DownloadProjectsLocationsRepositoriesFilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:download" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:download" }),
     svc,
   ) as unknown as Schema.Schema<DownloadProjectsLocationsRepositoriesFilesRequest>;
 
@@ -1425,7 +1425,7 @@ export const GetProjectsLocationsRepositoriesPackagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesPackagesRequest>;
 
@@ -1462,7 +1462,7 @@ export const PatchProjectsLocationsRepositoriesPackagesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Package).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesPackagesRequest>;
 
@@ -1502,7 +1502,7 @@ export const ListProjectsLocationsRepositoriesPackagesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{parent}/packages" }),
+    T.Http({ method: "GET", path: "v1beta2/{+parent}/packages" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesPackagesRequest>;
 
@@ -1538,7 +1538,7 @@ export const DeleteProjectsLocationsRepositoriesPackagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta2/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesPackagesRequest>;
 
@@ -1572,7 +1572,7 @@ export const GetProjectsLocationsRepositoriesPackagesVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesPackagesVersionsRequest>;
 
@@ -1607,7 +1607,7 @@ export const DeleteProjectsLocationsRepositoriesPackagesVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta2/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesPackagesVersionsRequest>;
 
@@ -1652,7 +1652,7 @@ export const ListProjectsLocationsRepositoriesPackagesVersionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1beta2/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesPackagesVersionsRequest>;
 
@@ -1695,7 +1695,7 @@ export const CreateProjectsLocationsRepositoriesPackagesTagsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Tag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta2/{parent}/tags", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta2/{+parent}/tags", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRepositoriesPackagesTagsRequest>;
 
@@ -1736,7 +1736,7 @@ export const ListProjectsLocationsRepositoriesPackagesTagsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{parent}/tags" }),
+    T.Http({ method: "GET", path: "v1beta2/{+parent}/tags" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesPackagesTagsRequest>;
 
@@ -1772,7 +1772,7 @@ export const DeleteProjectsLocationsRepositoriesPackagesTagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta2/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesPackagesTagsRequest>;
 
@@ -1804,7 +1804,7 @@ export const GetProjectsLocationsRepositoriesPackagesTagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesPackagesTagsRequest>;
 
@@ -1841,7 +1841,7 @@ export const PatchProjectsLocationsRepositoriesPackagesTagsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Tag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesPackagesTagsRequest>;
 

--- a/packages/gcp/src/services/assuredworkloads-v1.ts
+++ b/packages/gcp/src/services/assuredworkloads-v1.ts
@@ -1066,7 +1066,7 @@ export const ListOrganizationsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsOperationsRequest>;
 
@@ -1102,7 +1102,7 @@ export const GetOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsOperationsRequest>;
 
@@ -1142,7 +1142,7 @@ export const CreateOrganizationsLocationsWorkloadsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/workloads", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/workloads", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsLocationsWorkloadsRequest>;
 
@@ -1182,7 +1182,7 @@ export const PatchOrganizationsLocationsWorkloadsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsWorkloadsRequest>;
 
@@ -1221,7 +1221,7 @@ export const RestrictAllowedResourcesOrganizationsLocationsWorkloadsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:restrictAllowedResources",
+      path: "v1/{+name}:restrictAllowedResources",
       hasBody: true,
     }),
     svc,
@@ -1259,7 +1259,7 @@ export const DeleteOrganizationsLocationsWorkloadsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsWorkloadsRequest>;
 
@@ -1290,7 +1290,7 @@ export const GetOrganizationsLocationsWorkloadsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsWorkloadsRequest>;
 
@@ -1336,7 +1336,7 @@ export const AnalyzeWorkloadMoveOrganizationsLocationsWorkloadsRequest =
       T.HttpQuery("assetTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{target}:analyzeWorkloadMove" }),
+    T.Http({ method: "GET", path: "v1/{+target}:analyzeWorkloadMove" }),
     svc,
   ) as unknown as Schema.Schema<AnalyzeWorkloadMoveOrganizationsLocationsWorkloadsRequest>;
 
@@ -1382,7 +1382,7 @@ export const ListOrganizationsLocationsWorkloadsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/workloads" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/workloads" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsWorkloadsRequest>;
 
@@ -1425,7 +1425,7 @@ export const MutatePartnerPermissionsOrganizationsLocationsWorkloadsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1/{name}:mutatePartnerPermissions",
+      path: "v1/{+name}:mutatePartnerPermissions",
       hasBody: true,
     }),
     svc,
@@ -1462,7 +1462,7 @@ export const EnableResourceMonitoringOrganizationsLocationsWorkloadsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:enableResourceMonitoring",
+      path: "v1/{+name}:enableResourceMonitoring",
       hasBody: true,
     }),
     svc,
@@ -1499,7 +1499,7 @@ export const EnableComplianceUpdatesOrganizationsLocationsWorkloadsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "v1/{name}:enableComplianceUpdates",
+      path: "v1/{+name}:enableComplianceUpdates",
       hasBody: true,
     }),
     svc,
@@ -1553,7 +1553,7 @@ export const ListOrganizationsLocationsWorkloadsViolationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/violations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/violations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsWorkloadsViolationsRequest>;
 
@@ -1589,7 +1589,7 @@ export const GetOrganizationsLocationsWorkloadsViolationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsWorkloadsViolationsRequest>;
 
@@ -1626,7 +1626,7 @@ export const AcknowledgeOrganizationsLocationsWorkloadsViolationsRequest =
       GoogleCloudAssuredworkloadsV1AcknowledgeViolationRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:acknowledge", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:acknowledge", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AcknowledgeOrganizationsLocationsWorkloadsViolationsRequest>;
 
@@ -1665,7 +1665,7 @@ export const ListOrganizationsLocationsWorkloadsUpdatesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/updates" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/updates" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsWorkloadsUpdatesRequest>;
 
@@ -1706,7 +1706,7 @@ export const ApplyOrganizationsLocationsWorkloadsUpdatesRequest =
       GoogleCloudAssuredworkloadsV1ApplyWorkloadUpdateRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:apply", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:apply", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ApplyOrganizationsLocationsWorkloadsUpdatesRequest>;
 

--- a/packages/gcp/src/services/assuredworkloads-v1beta1.ts
+++ b/packages/gcp/src/services/assuredworkloads-v1beta1.ts
@@ -1160,7 +1160,7 @@ export const ListOrganizationsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsOperationsRequest>;
 
@@ -1196,7 +1196,7 @@ export const GetOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsOperationsRequest>;
 
@@ -1238,7 +1238,7 @@ export const CreateOrganizationsLocationsWorkloadsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/workloads",
+      path: "v1beta1/{+parent}/workloads",
       hasBody: true,
     }),
     svc,
@@ -1280,7 +1280,7 @@ export const PatchOrganizationsLocationsWorkloadsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsWorkloadsRequest>;
 
@@ -1319,7 +1319,7 @@ export const RestrictAllowedResourcesOrganizationsLocationsWorkloadsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:restrictAllowedResources",
+      path: "v1beta1/{+name}:restrictAllowedResources",
       hasBody: true,
     }),
     svc,
@@ -1357,7 +1357,7 @@ export const DeleteOrganizationsLocationsWorkloadsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsWorkloadsRequest>;
 
@@ -1388,7 +1388,7 @@ export const GetOrganizationsLocationsWorkloadsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsWorkloadsRequest>;
 
@@ -1434,7 +1434,7 @@ export const AnalyzeWorkloadMoveOrganizationsLocationsWorkloadsRequest =
       T.HttpQuery("assetTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{target}:analyzeWorkloadMove" }),
+    T.Http({ method: "GET", path: "v1beta1/{+target}:analyzeWorkloadMove" }),
     svc,
   ) as unknown as Schema.Schema<AnalyzeWorkloadMoveOrganizationsLocationsWorkloadsRequest>;
 
@@ -1480,7 +1480,7 @@ export const ListOrganizationsLocationsWorkloadsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/workloads" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/workloads" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsWorkloadsRequest>;
 
@@ -1518,7 +1518,7 @@ export const EnableResourceMonitoringOrganizationsLocationsWorkloadsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:enableResourceMonitoring",
+      path: "v1beta1/{+name}:enableResourceMonitoring",
       hasBody: true,
     }),
     svc,
@@ -1555,7 +1555,7 @@ export const EnableComplianceUpdatesOrganizationsLocationsWorkloadsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "v1beta1/{name}:enableComplianceUpdates",
+      path: "v1beta1/{+name}:enableComplianceUpdates",
       hasBody: true,
     }),
     svc,
@@ -1609,7 +1609,7 @@ export const ListOrganizationsLocationsWorkloadsViolationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/violations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/violations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsWorkloadsViolationsRequest>;
 
@@ -1645,7 +1645,7 @@ export const GetOrganizationsLocationsWorkloadsViolationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsWorkloadsViolationsRequest>;
 
@@ -1684,7 +1684,7 @@ export const AcknowledgeOrganizationsLocationsWorkloadsViolationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:acknowledge",
+      path: "v1beta1/{+name}:acknowledge",
       hasBody: true,
     }),
     svc,
@@ -1725,7 +1725,7 @@ export const ListOrganizationsLocationsWorkloadsUpdatesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/updates" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/updates" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsWorkloadsUpdatesRequest>;
 
@@ -1766,7 +1766,7 @@ export const ApplyOrganizationsLocationsWorkloadsUpdatesRequest =
       GoogleCloudAssuredworkloadsV1beta1ApplyWorkloadUpdateRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:apply", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:apply", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ApplyOrganizationsLocationsWorkloadsUpdatesRequest>;
 

--- a/packages/gcp/src/services/authorizedbuyersmarketplace-v1.ts
+++ b/packages/gcp/src/services/authorizedbuyersmarketplace-v1.ts
@@ -1260,7 +1260,7 @@ export const CreateBuyersClientsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Client).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/clients", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/clients", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateBuyersClientsRequest>;
 
@@ -1293,7 +1293,7 @@ export const ActivateBuyersClientsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ActivateClientRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:activate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:activate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ActivateBuyersClientsRequest>;
 
@@ -1323,7 +1323,7 @@ export const GetBuyersClientsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBuyersClientsRequest>;
 
@@ -1359,7 +1359,7 @@ export const PatchBuyersClientsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Client).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchBuyersClientsRequest>;
 
@@ -1392,7 +1392,7 @@ export const DeactivateBuyersClientsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DeactivateClientRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:deactivate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:deactivate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeactivateBuyersClientsRequest>;
 
@@ -1432,7 +1432,7 @@ export const ListBuyersClientsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/clients" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/clients" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersClientsRequest>;
 
@@ -1470,7 +1470,7 @@ export const CreateBuyersClientsUsersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(ClientUser).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/users", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/users", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateBuyersClientsUsersRequest>;
 
@@ -1504,7 +1504,7 @@ export const ActivateBuyersClientsUsersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ActivateClientUserRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:activate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:activate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ActivateBuyersClientsUsersRequest>;
 
@@ -1535,7 +1535,7 @@ export const GetBuyersClientsUsersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBuyersClientsUsersRequest>;
 
@@ -1569,7 +1569,7 @@ export const DeactivateBuyersClientsUsersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DeactivateClientUserRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:deactivate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:deactivate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeactivateBuyersClientsUsersRequest>;
 
@@ -1606,7 +1606,7 @@ export const ListBuyersClientsUsersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/users" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/users" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersClientsUsersRequest>;
 
@@ -1641,7 +1641,7 @@ export const DeleteBuyersClientsUsersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteBuyersClientsUsersRequest>;
 
@@ -1672,7 +1672,7 @@ export const GetBuyersProposalsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBuyersProposalsRequest>;
 
@@ -1707,7 +1707,7 @@ export const CancelNegotiationBuyersProposalsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{proposal}:cancelNegotiation",
+      path: "v1/{+proposal}:cancelNegotiation",
       hasBody: true,
     }),
     svc,
@@ -1746,7 +1746,7 @@ export const PatchBuyersProposalsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Proposal).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchBuyersProposalsRequest>;
 
@@ -1780,7 +1780,7 @@ export const AcceptBuyersProposalsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AcceptProposalRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:accept", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:accept", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AcceptBuyersProposalsRequest>;
 
@@ -1820,7 +1820,7 @@ export const ListBuyersProposalsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/proposals" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/proposals" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersProposalsRequest>;
 
@@ -1858,7 +1858,7 @@ export const AddNoteBuyersProposalsRequest =
     proposal: Schema.String.pipe(T.HttpPath("proposal")),
     body: Schema.optional(AddNoteRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{proposal}:addNote", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+proposal}:addNote", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AddNoteBuyersProposalsRequest>;
 
@@ -1894,7 +1894,7 @@ export const SendRfpBuyersProposalsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{buyer}/proposals:sendRfp",
+      path: "v1/{+buyer}/proposals:sendRfp",
       hasBody: true,
     }),
     svc,
@@ -1932,7 +1932,7 @@ export const BatchUpdateBuyersProposalsDealsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/deals:batchUpdate",
+      path: "v1/{+parent}/deals:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -1965,7 +1965,7 @@ export const GetBuyersProposalsDealsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBuyersProposalsDealsRequest>;
 
@@ -2001,7 +2001,7 @@ export const PatchBuyersProposalsDealsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Deal).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchBuyersProposalsDealsRequest>;
 
@@ -2038,7 +2038,7 @@ export const ListBuyersProposalsDealsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deals" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deals" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersProposalsDealsRequest>;
 
@@ -2073,7 +2073,7 @@ export const GetBuyersFinalizedDealsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBuyersFinalizedDealsRequest>;
 
@@ -2116,7 +2116,7 @@ export const ListBuyersFinalizedDealsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/finalizedDeals" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/finalizedDeals" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersFinalizedDealsRequest>;
 
@@ -2154,7 +2154,7 @@ export const ResumeBuyersFinalizedDealsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResumeFinalizedDealRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeBuyersFinalizedDealsRequest>;
 
@@ -2188,7 +2188,7 @@ export const AddCreativeBuyersFinalizedDealsRequest =
     deal: Schema.String.pipe(T.HttpPath("deal")),
     body: Schema.optional(AddCreativeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{deal}:addCreative", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+deal}:addCreative", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AddCreativeBuyersFinalizedDealsRequest>;
 
@@ -2224,7 +2224,7 @@ export const SetReadyToServeBuyersFinalizedDealsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{deal}:setReadyToServe",
+      path: "v1/{+deal}:setReadyToServe",
       hasBody: true,
     }),
     svc,
@@ -2260,7 +2260,7 @@ export const PauseBuyersFinalizedDealsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PauseFinalizedDealRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseBuyersFinalizedDealsRequest>;
 
@@ -2291,7 +2291,7 @@ export const GetBuyersPublisherProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBuyersPublisherProfilesRequest>;
 
@@ -2331,7 +2331,7 @@ export const ListBuyersPublisherProfilesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/publisherProfiles" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/publisherProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersPublisherProfilesRequest>;
 
@@ -2366,7 +2366,7 @@ export const GetBuyersAuctionPackagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBuyersAuctionPackagesRequest>;
 
@@ -2402,7 +2402,7 @@ export const SubscribeClientsBuyersAuctionPackagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{auctionPackage}:subscribeClients",
+      path: "v1/{+auctionPackage}:subscribeClients",
       hasBody: true,
     }),
     svc,
@@ -2440,7 +2440,7 @@ export const UnsubscribeClientsBuyersAuctionPackagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{auctionPackage}:unsubscribeClients",
+      path: "v1/{+auctionPackage}:unsubscribeClients",
       hasBody: true,
     }),
     svc,
@@ -2476,7 +2476,7 @@ export const SubscribeBuyersAuctionPackagesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SubscribeAuctionPackageRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:subscribe", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:subscribe", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SubscribeBuyersAuctionPackagesRequest>;
 
@@ -2519,7 +2519,7 @@ export const ListBuyersAuctionPackagesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/auctionPackages" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/auctionPackages" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersAuctionPackagesRequest>;
 
@@ -2557,7 +2557,7 @@ export const UnsubscribeBuyersAuctionPackagesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UnsubscribeAuctionPackageRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:unsubscribe", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:unsubscribe", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UnsubscribeBuyersAuctionPackagesRequest>;
 
@@ -2600,7 +2600,7 @@ export const ListBiddersAuctionPackagesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/auctionPackages" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/auctionPackages" }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersAuctionPackagesRequest>;
 
@@ -2647,7 +2647,7 @@ export const ListBiddersFinalizedDealsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/finalizedDeals" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/finalizedDeals" }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersFinalizedDealsRequest>;
 
@@ -2687,7 +2687,7 @@ export const SetReadyToServeBiddersFinalizedDealsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{deal}:setReadyToServe",
+      path: "v1/{+deal}:setReadyToServe",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/authorizedbuyersmarketplace-v1alpha.ts
+++ b/packages/gcp/src/services/authorizedbuyersmarketplace-v1alpha.ts
@@ -1673,7 +1673,7 @@ export const CreateBuyersDataSegmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/dataSegments",
+      path: "v1alpha/{+parent}/dataSegments",
       hasBody: true,
     }),
     svc,
@@ -1706,7 +1706,7 @@ export const GetBuyersDataSegmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBuyersDataSegmentsRequest>;
 
@@ -1743,7 +1743,7 @@ export const PatchBuyersDataSegmentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(DataSegment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchBuyersDataSegmentsRequest>;
 
@@ -1780,7 +1780,7 @@ export const ListBuyersDataSegmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/dataSegments" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/dataSegments" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersDataSegmentsRequest>;
 
@@ -1818,7 +1818,7 @@ export const ActivateBuyersDataSegmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ActivateDataSegmentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:activate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:activate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ActivateBuyersDataSegmentsRequest>;
 
@@ -1854,7 +1854,7 @@ export const DeactivateBuyersDataSegmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{name}:deactivate",
+      path: "v1alpha/{+name}:deactivate",
       hasBody: true,
     }),
     svc,
@@ -1887,7 +1887,7 @@ export const GetBuyersProposalsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBuyersProposalsRequest>;
 
@@ -1922,7 +1922,7 @@ export const AddNoteBuyersProposalsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{proposal}:addNote",
+      path: "v1alpha/{+proposal}:addNote",
       hasBody: true,
     }),
     svc,
@@ -1960,7 +1960,7 @@ export const SendRfpBuyersProposalsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{buyer}/proposals:sendRfp",
+      path: "v1alpha/{+buyer}/proposals:sendRfp",
       hasBody: true,
     }),
     svc,
@@ -1999,7 +1999,7 @@ export const PatchBuyersProposalsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Proposal).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchBuyersProposalsRequest>;
 
@@ -2033,7 +2033,7 @@ export const AcceptBuyersProposalsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AcceptProposalRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:accept", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:accept", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AcceptBuyersProposalsRequest>;
 
@@ -2069,7 +2069,7 @@ export const CancelNegotiationBuyersProposalsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{proposal}:cancelNegotiation",
+      path: "v1alpha/{+proposal}:cancelNegotiation",
       hasBody: true,
     }),
     svc,
@@ -2111,7 +2111,7 @@ export const ListBuyersProposalsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/proposals" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/proposals" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersProposalsRequest>;
 
@@ -2152,7 +2152,7 @@ export const PatchBuyersProposalsDealsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Deal).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchBuyersProposalsDealsRequest>;
 
@@ -2183,7 +2183,7 @@ export const GetBuyersProposalsDealsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBuyersProposalsDealsRequest>;
 
@@ -2219,7 +2219,7 @@ export const ListBuyersProposalsDealsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/deals" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/deals" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersProposalsDealsRequest>;
 
@@ -2259,7 +2259,7 @@ export const BatchUpdateBuyersProposalsDealsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/deals:batchUpdate",
+      path: "v1alpha/{+parent}/deals:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -2298,7 +2298,7 @@ export const PatchBuyersClientsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Client).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchBuyersClientsRequest>;
 
@@ -2328,7 +2328,7 @@ export const GetBuyersClientsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBuyersClientsRequest>;
 
@@ -2361,7 +2361,11 @@ export const CreateBuyersClientsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Client).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{parent}/clients", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1alpha/{+parent}/clients",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateBuyersClientsRequest>;
 
@@ -2396,7 +2400,7 @@ export const DeactivateBuyersClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{name}:deactivate",
+      path: "v1alpha/{+name}:deactivate",
       hasBody: true,
     }),
     svc,
@@ -2432,7 +2436,7 @@ export const ActivateBuyersClientsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ActivateClientRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:activate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:activate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ActivateBuyersClientsRequest>;
 
@@ -2471,7 +2475,7 @@ export const ListBuyersClientsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/clients" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/clients" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersClientsRequest>;
 
@@ -2509,7 +2513,7 @@ export const CreateBuyersClientsUsersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(ClientUser).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{parent}/users", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+parent}/users", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateBuyersClientsUsersRequest>;
 
@@ -2540,7 +2544,7 @@ export const GetBuyersClientsUsersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBuyersClientsUsersRequest>;
 
@@ -2577,7 +2581,7 @@ export const ListBuyersClientsUsersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/users" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/users" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersClientsUsersRequest>;
 
@@ -2615,7 +2619,7 @@ export const ActivateBuyersClientsUsersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ActivateClientUserRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:activate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:activate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ActivateBuyersClientsUsersRequest>;
 
@@ -2646,7 +2650,7 @@ export const DeleteBuyersClientsUsersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteBuyersClientsUsersRequest>;
 
@@ -2682,7 +2686,7 @@ export const DeactivateBuyersClientsUsersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{name}:deactivate",
+      path: "v1alpha/{+name}:deactivate",
       hasBody: true,
     }),
     svc,
@@ -2718,7 +2722,7 @@ export const PauseBuyersFinalizedDealsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PauseFinalizedDealRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseBuyersFinalizedDealsRequest>;
 
@@ -2749,7 +2753,7 @@ export const GetBuyersFinalizedDealsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBuyersFinalizedDealsRequest>;
 
@@ -2785,7 +2789,7 @@ export const AddCreativeBuyersFinalizedDealsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{deal}:addCreative",
+      path: "v1alpha/{+deal}:addCreative",
       hasBody: true,
     }),
     svc,
@@ -2823,7 +2827,7 @@ export const SetReadyToServeBuyersFinalizedDealsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{deal}:setReadyToServe",
+      path: "v1alpha/{+deal}:setReadyToServe",
       hasBody: true,
     }),
     svc,
@@ -2868,7 +2872,7 @@ export const ListBuyersFinalizedDealsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/finalizedDeals" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/finalizedDeals" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersFinalizedDealsRequest>;
 
@@ -2906,7 +2910,7 @@ export const ResumeBuyersFinalizedDealsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResumeFinalizedDealRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeBuyersFinalizedDealsRequest>;
 
@@ -2946,7 +2950,7 @@ export const ListBuyersPublisherProfilesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/publisherProfiles" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/publisherProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersPublisherProfilesRequest>;
 
@@ -2981,7 +2985,7 @@ export const GetBuyersPublisherProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBuyersPublisherProfilesRequest>;
 
@@ -3012,7 +3016,7 @@ export const GetBuyersAuctionPackagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBuyersAuctionPackagesRequest>;
 
@@ -3046,7 +3050,11 @@ export const SubscribeBuyersAuctionPackagesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SubscribeAuctionPackageRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:subscribe", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1alpha/{+name}:subscribe",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<SubscribeBuyersAuctionPackagesRequest>;
 
@@ -3082,7 +3090,7 @@ export const SubscribeClientsBuyersAuctionPackagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{auctionPackage}:subscribeClients",
+      path: "v1alpha/{+auctionPackage}:subscribeClients",
       hasBody: true,
     }),
     svc,
@@ -3127,7 +3135,7 @@ export const ListBuyersAuctionPackagesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/auctionPackages" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/auctionPackages" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersAuctionPackagesRequest>;
 
@@ -3167,7 +3175,7 @@ export const UnsubscribeBuyersAuctionPackagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{name}:unsubscribe",
+      path: "v1alpha/{+name}:unsubscribe",
       hasBody: true,
     }),
     svc,
@@ -3205,7 +3213,7 @@ export const UnsubscribeClientsBuyersAuctionPackagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{auctionPackage}:unsubscribeClients",
+      path: "v1alpha/{+auctionPackage}:unsubscribeClients",
       hasBody: true,
     }),
     svc,
@@ -3247,7 +3255,7 @@ export const ListCuratorsCuratedPackagesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/curatedPackages" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/curatedPackages" }),
     svc,
   ) as unknown as Schema.Schema<ListCuratorsCuratedPackagesRequest>;
 
@@ -3287,7 +3295,7 @@ export const DeactivateCuratorsCuratedPackagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{name}:deactivate",
+      path: "v1alpha/{+name}:deactivate",
       hasBody: true,
     }),
     svc,
@@ -3323,7 +3331,7 @@ export const ActivateCuratorsCuratedPackagesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ActivateCuratedPackageRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:activate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:activate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ActivateCuratorsCuratedPackagesRequest>;
 
@@ -3359,7 +3367,7 @@ export const CreateCuratorsCuratedPackagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/curatedPackages",
+      path: "v1alpha/{+parent}/curatedPackages",
       hasBody: true,
     }),
     svc,
@@ -3398,7 +3406,7 @@ export const PatchCuratorsCuratedPackagesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(CuratedPackage).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchCuratorsCuratedPackagesRequest>;
 
@@ -3429,7 +3437,7 @@ export const GetCuratorsCuratedPackagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCuratorsCuratedPackagesRequest>;
 
@@ -3472,7 +3480,7 @@ export const ListBiddersAuctionPackagesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/auctionPackages" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/auctionPackages" }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersAuctionPackagesRequest>;
 
@@ -3512,7 +3520,7 @@ export const SetReadyToServeBiddersFinalizedDealsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{deal}:setReadyToServe",
+      path: "v1alpha/{+deal}:setReadyToServe",
       hasBody: true,
     }),
     svc,
@@ -3557,7 +3565,7 @@ export const ListBiddersFinalizedDealsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/finalizedDeals" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/finalizedDeals" }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersFinalizedDealsRequest>;
 

--- a/packages/gcp/src/services/authorizedbuyersmarketplace-v1beta.ts
+++ b/packages/gcp/src/services/authorizedbuyersmarketplace-v1beta.ts
@@ -517,7 +517,7 @@ export const CreateCuratorsCuratedPackagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/curatedPackages",
+      path: "v1beta/{+parent}/curatedPackages",
       hasBody: true,
     }),
     svc,
@@ -556,7 +556,7 @@ export const PatchCuratorsCuratedPackagesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CuratedPackage).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchCuratorsCuratedPackagesRequest>;
 
@@ -587,7 +587,7 @@ export const GetCuratorsCuratedPackagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCuratorsCuratedPackagesRequest>;
 
@@ -627,7 +627,7 @@ export const ListCuratorsCuratedPackagesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/curatedPackages" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/curatedPackages" }),
     svc,
   ) as unknown as Schema.Schema<ListCuratorsCuratedPackagesRequest>;
 
@@ -665,7 +665,11 @@ export const DeactivateCuratorsCuratedPackagesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DeactivateCuratedPackageRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:deactivate", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+name}:deactivate",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<DeactivateCuratorsCuratedPackagesRequest>;
 
@@ -699,7 +703,7 @@ export const ActivateCuratorsCuratedPackagesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ActivateCuratedPackageRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:activate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:activate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ActivateCuratorsCuratedPackagesRequest>;
 
@@ -736,7 +740,7 @@ export const ListCuratorsDataSegmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/dataSegments" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/dataSegments" }),
     svc,
   ) as unknown as Schema.Schema<ListCuratorsDataSegmentsRequest>;
 
@@ -774,7 +778,11 @@ export const DeactivateCuratorsDataSegmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DeactivateDataSegmentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:deactivate", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+name}:deactivate",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<DeactivateCuratorsDataSegmentsRequest>;
 
@@ -808,7 +816,7 @@ export const ActivateCuratorsDataSegmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ActivateDataSegmentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:activate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:activate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ActivateCuratorsDataSegmentsRequest>;
 
@@ -844,7 +852,7 @@ export const CreateCuratorsDataSegmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/dataSegments",
+      path: "v1beta/{+parent}/dataSegments",
       hasBody: true,
     }),
     svc,
@@ -883,7 +891,7 @@ export const PatchCuratorsDataSegmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DataSegment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchCuratorsDataSegmentsRequest>;
 
@@ -914,7 +922,7 @@ export const GetCuratorsDataSegmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCuratorsDataSegmentsRequest>;
 

--- a/packages/gcp/src/services/backupdr-v1.ts
+++ b/packages/gcp/src/services/backupdr-v1.ts
@@ -2998,7 +2998,7 @@ export const ListProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -3033,7 +3033,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -3064,7 +3064,7 @@ export const GetTrialProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTrialProjectsLocationsRequest>;
 
@@ -3119,7 +3119,7 @@ export const DeleteProjectsLocationsBackupVaultsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupVaultsRequest>;
 
@@ -3166,7 +3166,11 @@ export const CreateProjectsLocationsBackupVaultsRequest =
     ),
     body: Schema.optional(BackupVault).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/backupVaults", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/backupVaults",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackupVaultsRequest>;
 
@@ -3202,7 +3206,7 @@ export const TestIamPermissionsProjectsLocationsBackupVaultsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3249,7 +3253,7 @@ export const FetchUsableProjectsLocationsBackupVaultsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backupVaults:fetchUsable" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backupVaults:fetchUsable" }),
     svc,
   ) as unknown as Schema.Schema<FetchUsableProjectsLocationsBackupVaultsRequest>;
 
@@ -3292,7 +3296,7 @@ export const GetProjectsLocationsBackupVaultsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupVaultsRequest>;
 
@@ -3345,7 +3349,7 @@ export const PatchProjectsLocationsBackupVaultsRequest =
     ),
     body: Schema.optional(BackupVault).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupVaultsRequest>;
 
@@ -3395,7 +3399,7 @@ export const ListProjectsLocationsBackupVaultsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backupVaults" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backupVaults" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupVaultsRequest>;
 
@@ -3436,7 +3440,7 @@ export const FetchAccessTokenProjectsLocationsBackupVaultsDataSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:fetchAccessToken",
+      path: "v1/{+name}:fetchAccessToken",
       hasBody: true,
     }),
     svc,
@@ -3476,7 +3480,7 @@ export const AbandonBackupProjectsLocationsBackupVaultsDataSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{dataSource}:abandonBackup",
+      path: "v1/{+dataSource}:abandonBackup",
       hasBody: true,
     }),
     svc,
@@ -3511,7 +3515,7 @@ export const GetProjectsLocationsBackupVaultsDataSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupVaultsDataSourcesRequest>;
 
@@ -3554,7 +3558,7 @@ export const ListProjectsLocationsBackupVaultsDataSourcesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dataSources" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dataSources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupVaultsDataSourcesRequest>;
 
@@ -3595,7 +3599,7 @@ export const InitiateBackupProjectsLocationsBackupVaultsDataSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{dataSource}:initiateBackup",
+      path: "v1/{+dataSource}:initiateBackup",
       hasBody: true,
     }),
     svc,
@@ -3644,7 +3648,7 @@ export const PatchProjectsLocationsBackupVaultsDataSourcesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(DataSource).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupVaultsDataSourcesRequest>;
 
@@ -3678,7 +3682,7 @@ export const RemoveProjectsLocationsBackupVaultsDataSourcesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RemoveDataSourceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:remove", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:remove", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RemoveProjectsLocationsBackupVaultsDataSourcesRequest>;
 
@@ -3714,7 +3718,7 @@ export const FinalizeBackupProjectsLocationsBackupVaultsDataSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{dataSource}:finalizeBackup",
+      path: "v1/{+dataSource}:finalizeBackup",
       hasBody: true,
     }),
     svc,
@@ -3754,7 +3758,7 @@ export const SetInternalStatusProjectsLocationsBackupVaultsDataSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{dataSource}:setInternalStatus",
+      path: "v1/{+dataSource}:setInternalStatus",
       hasBody: true,
     }),
     svc,
@@ -3808,7 +3812,7 @@ export const ListProjectsLocationsBackupVaultsDataSourcesBackupsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupVaultsDataSourcesBackupsRequest>;
 
@@ -3854,7 +3858,7 @@ export const PatchProjectsLocationsBackupVaultsDataSourcesBackupsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupVaultsDataSourcesBackupsRequest>;
 
@@ -3911,7 +3915,10 @@ export const FetchForResourceTypeProjectsLocationsBackupVaultsDataSourcesBackups
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backups:fetchForResourceType" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+parent}/backups:fetchForResourceType",
+    }),
     svc,
   ) as unknown as Schema.Schema<FetchForResourceTypeProjectsLocationsBackupVaultsDataSourcesBackupsRequest>;
 
@@ -3953,7 +3960,7 @@ export const DeleteProjectsLocationsBackupVaultsDataSourcesBackupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupVaultsDataSourcesBackupsRequest>;
 
@@ -3993,7 +4000,7 @@ export const GetProjectsLocationsBackupVaultsDataSourcesBackupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupVaultsDataSourcesBackupsRequest>;
 
@@ -4028,7 +4035,7 @@ export const RestoreProjectsLocationsBackupVaultsDataSourcesBackupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestoreBackupRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsBackupVaultsDataSourcesBackupsRequest>;
 
@@ -4061,7 +4068,7 @@ export const GetProjectsLocationsDataSourceReferencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataSourceReferencesRequest>;
 
@@ -4105,7 +4112,7 @@ export const ListProjectsLocationsDataSourceReferencesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dataSourceReferences" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dataSourceReferences" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataSourceReferencesRequest>;
 
@@ -4160,7 +4167,7 @@ export const FetchForResourceTypeProjectsLocationsDataSourceReferencesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/dataSourceReferences:fetchForResourceType",
+      path: "v1/{+parent}/dataSourceReferences:fetchForResourceType",
     }),
     svc,
   ) as unknown as Schema.Schema<FetchForResourceTypeProjectsLocationsDataSourceReferencesRequest>;
@@ -4201,7 +4208,7 @@ export const InitializeProjectsLocationsServiceConfigRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(InitializeServiceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:initialize", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:initialize", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<InitializeProjectsLocationsServiceConfigRequest>;
 
@@ -4244,7 +4251,7 @@ export const ListProjectsLocationsResourceBackupConfigsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/resourceBackupConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/resourceBackupConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsResourceBackupConfigsRequest>;
 
@@ -4293,7 +4300,7 @@ export const CreateProjectsLocationsBackupPlanAssociationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/backupPlanAssociations",
+      path: "v1/{+parent}/backupPlanAssociations",
       hasBody: true,
     }),
     svc,
@@ -4345,7 +4352,7 @@ export const FetchForResourceTypeProjectsLocationsBackupPlanAssociationsRequest 
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/backupPlanAssociations:fetchForResourceType",
+      path: "v1/{+parent}/backupPlanAssociations:fetchForResourceType",
     }),
     svc,
   ) as unknown as Schema.Schema<FetchForResourceTypeProjectsLocationsBackupPlanAssociationsRequest>;
@@ -4386,7 +4393,7 @@ export const DeleteProjectsLocationsBackupPlanAssociationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupPlanAssociationsRequest>;
 
@@ -4417,7 +4424,7 @@ export const GetProjectsLocationsBackupPlanAssociationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupPlanAssociationsRequest>;
 
@@ -4458,7 +4465,7 @@ export const ListProjectsLocationsBackupPlanAssociationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backupPlanAssociations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backupPlanAssociations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupPlanAssociationsRequest>;
 
@@ -4497,7 +4504,7 @@ export const TriggerBackupProjectsLocationsBackupPlanAssociationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(TriggerBackupRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:triggerBackup", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:triggerBackup", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TriggerBackupProjectsLocationsBackupPlanAssociationsRequest>;
 
@@ -4539,7 +4546,7 @@ export const PatchProjectsLocationsBackupPlanAssociationsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(BackupPlanAssociation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupPlanAssociationsRequest>;
 
@@ -4582,7 +4589,7 @@ export const ListProjectsLocationsManagementServersRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/managementServers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/managementServers" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsManagementServersRequest>;
 
@@ -4623,7 +4630,7 @@ export const SetIamPolicyProjectsLocationsManagementServersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4656,7 +4663,7 @@ export const GetProjectsLocationsManagementServersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsManagementServersRequest>;
 
@@ -4692,7 +4699,7 @@ export const GetIamPolicyProjectsLocationsManagementServersRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsManagementServersRequest>;
 
@@ -4728,7 +4735,7 @@ export const MsComplianceMetadataProjectsLocationsManagementServersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:msComplianceMetadata",
+      path: "v1/{+parent}:msComplianceMetadata",
       hasBody: true,
     }),
     svc,
@@ -4768,7 +4775,7 @@ export const TestIamPermissionsProjectsLocationsManagementServersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4816,7 +4823,7 @@ export const CreateProjectsLocationsManagementServersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/managementServers",
+      path: "v1/{+parent}/managementServers",
       hasBody: true,
     }),
     svc,
@@ -4852,7 +4859,7 @@ export const DeleteProjectsLocationsManagementServersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsManagementServersRequest>;
 
@@ -4886,7 +4893,7 @@ export const DeleteProjectsLocationsBackupPlansRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupPlansRequest>;
 
@@ -4928,7 +4935,7 @@ export const CreateProjectsLocationsBackupPlansRequest =
     ),
     body: Schema.optional(BackupPlan).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/backupPlans", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/backupPlans", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackupPlansRequest>;
 
@@ -4959,7 +4966,7 @@ export const GetProjectsLocationsBackupPlansRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupPlansRequest>;
 
@@ -4999,7 +5006,7 @@ export const PatchProjectsLocationsBackupPlansRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(BackupPlan).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupPlansRequest>;
 
@@ -5042,7 +5049,7 @@ export const ListProjectsLocationsBackupPlansRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backupPlans" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backupPlans" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupPlansRequest>;
 
@@ -5077,7 +5084,7 @@ export const GetProjectsLocationsBackupPlansRevisionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupPlansRevisionsRequest>;
 
@@ -5115,7 +5122,7 @@ export const ListProjectsLocationsBackupPlansRevisionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/revisions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/revisions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupPlansRevisionsRequest>;
 
@@ -5156,7 +5163,7 @@ export const SubscribeProjectsLocationsTrialRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/trial:subscribe",
+      path: "v1/{+parent}/trial:subscribe",
       hasBody: true,
     }),
     svc,
@@ -5192,7 +5199,7 @@ export const EndProjectsLocationsTrialRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(EndTrialRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/trial:end", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/trial:end", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EndProjectsLocationsTrialRequest>;
 
@@ -5237,7 +5244,7 @@ export const ListProjectsLocationsOperationsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -5272,7 +5279,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -5303,7 +5310,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -5337,7 +5344,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/baremetalsolution-v2.ts
+++ b/packages/gcp/src/services/baremetalsolution-v2.ts
@@ -1461,7 +1461,7 @@ export const ListProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1496,7 +1496,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1533,7 +1533,7 @@ export const PatchProjectsLocationsNetworksRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Network).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsNetworksRequest>;
 
@@ -1567,7 +1567,7 @@ export const RenameProjectsLocationsNetworksRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RenameNetworkRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:rename", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:rename", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RenameProjectsLocationsNetworksRequest>;
 
@@ -1598,7 +1598,7 @@ export const GetProjectsLocationsNetworksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNetworksRequest>;
 
@@ -1638,7 +1638,7 @@ export const ListProjectsLocationsNetworksRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/networks" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/networks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNetworksRequest>;
 
@@ -1673,7 +1673,7 @@ export const ListNetworkUsageProjectsLocationsNetworksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     location: Schema.String.pipe(T.HttpPath("location")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{location}/networks:listNetworkUsage" }),
+    T.Http({ method: "GET", path: "v2/{+location}/networks:listNetworkUsage" }),
     svc,
   ) as unknown as Schema.Schema<ListNetworkUsageProjectsLocationsNetworksRequest>;
 
@@ -1711,7 +1711,7 @@ export const ListProjectsLocationsProvisioningQuotasRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/provisioningQuotas" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/provisioningQuotas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProvisioningQuotasRequest>;
 
@@ -1747,7 +1747,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1784,7 +1784,7 @@ export const ListProjectsLocationsOsImagesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/osImages" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/osImages" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOsImagesRequest>;
 
@@ -1819,7 +1819,7 @@ export const GetProjectsLocationsOsImagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOsImagesRequest>;
 
@@ -1857,7 +1857,7 @@ export const DisableInteractiveSerialConsoleProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:disableInteractiveSerialConsole",
+      path: "v2/{+name}:disableInteractiveSerialConsole",
       hasBody: true,
     }),
     svc,
@@ -1897,7 +1897,7 @@ export const DisableHyperthreadingProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:disableHyperthreading",
+      path: "v2/{+name}:disableHyperthreading",
       hasBody: true,
     }),
     svc,
@@ -1936,7 +1936,7 @@ export const EnableHyperthreadingProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:enableHyperthreading",
+      path: "v2/{+name}:enableHyperthreading",
       hasBody: true,
     }),
     svc,
@@ -1975,7 +1975,7 @@ export const PatchProjectsLocationsInstancesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInstancesRequest>;
 
@@ -2009,7 +2009,7 @@ export const ResetProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResetInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:reset", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:reset", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResetProjectsLocationsInstancesRequest>;
 
@@ -2043,7 +2043,7 @@ export const ReimageProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ReimageInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:reimage", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:reimage", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReimageProjectsLocationsInstancesRequest>;
 
@@ -2077,7 +2077,7 @@ export const RenameProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RenameInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:rename", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:rename", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RenameProjectsLocationsInstancesRequest>;
 
@@ -2115,7 +2115,7 @@ export const EnableInteractiveSerialConsoleProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:enableInteractiveSerialConsole",
+      path: "v2/{+name}:enableInteractiveSerialConsole",
       hasBody: true,
     }),
     svc,
@@ -2159,7 +2159,7 @@ export const ListProjectsLocationsInstancesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesRequest>;
 
@@ -2197,7 +2197,7 @@ export const StopProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsInstancesRequest>;
 
@@ -2231,7 +2231,7 @@ export const DetachLunProjectsLocationsInstancesRequest =
     instance: Schema.String.pipe(T.HttpPath("instance")),
     body: Schema.optional(DetachLunRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{instance}:detachLun", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+instance}:detachLun", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DetachLunProjectsLocationsInstancesRequest>;
 
@@ -2262,7 +2262,7 @@ export const GetProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesRequest>;
 
@@ -2293,7 +2293,7 @@ export const LoadAuthInfoProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}:loadAuthInfo" }),
+    T.Http({ method: "GET", path: "v2/{+name}:loadAuthInfo" }),
     svc,
   ) as unknown as Schema.Schema<LoadAuthInfoProjectsLocationsInstancesRequest>;
 
@@ -2328,7 +2328,7 @@ export const StartProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StartInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsLocationsInstancesRequest>;
 
@@ -2362,7 +2362,7 @@ export const ResizeProjectsLocationsVolumesRequest =
     volume: Schema.String.pipe(T.HttpPath("volume")),
     body: Schema.optional(ResizeVolumeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{volume}:resize", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+volume}:resize", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResizeProjectsLocationsVolumesRequest>;
 
@@ -2402,7 +2402,7 @@ export const ListProjectsLocationsVolumesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/volumes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/volumes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVolumesRequest>;
 
@@ -2440,7 +2440,7 @@ export const EvictProjectsLocationsVolumesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EvictVolumeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:evict", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:evict", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EvictProjectsLocationsVolumesRequest>;
 
@@ -2477,7 +2477,7 @@ export const PatchProjectsLocationsVolumesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Volume).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsVolumesRequest>;
 
@@ -2511,7 +2511,7 @@ export const RenameProjectsLocationsVolumesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RenameVolumeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:rename", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:rename", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RenameProjectsLocationsVolumesRequest>;
 
@@ -2542,7 +2542,7 @@ export const GetProjectsLocationsVolumesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVolumesRequest>;
 
@@ -2579,7 +2579,7 @@ export const ListProjectsLocationsVolumesSnapshotsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/snapshots" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/snapshots" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVolumesSnapshotsRequest>;
 
@@ -2615,7 +2615,7 @@ export const GetProjectsLocationsVolumesSnapshotsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVolumesSnapshotsRequest>;
 
@@ -2649,7 +2649,7 @@ export const CreateProjectsLocationsVolumesSnapshotsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(VolumeSnapshot).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/snapshots", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/snapshots", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsVolumesSnapshotsRequest>;
 
@@ -2680,7 +2680,7 @@ export const DeleteProjectsLocationsVolumesSnapshotsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsVolumesSnapshotsRequest>;
 
@@ -2716,7 +2716,7 @@ export const RestoreVolumeSnapshotProjectsLocationsVolumesSnapshotsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{volumeSnapshot}:restoreVolumeSnapshot",
+      path: "v2/{+volumeSnapshot}:restoreVolumeSnapshot",
       hasBody: true,
     }),
     svc,
@@ -2757,7 +2757,7 @@ export const ListProjectsLocationsVolumesLunsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/luns" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/luns" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVolumesLunsRequest>;
 
@@ -2795,7 +2795,7 @@ export const EvictProjectsLocationsVolumesLunsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EvictLunRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:evict", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:evict", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EvictProjectsLocationsVolumesLunsRequest>;
 
@@ -2826,7 +2826,7 @@ export const GetProjectsLocationsVolumesLunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVolumesLunsRequest>;
 
@@ -2863,7 +2863,7 @@ export const ListProjectsLocationsSshKeysRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/sshKeys" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/sshKeys" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSshKeysRequest>;
 
@@ -2904,7 +2904,7 @@ export const CreateProjectsLocationsSshKeysRequest =
     sshKeyId: Schema.optional(Schema.String).pipe(T.HttpQuery("sshKeyId")),
     body: Schema.optional(SSHKey).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/sshKeys", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/sshKeys", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSshKeysRequest>;
 
@@ -2935,7 +2935,7 @@ export const DeleteProjectsLocationsSshKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSshKeysRequest>;
 
@@ -2975,7 +2975,7 @@ export const ListProjectsLocationsNfsSharesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/nfsShares" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/nfsShares" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNfsSharesRequest>;
 
@@ -3016,7 +3016,7 @@ export const PatchProjectsLocationsNfsSharesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(NfsShare).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsNfsSharesRequest>;
 
@@ -3047,7 +3047,7 @@ export const DeleteProjectsLocationsNfsSharesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNfsSharesRequest>;
 
@@ -3081,7 +3081,7 @@ export const CreateProjectsLocationsNfsSharesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(NfsShare).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/nfsShares", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/nfsShares", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsNfsSharesRequest>;
 
@@ -3115,7 +3115,7 @@ export const RenameProjectsLocationsNfsSharesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RenameNfsShareRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:rename", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:rename", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RenameProjectsLocationsNfsSharesRequest>;
 
@@ -3146,7 +3146,7 @@ export const GetProjectsLocationsNfsSharesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNfsSharesRequest>;
 
@@ -3177,7 +3177,7 @@ export const GetProjectsLocationsProvisioningConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProvisioningConfigsRequest>;
 
@@ -3214,7 +3214,7 @@ export const SubmitProjectsLocationsProvisioningConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/provisioningConfigs:submit",
+      path: "v2/{+parent}/provisioningConfigs:submit",
       hasBody: true,
     }),
     svc,
@@ -3256,7 +3256,7 @@ export const CreateProjectsLocationsProvisioningConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/provisioningConfigs",
+      path: "v2/{+parent}/provisioningConfigs",
       hasBody: true,
     }),
     svc,
@@ -3299,7 +3299,7 @@ export const PatchProjectsLocationsProvisioningConfigsRequest =
     email: Schema.optional(Schema.String).pipe(T.HttpQuery("email")),
     body: Schema.optional(ProvisioningConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsProvisioningConfigsRequest>;
 

--- a/packages/gcp/src/services/batch-v1.ts
+++ b/packages/gcp/src/services/batch-v1.ts
@@ -1218,7 +1218,7 @@ export const ListProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1253,7 +1253,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1287,7 +1287,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1332,7 +1332,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1367,7 +1367,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1398,7 +1398,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1432,7 +1432,11 @@ export const ReportProjectsLocationsStateRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(ReportAgentStateRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/state:report", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/state:report",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<ReportProjectsLocationsStateRequest>;
 
@@ -1469,7 +1473,7 @@ export const DeleteProjectsLocationsJobsRequest =
     reason: Schema.optional(Schema.String).pipe(T.HttpQuery("reason")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsJobsRequest>;
 
@@ -1503,7 +1507,7 @@ export const CancelProjectsLocationsJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsJobsRequest>;
 
@@ -1543,7 +1547,7 @@ export const CreateProjectsLocationsJobsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Job).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/jobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/jobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsJobsRequest>;
 
@@ -1574,7 +1578,7 @@ export const GetProjectsLocationsJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsJobsRequest>;
 
@@ -1616,7 +1620,7 @@ export const ListProjectsLocationsJobsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/jobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/jobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsJobsRequest>;
 
@@ -1651,7 +1655,7 @@ export const GetProjectsLocationsJobsTaskGroupsTasksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsJobsTaskGroupsTasksRequest>;
 
@@ -1691,7 +1695,7 @@ export const ListProjectsLocationsJobsTaskGroupsTasksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/tasks" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/tasks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsJobsTaskGroupsTasksRequest>;
 

--- a/packages/gcp/src/services/beyondcorp-v1.ts
+++ b/packages/gcp/src/services/beyondcorp-v1.ts
@@ -1739,7 +1739,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1775,7 +1775,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1806,7 +1806,7 @@ export const GetProjectsLocationsAppConnectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppConnectorsRequest>;
 
@@ -1838,7 +1838,7 @@ export const ResolveInstanceConfigProjectsLocationsAppConnectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     appConnector: Schema.String.pipe(T.HttpPath("appConnector")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{appConnector}:resolveInstanceConfig" }),
+    T.Http({ method: "GET", path: "v1/{+appConnector}:resolveInstanceConfig" }),
     svc,
   ) as unknown as Schema.Schema<ResolveInstanceConfigProjectsLocationsAppConnectorsRequest>;
 
@@ -1883,7 +1883,7 @@ export const ListProjectsLocationsAppConnectorsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/appConnectors" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/appConnectors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppConnectorsRequest>;
 
@@ -1926,7 +1926,7 @@ export const ReportStatusProjectsLocationsAppConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{appConnector}:reportStatus",
+      path: "v1/{+appConnector}:reportStatus",
       hasBody: true,
     }),
     svc,
@@ -1976,7 +1976,7 @@ export const PatchProjectsLocationsAppConnectorsRequest =
       GoogleCloudBeyondcorpAppconnectorsV1AppConnector,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppConnectorsRequest>;
 
@@ -2013,7 +2013,7 @@ export const SetIamPolicyProjectsLocationsAppConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2055,7 +2055,7 @@ export const DeleteProjectsLocationsAppConnectorsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppConnectorsRequest>;
 
@@ -2094,7 +2094,7 @@ export const TestIamPermissionsProjectsLocationsAppConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2149,7 +2149,7 @@ export const CreateProjectsLocationsAppConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/appConnectors",
+      path: "v1/{+parent}/appConnectors",
       hasBody: true,
     }),
     svc,
@@ -2188,7 +2188,7 @@ export const GetIamPolicyProjectsLocationsAppConnectorsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsAppConnectorsRequest>;
 
@@ -2232,7 +2232,7 @@ export const ListProjectsLocationsSecurityGatewaysRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/securityGateways" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/securityGateways" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSecurityGatewaysRequest>;
 
@@ -2275,7 +2275,7 @@ export const TestIamPermissionsProjectsLocationsSecurityGatewaysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2318,7 +2318,7 @@ export const DeleteProjectsLocationsSecurityGatewaysRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSecurityGatewaysRequest>;
 
@@ -2350,7 +2350,7 @@ export const GetProjectsLocationsSecurityGatewaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSecurityGatewaysRequest>;
 
@@ -2387,7 +2387,7 @@ export const GetIamPolicyProjectsLocationsSecurityGatewaysRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsSecurityGatewaysRequest>;
 
@@ -2434,7 +2434,7 @@ export const CreateProjectsLocationsSecurityGatewaysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/securityGateways",
+      path: "v1/{+parent}/securityGateways",
       hasBody: true,
     }),
     svc,
@@ -2479,7 +2479,7 @@ export const PatchProjectsLocationsSecurityGatewaysRequest =
       GoogleCloudBeyondcorpSecuritygatewaysV1SecurityGateway,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSecurityGatewaysRequest>;
 
@@ -2516,7 +2516,7 @@ export const SetIamPolicyProjectsLocationsSecurityGatewaysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2555,7 +2555,7 @@ export const GetIamPolicyProjectsLocationsSecurityGatewaysApplicationsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsSecurityGatewaysApplicationsRequest>;
 
@@ -2601,7 +2601,11 @@ export const CreateProjectsLocationsSecurityGatewaysApplicationsRequest =
       GoogleCloudBeyondcorpSecuritygatewaysV1Application,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/applications", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/applications",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSecurityGatewaysApplicationsRequest>;
 
@@ -2645,7 +2649,7 @@ export const PatchProjectsLocationsSecurityGatewaysApplicationsRequest =
       GoogleCloudBeyondcorpSecuritygatewaysV1Application,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSecurityGatewaysApplicationsRequest>;
 
@@ -2683,7 +2687,7 @@ export const SetIamPolicyProjectsLocationsSecurityGatewaysApplicationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2730,7 +2734,7 @@ export const ListProjectsLocationsSecurityGatewaysApplicationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/applications" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/applications" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSecurityGatewaysApplicationsRequest>;
 
@@ -2774,7 +2778,7 @@ export const TestIamPermissionsProjectsLocationsSecurityGatewaysApplicationsRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2810,7 +2814,7 @@ export const GetProjectsLocationsSecurityGatewaysApplicationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSecurityGatewaysApplicationsRequest>;
 
@@ -2851,7 +2855,7 @@ export const DeleteProjectsLocationsSecurityGatewaysApplicationsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSecurityGatewaysApplicationsRequest>;
 
@@ -2898,7 +2902,7 @@ export const ListProjectsLocationsOperationsRequest =
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2939,7 +2943,7 @@ export const CancelProjectsLocationsOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2970,7 +2974,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -3001,7 +3005,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -3044,7 +3048,7 @@ export const ListProjectsLocationsAppGatewaysRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/appGateways" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/appGateways" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppGatewaysRequest>;
 
@@ -3086,7 +3090,7 @@ export const TestIamPermissionsProjectsLocationsAppGatewaysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3128,7 +3132,7 @@ export const DeleteProjectsLocationsAppGatewaysRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppGatewaysRequest>;
 
@@ -3160,7 +3164,7 @@ export const GetProjectsLocationsAppGatewaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppGatewaysRequest>;
 
@@ -3196,7 +3200,7 @@ export const GetIamPolicyProjectsLocationsAppGatewaysRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsAppGatewaysRequest>;
 
@@ -3244,7 +3248,7 @@ export const CreateProjectsLocationsAppGatewaysRequest =
     ),
     body: Schema.optional(AppGateway).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/appGateways", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/appGateways", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAppGatewaysRequest>;
 
@@ -3281,7 +3285,7 @@ export const SetIamPolicyProjectsLocationsAppGatewaysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3336,7 +3340,7 @@ export const PatchProjectsLocationsAppConnectionsRequest =
       GoogleCloudBeyondcorpAppconnectionsV1AppConnection,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppConnectionsRequest>;
 
@@ -3373,7 +3377,7 @@ export const SetIamPolicyProjectsLocationsAppConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3407,7 +3411,7 @@ export const GetProjectsLocationsAppConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppConnectionsRequest>;
 
@@ -3451,7 +3455,7 @@ export const ListProjectsLocationsAppConnectionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/appConnections" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/appConnections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppConnectionsRequest>;
 
@@ -3498,7 +3502,7 @@ export const ResolveProjectsLocationsAppConnectionsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/appConnections:resolve" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/appConnections:resolve" }),
     svc,
   ) as unknown as Schema.Schema<ResolveProjectsLocationsAppConnectionsRequest>;
 
@@ -3554,7 +3558,7 @@ export const CreateProjectsLocationsAppConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/appConnections",
+      path: "v1/{+parent}/appConnections",
       hasBody: true,
     }),
     svc,
@@ -3593,7 +3597,7 @@ export const GetIamPolicyProjectsLocationsAppConnectionsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsAppConnectionsRequest>;
 
@@ -3633,7 +3637,7 @@ export const DeleteProjectsLocationsAppConnectionsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppConnectionsRequest>;
 
@@ -3672,7 +3676,7 @@ export const TestIamPermissionsProjectsLocationsAppConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3707,7 +3711,7 @@ export const GetOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsOperationsRequest>;
 
@@ -3739,7 +3743,7 @@ export const DeleteOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsOperationsRequest>;
 
@@ -3784,7 +3788,7 @@ export const ListOrganizationsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsOperationsRequest>;
 
@@ -3825,7 +3829,7 @@ export const CancelOrganizationsLocationsOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOrganizationsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/beyondcorp-v1alpha.ts
+++ b/packages/gcp/src/services/beyondcorp-v1alpha.ts
@@ -2366,7 +2366,7 @@ export const ListProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2402,7 +2402,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2438,7 +2438,7 @@ export const GetIamPolicyProjectsLocationsApplicationsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsApplicationsRequest>;
 
@@ -2475,7 +2475,7 @@ export const SetIamPolicyProjectsLocationsApplicationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2516,7 +2516,7 @@ export const TestIamPermissionsProjectsLocationsApplicationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:testIamPermissions",
+      path: "v1alpha/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2569,7 +2569,7 @@ export const CreateProjectsLocationsConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/connectors",
+      path: "v1alpha/{+parent}/connectors",
       hasBody: true,
     }),
     svc,
@@ -2617,7 +2617,7 @@ export const PatchProjectsLocationsConnectorsRequest =
     ),
     body: Schema.optional(Connector).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectorsRequest>;
 
@@ -2657,7 +2657,7 @@ export const DeleteProjectsLocationsConnectorsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectorsRequest>;
 
@@ -2694,7 +2694,7 @@ export const ReportStatusProjectsLocationsConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{connector}:reportStatus",
+      path: "v1alpha/{+connector}:reportStatus",
       hasBody: true,
     }),
     svc,
@@ -2728,7 +2728,7 @@ export const GetProjectsLocationsConnectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectorsRequest>;
 
@@ -2761,7 +2761,7 @@ export const ResolveInstanceConfigProjectsLocationsConnectorsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{connector}:resolveInstanceConfig",
+      path: "v1alpha/{+connector}:resolveInstanceConfig",
     }),
     svc,
   ) as unknown as Schema.Schema<ResolveInstanceConfigProjectsLocationsConnectorsRequest>;
@@ -2800,7 +2800,7 @@ export const SetIamPolicyProjectsLocationsConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2845,7 +2845,7 @@ export const ListProjectsLocationsConnectorsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/connectors" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/connectors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectorsRequest>;
 
@@ -2885,7 +2885,7 @@ export const GetIamPolicyProjectsLocationsConnectorsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsConnectorsRequest>;
 
@@ -2916,7 +2916,7 @@ export const GetProjectsLocationsSecurityGatewaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSecurityGatewaysRequest>;
 
@@ -2953,7 +2953,7 @@ export const SetIamPolicyProjectsLocationsSecurityGatewaysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2994,7 +2994,7 @@ export const TestIamPermissionsProjectsLocationsSecurityGatewaysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:testIamPermissions",
+      path: "v1alpha/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3041,7 +3041,7 @@ export const ListProjectsLocationsSecurityGatewaysRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/securityGateways" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/securityGateways" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSecurityGatewaysRequest>;
 
@@ -3082,7 +3082,7 @@ export const GetIamPolicyProjectsLocationsSecurityGatewaysRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsSecurityGatewaysRequest>;
 
@@ -3129,7 +3129,7 @@ export const CreateProjectsLocationsSecurityGatewaysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/securityGateways",
+      path: "v1alpha/{+parent}/securityGateways",
       hasBody: true,
     }),
     svc,
@@ -3174,7 +3174,7 @@ export const PatchProjectsLocationsSecurityGatewaysRequest =
       GoogleCloudBeyondcorpSecuritygatewaysV1alphaSecurityGateway,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSecurityGatewaysRequest>;
 
@@ -3214,7 +3214,7 @@ export const DeleteProjectsLocationsSecurityGatewaysRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSecurityGatewaysRequest>;
 
@@ -3254,7 +3254,7 @@ export const DeleteProjectsLocationsSecurityGatewaysApplicationsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSecurityGatewaysApplicationsRequest>;
 
@@ -3302,7 +3302,7 @@ export const CreateProjectsLocationsSecurityGatewaysApplicationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/applications",
+      path: "v1alpha/{+parent}/applications",
       hasBody: true,
     }),
     svc,
@@ -3348,7 +3348,7 @@ export const PatchProjectsLocationsSecurityGatewaysApplicationsRequest =
       GoogleCloudBeyondcorpSecuritygatewaysV1alphaApplication,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSecurityGatewaysApplicationsRequest>;
 
@@ -3386,7 +3386,7 @@ export const GetIamPolicyProjectsLocationsSecurityGatewaysApplicationsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsSecurityGatewaysApplicationsRequest>;
 
@@ -3431,7 +3431,7 @@ export const ListProjectsLocationsSecurityGatewaysApplicationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/applications" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/applications" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSecurityGatewaysApplicationsRequest>;
 
@@ -3473,7 +3473,7 @@ export const SetIamPolicyProjectsLocationsSecurityGatewaysApplicationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3515,7 +3515,7 @@ export const TestIamPermissionsProjectsLocationsSecurityGatewaysApplicationsRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:testIamPermissions",
+      path: "v1alpha/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3551,7 +3551,7 @@ export const GetProjectsLocationsSecurityGatewaysApplicationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSecurityGatewaysApplicationsRequest>;
 
@@ -3617,7 +3617,7 @@ export const ListProjectsLocationsInsightsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/insights" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/insights" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInsightsRequest>;
 
@@ -3656,7 +3656,7 @@ export const GetProjectsLocationsInsightsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInsightsRequest>;
 
@@ -3730,7 +3730,7 @@ export const ConfiguredInsightProjectsLocationsInsightsRequest =
       T.HttpQuery("customGrouping.fieldFilter"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{insight}:configuredInsight" }),
+    T.Http({ method: "GET", path: "v1alpha/{+insight}:configuredInsight" }),
     svc,
   ) as unknown as Schema.Schema<ConfiguredInsightProjectsLocationsInsightsRequest>;
 
@@ -3771,7 +3771,7 @@ export const GetIamPolicyProjectsLocationsConnectionsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsConnectionsRequest>;
 
@@ -3815,7 +3815,7 @@ export const ListProjectsLocationsConnectionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/connections" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/connections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsRequest>;
 
@@ -3855,7 +3855,7 @@ export const SetIamPolicyProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3889,7 +3889,7 @@ export const GetProjectsLocationsConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionsRequest>;
 
@@ -3928,7 +3928,7 @@ export const DeleteProjectsLocationsConnectionsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectionsRequest>;
 
@@ -3978,7 +3978,7 @@ export const CreateProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/connections",
+      path: "v1alpha/{+parent}/connections",
       hasBody: true,
     }),
     svc,
@@ -4031,7 +4031,7 @@ export const PatchProjectsLocationsConnectionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Connection).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectionsRequest>;
 
@@ -4074,7 +4074,7 @@ export const ResolveProjectsLocationsConnectionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/connections:resolve" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/connections:resolve" }),
     svc,
   ) as unknown as Schema.Schema<ResolveProjectsLocationsConnectionsRequest>;
 
@@ -4115,7 +4115,7 @@ export const GetIamPolicyProjectsLocationsApplicationDomainsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsApplicationDomainsRequest>;
 
@@ -4153,7 +4153,7 @@ export const SetIamPolicyProjectsLocationsApplicationDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4195,7 +4195,7 @@ export const TestIamPermissionsProjectsLocationsApplicationDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:testIamPermissions",
+      path: "v1alpha/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4248,7 +4248,7 @@ export const CreateProjectsLocationsAppGatewaysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/appGateways",
+      path: "v1alpha/{+parent}/appGateways",
       hasBody: true,
     }),
     svc,
@@ -4290,7 +4290,7 @@ export const DeleteProjectsLocationsAppGatewaysRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppGatewaysRequest>;
 
@@ -4322,7 +4322,7 @@ export const GetProjectsLocationsAppGatewaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppGatewaysRequest>;
 
@@ -4358,7 +4358,7 @@ export const SetIamPolicyProjectsLocationsAppGatewaysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4399,7 +4399,7 @@ export const TestIamPermissionsProjectsLocationsAppGatewaysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:testIamPermissions",
+      path: "v1alpha/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4445,7 +4445,7 @@ export const ListProjectsLocationsAppGatewaysRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/appGateways" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/appGateways" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppGatewaysRequest>;
 
@@ -4485,7 +4485,7 @@ export const GetIamPolicyProjectsLocationsAppGatewaysRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsAppGatewaysRequest>;
 
@@ -4531,7 +4531,7 @@ export const ListProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -4572,7 +4572,7 @@ export const CancelProjectsLocationsOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -4603,7 +4603,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -4634,7 +4634,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -4670,7 +4670,7 @@ export const GetIamPolicyProjectsLocationsAppConnectorsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsAppConnectorsRequest>;
 
@@ -4714,7 +4714,7 @@ export const ListProjectsLocationsAppConnectorsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/appConnectors" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/appConnectors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppConnectorsRequest>;
 
@@ -4752,7 +4752,7 @@ export const ResolveInstanceConfigProjectsLocationsAppConnectorsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{appConnector}:resolveInstanceConfig",
+      path: "v1alpha/{+appConnector}:resolveInstanceConfig",
     }),
     svc,
   ) as unknown as Schema.Schema<ResolveInstanceConfigProjectsLocationsAppConnectorsRequest>;
@@ -4791,7 +4791,7 @@ export const SetIamPolicyProjectsLocationsAppConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4825,7 +4825,7 @@ export const GetProjectsLocationsAppConnectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppConnectorsRequest>;
 
@@ -4865,7 +4865,7 @@ export const DeleteProjectsLocationsAppConnectorsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppConnectorsRequest>;
 
@@ -4904,7 +4904,7 @@ export const ReportStatusProjectsLocationsAppConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{appConnector}:reportStatus",
+      path: "v1alpha/{+appConnector}:reportStatus",
       hasBody: true,
     }),
     svc,
@@ -4958,7 +4958,7 @@ export const CreateProjectsLocationsAppConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/appConnectors",
+      path: "v1alpha/{+parent}/appConnectors",
       hasBody: true,
     }),
     svc,
@@ -5008,7 +5008,7 @@ export const PatchProjectsLocationsAppConnectorsRequest =
       GoogleCloudBeyondcorpAppconnectorsV1alphaAppConnector,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppConnectorsRequest>;
 
@@ -5047,7 +5047,7 @@ export const TestIamPermissionsProjectsLocationsAppConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:testIamPermissions",
+      path: "v1alpha/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5082,7 +5082,7 @@ export const GetProjectsLocationsAppConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppConnectionsRequest>;
 
@@ -5119,7 +5119,7 @@ export const SetIamPolicyProjectsLocationsAppConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5165,7 +5165,7 @@ export const ListProjectsLocationsAppConnectionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/appConnections" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/appConnections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppConnectionsRequest>;
 
@@ -5206,7 +5206,7 @@ export const GetIamPolicyProjectsLocationsAppConnectionsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsAppConnectionsRequest>;
 
@@ -5245,7 +5245,7 @@ export const TestIamPermissionsProjectsLocationsAppConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:testIamPermissions",
+      path: "v1alpha/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5300,7 +5300,7 @@ export const CreateProjectsLocationsAppConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/appConnections",
+      path: "v1alpha/{+parent}/appConnections",
       hasBody: true,
     }),
     svc,
@@ -5355,7 +5355,7 @@ export const PatchProjectsLocationsAppConnectionsRequest =
       GoogleCloudBeyondcorpAppconnectionsV1alphaAppConnection,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppConnectionsRequest>;
 
@@ -5398,7 +5398,7 @@ export const ResolveProjectsLocationsAppConnectionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/appConnections:resolve" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/appConnections:resolve" }),
     svc,
   ) as unknown as Schema.Schema<ResolveProjectsLocationsAppConnectionsRequest>;
 
@@ -5442,7 +5442,7 @@ export const DeleteProjectsLocationsAppConnectionsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppConnectionsRequest>;
 
@@ -5481,7 +5481,7 @@ export const CreateOrganizationsLocationsSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/subscriptions",
+      path: "v1alpha/{+parent}/subscriptions",
       hasBody: true,
     }),
     svc,
@@ -5526,7 +5526,7 @@ export const PatchOrganizationsLocationsSubscriptionsRequest =
       GoogleCloudBeyondcorpSaasplatformSubscriptionsV1alphaSubscription,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsSubscriptionsRequest>;
 
@@ -5561,7 +5561,7 @@ export const RestartOrganizationsLocationsSubscriptionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}:restart" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}:restart" }),
     svc,
   ) as unknown as Schema.Schema<RestartOrganizationsLocationsSubscriptionsRequest>;
 
@@ -5596,7 +5596,7 @@ export const CancelOrganizationsLocationsSubscriptionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}:cancel" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}:cancel" }),
     svc,
   ) as unknown as Schema.Schema<CancelOrganizationsLocationsSubscriptionsRequest>;
 
@@ -5634,7 +5634,7 @@ export const ListOrganizationsLocationsSubscriptionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/subscriptions" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/subscriptions" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsSubscriptionsRequest>;
 
@@ -5670,7 +5670,7 @@ export const GetOrganizationsLocationsSubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsSubscriptionsRequest>;
 
@@ -5716,7 +5716,7 @@ export const ListOrganizationsLocationsOperationsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsOperationsRequest>;
 
@@ -5757,7 +5757,7 @@ export const CancelOrganizationsLocationsOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOrganizationsLocationsOperationsRequest>;
 
@@ -5788,7 +5788,7 @@ export const DeleteOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsOperationsRequest>;
 
@@ -5819,7 +5819,7 @@ export const GetOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsOperationsRequest>;
 
@@ -5884,7 +5884,7 @@ export const ListOrganizationsLocationsInsightsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/insights" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/insights" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsInsightsRequest>;
 
@@ -5923,7 +5923,7 @@ export const GetOrganizationsLocationsInsightsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsInsightsRequest>;
 
@@ -5997,7 +5997,7 @@ export const ConfiguredInsightOrganizationsLocationsInsightsRequest =
     startTime: Schema.optional(Schema.String).pipe(T.HttpQuery("startTime")),
     insight: Schema.String.pipe(T.HttpPath("insight")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{insight}:configuredInsight" }),
+    T.Http({ method: "GET", path: "v1alpha/{+insight}:configuredInsight" }),
     svc,
   ) as unknown as Schema.Schema<ConfiguredInsightOrganizationsLocationsInsightsRequest>;
 

--- a/packages/gcp/src/services/biglake-v1.ts
+++ b/packages/gcp/src/services/biglake-v1.ts
@@ -329,7 +329,7 @@ export const GetIamPolicyProjectsCatalogsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsCatalogsRequest>;
 
@@ -365,7 +365,7 @@ export const SetIamPolicyProjectsCatalogsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -403,7 +403,7 @@ export const TestIamPermissionsProjectsCatalogsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -442,7 +442,7 @@ export const GetIamPolicyProjectsCatalogsNamespacesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsCatalogsNamespacesRequest>;
 
@@ -478,7 +478,7 @@ export const SetIamPolicyProjectsCatalogsNamespacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -516,7 +516,7 @@ export const TestIamPermissionsProjectsCatalogsNamespacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -555,7 +555,7 @@ export const GetIamPolicyProjectsCatalogsNamespacesTablesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsCatalogsNamespacesTablesRequest>;
 
@@ -591,7 +591,7 @@ export const SetIamPolicyProjectsCatalogsNamespacesTablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -629,7 +629,7 @@ export const TestIamPermissionsProjectsCatalogsNamespacesTablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -670,7 +670,7 @@ export const CreateProjectsLocationsCatalogsRequest =
     catalogId: Schema.optional(Schema.String).pipe(T.HttpQuery("catalogId")),
     body: Schema.optional(Catalog).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/catalogs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/catalogs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCatalogsRequest>;
 
@@ -701,7 +701,7 @@ export const DeleteProjectsLocationsCatalogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCatalogsRequest>;
 
@@ -732,7 +732,7 @@ export const GetProjectsLocationsCatalogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsRequest>;
 
@@ -769,7 +769,7 @@ export const ListProjectsLocationsCatalogsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/catalogs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/catalogs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsRequest>;
 
@@ -810,7 +810,7 @@ export const CreateProjectsLocationsCatalogsDatabasesRequest =
     databaseId: Schema.optional(Schema.String).pipe(T.HttpQuery("databaseId")),
     body: Schema.optional(Database).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/databases", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/databases", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCatalogsDatabasesRequest>;
 
@@ -841,7 +841,7 @@ export const DeleteProjectsLocationsCatalogsDatabasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCatalogsDatabasesRequest>;
 
@@ -878,7 +878,7 @@ export const PatchProjectsLocationsCatalogsDatabasesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Database).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsDatabasesRequest>;
 
@@ -909,7 +909,7 @@ export const GetProjectsLocationsCatalogsDatabasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsDatabasesRequest>;
 
@@ -946,7 +946,7 @@ export const ListProjectsLocationsCatalogsDatabasesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/databases" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/databases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsDatabasesRequest>;
 
@@ -988,7 +988,7 @@ export const CreateProjectsLocationsCatalogsDatabasesTablesRequest =
     tableId: Schema.optional(Schema.String).pipe(T.HttpQuery("tableId")),
     body: Schema.optional(Table).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/tables", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/tables", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCatalogsDatabasesTablesRequest>;
 
@@ -1019,7 +1019,7 @@ export const DeleteProjectsLocationsCatalogsDatabasesTablesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCatalogsDatabasesTablesRequest>;
 
@@ -1056,7 +1056,7 @@ export const PatchProjectsLocationsCatalogsDatabasesTablesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Table).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsDatabasesTablesRequest>;
 
@@ -1090,7 +1090,7 @@ export const RenameProjectsLocationsCatalogsDatabasesTablesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RenameTableRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:rename", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:rename", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RenameProjectsLocationsCatalogsDatabasesTablesRequest>;
 
@@ -1121,7 +1121,7 @@ export const GetProjectsLocationsCatalogsDatabasesTablesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsDatabasesTablesRequest>;
 
@@ -1161,7 +1161,7 @@ export const ListProjectsLocationsCatalogsDatabasesTablesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/tables" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/tables" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsDatabasesTablesRequest>;
 

--- a/packages/gcp/src/services/bigquery-v2.ts
+++ b/packages/gcp/src/services/bigquery-v2.ts
@@ -5874,7 +5874,7 @@ export const DeleteDatasetsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "DELETE",
-    path: "projects/{projectId}/datasets/{datasetId}",
+    path: "projects/{+projectId}/datasets/{+datasetId}",
   }),
   svc,
 ) as unknown as Schema.Schema<DeleteDatasetsRequest>;
@@ -5923,7 +5923,10 @@ export const GetDatasetsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   datasetView: Schema.optional(Schema.String).pipe(T.HttpQuery("datasetView")),
   projectId: Schema.String.pipe(T.HttpPath("projectId")),
 }).pipe(
-  T.Http({ method: "GET", path: "projects/{projectId}/datasets/{datasetId}" }),
+  T.Http({
+    method: "GET",
+    path: "projects/{+projectId}/datasets/{+datasetId}",
+  }),
   svc,
 ) as unknown as Schema.Schema<GetDatasetsRequest>;
 
@@ -5962,7 +5965,7 @@ export const InsertDatasetsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "projects/{projectId}/datasets",
+    path: "projects/{+projectId}/datasets",
     hasBody: true,
   }),
   svc,
@@ -6005,7 +6008,7 @@ export const ListDatasetsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   projectId: Schema.String.pipe(T.HttpPath("projectId")),
 }).pipe(
-  T.Http({ method: "GET", path: "projects/{projectId}/datasets" }),
+  T.Http({ method: "GET", path: "projects/{+projectId}/datasets" }),
   svc,
 ) as unknown as Schema.Schema<ListDatasetsRequest>;
 
@@ -6059,7 +6062,7 @@ export const PatchDatasetsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "projects/{projectId}/datasets/{datasetId}",
+    path: "projects/{+projectId}/datasets/{+datasetId}",
     hasBody: true,
   }),
   svc,
@@ -6099,7 +6102,7 @@ export const UndeleteDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{projectId}/datasets/{datasetId}:undelete",
+      path: "projects/{+projectId}/datasets/{+datasetId}:undelete",
       hasBody: true,
     }),
     svc,
@@ -6151,7 +6154,7 @@ export const UpdateDatasetsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PUT",
-    path: "projects/{projectId}/datasets/{datasetId}",
+    path: "projects/{+projectId}/datasets/{+datasetId}",
     hasBody: true,
   }),
   svc,
@@ -6190,7 +6193,7 @@ export const CancelJobsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "projects/{projectId}/jobs/{jobId}/cancel",
+    path: "projects/{+projectId}/jobs/{+jobId}/cancel",
     hasBody: true,
   }),
   svc,
@@ -6229,7 +6232,7 @@ export const DeleteJobsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "DELETE",
-    path: "projects/{projectId}/jobs/{jobId}/delete",
+    path: "projects/{+projectId}/jobs/{+jobId}/delete",
   }),
   svc,
 ) as unknown as Schema.Schema<DeleteJobsRequest>;
@@ -6268,7 +6271,7 @@ export const GetJobsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   location: Schema.optional(Schema.String).pipe(T.HttpQuery("location")),
   projectId: Schema.String.pipe(T.HttpPath("projectId")),
 }).pipe(
-  T.Http({ method: "GET", path: "projects/{projectId}/jobs/{jobId}" }),
+  T.Http({ method: "GET", path: "projects/{+projectId}/jobs/{+jobId}" }),
   svc,
 ) as unknown as Schema.Schema<GetJobsRequest>;
 
@@ -6331,7 +6334,7 @@ export const GetQueryResultsJobsRequest =
     startIndex: Schema.optional(Schema.String).pipe(T.HttpQuery("startIndex")),
     timeoutMs: Schema.optional(Schema.Number).pipe(T.HttpQuery("timeoutMs")),
   }).pipe(
-    T.Http({ method: "GET", path: "projects/{projectId}/queries/{jobId}" }),
+    T.Http({ method: "GET", path: "projects/{+projectId}/queries/{+jobId}" }),
     svc,
   ) as unknown as Schema.Schema<GetQueryResultsJobsRequest>;
 
@@ -6364,7 +6367,7 @@ export const InsertJobsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   projectId: Schema.String.pipe(T.HttpPath("projectId")),
   body: Schema.optional(Job).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "projects/{projectId}/jobs", hasBody: true }),
+  T.Http({ method: "POST", path: "projects/{+projectId}/jobs", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<InsertJobsRequest>;
 
@@ -6423,7 +6426,7 @@ export const ListJobsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("stateFilter"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "projects/{projectId}/jobs" }),
+  T.Http({ method: "GET", path: "projects/{+projectId}/jobs" }),
   svc,
 ) as unknown as Schema.Schema<ListJobsRequest>;
 
@@ -6461,7 +6464,7 @@ export const QueryJobsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "projects/{projectId}/queries",
+    path: "projects/{+projectId}/queries",
     hasBody: true,
   }),
   svc,
@@ -6500,7 +6503,7 @@ export const DeleteModelsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "DELETE",
-    path: "projects/{projectId}/datasets/{datasetId}/models/{modelId}",
+    path: "projects/{+projectId}/datasets/{+datasetId}/models/{+modelId}",
   }),
   svc,
 ) as unknown as Schema.Schema<DeleteModelsRequest>;
@@ -6541,7 +6544,7 @@ export const GetModelsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "GET",
-    path: "projects/{projectId}/datasets/{datasetId}/models/{modelId}",
+    path: "projects/{+projectId}/datasets/{+datasetId}/models/{+modelId}",
   }),
   svc,
 ) as unknown as Schema.Schema<GetModelsRequest>;
@@ -6582,7 +6585,7 @@ export const ListModelsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "GET",
-    path: "projects/{projectId}/datasets/{datasetId}/models",
+    path: "projects/{+projectId}/datasets/{+datasetId}/models",
   }),
   svc,
 ) as unknown as Schema.Schema<ListModelsRequest>;
@@ -6628,7 +6631,7 @@ export const PatchModelsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "projects/{projectId}/datasets/{datasetId}/models/{modelId}",
+    path: "projects/{+projectId}/datasets/{+datasetId}/models/{+modelId}",
     hasBody: true,
   }),
   svc,
@@ -6660,7 +6663,7 @@ export const GetServiceAccountProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     projectId: Schema.String.pipe(T.HttpPath("projectId")),
   }).pipe(
-    T.Http({ method: "GET", path: "projects/{projectId}/serviceAccount" }),
+    T.Http({ method: "GET", path: "projects/{+projectId}/serviceAccount" }),
     svc,
   ) as unknown as Schema.Schema<GetServiceAccountProjectsRequest>;
 
@@ -6734,7 +6737,7 @@ export const DeleteRoutinesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "DELETE",
-    path: "projects/{projectId}/datasets/{datasetId}/routines/{routineId}",
+    path: "projects/{+projectId}/datasets/{+datasetId}/routines/{+routineId}",
   }),
   svc,
 ) as unknown as Schema.Schema<DeleteRoutinesRequest>;
@@ -6778,7 +6781,7 @@ export const GetRoutinesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "GET",
-    path: "projects/{projectId}/datasets/{datasetId}/routines/{routineId}",
+    path: "projects/{+projectId}/datasets/{+datasetId}/routines/{+routineId}",
   }),
   svc,
 ) as unknown as Schema.Schema<GetRoutinesRequest>;
@@ -6812,7 +6815,7 @@ export const GetIamPolicyRoutinesRequest =
     resource: Schema.String.pipe(T.HttpPath("resource")),
     body: Schema.optional(GetIamPolicyRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "{resource}:getIamPolicy", hasBody: true }),
+    T.Http({ method: "POST", path: "{+resource}:getIamPolicy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyRoutinesRequest>;
 
@@ -6849,7 +6852,7 @@ export const InsertRoutinesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "projects/{projectId}/datasets/{datasetId}/routines",
+    path: "projects/{+projectId}/datasets/{+datasetId}/routines",
     hasBody: true,
   }),
   svc,
@@ -6897,7 +6900,7 @@ export const ListRoutinesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "GET",
-    path: "projects/{projectId}/datasets/{datasetId}/routines",
+    path: "projects/{+projectId}/datasets/{+datasetId}/routines",
   }),
   svc,
 ) as unknown as Schema.Schema<ListRoutinesRequest>;
@@ -6936,7 +6939,7 @@ export const SetIamPolicyRoutinesRequest =
     resource: Schema.String.pipe(T.HttpPath("resource")),
     body: Schema.optional(SetIamPolicyRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "{resource}:setIamPolicy", hasBody: true }),
+    T.Http({ method: "POST", path: "{+resource}:setIamPolicy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetIamPolicyRoutinesRequest>;
 
@@ -6971,7 +6974,7 @@ export const TestIamPermissionsRoutinesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "{resource}:testIamPermissions",
+      path: "{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -7014,7 +7017,7 @@ export const UpdateRoutinesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PUT",
-    path: "projects/{projectId}/datasets/{datasetId}/routines/{routineId}",
+    path: "projects/{+projectId}/datasets/{+datasetId}/routines/{+routineId}",
     hasBody: true,
   }),
   svc,
@@ -7059,7 +7062,7 @@ export const BatchDeleteRowAccessPoliciesRequest_Op =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{projectId}/datasets/{datasetId}/tables/{tableId}/rowAccessPolicies:batchDelete",
+      path: "projects/{+projectId}/datasets/{+datasetId}/tables/{+tableId}/rowAccessPolicies:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -7108,7 +7111,7 @@ export const DeleteRowAccessPoliciesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "projects/{projectId}/datasets/{datasetId}/tables/{tableId}/rowAccessPolicies/{policyId}",
+      path: "projects/{+projectId}/datasets/{+datasetId}/tables/{+tableId}/rowAccessPolicies/{+policyId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteRowAccessPoliciesRequest>;
@@ -7153,7 +7156,7 @@ export const GetRowAccessPoliciesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "projects/{projectId}/datasets/{datasetId}/tables/{tableId}/rowAccessPolicies/{policyId}",
+      path: "projects/{+projectId}/datasets/{+datasetId}/tables/{+tableId}/rowAccessPolicies/{+policyId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetRowAccessPoliciesRequest>;
@@ -7188,7 +7191,7 @@ export const GetIamPolicyRowAccessPoliciesRequest =
     resource: Schema.String.pipe(T.HttpPath("resource")),
     body: Schema.optional(GetIamPolicyRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "{resource}:getIamPolicy", hasBody: true }),
+    T.Http({ method: "POST", path: "{+resource}:getIamPolicy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyRowAccessPoliciesRequest>;
 
@@ -7230,7 +7233,7 @@ export const InsertRowAccessPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{projectId}/datasets/{datasetId}/tables/{tableId}/rowAccessPolicies",
+      path: "projects/{+projectId}/datasets/{+datasetId}/tables/{+tableId}/rowAccessPolicies",
       hasBody: true,
     }),
     svc,
@@ -7277,7 +7280,7 @@ export const ListRowAccessPoliciesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "projects/{projectId}/datasets/{datasetId}/tables/{tableId}/rowAccessPolicies",
+      path: "projects/{+projectId}/datasets/{+datasetId}/tables/{+tableId}/rowAccessPolicies",
     }),
     svc,
   ) as unknown as Schema.Schema<ListRowAccessPoliciesRequest>;
@@ -7318,7 +7321,7 @@ export const TestIamPermissionsRowAccessPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "{resource}:testIamPermissions",
+      path: "{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -7366,7 +7369,7 @@ export const UpdateRowAccessPoliciesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "projects/{projectId}/datasets/{datasetId}/tables/{tableId}/rowAccessPolicies/{policyId}",
+      path: "projects/{+projectId}/datasets/{+datasetId}/tables/{+tableId}/rowAccessPolicies/{+policyId}",
       hasBody: true,
     }),
     svc,
@@ -7410,7 +7413,7 @@ export const InsertAllTabledataRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{projectId}/datasets/{datasetId}/tables/{tableId}/insertAll",
+      path: "projects/{+projectId}/datasets/{+datasetId}/tables/{+tableId}/insertAll",
       hasBody: true,
     }),
     svc,
@@ -7479,7 +7482,7 @@ export const ListTabledataRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "GET",
-    path: "projects/{projectId}/datasets/{datasetId}/tables/{tableId}/data",
+    path: "projects/{+projectId}/datasets/{+datasetId}/tables/{+tableId}/data",
   }),
   svc,
 ) as unknown as Schema.Schema<ListTabledataRequest>;
@@ -7517,7 +7520,7 @@ export const DeleteTablesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "DELETE",
-    path: "projects/{projectId}/datasets/{datasetId}/tables/{tableId}",
+    path: "projects/{+projectId}/datasets/{+datasetId}/tables/{+tableId}",
   }),
   svc,
 ) as unknown as Schema.Schema<DeleteTablesRequest>;
@@ -7571,7 +7574,7 @@ export const GetTablesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "GET",
-    path: "projects/{projectId}/datasets/{datasetId}/tables/{tableId}",
+    path: "projects/{+projectId}/datasets/{+datasetId}/tables/{+tableId}",
   }),
   svc,
 ) as unknown as Schema.Schema<GetTablesRequest>;
@@ -7605,7 +7608,7 @@ export const GetIamPolicyTablesRequest =
     resource: Schema.String.pipe(T.HttpPath("resource")),
     body: Schema.optional(GetIamPolicyRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "{resource}:getIamPolicy", hasBody: true }),
+    T.Http({ method: "POST", path: "{+resource}:getIamPolicy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyTablesRequest>;
 
@@ -7642,7 +7645,7 @@ export const InsertTablesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "projects/{projectId}/datasets/{datasetId}/tables",
+    path: "projects/{+projectId}/datasets/{+datasetId}/tables",
     hasBody: true,
   }),
   svc,
@@ -7684,7 +7687,7 @@ export const ListTablesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "GET",
-    path: "projects/{projectId}/datasets/{datasetId}/tables",
+    path: "projects/{+projectId}/datasets/{+datasetId}/tables",
   }),
   svc,
 ) as unknown as Schema.Schema<ListTablesRequest>;
@@ -7734,7 +7737,7 @@ export const PatchTablesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "projects/{projectId}/datasets/{datasetId}/tables/{tableId}",
+    path: "projects/{+projectId}/datasets/{+datasetId}/tables/{+tableId}",
     hasBody: true,
   }),
   svc,
@@ -7769,7 +7772,7 @@ export const SetIamPolicyTablesRequest =
     resource: Schema.String.pipe(T.HttpPath("resource")),
     body: Schema.optional(SetIamPolicyRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "{resource}:setIamPolicy", hasBody: true }),
+    T.Http({ method: "POST", path: "{+resource}:setIamPolicy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetIamPolicyTablesRequest>;
 
@@ -7804,7 +7807,7 @@ export const TestIamPermissionsTablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "{resource}:testIamPermissions",
+      path: "{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -7852,7 +7855,7 @@ export const UpdateTablesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PUT",
-    path: "projects/{projectId}/datasets/{datasetId}/tables/{tableId}",
+    path: "projects/{+projectId}/datasets/{+datasetId}/tables/{+tableId}",
     hasBody: true,
   }),
   svc,

--- a/packages/gcp/src/services/bigqueryconnection-v1.ts
+++ b/packages/gcp/src/services/bigqueryconnection-v1.ts
@@ -519,7 +519,7 @@ export const CreateProjectsLocationsConnectionsRequest =
     ),
     body: Schema.optional(Connection).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/connections", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/connections", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsConnectionsRequest>;
 
@@ -550,7 +550,7 @@ export const GetProjectsLocationsConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionsRequest>;
 
@@ -587,7 +587,7 @@ export const ListProjectsLocationsConnectionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/connections" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/connections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsRequest>;
 
@@ -628,7 +628,7 @@ export const PatchProjectsLocationsConnectionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Connection).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectionsRequest>;
 
@@ -659,7 +659,7 @@ export const DeleteProjectsLocationsConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectionsRequest>;
 
@@ -695,7 +695,7 @@ export const GetIamPolicyProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -733,7 +733,7 @@ export const SetIamPolicyProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -771,7 +771,7 @@ export const TestIamPermissionsProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/bigqueryconnection-v1beta1.ts
+++ b/packages/gcp/src/services/bigqueryconnection-v1beta1.ts
@@ -263,7 +263,7 @@ export const CreateProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/connections",
+      path: "v1beta1/{+parent}/connections",
       hasBody: true,
     }),
     svc,
@@ -296,7 +296,7 @@ export const GetProjectsLocationsConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionsRequest>;
 
@@ -333,7 +333,7 @@ export const ListProjectsLocationsConnectionsRequest =
     maxResults: Schema.optional(Schema.Number).pipe(T.HttpQuery("maxResults")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/connections" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/connections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsRequest>;
 
@@ -374,7 +374,7 @@ export const PatchProjectsLocationsConnectionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Connection).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectionsRequest>;
 
@@ -408,7 +408,7 @@ export const UpdateCredentialProjectsLocationsConnectionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ConnectionCredential).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateCredentialProjectsLocationsConnectionsRequest>;
 
@@ -439,7 +439,7 @@ export const DeleteProjectsLocationsConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectionsRequest>;
 
@@ -475,7 +475,7 @@ export const GetIamPolicyProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -513,7 +513,7 @@ export const SetIamPolicyProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -551,7 +551,7 @@ export const TestIamPermissionsProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/bigquerydatapolicy-v1.ts
+++ b/packages/gcp/src/services/bigquerydatapolicy-v1.ts
@@ -244,7 +244,11 @@ export const CreateProjectsLocationsDataPoliciesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(DataPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/dataPolicies", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/dataPolicies",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataPoliciesRequest>;
 
@@ -280,7 +284,7 @@ export const TestIamPermissionsProjectsLocationsDataPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -324,7 +328,7 @@ export const ListProjectsLocationsDataPoliciesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dataPolicies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dataPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataPoliciesRequest>;
 
@@ -360,7 +364,7 @@ export const GetProjectsLocationsDataPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataPoliciesRequest>;
 
@@ -394,7 +398,7 @@ export const DeleteProjectsLocationsDataPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataPoliciesRequest>;
 
@@ -430,7 +434,7 @@ export const GetIamPolicyProjectsLocationsDataPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -474,7 +478,7 @@ export const PatchProjectsLocationsDataPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DataPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataPoliciesRequest>;
 
@@ -508,7 +512,7 @@ export const RenameProjectsLocationsDataPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RenameDataPolicyRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:rename", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:rename", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RenameProjectsLocationsDataPoliciesRequest>;
 
@@ -544,7 +548,7 @@ export const SetIamPolicyProjectsLocationsDataPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/bigquerydatapolicy-v2.ts
+++ b/packages/gcp/src/services/bigquerydatapolicy-v2.ts
@@ -292,7 +292,7 @@ export const AddGranteesProjectsLocationsDataPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{dataPolicy}:addGrantees",
+      path: "v2/{+dataPolicy}:addGrantees",
       hasBody: true,
     }),
     svc,
@@ -328,7 +328,11 @@ export const CreateProjectsLocationsDataPoliciesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateDataPolicyRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/dataPolicies", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+parent}/dataPolicies",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataPoliciesRequest>;
 
@@ -364,7 +368,7 @@ export const SetIamPolicyProjectsLocationsDataPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -402,7 +406,7 @@ export const GetIamPolicyProjectsLocationsDataPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:getIamPolicy",
+      path: "v2/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -440,7 +444,7 @@ export const RemoveGranteesProjectsLocationsDataPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{dataPolicy}:removeGrantees",
+      path: "v2/{+dataPolicy}:removeGrantees",
       hasBody: true,
     }),
     svc,
@@ -482,7 +486,7 @@ export const ListProjectsLocationsDataPoliciesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/dataPolicies" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/dataPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataPoliciesRequest>;
 
@@ -523,7 +527,7 @@ export const TestIamPermissionsProjectsLocationsDataPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -558,7 +562,7 @@ export const DeleteProjectsLocationsDataPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataPoliciesRequest>;
 
@@ -589,7 +593,7 @@ export const GetProjectsLocationsDataPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataPoliciesRequest>;
 
@@ -631,7 +635,7 @@ export const PatchProjectsLocationsDataPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DataPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataPoliciesRequest>;
 

--- a/packages/gcp/src/services/bigquerydatatransfer-v1.ts
+++ b/packages/gcp/src/services/bigquerydatatransfer-v1.ts
@@ -795,7 +795,7 @@ export const EnrollDataSourcesProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:enrollDataSources",
+      path: "v1/{+name}:enrollDataSources",
       hasBody: true,
     }),
     svc,
@@ -828,7 +828,7 @@ export const GetProjectsDataSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDataSourcesRequest>;
 
@@ -864,7 +864,7 @@ export const CheckValidCredsProjectsDataSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:checkValidCreds",
+      path: "v1/{+name}:checkValidCreds",
       hasBody: true,
     }),
     svc,
@@ -904,7 +904,7 @@ export const ListProjectsDataSourcesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dataSources" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dataSources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDataSourcesRequest>;
 
@@ -944,7 +944,7 @@ export const UnenrollDataSourcesProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:unenrollDataSources",
+      path: "v1/{+name}:unenrollDataSources",
       hasBody: true,
     }),
     svc,
@@ -991,7 +991,7 @@ export const ListProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1031,7 +1031,7 @@ export const EnrollDataSourcesProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:enrollDataSources",
+      path: "v1/{+name}:enrollDataSources",
       hasBody: true,
     }),
     svc,
@@ -1064,7 +1064,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1115,7 +1115,7 @@ export const CreateProjectsLocationsTransferConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/transferConfigs",
+      path: "v1/{+parent}/transferConfigs",
       hasBody: true,
     }),
     svc,
@@ -1159,7 +1159,7 @@ export const ListProjectsLocationsTransferConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/transferConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/transferConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTransferConfigsRequest>;
 
@@ -1216,7 +1216,7 @@ export const PatchProjectsLocationsTransferConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(TransferConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTransferConfigsRequest>;
 
@@ -1247,7 +1247,7 @@ export const DeleteProjectsLocationsTransferConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTransferConfigsRequest>;
 
@@ -1278,7 +1278,7 @@ export const GetProjectsLocationsTransferConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTransferConfigsRequest>;
 
@@ -1314,7 +1314,7 @@ export const StartManualRunsProjectsLocationsTransferConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:startManualRuns",
+      path: "v1/{+parent}:startManualRuns",
       hasBody: true,
     }),
     svc,
@@ -1352,7 +1352,11 @@ export const ScheduleRunsProjectsLocationsTransferConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(ScheduleTransferRunsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:scheduleRuns", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}:scheduleRuns",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<ScheduleRunsProjectsLocationsTransferConfigsRequest>;
 
@@ -1384,7 +1388,7 @@ export const GetProjectsLocationsTransferConfigsRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTransferConfigsRunsRequest>;
 
@@ -1415,7 +1419,7 @@ export const DeleteProjectsLocationsTransferConfigsRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTransferConfigsRunsRequest>;
 
@@ -1467,7 +1471,7 @@ export const ListProjectsLocationsTransferConfigsRunsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     runAttempt: Schema.optional(Schema.String).pipe(T.HttpQuery("runAttempt")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/runs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/runs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTransferConfigsRunsRequest>;
 
@@ -1519,7 +1523,7 @@ export const ListProjectsLocationsTransferConfigsRunsTransferLogsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/transferLogs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/transferLogs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTransferConfigsRunsTransferLogsRequest>;
 
@@ -1556,7 +1560,7 @@ export const GetProjectsLocationsTransferConfigsTransferResourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTransferConfigsTransferResourcesRequest>;
 
@@ -1598,7 +1602,7 @@ export const ListProjectsLocationsTransferConfigsTransferResourcesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/transferResources" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/transferResources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTransferConfigsTransferResourcesRequest>;
 
@@ -1635,7 +1639,7 @@ export const GetProjectsLocationsDataSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataSourcesRequest>;
 
@@ -1671,7 +1675,7 @@ export const CheckValidCredsProjectsLocationsDataSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:checkValidCreds",
+      path: "v1/{+name}:checkValidCreds",
       hasBody: true,
     }),
     svc,
@@ -1711,7 +1715,7 @@ export const ListProjectsLocationsDataSourcesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dataSources" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dataSources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataSourcesRequest>;
 
@@ -1746,7 +1750,7 @@ export const DeleteProjectsTransferConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsTransferConfigsRequest>;
 
@@ -1777,7 +1781,7 @@ export const GetProjectsTransferConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsTransferConfigsRequest>;
 
@@ -1813,7 +1817,7 @@ export const StartManualRunsProjectsTransferConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:startManualRuns",
+      path: "v1/{+parent}:startManualRuns",
       hasBody: true,
     }),
     svc,
@@ -1868,7 +1872,7 @@ export const PatchProjectsTransferConfigsRequest =
     ),
     body: Schema.optional(TransferConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsTransferConfigsRequest>;
 
@@ -1910,7 +1914,7 @@ export const ListProjectsTransferConfigsRequest =
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/transferConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/transferConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTransferConfigsRequest>;
 
@@ -1965,7 +1969,7 @@ export const CreateProjectsTransferConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/transferConfigs",
+      path: "v1/{+parent}/transferConfigs",
       hasBody: true,
     }),
     svc,
@@ -2001,7 +2005,11 @@ export const ScheduleRunsProjectsTransferConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(ScheduleTransferRunsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:scheduleRuns", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}:scheduleRuns",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<ScheduleRunsProjectsTransferConfigsRequest>;
 
@@ -2054,7 +2062,7 @@ export const ListProjectsTransferConfigsRunsRequest =
       T.HttpQuery("states"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/runs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/runs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTransferConfigsRunsRequest>;
 
@@ -2089,7 +2097,7 @@ export const GetProjectsTransferConfigsRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsTransferConfigsRunsRequest>;
 
@@ -2120,7 +2128,7 @@ export const DeleteProjectsTransferConfigsRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsTransferConfigsRunsRequest>;
 
@@ -2167,7 +2175,7 @@ export const ListProjectsTransferConfigsRunsTransferLogsRequest =
       T.HttpQuery("messageTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/transferLogs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/transferLogs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTransferConfigsRunsTransferLogsRequest>;
 
@@ -2203,7 +2211,7 @@ export const GetProjectsTransferConfigsTransferResourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsTransferConfigsTransferResourcesRequest>;
 
@@ -2244,7 +2252,7 @@ export const ListProjectsTransferConfigsTransferResourcesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/transferResources" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/transferResources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTransferConfigsTransferResourcesRequest>;
 

--- a/packages/gcp/src/services/bigqueryreservation-v1.ts
+++ b/packages/gcp/src/services/bigqueryreservation-v1.ts
@@ -572,7 +572,7 @@ export const SearchAssignmentsProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}:searchAssignments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}:searchAssignments" }),
     svc,
   ) as unknown as Schema.Schema<SearchAssignmentsProjectsLocationsRequest>;
 
@@ -617,7 +617,7 @@ export const SearchAllAssignmentsProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}:searchAllAssignments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}:searchAllAssignments" }),
     svc,
   ) as unknown as Schema.Schema<SearchAllAssignmentsProjectsLocationsRequest>;
 
@@ -653,7 +653,7 @@ export const GetBiReservationProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBiReservationProjectsLocationsRequest>;
 
@@ -690,7 +690,7 @@ export const UpdateBiReservationProjectsLocationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(BiReservation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateBiReservationProjectsLocationsRequest>;
 
@@ -729,7 +729,11 @@ export const CreateProjectsLocationsReservationsRequest =
     ),
     body: Schema.optional(Reservation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/reservations", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/reservations",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsReservationsRequest>;
 
@@ -766,7 +770,7 @@ export const ListProjectsLocationsReservationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/reservations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/reservations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReservationsRequest>;
 
@@ -802,7 +806,7 @@ export const GetProjectsLocationsReservationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReservationsRequest>;
 
@@ -833,7 +837,7 @@ export const DeleteProjectsLocationsReservationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReservationsRequest>;
 
@@ -870,7 +874,7 @@ export const PatchProjectsLocationsReservationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Reservation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsReservationsRequest>;
 
@@ -906,7 +910,7 @@ export const FailoverReservationProjectsLocationsReservationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:failoverReservation",
+      path: "v1/{+name}:failoverReservation",
       hasBody: true,
     }),
     svc,
@@ -946,7 +950,7 @@ export const GetIamPolicyProjectsLocationsReservationsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsReservationsRequest>;
 
@@ -982,7 +986,7 @@ export const SetIamPolicyProjectsLocationsReservationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1020,7 +1024,7 @@ export const TestIamPermissionsProjectsLocationsReservationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1063,7 +1067,7 @@ export const CreateProjectsLocationsReservationsAssignmentsRequest =
     ),
     body: Schema.optional(Assignment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/assignments", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/assignments", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsReservationsAssignmentsRequest>;
 
@@ -1100,7 +1104,7 @@ export const ListProjectsLocationsReservationsAssignmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/assignments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/assignments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReservationsAssignmentsRequest>;
 
@@ -1136,7 +1140,7 @@ export const DeleteProjectsLocationsReservationsAssignmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReservationsAssignmentsRequest>;
 
@@ -1170,7 +1174,7 @@ export const MoveProjectsLocationsReservationsAssignmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MoveAssignmentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveProjectsLocationsReservationsAssignmentsRequest>;
 
@@ -1207,7 +1211,7 @@ export const PatchProjectsLocationsReservationsAssignmentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Assignment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsReservationsAssignmentsRequest>;
 
@@ -1243,7 +1247,7 @@ export const GetIamPolicyProjectsLocationsReservationsAssignmentsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsReservationsAssignmentsRequest>;
 
@@ -1281,7 +1285,7 @@ export const SetIamPolicyProjectsLocationsReservationsAssignmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1321,7 +1325,7 @@ export const TestIamPermissionsProjectsLocationsReservationsAssignmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1371,7 +1375,7 @@ export const CreateProjectsLocationsCapacityCommitmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/capacityCommitments",
+      path: "v1/{+parent}/capacityCommitments",
       hasBody: true,
     }),
     svc,
@@ -1411,7 +1415,7 @@ export const ListProjectsLocationsCapacityCommitmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/capacityCommitments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/capacityCommitments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCapacityCommitmentsRequest>;
 
@@ -1447,7 +1451,7 @@ export const GetProjectsLocationsCapacityCommitmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCapacityCommitmentsRequest>;
 
@@ -1482,7 +1486,7 @@ export const DeleteProjectsLocationsCapacityCommitmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCapacityCommitmentsRequest>;
 
@@ -1519,7 +1523,7 @@ export const PatchProjectsLocationsCapacityCommitmentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(CapacityCommitment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCapacityCommitmentsRequest>;
 
@@ -1554,7 +1558,7 @@ export const SplitProjectsLocationsCapacityCommitmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SplitCapacityCommitmentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:split", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:split", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SplitProjectsLocationsCapacityCommitmentsRequest>;
 
@@ -1591,7 +1595,7 @@ export const MergeProjectsLocationsCapacityCommitmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/capacityCommitments:merge",
+      path: "v1/{+parent}/capacityCommitments:merge",
       hasBody: true,
     }),
     svc,
@@ -1635,7 +1639,7 @@ export const CreateProjectsLocationsReservationGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/reservationGroups",
+      path: "v1/{+parent}/reservationGroups",
       hasBody: true,
     }),
     svc,
@@ -1668,7 +1672,7 @@ export const GetProjectsLocationsReservationGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReservationGroupsRequest>;
 
@@ -1699,7 +1703,7 @@ export const DeleteProjectsLocationsReservationGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReservationGroupsRequest>;
 
@@ -1736,7 +1740,7 @@ export const ListProjectsLocationsReservationGroupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/reservationGroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/reservationGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReservationGroupsRequest>;
 

--- a/packages/gcp/src/services/bigtableadmin-v2.ts
+++ b/packages/gcp/src/services/bigtableadmin-v2.ts
@@ -2317,7 +2317,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{name}" }),
+  T.Http({ method: "GET", path: "v2/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -2361,7 +2361,7 @@ export const ListOperationsProjectsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListOperationsProjectsOperationsRequest>;
 
@@ -2399,7 +2399,7 @@ export const CreateProjectsInstancesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/instances", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/instances", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsInstancesRequest>;
 
@@ -2430,7 +2430,7 @@ export const GetProjectsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesRequest>;
 
@@ -2464,7 +2464,7 @@ export const ListProjectsInstancesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesRequest>;
 
@@ -2502,7 +2502,7 @@ export const UpdateProjectsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsInstancesRequest>;
 
@@ -2539,7 +2539,7 @@ export const PartialUpdateInstanceProjectsInstancesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PartialUpdateInstanceProjectsInstancesRequest>;
 
@@ -2570,7 +2570,7 @@ export const DeleteProjectsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstancesRequest>;
 
@@ -2606,7 +2606,7 @@ export const GetIamPolicyProjectsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:getIamPolicy",
+      path: "v2/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2644,7 +2644,7 @@ export const SetIamPolicyProjectsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2682,7 +2682,7 @@ export const TestIamPermissionsProjectsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2722,7 +2722,7 @@ export const CreateProjectsInstancesClustersRequest =
     clusterId: Schema.optional(Schema.String).pipe(T.HttpQuery("clusterId")),
     body: Schema.optional(Cluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/clusters", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/clusters", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsInstancesClustersRequest>;
 
@@ -2753,7 +2753,7 @@ export const GetProjectsInstancesClustersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesClustersRequest>;
 
@@ -2787,7 +2787,7 @@ export const ListProjectsInstancesClustersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/clusters" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/clusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesClustersRequest>;
 
@@ -2825,7 +2825,7 @@ export const UpdateProjectsInstancesClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Cluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsInstancesClustersRequest>;
 
@@ -2862,7 +2862,7 @@ export const PartialUpdateClusterProjectsInstancesClustersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Cluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PartialUpdateClusterProjectsInstancesClustersRequest>;
 
@@ -2893,7 +2893,7 @@ export const DeleteProjectsInstancesClustersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstancesClustersRequest>;
 
@@ -2930,7 +2930,7 @@ export const UpdateMemoryLayerProjectsInstancesClustersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(MemoryLayer).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateMemoryLayerProjectsInstancesClustersRequest>;
 
@@ -2961,7 +2961,7 @@ export const GetMemoryLayerProjectsInstancesClustersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetMemoryLayerProjectsInstancesClustersRequest>;
 
@@ -2998,7 +2998,7 @@ export const ListProjectsInstancesClustersMemoryLayersRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/memoryLayers" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/memoryLayers" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesClustersMemoryLayersRequest>;
 
@@ -3046,7 +3046,7 @@ export const ListProjectsInstancesClustersHotTabletsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/hotTablets" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/hotTablets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesClustersHotTabletsRequest>;
 
@@ -3088,7 +3088,7 @@ export const CreateProjectsInstancesClustersBackupsRequest =
     backupId: Schema.optional(Schema.String).pipe(T.HttpQuery("backupId")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/backups", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/backups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsInstancesClustersBackupsRequest>;
 
@@ -3119,7 +3119,7 @@ export const GetProjectsInstancesClustersBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesClustersBackupsRequest>;
 
@@ -3156,7 +3156,7 @@ export const PatchProjectsInstancesClustersBackupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsInstancesClustersBackupsRequest>;
 
@@ -3187,7 +3187,7 @@ export const DeleteProjectsInstancesClustersBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstancesClustersBackupsRequest>;
 
@@ -3230,7 +3230,7 @@ export const ListProjectsInstancesClustersBackupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesClustersBackupsRequest>;
 
@@ -3268,7 +3268,11 @@ export const CopyProjectsInstancesClustersBackupsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CopyBackupRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/backups:copy", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+parent}/backups:copy",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CopyProjectsInstancesClustersBackupsRequest>;
 
@@ -3304,7 +3308,7 @@ export const GetIamPolicyProjectsInstancesClustersBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:getIamPolicy",
+      path: "v2/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3342,7 +3346,7 @@ export const SetIamPolicyProjectsInstancesClustersBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3380,7 +3384,7 @@ export const TestIamPermissionsProjectsInstancesClustersBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3428,7 +3432,7 @@ export const CreateProjectsInstancesAppProfilesRequest =
     ),
     body: Schema.optional(AppProfile).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/appProfiles", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/appProfiles", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsInstancesAppProfilesRequest>;
 
@@ -3459,7 +3463,7 @@ export const GetProjectsInstancesAppProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesAppProfilesRequest>;
 
@@ -3496,7 +3500,7 @@ export const ListProjectsInstancesAppProfilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/appProfiles" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/appProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesAppProfilesRequest>;
 
@@ -3542,7 +3546,7 @@ export const PatchProjectsInstancesAppProfilesRequest =
     ),
     body: Schema.optional(AppProfile).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsInstancesAppProfilesRequest>;
 
@@ -3578,7 +3582,7 @@ export const DeleteProjectsInstancesAppProfilesRequest =
       T.HttpQuery("ignoreWarnings"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstancesAppProfilesRequest>;
 
@@ -3614,7 +3618,7 @@ export const GetIamPolicyProjectsInstancesMaterializedViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:getIamPolicy",
+      path: "v2/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3652,7 +3656,7 @@ export const SetIamPolicyProjectsInstancesMaterializedViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3690,7 +3694,7 @@ export const TestIamPermissionsProjectsInstancesMaterializedViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3735,7 +3739,7 @@ export const CreateProjectsInstancesMaterializedViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/materializedViews",
+      path: "v2/{+parent}/materializedViews",
       hasBody: true,
     }),
     svc,
@@ -3776,7 +3780,7 @@ export const GetProjectsInstancesMaterializedViewsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesMaterializedViewsRequest>;
 
@@ -3821,7 +3825,7 @@ export const ListProjectsInstancesMaterializedViewsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/materializedViews" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/materializedViews" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesMaterializedViewsRequest>;
 
@@ -3863,7 +3867,7 @@ export const PatchProjectsInstancesMaterializedViewsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(MaterializedView).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsInstancesMaterializedViewsRequest>;
 
@@ -3897,7 +3901,7 @@ export const DeleteProjectsInstancesMaterializedViewsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstancesMaterializedViewsRequest>;
 
@@ -3933,7 +3937,7 @@ export const GetIamPolicyProjectsInstancesLogicalViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:getIamPolicy",
+      path: "v2/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3971,7 +3975,7 @@ export const SetIamPolicyProjectsInstancesLogicalViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4009,7 +4013,7 @@ export const TestIamPermissionsProjectsInstancesLogicalViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4052,7 +4056,11 @@ export const CreateProjectsInstancesLogicalViewsRequest =
     ),
     body: Schema.optional(LogicalView).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/logicalViews", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+parent}/logicalViews",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsInstancesLogicalViewsRequest>;
 
@@ -4083,7 +4091,7 @@ export const GetProjectsInstancesLogicalViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesLogicalViewsRequest>;
 
@@ -4120,7 +4128,7 @@ export const ListProjectsInstancesLogicalViewsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/logicalViews" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/logicalViews" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesLogicalViewsRequest>;
 
@@ -4162,7 +4170,7 @@ export const PatchProjectsInstancesLogicalViewsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LogicalView).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsInstancesLogicalViewsRequest>;
 
@@ -4196,7 +4204,7 @@ export const DeleteProjectsInstancesLogicalViewsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstancesLogicalViewsRequest>;
 
@@ -4230,7 +4238,7 @@ export const CreateProjectsInstancesTablesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateTableRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/tables", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/tables", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsInstancesTablesRequest>;
 
@@ -4278,7 +4286,7 @@ export const ListProjectsInstancesTablesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/tables" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/tables" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesTablesRequest>;
 
@@ -4324,7 +4332,7 @@ export const GetProjectsInstancesTablesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesTablesRequest>;
 
@@ -4366,7 +4374,7 @@ export const PatchProjectsInstancesTablesRequest =
     ),
     body: Schema.optional(Table).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsInstancesTablesRequest>;
 
@@ -4397,7 +4405,7 @@ export const DeleteProjectsInstancesTablesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstancesTablesRequest>;
 
@@ -4431,7 +4439,7 @@ export const UndeleteProjectsInstancesTablesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndeleteTableRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsInstancesTablesRequest>;
 
@@ -4467,7 +4475,7 @@ export const ModifyColumnFamiliesProjectsInstancesTablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:modifyColumnFamilies",
+      path: "v2/{+name}:modifyColumnFamilies",
       hasBody: true,
     }),
     svc,
@@ -4503,7 +4511,7 @@ export const DropRowRangeProjectsInstancesTablesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DropRowRangeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:dropRowRange", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:dropRowRange", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DropRowRangeProjectsInstancesTablesRequest>;
 
@@ -4539,7 +4547,7 @@ export const GenerateConsistencyTokenProjectsInstancesTablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:generateConsistencyToken",
+      path: "v2/{+name}:generateConsistencyToken",
       hasBody: true,
     }),
     svc,
@@ -4579,7 +4587,7 @@ export const CheckConsistencyProjectsInstancesTablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:checkConsistency",
+      path: "v2/{+name}:checkConsistency",
       hasBody: true,
     }),
     svc,
@@ -4618,7 +4626,7 @@ export const RestoreProjectsInstancesTablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/tables:restore",
+      path: "v2/{+parent}/tables:restore",
       hasBody: true,
     }),
     svc,
@@ -4656,7 +4664,7 @@ export const GetIamPolicyProjectsInstancesTablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:getIamPolicy",
+      path: "v2/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4694,7 +4702,7 @@ export const SetIamPolicyProjectsInstancesTablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4732,7 +4740,7 @@ export const TestIamPermissionsProjectsInstancesTablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4776,7 +4784,7 @@ export const CreateProjectsInstancesTablesAuthorizedViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/authorizedViews",
+      path: "v2/{+parent}/authorizedViews",
       hasBody: true,
     }),
     svc,
@@ -4823,7 +4831,7 @@ export const ListProjectsInstancesTablesAuthorizedViewsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/authorizedViews" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/authorizedViews" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesTablesAuthorizedViewsRequest>;
 
@@ -4867,7 +4875,7 @@ export const GetProjectsInstancesTablesAuthorizedViewsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesTablesAuthorizedViewsRequest>;
 
@@ -4909,7 +4917,7 @@ export const PatchProjectsInstancesTablesAuthorizedViewsRequest =
     ),
     body: Schema.optional(AuthorizedView).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsInstancesTablesAuthorizedViewsRequest>;
 
@@ -4943,7 +4951,7 @@ export const DeleteProjectsInstancesTablesAuthorizedViewsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstancesTablesAuthorizedViewsRequest>;
 
@@ -4979,7 +4987,7 @@ export const GetIamPolicyProjectsInstancesTablesAuthorizedViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:getIamPolicy",
+      path: "v2/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5018,7 +5026,7 @@ export const SetIamPolicyProjectsInstancesTablesAuthorizedViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5057,7 +5065,7 @@ export const TestIamPermissionsProjectsInstancesTablesAuthorizedViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5097,7 +5105,7 @@ export const GetIamPolicyProjectsInstancesTablesSchemaBundlesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:getIamPolicy",
+      path: "v2/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5136,7 +5144,7 @@ export const SetIamPolicyProjectsInstancesTablesSchemaBundlesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5175,7 +5183,7 @@ export const TestIamPermissionsProjectsInstancesTablesSchemaBundlesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5220,7 +5228,7 @@ export const CreateProjectsInstancesTablesSchemaBundlesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/schemaBundles",
+      path: "v2/{+parent}/schemaBundles",
       hasBody: true,
     }),
     svc,
@@ -5264,7 +5272,7 @@ export const PatchProjectsInstancesTablesSchemaBundlesRequest =
     ),
     body: Schema.optional(SchemaBundle).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsInstancesTablesSchemaBundlesRequest>;
 
@@ -5295,7 +5303,7 @@ export const GetProjectsInstancesTablesSchemaBundlesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesTablesSchemaBundlesRequest>;
 
@@ -5340,7 +5348,7 @@ export const ListProjectsInstancesTablesSchemaBundlesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/schemaBundles" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/schemaBundles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesTablesSchemaBundlesRequest>;
 
@@ -5379,7 +5387,7 @@ export const DeleteProjectsInstancesTablesSchemaBundlesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstancesTablesSchemaBundlesRequest>;
 
@@ -5424,7 +5432,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 

--- a/packages/gcp/src/services/billingbudgets-v1.ts
+++ b/packages/gcp/src/services/billingbudgets-v1.ts
@@ -247,7 +247,7 @@ export const CreateBillingAccountsBudgetsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudBillingBudgetsV1Budget).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/budgets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/budgets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateBillingAccountsBudgetsRequest>;
 
@@ -285,7 +285,7 @@ export const PatchBillingAccountsBudgetsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudBillingBudgetsV1Budget).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchBillingAccountsBudgetsRequest>;
 
@@ -317,7 +317,7 @@ export const GetBillingAccountsBudgetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsBudgetsRequest>;
 
@@ -358,7 +358,7 @@ export const ListBillingAccountsBudgetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/budgets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/budgets" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsBudgetsRequest>;
 
@@ -394,7 +394,7 @@ export const DeleteBillingAccountsBudgetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteBillingAccountsBudgetsRequest>;
 

--- a/packages/gcp/src/services/billingbudgets-v1beta1.ts
+++ b/packages/gcp/src/services/billingbudgets-v1beta1.ts
@@ -280,7 +280,11 @@ export const CreateBillingAccountsBudgetsRequest =
       GoogleCloudBillingBudgetsV1beta1CreateBudgetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/budgets", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/budgets",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateBillingAccountsBudgetsRequest>;
 
@@ -317,7 +321,7 @@ export const PatchBillingAccountsBudgetsRequest =
       GoogleCloudBillingBudgetsV1beta1UpdateBudgetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchBillingAccountsBudgetsRequest>;
 
@@ -349,7 +353,7 @@ export const GetBillingAccountsBudgetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsBudgetsRequest>;
 
@@ -390,7 +394,7 @@ export const ListBillingAccountsBudgetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/budgets" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/budgets" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsBudgetsRequest>;
 
@@ -426,7 +430,7 @@ export const DeleteBillingAccountsBudgetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteBillingAccountsBudgetsRequest>;
 

--- a/packages/gcp/src/services/binaryauthorization-v1.ts
+++ b/packages/gcp/src/services/binaryauthorization-v1.ts
@@ -833,7 +833,7 @@ export const GetPolicyProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPolicyProjectsRequest>;
 
@@ -866,7 +866,7 @@ export const UpdatePolicyProjectsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Policy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdatePolicyProjectsRequest>;
 
@@ -899,7 +899,7 @@ export const UpdateProjectsAttestorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Attestor).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsAttestorsRequest>;
 
@@ -936,7 +936,7 @@ export const ListProjectsAttestorsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/attestors" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/attestors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAttestorsRequest>;
 
@@ -976,7 +976,7 @@ export const GetIamPolicyProjectsAttestorsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsAttestorsRequest>;
 
@@ -1012,7 +1012,7 @@ export const SetIamPolicyProjectsAttestorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1045,7 +1045,7 @@ export const GetProjectsAttestorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAttestorsRequest>;
 
@@ -1083,7 +1083,7 @@ export const ValidateAttestationOccurrenceProjectsAttestorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{attestor}:validateAttestationOccurrence",
+      path: "v1/{+attestor}:validateAttestationOccurrence",
       hasBody: true,
     }),
     svc,
@@ -1122,7 +1122,7 @@ export const TestIamPermissionsProjectsAttestorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1162,7 +1162,7 @@ export const CreateProjectsAttestorsRequest =
     attestorId: Schema.optional(Schema.String).pipe(T.HttpQuery("attestorId")),
     body: Schema.optional(Attestor).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/attestors", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/attestors", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsAttestorsRequest>;
 
@@ -1193,7 +1193,7 @@ export const DeleteProjectsAttestorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAttestorsRequest>;
 
@@ -1229,7 +1229,7 @@ export const SetIamPolicyProjectsPolicyRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1267,7 +1267,7 @@ export const TestIamPermissionsProjectsPolicyRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1306,7 +1306,7 @@ export const GetIamPolicyProjectsPolicyRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsPolicyRequest>;
 
@@ -1340,7 +1340,7 @@ export const EvaluateProjectsPlatformsGkePoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EvaluateGkePolicyRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:evaluate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:evaluate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EvaluateProjectsPlatformsGkePoliciesRequest>;
 
@@ -1378,7 +1378,7 @@ export const CreateProjectsPlatformsPoliciesRequest =
     policyId: Schema.optional(Schema.String).pipe(T.HttpQuery("policyId")),
     body: Schema.optional(PlatformPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/policies", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/policies", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsPlatformsPoliciesRequest>;
 
@@ -1412,7 +1412,7 @@ export const DeleteProjectsPlatformsPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsPlatformsPoliciesRequest>;
 
@@ -1449,7 +1449,7 @@ export const ListProjectsPlatformsPoliciesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/policies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/policies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsPlatformsPoliciesRequest>;
 
@@ -1488,7 +1488,7 @@ export const ReplacePlatformPolicyProjectsPlatformsPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PlatformPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReplacePlatformPolicyProjectsPlatformsPoliciesRequest>;
 
@@ -1520,7 +1520,7 @@ export const GetProjectsPlatformsPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsPlatformsPoliciesRequest>;
 
@@ -1551,7 +1551,7 @@ export const GetPolicySystempolicyRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPolicySystempolicyRequest>;
 

--- a/packages/gcp/src/services/binaryauthorization-v1beta1.ts
+++ b/packages/gcp/src/services/binaryauthorization-v1beta1.ts
@@ -371,7 +371,7 @@ export const GetPolicySystempolicyRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPolicySystempolicyRequest>;
 
@@ -401,7 +401,7 @@ export const GetPolicyProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPolicyProjectsRequest>;
 
@@ -434,7 +434,7 @@ export const UpdatePolicyProjectsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Policy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdatePolicyProjectsRequest>;
 
@@ -464,7 +464,7 @@ export const GetProjectsAttestorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAttestorsRequest>;
 
@@ -501,7 +501,7 @@ export const ListProjectsAttestorsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/attestors" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/attestors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAttestorsRequest>;
 
@@ -541,7 +541,7 @@ export const TestIamPermissionsProjectsAttestorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -578,7 +578,7 @@ export const UpdateProjectsAttestorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Attestor).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsAttestorsRequest>;
 
@@ -617,7 +617,7 @@ export const CreateProjectsAttestorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/attestors",
+      path: "v1beta1/{+parent}/attestors",
       hasBody: true,
     }),
     svc,
@@ -655,7 +655,7 @@ export const SetIamPolicyProjectsAttestorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -688,7 +688,7 @@ export const DeleteProjectsAttestorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAttestorsRequest>;
 
@@ -726,7 +726,7 @@ export const ValidateAttestationOccurrenceProjectsAttestorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{attestor}:validateAttestationOccurrence",
+      path: "v1beta1/{+attestor}:validateAttestationOccurrence",
       hasBody: true,
     }),
     svc,
@@ -765,7 +765,7 @@ export const GetIamPolicyProjectsAttestorsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsAttestorsRequest>;
 
@@ -801,7 +801,7 @@ export const SetIamPolicyProjectsPolicyRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -839,7 +839,7 @@ export const GetIamPolicyProjectsPolicyRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsPolicyRequest>;
 
@@ -875,7 +875,7 @@ export const TestIamPermissionsProjectsPolicyRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/blockchainnodeengine-v1.ts
+++ b/packages/gcp/src/services/blockchainnodeengine-v1.ts
@@ -351,7 +351,7 @@ export const ListProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -386,7 +386,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -426,7 +426,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -461,7 +461,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -492,7 +492,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -526,7 +526,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -569,7 +569,7 @@ export const ListProjectsLocationsBlockchainNodesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/blockchainNodes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/blockchainNodes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBlockchainNodesRequest>;
 
@@ -605,7 +605,7 @@ export const GetProjectsLocationsBlockchainNodesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBlockchainNodesRequest>;
 
@@ -649,7 +649,7 @@ export const CreateProjectsLocationsBlockchainNodesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/blockchainNodes",
+      path: "v1/{+parent}/blockchainNodes",
       hasBody: true,
     }),
     svc,
@@ -691,7 +691,7 @@ export const PatchProjectsLocationsBlockchainNodesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(BlockchainNode).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBlockchainNodesRequest>;
 
@@ -725,7 +725,7 @@ export const DeleteProjectsLocationsBlockchainNodesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBlockchainNodesRequest>;
 

--- a/packages/gcp/src/services/businessprofileperformance-v1.ts
+++ b/packages/gcp/src/services/businessprofileperformance-v1.ts
@@ -258,7 +258,7 @@ export const FetchMultiDailyMetricsTimeSeriesLocationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{location}:fetchMultiDailyMetricsTimeSeries",
+      path: "v1/{+location}:fetchMultiDailyMetricsTimeSeries",
     }),
     svc,
   ) as unknown as Schema.Schema<FetchMultiDailyMetricsTimeSeriesLocationsRequest>;
@@ -373,7 +373,7 @@ export const GetDailyMetricsTimeSeriesLocationsRequest =
       T.HttpQuery("dailySubEntityType.timeOfDay.minutes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getDailyMetricsTimeSeries" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getDailyMetricsTimeSeries" }),
     svc,
   ) as unknown as Schema.Schema<GetDailyMetricsTimeSeriesLocationsRequest>;
 
@@ -443,7 +443,7 @@ export const ListLocationsSearchkeywordsImpressionsMonthlyRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/searchkeywords/impressions/monthly",
+      path: "v1/{+parent}/searchkeywords/impressions/monthly",
     }),
     svc,
   ) as unknown as Schema.Schema<ListLocationsSearchkeywordsImpressionsMonthlyRequest>;

--- a/packages/gcp/src/services/certificatemanager-v1.ts
+++ b/packages/gcp/src/services/certificatemanager-v1.ts
@@ -772,7 +772,7 @@ export const ListProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -807,7 +807,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -838,7 +838,7 @@ export const DeleteProjectsLocationsDnsAuthorizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDnsAuthorizationsRequest>;
 
@@ -879,7 +879,7 @@ export const CreateProjectsLocationsDnsAuthorizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/dnsAuthorizations",
+      path: "v1/{+parent}/dnsAuthorizations",
       hasBody: true,
     }),
     svc,
@@ -924,7 +924,7 @@ export const ListProjectsLocationsDnsAuthorizationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dnsAuthorizations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dnsAuthorizations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDnsAuthorizationsRequest>;
 
@@ -960,7 +960,7 @@ export const GetProjectsLocationsDnsAuthorizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDnsAuthorizationsRequest>;
 
@@ -997,7 +997,7 @@ export const PatchProjectsLocationsDnsAuthorizationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(DnsAuthorization).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDnsAuthorizationsRequest>;
 
@@ -1028,7 +1028,7 @@ export const DeleteProjectsLocationsCertificateIssuanceConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCertificateIssuanceConfigsRequest>;
 
@@ -1071,7 +1071,7 @@ export const CreateProjectsLocationsCertificateIssuanceConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/certificateIssuanceConfigs",
+      path: "v1/{+parent}/certificateIssuanceConfigs",
       hasBody: true,
     }),
     svc,
@@ -1118,7 +1118,7 @@ export const ListProjectsLocationsCertificateIssuanceConfigsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/certificateIssuanceConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/certificateIssuanceConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCertificateIssuanceConfigsRequest>;
 
@@ -1155,7 +1155,7 @@ export const GetProjectsLocationsCertificateIssuanceConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCertificateIssuanceConfigsRequest>;
 
@@ -1193,7 +1193,7 @@ export const PatchProjectsLocationsCertificateIssuanceConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(CertificateIssuanceConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCertificateIssuanceConfigsRequest>;
 
@@ -1226,7 +1226,7 @@ export const DeleteProjectsLocationsCertificatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCertificatesRequest>;
 
@@ -1269,7 +1269,7 @@ export const ListProjectsLocationsCertificatesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/certificates" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/certificates" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCertificatesRequest>;
 
@@ -1305,7 +1305,7 @@ export const GetProjectsLocationsCertificatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCertificatesRequest>;
 
@@ -1342,7 +1342,7 @@ export const PatchProjectsLocationsCertificatesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Certificate).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCertificatesRequest>;
 
@@ -1381,7 +1381,11 @@ export const CreateProjectsLocationsCertificatesRequest =
     ),
     body: Schema.optional(Certificate).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/certificates", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/certificates",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCertificatesRequest>;
 
@@ -1424,7 +1428,7 @@ export const ListProjectsLocationsCertificateMapsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/certificateMaps" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/certificateMaps" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCertificateMapsRequest>;
 
@@ -1460,7 +1464,7 @@ export const GetProjectsLocationsCertificateMapsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCertificateMapsRequest>;
 
@@ -1497,7 +1501,7 @@ export const PatchProjectsLocationsCertificateMapsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(CertificateMap).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCertificateMapsRequest>;
 
@@ -1538,7 +1542,7 @@ export const CreateProjectsLocationsCertificateMapsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/certificateMaps",
+      path: "v1/{+parent}/certificateMaps",
       hasBody: true,
     }),
     svc,
@@ -1571,7 +1575,7 @@ export const DeleteProjectsLocationsCertificateMapsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCertificateMapsRequest>;
 
@@ -1614,7 +1618,7 @@ export const ListProjectsLocationsCertificateMapsCertificateMapEntriesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/certificateMapEntries" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/certificateMapEntries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCertificateMapsCertificateMapEntriesRequest>;
 
@@ -1651,7 +1655,7 @@ export const GetProjectsLocationsCertificateMapsCertificateMapEntriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCertificateMapsCertificateMapEntriesRequest>;
 
@@ -1690,7 +1694,7 @@ export const PatchProjectsLocationsCertificateMapsCertificateMapEntriesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(CertificateMapEntry).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCertificateMapsCertificateMapEntriesRequest>;
 
@@ -1733,7 +1737,7 @@ export const CreateProjectsLocationsCertificateMapsCertificateMapEntriesRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/certificateMapEntries",
+      path: "v1/{+parent}/certificateMapEntries",
       hasBody: true,
     }),
     svc,
@@ -1768,7 +1772,7 @@ export const DeleteProjectsLocationsCertificateMapsCertificateMapEntriesRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCertificateMapsCertificateMapEntriesRequest>;
 
@@ -1804,7 +1808,7 @@ export const DeleteProjectsLocationsTrustConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTrustConfigsRequest>;
 
@@ -1847,7 +1851,7 @@ export const ListProjectsLocationsTrustConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/trustConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/trustConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTrustConfigsRequest>;
 
@@ -1883,7 +1887,7 @@ export const GetProjectsLocationsTrustConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTrustConfigsRequest>;
 
@@ -1920,7 +1924,7 @@ export const PatchProjectsLocationsTrustConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(TrustConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTrustConfigsRequest>;
 
@@ -1959,7 +1963,11 @@ export const CreateProjectsLocationsTrustConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(TrustConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/trustConfigs", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/trustConfigs",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTrustConfigsRequest>;
 
@@ -1990,7 +1998,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2035,7 +2043,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2070,7 +2078,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2104,7 +2112,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/ces-v1.ts
+++ b/packages/gcp/src/services/ces-v1.ts
@@ -3466,7 +3466,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -3501,7 +3501,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -3546,7 +3546,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -3581,7 +3581,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -3612,7 +3612,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -3646,7 +3646,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -3689,7 +3689,7 @@ export const ListProjectsLocationsAppsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/apps" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/apps" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsRequest>;
 
@@ -3724,7 +3724,7 @@ export const GetProjectsLocationsAppsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsRequest>;
 
@@ -3760,7 +3760,7 @@ export const CreateProjectsLocationsAppsRequest =
     appId: Schema.optional(Schema.String).pipe(T.HttpQuery("appId")),
     body: Schema.optional(App).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/apps", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/apps", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAppsRequest>;
 
@@ -3797,7 +3797,7 @@ export const PatchProjectsLocationsAppsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(App).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppsRequest>;
 
@@ -3831,7 +3831,7 @@ export const DeleteProjectsLocationsAppsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsRequest>;
 
@@ -3865,7 +3865,7 @@ export const ExportAppProjectsLocationsAppsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportAppRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:exportApp", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:exportApp", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportAppProjectsLocationsAppsRequest>;
 
@@ -3901,7 +3901,7 @@ export const ImportAppProjectsLocationsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/apps:importApp",
+      path: "v1/{+parent}/apps:importApp",
       hasBody: true,
     }),
     svc,
@@ -3937,7 +3937,7 @@ export const ExecuteToolProjectsLocationsAppsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(ExecuteToolRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:executeTool", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}:executeTool", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteToolProjectsLocationsAppsRequest>;
 
@@ -3973,7 +3973,7 @@ export const RetrieveToolSchemaProjectsLocationsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:retrieveToolSchema",
+      path: "v1/{+parent}:retrieveToolSchema",
       hasBody: true,
     }),
     svc,
@@ -4010,7 +4010,7 @@ export const RunSessionProjectsLocationsAppsSessionsRequest =
     session: Schema.String.pipe(T.HttpPath("session")),
     body: Schema.optional(RunSessionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{session}:runSession", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+session}:runSession", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunSessionProjectsLocationsAppsSessionsRequest>;
 
@@ -4047,7 +4047,7 @@ export const StreamRunSessionProjectsLocationsAppsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{session}:streamRunSession",
+      path: "v1/{+session}:streamRunSession",
       hasBody: true,
     }),
     svc,
@@ -4086,7 +4086,7 @@ export const GenerateChatTokenProjectsLocationsAppsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:generateChatToken",
+      path: "v1/{+name}:generateChatToken",
       hasBody: true,
     }),
     svc,
@@ -4132,7 +4132,7 @@ export const ListProjectsLocationsAppsAgentsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/agents" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/agents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsAgentsRequest>;
 
@@ -4167,7 +4167,7 @@ export const GetProjectsLocationsAppsAgentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsAgentsRequest>;
 
@@ -4204,7 +4204,7 @@ export const CreateProjectsLocationsAppsAgentsRequest =
     agentId: Schema.optional(Schema.String).pipe(T.HttpQuery("agentId")),
     body: Schema.optional(Agent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/agents", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/agents", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAppsAgentsRequest>;
 
@@ -4241,7 +4241,7 @@ export const PatchProjectsLocationsAppsAgentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Agent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppsAgentsRequest>;
 
@@ -4278,7 +4278,7 @@ export const DeleteProjectsLocationsAppsAgentsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsAgentsRequest>;
 
@@ -4321,7 +4321,7 @@ export const ListProjectsLocationsAppsExamplesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/examples" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/examples" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsExamplesRequest>;
 
@@ -4356,7 +4356,7 @@ export const GetProjectsLocationsAppsExamplesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsExamplesRequest>;
 
@@ -4393,7 +4393,7 @@ export const CreateProjectsLocationsAppsExamplesRequest =
     exampleId: Schema.optional(Schema.String).pipe(T.HttpQuery("exampleId")),
     body: Schema.optional(Example).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/examples", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/examples", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAppsExamplesRequest>;
 
@@ -4430,7 +4430,7 @@ export const PatchProjectsLocationsAppsExamplesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Example).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppsExamplesRequest>;
 
@@ -4464,7 +4464,7 @@ export const DeleteProjectsLocationsAppsExamplesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsExamplesRequest>;
 
@@ -4507,7 +4507,7 @@ export const ListProjectsLocationsAppsToolsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/tools" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/tools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsToolsRequest>;
 
@@ -4542,7 +4542,7 @@ export const GetProjectsLocationsAppsToolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsToolsRequest>;
 
@@ -4579,7 +4579,7 @@ export const CreateProjectsLocationsAppsToolsRequest =
     toolId: Schema.optional(Schema.String).pipe(T.HttpQuery("toolId")),
     body: Schema.optional(Tool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/tools", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/tools", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAppsToolsRequest>;
 
@@ -4616,7 +4616,7 @@ export const PatchProjectsLocationsAppsToolsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Tool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppsToolsRequest>;
 
@@ -4653,7 +4653,7 @@ export const DeleteProjectsLocationsAppsToolsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsToolsRequest>;
 
@@ -4713,7 +4713,7 @@ export const ListProjectsLocationsAppsConversationsRequest =
       T.HttpQuery("sources"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsConversationsRequest>;
 
@@ -4758,7 +4758,7 @@ export const GetProjectsLocationsAppsConversationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     source: Schema.optional(Schema.String).pipe(T.HttpQuery("source")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsConversationsRequest>;
 
@@ -4798,7 +4798,7 @@ export const DeleteProjectsLocationsAppsConversationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     source: Schema.optional(Schema.String).pipe(T.HttpQuery("source")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsConversationsRequest>;
 
@@ -4834,7 +4834,7 @@ export const BatchDeleteProjectsLocationsAppsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/conversations:batchDelete",
+      path: "v1/{+parent}/conversations:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -4879,7 +4879,7 @@ export const ListProjectsLocationsAppsGuardrailsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/guardrails" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/guardrails" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsGuardrailsRequest>;
 
@@ -4915,7 +4915,7 @@ export const GetProjectsLocationsAppsGuardrailsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsGuardrailsRequest>;
 
@@ -4954,7 +4954,7 @@ export const CreateProjectsLocationsAppsGuardrailsRequest =
     ),
     body: Schema.optional(Guardrail).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/guardrails", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/guardrails", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAppsGuardrailsRequest>;
 
@@ -4991,7 +4991,7 @@ export const PatchProjectsLocationsAppsGuardrailsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Guardrail).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppsGuardrailsRequest>;
 
@@ -5028,7 +5028,7 @@ export const DeleteProjectsLocationsAppsGuardrailsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsGuardrailsRequest>;
 
@@ -5068,7 +5068,7 @@ export const ListProjectsLocationsAppsDeploymentsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsDeploymentsRequest>;
 
@@ -5104,7 +5104,7 @@ export const GetProjectsLocationsAppsDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsDeploymentsRequest>;
 
@@ -5143,7 +5143,7 @@ export const CreateProjectsLocationsAppsDeploymentsRequest =
     ),
     body: Schema.optional(Deployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/deployments", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/deployments", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAppsDeploymentsRequest>;
 
@@ -5180,7 +5180,7 @@ export const PatchProjectsLocationsAppsDeploymentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Deployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppsDeploymentsRequest>;
 
@@ -5214,7 +5214,7 @@ export const DeleteProjectsLocationsAppsDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsDeploymentsRequest>;
 
@@ -5257,7 +5257,7 @@ export const ListProjectsLocationsAppsToolsetsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/toolsets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/toolsets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsToolsetsRequest>;
 
@@ -5292,7 +5292,7 @@ export const GetProjectsLocationsAppsToolsetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsToolsetsRequest>;
 
@@ -5329,7 +5329,7 @@ export const CreateProjectsLocationsAppsToolsetsRequest =
     toolsetId: Schema.optional(Schema.String).pipe(T.HttpQuery("toolsetId")),
     body: Schema.optional(Toolset).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/toolsets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/toolsets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAppsToolsetsRequest>;
 
@@ -5366,7 +5366,7 @@ export const PatchProjectsLocationsAppsToolsetsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Toolset).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppsToolsetsRequest>;
 
@@ -5403,7 +5403,7 @@ export const DeleteProjectsLocationsAppsToolsetsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsToolsetsRequest>;
 
@@ -5439,7 +5439,7 @@ export const RetrieveToolsProjectsLocationsAppsToolsetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{toolset}:retrieveTools",
+      path: "v1/{+toolset}:retrieveTools",
       hasBody: true,
     }),
     svc,
@@ -5485,7 +5485,7 @@ export const ListProjectsLocationsAppsVersionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsVersionsRequest>;
 
@@ -5520,7 +5520,7 @@ export const GetProjectsLocationsAppsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsVersionsRequest>;
 
@@ -5559,7 +5559,7 @@ export const CreateProjectsLocationsAppsVersionsRequest =
     ),
     body: Schema.optional(AppVersion).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/versions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/versions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAppsVersionsRequest>;
 
@@ -5593,7 +5593,7 @@ export const DeleteProjectsLocationsAppsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsVersionsRequest>;
 
@@ -5627,7 +5627,7 @@ export const RestoreProjectsLocationsAppsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestoreAppVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsAppsVersionsRequest>;
 
@@ -5670,7 +5670,7 @@ export const ListProjectsLocationsAppsChangelogsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/changelogs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/changelogs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsChangelogsRequest>;
 
@@ -5706,7 +5706,7 @@ export const GetProjectsLocationsAppsChangelogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsChangelogsRequest>;
 

--- a/packages/gcp/src/services/ces-v1beta.ts
+++ b/packages/gcp/src/services/ces-v1beta.ts
@@ -5533,7 +5533,7 @@ export const GetSecuritySettingsProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSecuritySettingsProjectsLocationsRequest>;
 
@@ -5570,7 +5570,7 @@ export const UpdateSecuritySettingsProjectsLocationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SecuritySettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSecuritySettingsProjectsLocationsRequest>;
 
@@ -5615,7 +5615,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -5650,7 +5650,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -5695,7 +5695,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -5730,7 +5730,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -5761,7 +5761,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -5795,7 +5795,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -5838,7 +5838,7 @@ export const ListProjectsLocationsAppsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/apps" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/apps" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsRequest>;
 
@@ -5873,7 +5873,7 @@ export const GetProjectsLocationsAppsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsRequest>;
 
@@ -5909,7 +5909,7 @@ export const CreateProjectsLocationsAppsRequest =
     appId: Schema.optional(Schema.String).pipe(T.HttpQuery("appId")),
     body: Schema.optional(App).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/apps", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/apps", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAppsRequest>;
 
@@ -5946,7 +5946,7 @@ export const PatchProjectsLocationsAppsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(App).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppsRequest>;
 
@@ -5980,7 +5980,7 @@ export const DeleteProjectsLocationsAppsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsRequest>;
 
@@ -6014,7 +6014,7 @@ export const ExportAppProjectsLocationsAppsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportAppRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:exportApp", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:exportApp", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportAppProjectsLocationsAppsRequest>;
 
@@ -6050,7 +6050,7 @@ export const ImportAppProjectsLocationsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/apps:importApp",
+      path: "v1beta/{+parent}/apps:importApp",
       hasBody: true,
     }),
     svc,
@@ -6088,7 +6088,7 @@ export const GenerateAppResourceProjectsLocationsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}:generateAppResource",
+      path: "v1beta/{+parent}:generateAppResource",
       hasBody: true,
     }),
     svc,
@@ -6126,7 +6126,7 @@ export const RunEvaluationProjectsLocationsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{app}:runEvaluation",
+      path: "v1beta/{+app}:runEvaluation",
       hasBody: true,
     }),
     svc,
@@ -6164,7 +6164,7 @@ export const ImportEvaluationsProjectsLocationsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}:importEvaluations",
+      path: "v1beta/{+parent}:importEvaluations",
       hasBody: true,
     }),
     svc,
@@ -6202,7 +6202,7 @@ export const TestPersonaVoiceProjectsLocationsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{app}:testPersonaVoice",
+      path: "v1beta/{+app}:testPersonaVoice",
       hasBody: true,
     }),
     svc,
@@ -6241,7 +6241,7 @@ export const ExecuteToolProjectsLocationsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}:executeTool",
+      path: "v1beta/{+parent}:executeTool",
       hasBody: true,
     }),
     svc,
@@ -6279,7 +6279,7 @@ export const RetrieveToolSchemaProjectsLocationsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}:retrieveToolSchema",
+      path: "v1beta/{+parent}:retrieveToolSchema",
       hasBody: true,
     }),
     svc,
@@ -6318,7 +6318,7 @@ export const RunSessionProjectsLocationsAppsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{session}:runSession",
+      path: "v1beta/{+session}:runSession",
       hasBody: true,
     }),
     svc,
@@ -6357,7 +6357,7 @@ export const StreamRunSessionProjectsLocationsAppsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{session}:streamRunSession",
+      path: "v1beta/{+session}:streamRunSession",
       hasBody: true,
     }),
     svc,
@@ -6396,7 +6396,7 @@ export const GenerateChatTokenProjectsLocationsAppsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{name}:generateChatToken",
+      path: "v1beta/{+name}:generateChatToken",
       hasBody: true,
     }),
     svc,
@@ -6442,7 +6442,7 @@ export const ListProjectsLocationsAppsAgentsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/agents" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/agents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsAgentsRequest>;
 
@@ -6477,7 +6477,7 @@ export const GetProjectsLocationsAppsAgentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsAgentsRequest>;
 
@@ -6514,7 +6514,7 @@ export const CreateProjectsLocationsAppsAgentsRequest =
     agentId: Schema.optional(Schema.String).pipe(T.HttpQuery("agentId")),
     body: Schema.optional(Agent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/agents", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/agents", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAppsAgentsRequest>;
 
@@ -6551,7 +6551,7 @@ export const PatchProjectsLocationsAppsAgentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Agent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppsAgentsRequest>;
 
@@ -6588,7 +6588,7 @@ export const DeleteProjectsLocationsAppsAgentsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsAgentsRequest>;
 
@@ -6631,7 +6631,7 @@ export const ListProjectsLocationsAppsExamplesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/examples" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/examples" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsExamplesRequest>;
 
@@ -6666,7 +6666,7 @@ export const GetProjectsLocationsAppsExamplesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsExamplesRequest>;
 
@@ -6703,7 +6703,11 @@ export const CreateProjectsLocationsAppsExamplesRequest =
     exampleId: Schema.optional(Schema.String).pipe(T.HttpQuery("exampleId")),
     body: Schema.optional(Example).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/examples", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/examples",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAppsExamplesRequest>;
 
@@ -6740,7 +6744,7 @@ export const PatchProjectsLocationsAppsExamplesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Example).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppsExamplesRequest>;
 
@@ -6774,7 +6778,7 @@ export const DeleteProjectsLocationsAppsExamplesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsExamplesRequest>;
 
@@ -6817,7 +6821,7 @@ export const ListProjectsLocationsAppsToolsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/tools" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/tools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsToolsRequest>;
 
@@ -6852,7 +6856,7 @@ export const GetProjectsLocationsAppsToolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsToolsRequest>;
 
@@ -6889,7 +6893,7 @@ export const CreateProjectsLocationsAppsToolsRequest =
     toolId: Schema.optional(Schema.String).pipe(T.HttpQuery("toolId")),
     body: Schema.optional(Tool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/tools", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/tools", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAppsToolsRequest>;
 
@@ -6926,7 +6930,7 @@ export const PatchProjectsLocationsAppsToolsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Tool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppsToolsRequest>;
 
@@ -6963,7 +6967,7 @@ export const DeleteProjectsLocationsAppsToolsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsToolsRequest>;
 
@@ -7023,7 +7027,7 @@ export const ListProjectsLocationsAppsConversationsRequest =
       T.HttpQuery("sources"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsConversationsRequest>;
 
@@ -7068,7 +7072,7 @@ export const GetProjectsLocationsAppsConversationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     source: Schema.optional(Schema.String).pipe(T.HttpQuery("source")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsConversationsRequest>;
 
@@ -7108,7 +7112,7 @@ export const DeleteProjectsLocationsAppsConversationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     source: Schema.optional(Schema.String).pipe(T.HttpQuery("source")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsConversationsRequest>;
 
@@ -7144,7 +7148,7 @@ export const BatchDeleteProjectsLocationsAppsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/conversations:batchDelete",
+      path: "v1beta/{+parent}/conversations:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -7182,7 +7186,7 @@ export const GenerateEvaluationProjectsLocationsAppsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{conversation}:generateEvaluation",
+      path: "v1beta/{+conversation}:generateEvaluation",
       hasBody: true,
     }),
     svc,
@@ -7229,7 +7233,7 @@ export const ListProjectsLocationsAppsGuardrailsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/guardrails" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/guardrails" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsGuardrailsRequest>;
 
@@ -7265,7 +7269,7 @@ export const GetProjectsLocationsAppsGuardrailsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsGuardrailsRequest>;
 
@@ -7306,7 +7310,7 @@ export const CreateProjectsLocationsAppsGuardrailsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/guardrails",
+      path: "v1beta/{+parent}/guardrails",
       hasBody: true,
     }),
     svc,
@@ -7345,7 +7349,7 @@ export const PatchProjectsLocationsAppsGuardrailsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Guardrail).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppsGuardrailsRequest>;
 
@@ -7382,7 +7386,7 @@ export const DeleteProjectsLocationsAppsGuardrailsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsGuardrailsRequest>;
 
@@ -7422,7 +7426,7 @@ export const ListProjectsLocationsAppsDeploymentsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsDeploymentsRequest>;
 
@@ -7458,7 +7462,7 @@ export const GetProjectsLocationsAppsDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsDeploymentsRequest>;
 
@@ -7499,7 +7503,7 @@ export const CreateProjectsLocationsAppsDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/deployments",
+      path: "v1beta/{+parent}/deployments",
       hasBody: true,
     }),
     svc,
@@ -7538,7 +7542,7 @@ export const PatchProjectsLocationsAppsDeploymentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Deployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppsDeploymentsRequest>;
 
@@ -7572,7 +7576,7 @@ export const DeleteProjectsLocationsAppsDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsDeploymentsRequest>;
 
@@ -7615,7 +7619,7 @@ export const ListProjectsLocationsAppsToolsetsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/toolsets" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/toolsets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsToolsetsRequest>;
 
@@ -7650,7 +7654,7 @@ export const GetProjectsLocationsAppsToolsetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsToolsetsRequest>;
 
@@ -7687,7 +7691,11 @@ export const CreateProjectsLocationsAppsToolsetsRequest =
     toolsetId: Schema.optional(Schema.String).pipe(T.HttpQuery("toolsetId")),
     body: Schema.optional(Toolset).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/toolsets", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/toolsets",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAppsToolsetsRequest>;
 
@@ -7724,7 +7732,7 @@ export const PatchProjectsLocationsAppsToolsetsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Toolset).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppsToolsetsRequest>;
 
@@ -7761,7 +7769,7 @@ export const DeleteProjectsLocationsAppsToolsetsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsToolsetsRequest>;
 
@@ -7797,7 +7805,7 @@ export const RetrieveToolsProjectsLocationsAppsToolsetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{toolset}:retrieveTools",
+      path: "v1beta/{+toolset}:retrieveTools",
       hasBody: true,
     }),
     svc,
@@ -7843,7 +7851,7 @@ export const ListProjectsLocationsAppsVersionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsVersionsRequest>;
 
@@ -7878,7 +7886,7 @@ export const GetProjectsLocationsAppsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsVersionsRequest>;
 
@@ -7917,7 +7925,11 @@ export const CreateProjectsLocationsAppsVersionsRequest =
     ),
     body: Schema.optional(AppVersion).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/versions", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/versions",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAppsVersionsRequest>;
 
@@ -7951,7 +7963,7 @@ export const DeleteProjectsLocationsAppsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsVersionsRequest>;
 
@@ -7985,7 +7997,7 @@ export const RestoreProjectsLocationsAppsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestoreAppVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsAppsVersionsRequest>;
 
@@ -8028,7 +8040,7 @@ export const ListProjectsLocationsAppsChangelogsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/changelogs" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/changelogs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsChangelogsRequest>;
 
@@ -8064,7 +8076,7 @@ export const GetProjectsLocationsAppsChangelogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsChangelogsRequest>;
 
@@ -8100,7 +8112,7 @@ export const UploadEvaluationAudioProjectsLocationsAppsEvaluationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{name}:uploadEvaluationAudio",
+      path: "v1beta/{+name}:uploadEvaluationAudio",
       hasBody: true,
     }),
     svc,
@@ -8145,7 +8157,7 @@ export const CreateProjectsLocationsAppsEvaluationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/evaluations",
+      path: "v1beta/{+parent}/evaluations",
       hasBody: true,
     }),
     svc,
@@ -8184,7 +8196,7 @@ export const PatchProjectsLocationsAppsEvaluationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Evaluation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppsEvaluationsRequest>;
 
@@ -8221,7 +8233,7 @@ export const DeleteProjectsLocationsAppsEvaluationsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsEvaluationsRequest>;
 
@@ -8252,7 +8264,7 @@ export const GetProjectsLocationsAppsEvaluationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsEvaluationsRequest>;
 
@@ -8310,7 +8322,7 @@ export const ListProjectsLocationsAppsEvaluationsRequest =
       T.HttpQuery("lastTenResults"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/evaluations" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/evaluations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsEvaluationsRequest>;
 
@@ -8351,7 +8363,7 @@ export const ExportProjectsLocationsAppsEvaluationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/evaluations:export",
+      path: "v1beta/{+parent}/evaluations:export",
       hasBody: true,
     }),
     svc,
@@ -8384,7 +8396,7 @@ export const DeleteProjectsLocationsAppsEvaluationsResultsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsEvaluationsResultsRequest>;
 
@@ -8415,7 +8427,7 @@ export const GetProjectsLocationsAppsEvaluationsResultsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsEvaluationsResultsRequest>;
 
@@ -8459,7 +8471,7 @@ export const ListProjectsLocationsAppsEvaluationsResultsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/results" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/results" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsEvaluationsResultsRequest>;
 
@@ -8505,7 +8517,7 @@ export const CreateProjectsLocationsAppsEvaluationDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/evaluationDatasets",
+      path: "v1beta/{+parent}/evaluationDatasets",
       hasBody: true,
     }),
     svc,
@@ -8545,7 +8557,7 @@ export const PatchProjectsLocationsAppsEvaluationDatasetsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(EvaluationDataset).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppsEvaluationDatasetsRequest>;
 
@@ -8580,7 +8592,7 @@ export const DeleteProjectsLocationsAppsEvaluationDatasetsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsEvaluationDatasetsRequest>;
 
@@ -8611,7 +8623,7 @@ export const GetProjectsLocationsAppsEvaluationDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsEvaluationDatasetsRequest>;
 
@@ -8655,7 +8667,7 @@ export const ListProjectsLocationsAppsEvaluationDatasetsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/evaluationDatasets" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/evaluationDatasets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsEvaluationDatasetsRequest>;
 
@@ -8691,7 +8703,7 @@ export const DeleteProjectsLocationsAppsEvaluationRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsEvaluationRunsRequest>;
 
@@ -8722,7 +8734,7 @@ export const GetProjectsLocationsAppsEvaluationRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsEvaluationRunsRequest>;
 
@@ -8765,7 +8777,7 @@ export const ListProjectsLocationsAppsEvaluationRunsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/evaluationRuns" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/evaluationRuns" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsEvaluationRunsRequest>;
 
@@ -8813,7 +8825,7 @@ export const ListProjectsLocationsAppsEvaluationExpectationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/evaluationExpectations" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/evaluationExpectations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsEvaluationExpectationsRequest>;
 
@@ -8850,7 +8862,7 @@ export const GetProjectsLocationsAppsEvaluationExpectationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsEvaluationExpectationsRequest>;
 
@@ -8892,7 +8904,7 @@ export const CreateProjectsLocationsAppsEvaluationExpectationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/evaluationExpectations",
+      path: "v1beta/{+parent}/evaluationExpectations",
       hasBody: true,
     }),
     svc,
@@ -8933,7 +8945,7 @@ export const PatchProjectsLocationsAppsEvaluationExpectationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(EvaluationExpectation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppsEvaluationExpectationsRequest>;
 
@@ -8969,7 +8981,7 @@ export const DeleteProjectsLocationsAppsEvaluationExpectationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsEvaluationExpectationsRequest>;
 
@@ -9011,7 +9023,7 @@ export const CreateProjectsLocationsAppsScheduledEvaluationRunsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/scheduledEvaluationRuns",
+      path: "v1beta/{+parent}/scheduledEvaluationRuns",
       hasBody: true,
     }),
     svc,
@@ -9046,7 +9058,7 @@ export const GetProjectsLocationsAppsScheduledEvaluationRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAppsScheduledEvaluationRunsRequest>;
 
@@ -9091,7 +9103,7 @@ export const ListProjectsLocationsAppsScheduledEvaluationRunsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/scheduledEvaluationRuns" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/scheduledEvaluationRuns" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAppsScheduledEvaluationRunsRequest>;
 
@@ -9134,7 +9146,7 @@ export const PatchProjectsLocationsAppsScheduledEvaluationRunsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ScheduledEvaluationRun).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAppsScheduledEvaluationRunsRequest>;
 
@@ -9170,7 +9182,7 @@ export const DeleteProjectsLocationsAppsScheduledEvaluationRunsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAppsScheduledEvaluationRunsRequest>;
 

--- a/packages/gcp/src/services/chat-v1.ts
+++ b/packages/gcp/src/services/chat-v1.ts
@@ -3267,7 +3267,7 @@ export const GetSpacesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("useAdminAccess"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetSpacesRequest>;
 
@@ -3333,7 +3333,7 @@ export const DeleteSpacesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("useAdminAccess"),
   ),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v1/{name}" }),
+  T.Http({ method: "DELETE", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteSpacesRequest>;
 
@@ -3406,7 +3406,11 @@ export const CompleteImportSpacesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CompleteImportSpaceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:completeImport", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+name}:completeImport",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CompleteImportSpacesRequest>;
 
@@ -3497,7 +3501,7 @@ export const PatchSpacesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(Space).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchSpacesRequest>;
 
@@ -3575,7 +3579,7 @@ export const ListSpacesMessagesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/messages" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/messages" }),
     svc,
   ) as unknown as Schema.Schema<ListSpacesMessagesRequest>;
 
@@ -3621,7 +3625,7 @@ export const PatchSpacesMessagesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Message).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchSpacesMessagesRequest>;
 
@@ -3662,7 +3666,7 @@ export const UpdateSpacesMessagesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Message).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSpacesMessagesRequest>;
 
@@ -3713,7 +3717,7 @@ export const CreateSpacesMessagesRequest =
     messageId: Schema.optional(Schema.String).pipe(T.HttpQuery("messageId")),
     body: Schema.optional(Message).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/messages", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/messages", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateSpacesMessagesRequest>;
 
@@ -3743,7 +3747,7 @@ export const GetSpacesMessagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSpacesMessagesRequest>;
 
@@ -3776,7 +3780,7 @@ export const DeleteSpacesMessagesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteSpacesMessagesRequest>;
 
@@ -3806,7 +3810,7 @@ export const GetSpacesMessagesAttachmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSpacesMessagesAttachmentsRequest>;
 
@@ -3846,7 +3850,7 @@ export const ListSpacesMessagesReactionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/reactions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/reactions" }),
     svc,
   ) as unknown as Schema.Schema<ListSpacesMessagesReactionsRequest>;
 
@@ -3884,7 +3888,7 @@ export const CreateSpacesMessagesReactionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Reaction).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/reactions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/reactions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateSpacesMessagesReactionsRequest>;
 
@@ -3915,7 +3919,7 @@ export const DeleteSpacesMessagesReactionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteSpacesMessagesReactionsRequest>;
 
@@ -3968,7 +3972,7 @@ export const ListSpacesMembersRequest =
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/members" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/members" }),
     svc,
   ) as unknown as Schema.Schema<ListSpacesMembersRequest>;
 
@@ -4014,7 +4018,7 @@ export const PatchSpacesMembersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Membership).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchSpacesMembersRequest>;
 
@@ -4050,7 +4054,7 @@ export const GetSpacesMembersRequest =
       T.HttpQuery("useAdminAccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSpacesMembersRequest>;
 
@@ -4088,7 +4092,7 @@ export const CreateSpacesMembersRequest =
     ),
     body: Schema.optional(Membership).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/members", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/members", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateSpacesMembersRequest>;
 
@@ -4124,7 +4128,7 @@ export const DeleteSpacesMembersRequest =
       T.HttpQuery("useAdminAccess"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteSpacesMembersRequest>;
 
@@ -4164,7 +4168,7 @@ export const ListSpacesSpaceEventsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/spaceEvents" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/spaceEvents" }),
     svc,
   ) as unknown as Schema.Schema<ListSpacesSpaceEventsRequest>;
 
@@ -4199,7 +4203,7 @@ export const GetSpacesSpaceEventsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSpacesSpaceEventsRequest>;
 
@@ -4303,7 +4307,7 @@ export const GetCustomEmojisRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     name: Schema.String.pipe(T.HttpPath("name")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetCustomEmojisRequest>;
 
@@ -4333,7 +4337,7 @@ export const DeleteCustomEmojisRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteCustomEmojisRequest>;
 
@@ -4362,7 +4366,7 @@ export interface DownloadMediaRequest {
 export const DownloadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   resourceName: Schema.String.pipe(T.HttpPath("resourceName")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/media/{resourceName}" }),
+  T.Http({ method: "GET", path: "v1/media/{+resourceName}" }),
   svc,
 ) as unknown as Schema.Schema<DownloadMediaRequest>;
 
@@ -4396,7 +4400,7 @@ export const UploadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "v1/{parent}/attachments:upload",
+    path: "v1/{+parent}/attachments:upload",
     hasBody: true,
   }),
   svc,
@@ -4432,7 +4436,7 @@ export const PositionUsersSectionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PositionSectionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:position", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:position", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PositionUsersSectionsRequest>;
 
@@ -4469,7 +4473,7 @@ export const ListUsersSectionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sections" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sections" }),
     svc,
   ) as unknown as Schema.Schema<ListUsersSectionsRequest>;
 
@@ -4510,7 +4514,7 @@ export const PatchUsersSectionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleChatV1Section).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchUsersSectionsRequest>;
 
@@ -4544,7 +4548,7 @@ export const CreateUsersSectionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleChatV1Section).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/sections", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/sections", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateUsersSectionsRequest>;
 
@@ -4575,7 +4579,7 @@ export const DeleteUsersSectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteUsersSectionsRequest>;
 
@@ -4614,7 +4618,7 @@ export const ListUsersSectionsItemsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/items" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/items" }),
     svc,
   ) as unknown as Schema.Schema<ListUsersSectionsItemsRequest>;
 
@@ -4652,7 +4656,7 @@ export const MoveUsersSectionsItemsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MoveSectionItemRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveUsersSectionsItemsRequest>;
 
@@ -4689,7 +4693,7 @@ export const UpdateSpaceReadStateUsersSpacesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SpaceReadState).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSpaceReadStateUsersSpacesRequest>;
 
@@ -4720,7 +4724,7 @@ export const GetSpaceReadStateUsersSpacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSpaceReadStateUsersSpacesRequest>;
 
@@ -4751,7 +4755,7 @@ export const GetThreadReadStateUsersSpacesThreadsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetThreadReadStateUsersSpacesThreadsRequest>;
 
@@ -4782,7 +4786,7 @@ export const GetUsersSpacesSpaceNotificationSettingRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetUsersSpacesSpaceNotificationSettingRequest>;
 
@@ -4820,7 +4824,7 @@ export const PatchUsersSpacesSpaceNotificationSettingRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SpaceNotificationSetting).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchUsersSpacesSpaceNotificationSettingRequest>;
 

--- a/packages/gcp/src/services/checks-v1alpha.ts
+++ b/packages/gcp/src/services/checks-v1alpha.ts
@@ -1454,7 +1454,7 @@ export const UploadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "v1alpha/{parent}/reports:analyzeUpload",
+    path: "v1alpha/{+parent}/reports:analyzeUpload",
     hasBody: true,
   }),
   svc,
@@ -1492,7 +1492,7 @@ export const ListAccountsAppsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/apps" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/apps" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAppsRequest>;
 
@@ -1529,7 +1529,7 @@ export const GetAccountsAppsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     name: Schema.String.pipe(T.HttpPath("name")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "v1alpha/{name}" }),
+  T.Http({ method: "GET", path: "v1alpha/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetAccountsAppsRequest>;
 
@@ -1574,7 +1574,7 @@ export const ListAccountsAppsReportsRequest =
       T.HttpQuery("checksFilter"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/reports" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/reports" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAppsReportsRequest>;
 
@@ -1615,7 +1615,7 @@ export const GetAccountsAppsReportsRequest =
       T.HttpQuery("checksFilter"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsAppsReportsRequest>;
 
@@ -1649,7 +1649,7 @@ export const WaitAccountsAppsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(WaitOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitAccountsAppsOperationsRequest>;
 
@@ -1680,7 +1680,7 @@ export const GetAccountsAppsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsAppsOperationsRequest>;
 
@@ -1725,7 +1725,7 @@ export const ListAccountsAppsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAppsOperationsRequest>;
 
@@ -1760,7 +1760,7 @@ export const DeleteAccountsAppsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsAppsOperationsRequest>;
 
@@ -1794,7 +1794,7 @@ export const CancelAccountsAppsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelAccountsAppsOperationsRequest>;
 
@@ -1825,7 +1825,7 @@ export const GetAccountsReposOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsReposOperationsRequest>;
 
@@ -1863,7 +1863,7 @@ export const GenerateAccountsReposScansRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/scans:generate",
+      path: "v1alpha/{+parent}/scans:generate",
       hasBody: true,
     }),
     svc,
@@ -1896,7 +1896,7 @@ export const GetAccountsReposScansRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsReposScansRequest>;
 
@@ -1936,7 +1936,7 @@ export const ListAccountsReposScansRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/scans" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/scans" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsReposScansRequest>;
 

--- a/packages/gcp/src/services/chromemanagement-v1.ts
+++ b/packages/gcp/src/services/chromemanagement-v1.ts
@@ -3495,7 +3495,7 @@ export const ListCustomersTelemetryEventsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/telemetry/events" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/telemetry/events" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersTelemetryEventsRequest>;
 
@@ -3543,7 +3543,7 @@ export const ListCustomersTelemetryDevicesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/telemetry/devices" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/telemetry/devices" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersTelemetryDevicesRequest>;
 
@@ -3582,7 +3582,7 @@ export const GetCustomersTelemetryDevicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersTelemetryDevicesRequest>;
 
@@ -3626,7 +3626,7 @@ export const ListCustomersTelemetryUsersRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/telemetry/users" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/telemetry/users" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersTelemetryUsersRequest>;
 
@@ -3665,7 +3665,7 @@ export const GetCustomersTelemetryUsersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersTelemetryUsersRequest>;
 
@@ -3705,7 +3705,7 @@ export const ListCustomersTelemetryNotificationConfigsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/telemetry/notificationConfigs",
+      path: "v1/{+parent}/telemetry/notificationConfigs",
     }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersTelemetryNotificationConfigsRequest>;
@@ -3749,7 +3749,7 @@ export const CreateCustomersTelemetryNotificationConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/telemetry/notificationConfigs",
+      path: "v1/{+parent}/telemetry/notificationConfigs",
       hasBody: true,
     }),
     svc,
@@ -3783,7 +3783,7 @@ export const DeleteCustomersTelemetryNotificationConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteCustomersTelemetryNotificationConfigsRequest>;
 
@@ -3827,7 +3827,7 @@ export const ListCustomersProfilesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/profiles" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/profiles" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersProfilesRequest>;
 
@@ -3863,7 +3863,7 @@ export const GetCustomersProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersProfilesRequest>;
 
@@ -3895,7 +3895,7 @@ export const DeleteCustomersProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteCustomersProfilesRequest>;
 
@@ -3931,7 +3931,7 @@ export const CreateCustomersProfilesCommandsRequest =
       GoogleChromeManagementVersionsV1ChromeBrowserProfileCommand,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/commands", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/commands", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateCustomersProfilesCommandsRequest>;
 
@@ -3963,7 +3963,7 @@ export const GetCustomersProfilesCommandsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersProfilesCommandsRequest>;
 
@@ -4001,7 +4001,7 @@ export const ListCustomersProfilesCommandsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/commands" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/commands" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersProfilesCommandsRequest>;
 
@@ -4042,7 +4042,7 @@ export const MoveCustomersThirdPartyProfileUsersRequest =
       GoogleChromeManagementVersionsV1MoveThirdPartyProfileUserRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveCustomersThirdPartyProfileUsersRequest>;
 
@@ -4088,7 +4088,7 @@ export const CountChromeAppRequestsCustomersAppsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{customer}/apps:countChromeAppRequests",
+      path: "v1/{+customer}/apps:countChromeAppRequests",
     }),
     svc,
   ) as unknown as Schema.Schema<CountChromeAppRequestsCustomersAppsRequest>;
@@ -4141,7 +4141,7 @@ export const FetchDevicesRequestingExtensionCustomersAppsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{customer}/apps:fetchDevicesRequestingExtension",
+      path: "v1/{+customer}/apps:fetchDevicesRequestingExtension",
     }),
     svc,
   ) as unknown as Schema.Schema<FetchDevicesRequestingExtensionCustomersAppsRequest>;
@@ -4194,7 +4194,7 @@ export const FetchUsersRequestingExtensionCustomersAppsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{customer}/apps:fetchUsersRequestingExtension",
+      path: "v1/{+customer}/apps:fetchUsersRequestingExtension",
     }),
     svc,
   ) as unknown as Schema.Schema<FetchUsersRequestingExtensionCustomersAppsRequest>;
@@ -4231,7 +4231,7 @@ export const GetCustomersAppsAndroidRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersAppsAndroidRequest>;
 
@@ -4263,7 +4263,7 @@ export const GetCustomersAppsChromeRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersAppsChromeRequest>;
 
@@ -4294,7 +4294,7 @@ export const GetCustomersAppsWebRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersAppsWebRequest>;
 
@@ -4336,7 +4336,7 @@ export const CountChromeDevicesReachingAutoExpirationDateCustomersReportsRequest
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{customer}/reports:countChromeDevicesReachingAutoExpirationDate",
+      path: "v1/{+customer}/reports:countChromeDevicesReachingAutoExpirationDate",
     }),
     svc,
   ) as unknown as Schema.Schema<CountChromeDevicesReachingAutoExpirationDateCustomersReportsRequest>;
@@ -4387,7 +4387,10 @@ export const EnumeratePrintJobsCustomersReportsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{customer}/reports:enumeratePrintJobs" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+customer}/reports:enumeratePrintJobs",
+    }),
     svc,
   ) as unknown as Schema.Schema<EnumeratePrintJobsCustomersReportsRequest>;
 
@@ -4442,7 +4445,7 @@ export const CountPrintJobsByPrinterCustomersReportsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{customer}/reports:countPrintJobsByPrinter",
+      path: "v1/{+customer}/reports:countPrintJobsByPrinter",
     }),
     svc,
   ) as unknown as Schema.Schema<CountPrintJobsByPrinterCustomersReportsRequest>;
@@ -4498,7 +4501,7 @@ export const CountPrintJobsByUserCustomersReportsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{customer}/reports:countPrintJobsByUser",
+      path: "v1/{+customer}/reports:countPrintJobsByUser",
     }),
     svc,
   ) as unknown as Schema.Schema<CountPrintJobsByUserCustomersReportsRequest>;
@@ -4546,7 +4549,10 @@ export const CountActiveDevicesCustomersReportsRequest =
       T.HttpQuery("date.month"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{customer}/reports:countActiveDevices" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+customer}/reports:countActiveDevices",
+    }),
     svc,
   ) as unknown as Schema.Schema<CountActiveDevicesCustomersReportsRequest>;
 
@@ -4608,7 +4614,7 @@ export const FindInstalledAppDevicesCustomersReportsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{customer}/reports:findInstalledAppDevices",
+      path: "v1/{+customer}/reports:findInstalledAppDevices",
     }),
     svc,
   ) as unknown as Schema.Schema<FindInstalledAppDevicesCustomersReportsRequest>;
@@ -4656,7 +4662,7 @@ export const CountChromeCrashEventsCustomersReportsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{customer}/reports:countChromeCrashEvents",
+      path: "v1/{+customer}/reports:countChromeCrashEvents",
     }),
     svc,
   ) as unknown as Schema.Schema<CountChromeCrashEventsCustomersReportsRequest>;
@@ -4697,7 +4703,7 @@ export const CountChromeHardwareFleetDevicesCustomersReportsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{customer}/reports:countChromeHardwareFleetDevices",
+      path: "v1/{+customer}/reports:countChromeHardwareFleetDevices",
     }),
     svc,
   ) as unknown as Schema.Schema<CountChromeHardwareFleetDevicesCustomersReportsRequest>;
@@ -4744,7 +4750,7 @@ export const CountDevicesPerBootTypeCustomersReportsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{customer}/reports:countDevicesPerBootType",
+      path: "v1/{+customer}/reports:countDevicesPerBootType",
     }),
     svc,
   ) as unknown as Schema.Schema<CountDevicesPerBootTypeCustomersReportsRequest>;
@@ -4791,7 +4797,7 @@ export const CountChromeVersionsCustomersReportsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{customer}/reports:countChromeVersions",
+      path: "v1/{+customer}/reports:countChromeVersions",
     }),
     svc,
   ) as unknown as Schema.Schema<CountChromeVersionsCustomersReportsRequest>;
@@ -4841,7 +4847,7 @@ export const CountDevicesPerReleaseChannelCustomersReportsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{customer}/reports:countDevicesPerReleaseChannel",
+      path: "v1/{+customer}/reports:countDevicesPerReleaseChannel",
     }),
     svc,
   ) as unknown as Schema.Schema<CountDevicesPerReleaseChannelCustomersReportsRequest>;
@@ -4879,7 +4885,7 @@ export const CountChromeBrowsersNeedingAttentionCustomersReportsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{customer}/reports:countChromeBrowsersNeedingAttention",
+      path: "v1/{+customer}/reports:countChromeBrowsersNeedingAttention",
     }),
     svc,
   ) as unknown as Schema.Schema<CountChromeBrowsersNeedingAttentionCustomersReportsRequest>;
@@ -4921,7 +4927,7 @@ export const CountChromeDevicesThatNeedAttentionCustomersReportsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{customer}/reports:countChromeDevicesThatNeedAttention",
+      path: "v1/{+customer}/reports:countChromeDevicesThatNeedAttention",
     }),
     svc,
   ) as unknown as Schema.Schema<CountChromeDevicesThatNeedAttentionCustomersReportsRequest>;
@@ -4970,7 +4976,10 @@ export const CountInstalledAppsCustomersReportsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     customer: Schema.String.pipe(T.HttpPath("customer")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{customer}/reports:countInstalledApps" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+customer}/reports:countInstalledApps",
+    }),
     svc,
   ) as unknown as Schema.Schema<CountInstalledAppsCustomersReportsRequest>;
 
@@ -5006,7 +5015,7 @@ export const GetCustomersCertificateProvisioningProcessesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersCertificateProvisioningProcessesRequest>;
 
@@ -5045,7 +5054,7 @@ export const UploadCertificateCustomersCertificateProvisioningProcessesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:uploadCertificate",
+      path: "v1/{+name}:uploadCertificate",
       hasBody: true,
     }),
     svc,
@@ -5085,7 +5094,7 @@ export const SignDataCustomersCertificateProvisioningProcessesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:signData", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:signData", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SignDataCustomersCertificateProvisioningProcessesRequest>;
 
@@ -5123,7 +5132,7 @@ export const SetFailureCustomersCertificateProvisioningProcessesRequest =
       GoogleChromeManagementVersionsV1SetFailureRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setFailure", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setFailure", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetFailureCustomersCertificateProvisioningProcessesRequest>;
 
@@ -5161,7 +5170,7 @@ export const ClaimCustomersCertificateProvisioningProcessesRequest =
       GoogleChromeManagementVersionsV1ClaimCertificateProvisioningProcessRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:claim", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:claim", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ClaimCustomersCertificateProvisioningProcessesRequest>;
 
@@ -5193,7 +5202,7 @@ export const GetCustomersCertificateProvisioningProcessesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersCertificateProvisioningProcessesOperationsRequest>;
 
@@ -5239,7 +5248,7 @@ export const ListOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   ),
   filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<ListOperationsRequest>;
 
@@ -5279,7 +5288,7 @@ export const CancelOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOperationsRequest>;
 
@@ -5310,7 +5319,7 @@ export const DeleteOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOperationsRequest>;
 

--- a/packages/gcp/src/services/chromepolicy-v1.ts
+++ b/packages/gcp/src/services/chromepolicy-v1.ts
@@ -1051,7 +1051,7 @@ export const UploadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "v1/{customer}/policies/files:uploadPolicyFile",
+    path: "v1/{+customer}/policies/files:uploadPolicyFile",
     hasBody: true,
   }),
   svc,
@@ -1092,7 +1092,7 @@ export const ResolveCustomersPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{customer}/policies:resolve",
+      path: "v1/{+customer}/policies:resolve",
       hasBody: true,
     }),
     svc,
@@ -1133,7 +1133,7 @@ export const BatchDeleteCustomersPoliciesGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{customer}/policies/groups:batchDelete",
+      path: "v1/{+customer}/policies/groups:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -1173,7 +1173,7 @@ export const UpdateGroupPriorityOrderingCustomersPoliciesGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{customer}/policies/groups:updateGroupPriorityOrdering",
+      path: "v1/{+customer}/policies/groups:updateGroupPriorityOrdering",
       hasBody: true,
     }),
     svc,
@@ -1215,7 +1215,7 @@ export const BatchModifyCustomersPoliciesGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{customer}/policies/groups:batchModify",
+      path: "v1/{+customer}/policies/groups:batchModify",
       hasBody: true,
     }),
     svc,
@@ -1255,7 +1255,7 @@ export const ListGroupPriorityOrderingCustomersPoliciesGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{customer}/policies/groups:listGroupPriorityOrdering",
+      path: "v1/{+customer}/policies/groups:listGroupPriorityOrdering",
       hasBody: true,
     }),
     svc,
@@ -1297,7 +1297,7 @@ export const DefineNetworkCustomersPoliciesNetworksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{customer}/policies/networks:defineNetwork",
+      path: "v1/{+customer}/policies/networks:defineNetwork",
       hasBody: true,
     }),
     svc,
@@ -1338,7 +1338,7 @@ export const RemoveCertificateCustomersPoliciesNetworksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{customer}/policies/networks:removeCertificate",
+      path: "v1/{+customer}/policies/networks:removeCertificate",
       hasBody: true,
     }),
     svc,
@@ -1379,7 +1379,7 @@ export const RemoveNetworkCustomersPoliciesNetworksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{customer}/policies/networks:removeNetwork",
+      path: "v1/{+customer}/policies/networks:removeNetwork",
       hasBody: true,
     }),
     svc,
@@ -1420,7 +1420,7 @@ export const DefineCertificateCustomersPoliciesNetworksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{customer}/policies/networks:defineCertificate",
+      path: "v1/{+customer}/policies/networks:defineCertificate",
       hasBody: true,
     }),
     svc,
@@ -1461,7 +1461,7 @@ export const BatchInheritCustomersPoliciesOrgunitsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{customer}/policies/orgunits:batchInherit",
+      path: "v1/{+customer}/policies/orgunits:batchInherit",
       hasBody: true,
     }),
     svc,
@@ -1501,7 +1501,7 @@ export const BatchModifyCustomersPoliciesOrgunitsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{customer}/policies/orgunits:batchModify",
+      path: "v1/{+customer}/policies/orgunits:batchModify",
       hasBody: true,
     }),
     svc,
@@ -1534,7 +1534,7 @@ export const GetCustomersPolicySchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersPolicySchemasRequest>;
 
@@ -1575,7 +1575,7 @@ export const ListCustomersPolicySchemasRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/policySchemas" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/policySchemas" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersPolicySchemasRequest>;
 

--- a/packages/gcp/src/services/chromewebstore-v2.ts
+++ b/packages/gcp/src/services/chromewebstore-v2.ts
@@ -221,7 +221,7 @@ export const PublishPublishersItemsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PublishItemRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:publish", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:publish", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PublishPublishersItemsRequest>;
 
@@ -252,7 +252,7 @@ export const FetchStatusPublishersItemsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}:fetchStatus" }),
+    T.Http({ method: "GET", path: "v2/{+name}:fetchStatus" }),
     svc,
   ) as unknown as Schema.Schema<FetchStatusPublishersItemsRequest>;
 
@@ -288,7 +288,7 @@ export const CancelSubmissionPublishersItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:cancelSubmission",
+      path: "v2/{+name}:cancelSubmission",
       hasBody: true,
     }),
     svc,
@@ -328,7 +328,7 @@ export const SetPublishedDeployPercentagePublishersItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:setPublishedDeployPercentage",
+      path: "v2/{+name}:setPublishedDeployPercentage",
       hasBody: true,
     }),
     svc,
@@ -364,7 +364,7 @@ export const UploadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(UploadItemPackageRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v2/{name}:upload", hasBody: true }),
+  T.Http({ method: "POST", path: "v2/{+name}:upload", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<UploadMediaRequest>;
 

--- a/packages/gcp/src/services/cloudasset-v1.ts
+++ b/packages/gcp/src/services/cloudasset-v1.ts
@@ -2693,7 +2693,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -2725,7 +2725,7 @@ export const ExportAssetsV1Request = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   parent: Schema.String.pipe(T.HttpPath("parent")),
   body: Schema.optional(ExportAssetsRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v1/{parent}:exportAssets", hasBody: true }),
+  T.Http({ method: "POST", path: "v1/{+parent}:exportAssets", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<ExportAssetsV1Request>;
 
@@ -2788,7 +2788,7 @@ export const BatchGetAssetsHistoryV1Request =
       T.HttpQuery("relationshipTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}:batchGetAssetsHistory" }),
+    T.Http({ method: "GET", path: "v1/{+parent}:batchGetAssetsHistory" }),
     svc,
   ) as unknown as Schema.Schema<BatchGetAssetsHistoryV1Request>;
 
@@ -2839,7 +2839,7 @@ export const SearchAllResourcesV1Request =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{scope}:searchAllResources" }),
+    T.Http({ method: "GET", path: "v1/{+scope}:searchAllResources" }),
     svc,
   ) as unknown as Schema.Schema<SearchAllResourcesV1Request>;
 
@@ -2891,7 +2891,7 @@ export const SearchAllIamPoliciesV1Request =
     ),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{scope}:searchAllIamPolicies" }),
+    T.Http({ method: "GET", path: "v1/{+scope}:searchAllIamPolicies" }),
     svc,
   ) as unknown as Schema.Schema<SearchAllIamPoliciesV1Request>;
 
@@ -2993,7 +2993,7 @@ export const AnalyzeIamPolicyV1Request =
       T.HttpQuery("executionTimeout"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{scope}:analyzeIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+scope}:analyzeIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<AnalyzeIamPolicyV1Request>;
 
@@ -3031,7 +3031,7 @@ export const AnalyzeIamPolicyLongrunningV1Request =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{scope}:analyzeIamPolicyLongrunning",
+      path: "v1/{+scope}:analyzeIamPolicyLongrunning",
       hasBody: true,
     }),
     svc,
@@ -3071,7 +3071,7 @@ export const AnalyzeMoveV1Request = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   ),
   view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{resource}:analyzeMove" }),
+  T.Http({ method: "GET", path: "v1/{+resource}:analyzeMove" }),
   svc,
 ) as unknown as Schema.Schema<AnalyzeMoveV1Request>;
 
@@ -3104,7 +3104,7 @@ export const QueryAssetsV1Request = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   parent: Schema.String.pipe(T.HttpPath("parent")),
   body: Schema.optional(QueryAssetsRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v1/{parent}:queryAssets", hasBody: true }),
+  T.Http({ method: "POST", path: "v1/{+parent}:queryAssets", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<QueryAssetsV1Request>;
 
@@ -3147,7 +3147,7 @@ export const AnalyzeOrgPoliciesV1Request =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{scope}:analyzeOrgPolicies" }),
+    T.Http({ method: "GET", path: "v1/{+scope}:analyzeOrgPolicies" }),
     svc,
   ) as unknown as Schema.Schema<AnalyzeOrgPoliciesV1Request>;
 
@@ -3196,7 +3196,7 @@ export const AnalyzeOrgPolicyGovernedContainersV1Request =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{scope}:analyzeOrgPolicyGovernedContainers",
+      path: "v1/{+scope}:analyzeOrgPolicyGovernedContainers",
     }),
     svc,
   ) as unknown as Schema.Schema<AnalyzeOrgPolicyGovernedContainersV1Request>;
@@ -3247,7 +3247,7 @@ export const AnalyzeOrgPolicyGovernedAssetsV1Request =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{scope}:analyzeOrgPolicyGovernedAssets",
+      path: "v1/{+scope}:analyzeOrgPolicyGovernedAssets",
     }),
     svc,
   ) as unknown as Schema.Schema<AnalyzeOrgPolicyGovernedAssetsV1Request>;
@@ -3313,7 +3313,7 @@ export const ListAssetsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("relationshipTypes"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{parent}/assets" }),
+  T.Http({ method: "GET", path: "v1/{+parent}/assets" }),
   svc,
 ) as unknown as Schema.Schema<ListAssetsRequest>;
 
@@ -3350,7 +3350,7 @@ export const CreateFeedsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   parent: Schema.String.pipe(T.HttpPath("parent")),
   body: Schema.optional(CreateFeedRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v1/{parent}/feeds", hasBody: true }),
+  T.Http({ method: "POST", path: "v1/{+parent}/feeds", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<CreateFeedsRequest>;
 
@@ -3379,7 +3379,7 @@ export interface GetFeedsRequest {
 export const GetFeedsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetFeedsRequest>;
 
@@ -3408,7 +3408,7 @@ export interface ListFeedsRequest {
 export const ListFeedsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   parent: Schema.String.pipe(T.HttpPath("parent")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{parent}/feeds" }),
+  T.Http({ method: "GET", path: "v1/{+parent}/feeds" }),
   svc,
 ) as unknown as Schema.Schema<ListFeedsRequest>;
 
@@ -3441,7 +3441,7 @@ export const PatchFeedsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(UpdateFeedRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchFeedsRequest>;
 
@@ -3470,7 +3470,7 @@ export interface DeleteFeedsRequest {
 export const DeleteFeedsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v1/{name}" }),
+  T.Http({ method: "DELETE", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteFeedsRequest>;
 
@@ -3508,7 +3508,11 @@ export const CreateSavedQueriesRequest =
     ),
     body: Schema.optional(SavedQuery).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/savedQueries", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/savedQueries",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateSavedQueriesRequest>;
 
@@ -3540,7 +3544,7 @@ export const GetSavedQueriesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     name: Schema.String.pipe(T.HttpPath("name")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetSavedQueriesRequest>;
 
@@ -3579,7 +3583,7 @@ export const ListSavedQueriesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/savedQueries" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/savedQueries" }),
     svc,
   ) as unknown as Schema.Schema<ListSavedQueriesRequest>;
 
@@ -3620,7 +3624,7 @@ export const PatchSavedQueriesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SavedQuery).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchSavedQueriesRequest>;
 
@@ -3650,7 +3654,7 @@ export const DeleteSavedQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteSavedQueriesRequest>;
 
@@ -3685,7 +3689,10 @@ export const BatchGetEffectiveIamPoliciesRequest =
       T.HttpQuery("names"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{scope}/effectiveIamPolicies:batchGet" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+scope}/effectiveIamPolicies:batchGet",
+    }),
     svc,
   ) as unknown as Schema.Schema<BatchGetEffectiveIamPoliciesRequest>;
 

--- a/packages/gcp/src/services/cloudasset-v1beta1.ts
+++ b/packages/gcp/src/services/cloudasset-v1beta1.ts
@@ -989,7 +989,7 @@ export const ExportAssetsProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:exportAssets",
+      path: "v1beta1/{+parent}:exportAssets",
       hasBody: true,
     }),
     svc,
@@ -1046,7 +1046,7 @@ export const BatchGetAssetsHistoryProjectsRequest =
       T.HttpQuery("readTimeWindow.endTime"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}:batchGetAssetsHistory" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}:batchGetAssetsHistory" }),
     svc,
   ) as unknown as Schema.Schema<BatchGetAssetsHistoryProjectsRequest>;
 
@@ -1078,7 +1078,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 
@@ -1114,7 +1114,7 @@ export const ExportAssetsFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:exportAssets",
+      path: "v1beta1/{+parent}:exportAssets",
       hasBody: true,
     }),
     svc,
@@ -1147,7 +1147,7 @@ export const GetFoldersOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersOperationsRequest>;
 
@@ -1183,7 +1183,7 @@ export const ExportAssetsOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:exportAssets",
+      path: "v1beta1/{+parent}:exportAssets",
       hasBody: true,
     }),
     svc,
@@ -1240,7 +1240,7 @@ export const BatchGetAssetsHistoryOrganizationsRequest =
       T.HttpQuery("readTimeWindow.endTime"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}:batchGetAssetsHistory" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}:batchGetAssetsHistory" }),
     svc,
   ) as unknown as Schema.Schema<BatchGetAssetsHistoryOrganizationsRequest>;
 
@@ -1272,7 +1272,7 @@ export const GetOrganizationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsOperationsRequest>;
 

--- a/packages/gcp/src/services/cloudasset-v1p1beta1.ts
+++ b/packages/gcp/src/services/cloudasset-v1p1beta1.ts
@@ -923,7 +923,7 @@ export const SearchAllResourcesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1p1beta1/{scope}/resources:searchAll" }),
+    T.Http({ method: "GET", path: "v1p1beta1/{+scope}/resources:searchAll" }),
     svc,
   ) as unknown as Schema.Schema<SearchAllResourcesRequest>;
 
@@ -967,7 +967,7 @@ export const SearchAllIamPoliciesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1p1beta1/{scope}/iamPolicies:searchAll" }),
+    T.Http({ method: "GET", path: "v1p1beta1/{+scope}/iamPolicies:searchAll" }),
     svc,
   ) as unknown as Schema.Schema<SearchAllIamPoliciesRequest>;
 

--- a/packages/gcp/src/services/cloudasset-v1p5beta1.ts
+++ b/packages/gcp/src/services/cloudasset-v1p5beta1.ts
@@ -906,7 +906,7 @@ export const ListAssetsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1p5beta1/{parent}/assets" }),
+  T.Http({ method: "GET", path: "v1p5beta1/{+parent}/assets" }),
   svc,
 ) as unknown as Schema.Schema<ListAssetsRequest>;
 

--- a/packages/gcp/src/services/cloudasset-v1p7beta1.ts
+++ b/packages/gcp/src/services/cloudasset-v1p7beta1.ts
@@ -938,7 +938,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1p7beta1/{name}" }),
+  T.Http({ method: "GET", path: "v1p7beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -975,7 +975,7 @@ export const ExportAssetsV1p7beta1Request =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p7beta1/{parent}:exportAssets",
+      path: "v1p7beta1/{+parent}:exportAssets",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/cloudbilling-v1.ts
+++ b/packages/gcp/src/services/cloudbilling-v1.ts
@@ -428,7 +428,7 @@ export const GetBillingAccountsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsRequest>;
 
@@ -509,7 +509,7 @@ export const PatchBillingAccountsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(BillingAccount).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchBillingAccountsRequest>;
 
@@ -579,7 +579,7 @@ export const GetIamPolicyBillingAccountsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyBillingAccountsRequest>;
 
@@ -615,7 +615,7 @@ export const SetIamPolicyBillingAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -653,7 +653,7 @@ export const TestIamPermissionsBillingAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -690,7 +690,7 @@ export const MoveBillingAccountsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MoveBillingAccountRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveBillingAccountsRequest>;
 
@@ -730,7 +730,7 @@ export const ListBillingAccountsSubAccountsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/subAccounts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/subAccounts" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsSubAccountsRequest>;
 
@@ -769,7 +769,7 @@ export const CreateBillingAccountsSubAccountsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(BillingAccount).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/subAccounts", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/subAccounts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateBillingAccountsSubAccountsRequest>;
 
@@ -806,7 +806,7 @@ export const ListBillingAccountsProjectsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/projects" }),
+    T.Http({ method: "GET", path: "v1/{+name}/projects" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsProjectsRequest>;
 
@@ -851,7 +851,7 @@ export const ListOrganizationsBillingAccountsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/billingAccounts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/billingAccounts" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsBillingAccountsRequest>;
 
@@ -892,7 +892,7 @@ export const CreateOrganizationsBillingAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/billingAccounts",
+      path: "v1/{+parent}/billingAccounts",
       hasBody: true,
     }),
     svc,
@@ -928,7 +928,7 @@ export const MoveOrganizationsBillingAccountsRequest =
     destinationParent: Schema.String.pipe(T.HttpPath("destinationParent")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{destinationParent}/{name}:move" }),
+    T.Http({ method: "GET", path: "v1/{+destinationParent}/{+name}:move" }),
     svc,
   ) as unknown as Schema.Schema<MoveOrganizationsBillingAccountsRequest>;
 
@@ -959,7 +959,7 @@ export const GetBillingInfoProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/billingInfo" }),
+    T.Http({ method: "GET", path: "v1/{+name}/billingInfo" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingInfoProjectsRequest>;
 
@@ -993,7 +993,7 @@ export const UpdateBillingInfoProjectsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ProjectBillingInfo).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}/billingInfo", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}/billingInfo", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateBillingInfoProjectsRequest>;
 
@@ -1078,7 +1078,7 @@ export const ListServicesSkusRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/skus" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/skus" }),
     svc,
   ) as unknown as Schema.Schema<ListServicesSkusRequest>;
 

--- a/packages/gcp/src/services/cloudbilling-v1.ts
+++ b/packages/gcp/src/services/cloudbilling-v1.ts
@@ -53,11 +53,10 @@ export interface ListBillingAccountsResponse {
   nextPageToken?: string;
 }
 
-export const ListBillingAccountsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    billingAccounts: Schema.optional(Schema.Array(BillingAccount)),
-    nextPageToken: Schema.optional(Schema.String),
-  }).annotate({ identifier: "ListBillingAccountsResponse" });
+export const ListBillingAccountsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  billingAccounts: Schema.optional(Schema.Array(BillingAccount)),
+  nextPageToken: Schema.optional(Schema.String),
+}).annotate({ identifier: "ListBillingAccountsResponse" });
 
 export interface ProjectBillingInfo {
   /** Output only. The resource name for the `ProjectBillingInfo`; has the form `projects/{project_id}/billingInfo`. For example, the resource name for the billing information for project `tokyo-rain-123` would be `projects/tokyo-rain-123/billingInfo`. */
@@ -84,11 +83,10 @@ export interface ListProjectBillingInfoResponse {
   nextPageToken?: string;
 }
 
-export const ListProjectBillingInfoResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    projectBillingInfo: Schema.optional(Schema.Array(ProjectBillingInfo)),
-    nextPageToken: Schema.optional(Schema.String),
-  }).annotate({ identifier: "ListProjectBillingInfoResponse" });
+export const ListProjectBillingInfoResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  projectBillingInfo: Schema.optional(Schema.Array(ProjectBillingInfo)),
+  nextPageToken: Schema.optional(Schema.String),
+}).annotate({ identifier: "ListProjectBillingInfoResponse" });
 
 export interface Expr {
   /** Textual representation of an expression in Common Expression Language syntax. */
@@ -125,12 +123,7 @@ export const Binding = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export interface AuditLogConfig {
   /** The log type that this config enables. */
-  logType?:
-    | "LOG_TYPE_UNSPECIFIED"
-    | "ADMIN_READ"
-    | "DATA_WRITE"
-    | "DATA_READ"
-    | (string & {});
+  logType?: "LOG_TYPE_UNSPECIFIED" | "ADMIN_READ" | "DATA_WRITE" | "DATA_READ" | (string & {});
   /** Specifies the identities that do not cause logging for this type of permission. Follows the same format of Binding.members. */
   exemptedMembers?: ReadonlyArray<string>;
 }
@@ -187,30 +180,27 @@ export interface TestIamPermissionsRequest {
   permissions?: ReadonlyArray<string>;
 }
 
-export const TestIamPermissionsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    permissions: Schema.optional(Schema.Array(Schema.String)),
-  }).annotate({ identifier: "TestIamPermissionsRequest" });
+export const TestIamPermissionsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  permissions: Schema.optional(Schema.Array(Schema.String)),
+}).annotate({ identifier: "TestIamPermissionsRequest" });
 
 export interface TestIamPermissionsResponse {
   /** A subset of `TestPermissionsRequest.permissions` that the caller is allowed. */
   permissions?: ReadonlyArray<string>;
 }
 
-export const TestIamPermissionsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    permissions: Schema.optional(Schema.Array(Schema.String)),
-  }).annotate({ identifier: "TestIamPermissionsResponse" });
+export const TestIamPermissionsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  permissions: Schema.optional(Schema.Array(Schema.String)),
+}).annotate({ identifier: "TestIamPermissionsResponse" });
 
 export interface MoveBillingAccountRequest {
   /** Required. The resource name of the Organization to move the billing account under. Must be of the form `organizations/{organization_id}`. */
   destinationParent?: string;
 }
 
-export const MoveBillingAccountRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    destinationParent: Schema.optional(Schema.String),
-  }).annotate({ identifier: "MoveBillingAccountRequest" });
+export const MoveBillingAccountRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  destinationParent: Schema.optional(Schema.String),
+}).annotate({ identifier: "MoveBillingAccountRequest" });
 
 export interface Service {
   /** The resource name for the service. Example: "services/6F81-5844-456A" */
@@ -315,16 +305,8 @@ export const PricingExpression = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).annotate({ identifier: "PricingExpression" });
 
 export interface AggregationInfo {
-  aggregationLevel?:
-    | "AGGREGATION_LEVEL_UNSPECIFIED"
-    | "ACCOUNT"
-    | "PROJECT"
-    | (string & {});
-  aggregationInterval?:
-    | "AGGREGATION_INTERVAL_UNSPECIFIED"
-    | "DAILY"
-    | "MONTHLY"
-    | (string & {});
+  aggregationLevel?: "AGGREGATION_LEVEL_UNSPECIFIED" | "ACCOUNT" | "PROJECT" | (string & {});
+  aggregationInterval?: "AGGREGATION_INTERVAL_UNSPECIFIED" | "DAILY" | "MONTHLY" | (string & {});
   /** The number of intervals to aggregate over. Example: If aggregation_level is "DAILY" and aggregation_count is 14, aggregation will be over 14 days. */
   aggregationCount?: number;
 }
@@ -358,12 +340,7 @@ export const PricingInfo = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export interface GeoTaxonomy {
   /** The type of Geo Taxonomy: GLOBAL, REGIONAL, or MULTI_REGIONAL. */
-  type?:
-    | "TYPE_UNSPECIFIED"
-    | "GLOBAL"
-    | "REGIONAL"
-    | "MULTI_REGIONAL"
-    | (string & {});
+  type?: "TYPE_UNSPECIFIED" | "GLOBAL" | "REGIONAL" | "MULTI_REGIONAL" | (string & {});
   /** The list of regions associated with a sku. Empty for Global skus, which are associated with all Google Cloud regions. */
   regions?: ReadonlyArray<string>;
 }
@@ -416,6 +393,58 @@ export const ListSkusResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).annotate({ identifier: "ListSkusResponse" });
 
 // ==========================================================================
+// Errors
+// ==========================================================================
+
+export class NotFound extends Schema.TaggedErrorClass<NotFound>()(
+  "NotFound",
+  {
+    code: Schema.optional(Schema.Number),
+    message: Schema.String,
+    status: Schema.optional(Schema.String),
+    reason: Schema.optional(Schema.String),
+    domain: Schema.optional(Schema.String),
+  },
+) {}
+T.applyErrorMatchers(NotFound, [{"httpStatus":404}]);
+
+export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
+  "BadRequest",
+  {
+    code: Schema.optional(Schema.Number),
+    message: Schema.String,
+    status: Schema.optional(Schema.String),
+    reason: Schema.optional(Schema.String),
+    domain: Schema.optional(Schema.String),
+  },
+) {}
+T.applyErrorMatchers(BadRequest, [{"httpStatus":400}]);
+
+export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
+  "Forbidden",
+  {
+    code: Schema.optional(Schema.Number),
+    message: Schema.String,
+    status: Schema.optional(Schema.String),
+    reason: Schema.optional(Schema.String),
+    domain: Schema.optional(Schema.String),
+  },
+) {}
+T.applyErrorMatchers(Forbidden, [{"httpStatus":403}]);
+
+export class Conflict extends Schema.TaggedErrorClass<Conflict>()(
+  "Conflict",
+  {
+    code: Schema.optional(Schema.Number),
+    message: Schema.String,
+    status: Schema.optional(Schema.String),
+    reason: Schema.optional(Schema.String),
+    domain: Schema.optional(Schema.String),
+  },
+) {}
+T.applyErrorMatchers(Conflict, [{"httpStatus":409}]);
+
+// ==========================================================================
 // Operations
 // ==========================================================================
 
@@ -424,27 +453,20 @@ export interface GetBillingAccountsRequest {
   name: string;
 }
 
-export const GetBillingAccountsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    name: Schema.String.pipe(T.HttpPath("name")),
-  }).pipe(
-    T.Http({ method: "GET", path: "v1/{+name}" }),
-    svc,
-  ) as unknown as Schema.Schema<GetBillingAccountsRequest>;
+export const GetBillingAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  name: Schema.String.pipe(T.HttpPath("name")),
+}).pipe(
+  T.Http({ method: "GET", path: "v1/{+name}" }),
+  svc,
+) as unknown as Schema.Schema<GetBillingAccountsRequest>;
 
 export type GetBillingAccountsResponse = BillingAccount;
-export const GetBillingAccountsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ BillingAccount;
+export const GetBillingAccountsResponse = /*@__PURE__*/ /*#__PURE__*/ BillingAccount;
 
 export type GetBillingAccountsError = DefaultErrors;
 
 /** Gets information about a billing account. The current authenticated user must be a [viewer of the billing account](https://cloud.google.com/billing/docs/how-to/billing-access). */
-export const getBillingAccounts: API.OperationMethod<
-  GetBillingAccountsRequest,
-  GetBillingAccountsResponse,
-  GetBillingAccountsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const getBillingAccounts: API.OperationMethod<GetBillingAccountsRequest, GetBillingAccountsResponse, GetBillingAccountsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetBillingAccountsRequest,
   output: GetBillingAccountsResponse,
   errors: [],
@@ -461,30 +483,23 @@ export interface ListBillingAccountsRequest {
   parent?: string;
 }
 
-export const ListBillingAccountsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
-    pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
-    filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
-    parent: Schema.optional(Schema.String).pipe(T.HttpQuery("parent")),
-  }).pipe(
-    T.Http({ method: "GET", path: "v1/billingAccounts" }),
-    svc,
-  ) as unknown as Schema.Schema<ListBillingAccountsRequest>;
+export const ListBillingAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
+  pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
+  filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
+  parent: Schema.optional(Schema.String).pipe(T.HttpQuery("parent")),
+}).pipe(
+  T.Http({ method: "GET", path: "v1/billingAccounts" }),
+  svc,
+) as unknown as Schema.Schema<ListBillingAccountsRequest>;
 
 export type ListBillingAccountsResponse_Op = ListBillingAccountsResponse;
-export const ListBillingAccountsResponse_Op =
-  /*@__PURE__*/ /*#__PURE__*/ ListBillingAccountsResponse;
+export const ListBillingAccountsResponse_Op = /*@__PURE__*/ /*#__PURE__*/ ListBillingAccountsResponse;
 
 export type ListBillingAccountsError = DefaultErrors;
 
 /** Lists the billing accounts that the current authenticated user has permission to [view](https://cloud.google.com/billing/docs/how-to/billing-access). */
-export const listBillingAccounts: API.PaginatedOperationMethod<
-  ListBillingAccountsRequest,
-  ListBillingAccountsResponse_Op,
-  ListBillingAccountsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+export const listBillingAccounts: API.PaginatedOperationMethod<ListBillingAccountsRequest, ListBillingAccountsResponse_Op, ListBillingAccountsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
   input: ListBillingAccountsRequest,
   output: ListBillingAccountsResponse_Op,
   errors: [],
@@ -503,29 +518,22 @@ export interface PatchBillingAccountsRequest {
   body?: BillingAccount;
 }
 
-export const PatchBillingAccountsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    name: Schema.String.pipe(T.HttpPath("name")),
-    updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
-    body: Schema.optional(BillingAccount).pipe(T.HttpBody()),
-  }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
-    svc,
-  ) as unknown as Schema.Schema<PatchBillingAccountsRequest>;
+export const PatchBillingAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  name: Schema.String.pipe(T.HttpPath("name")),
+  updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
+  body: Schema.optional(BillingAccount).pipe(T.HttpBody()),
+}).pipe(
+  T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
+  svc,
+) as unknown as Schema.Schema<PatchBillingAccountsRequest>;
 
 export type PatchBillingAccountsResponse = BillingAccount;
-export const PatchBillingAccountsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ BillingAccount;
+export const PatchBillingAccountsResponse = /*@__PURE__*/ /*#__PURE__*/ BillingAccount;
 
 export type PatchBillingAccountsError = DefaultErrors;
 
 /** Updates a billing account's fields. Currently the only field that can be edited is `display_name`. The current authenticated user must have the `billing.accounts.update` IAM permission, which is typically given to the [administrator](https://cloud.google.com/billing/docs/how-to/billing-access) of the billing account. */
-export const patchBillingAccounts: API.OperationMethod<
-  PatchBillingAccountsRequest,
-  PatchBillingAccountsResponse,
-  PatchBillingAccountsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const patchBillingAccounts: API.OperationMethod<PatchBillingAccountsRequest, PatchBillingAccountsResponse, PatchBillingAccountsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: PatchBillingAccountsRequest,
   output: PatchBillingAccountsResponse,
   errors: [],
@@ -538,28 +546,21 @@ export interface CreateBillingAccountsRequest {
   body?: BillingAccount;
 }
 
-export const CreateBillingAccountsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    parent: Schema.optional(Schema.String).pipe(T.HttpQuery("parent")),
-    body: Schema.optional(BillingAccount).pipe(T.HttpBody()),
-  }).pipe(
-    T.Http({ method: "POST", path: "v1/billingAccounts", hasBody: true }),
-    svc,
-  ) as unknown as Schema.Schema<CreateBillingAccountsRequest>;
+export const CreateBillingAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  parent: Schema.optional(Schema.String).pipe(T.HttpQuery("parent")),
+  body: Schema.optional(BillingAccount).pipe(T.HttpBody()),
+}).pipe(
+  T.Http({ method: "POST", path: "v1/billingAccounts", hasBody: true }),
+  svc,
+) as unknown as Schema.Schema<CreateBillingAccountsRequest>;
 
 export type CreateBillingAccountsResponse = BillingAccount;
-export const CreateBillingAccountsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ BillingAccount;
+export const CreateBillingAccountsResponse = /*@__PURE__*/ /*#__PURE__*/ BillingAccount;
 
 export type CreateBillingAccountsError = DefaultErrors;
 
 /** This method creates [billing subaccounts](https://cloud.google.com/billing/docs/concepts#subaccounts). Google Cloud resellers should use the Channel Services APIs, [accounts.customers.create](https://cloud.google.com/channel/docs/reference/rest/v1/accounts.customers/create) and [accounts.customers.entitlements.create](https://cloud.google.com/channel/docs/reference/rest/v1/accounts.customers.entitlements/create). When creating a subaccount, the current authenticated user must have the `billing.accounts.update` IAM permission on the parent account, which is typically given to billing account [administrators](https://cloud.google.com/billing/docs/how-to/billing-access). This method will return an error if the parent account has not been provisioned for subaccounts. */
-export const createBillingAccounts: API.OperationMethod<
-  CreateBillingAccountsRequest,
-  CreateBillingAccountsResponse,
-  CreateBillingAccountsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const createBillingAccounts: API.OperationMethod<CreateBillingAccountsRequest, CreateBillingAccountsResponse, CreateBillingAccountsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: CreateBillingAccountsRequest,
   output: CreateBillingAccountsResponse,
   errors: [],
@@ -572,30 +573,21 @@ export interface GetIamPolicyBillingAccountsRequest {
   "options.requestedPolicyVersion"?: number;
 }
 
-export const GetIamPolicyBillingAccountsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    resource: Schema.String.pipe(T.HttpPath("resource")),
-    "options.requestedPolicyVersion": Schema.optional(Schema.Number).pipe(
-      T.HttpQuery("options.requestedPolicyVersion"),
-    ),
-  }).pipe(
-    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
-    svc,
-  ) as unknown as Schema.Schema<GetIamPolicyBillingAccountsRequest>;
+export const GetIamPolicyBillingAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  resource: Schema.String.pipe(T.HttpPath("resource")),
+  "options.requestedPolicyVersion": Schema.optional(Schema.Number).pipe(T.HttpQuery("options.requestedPolicyVersion")),
+}).pipe(
+  T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
+  svc,
+) as unknown as Schema.Schema<GetIamPolicyBillingAccountsRequest>;
 
 export type GetIamPolicyBillingAccountsResponse = Policy;
-export const GetIamPolicyBillingAccountsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Policy;
+export const GetIamPolicyBillingAccountsResponse = /*@__PURE__*/ /*#__PURE__*/ Policy;
 
 export type GetIamPolicyBillingAccountsError = DefaultErrors;
 
 /** Gets the access control policy for a billing account. The caller must have the `billing.accounts.getIamPolicy` permission on the account, which is often given to billing account [viewers](https://cloud.google.com/billing/docs/how-to/billing-access). */
-export const getIamPolicyBillingAccounts: API.OperationMethod<
-  GetIamPolicyBillingAccountsRequest,
-  GetIamPolicyBillingAccountsResponse,
-  GetIamPolicyBillingAccountsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const getIamPolicyBillingAccounts: API.OperationMethod<GetIamPolicyBillingAccountsRequest, GetIamPolicyBillingAccountsResponse, GetIamPolicyBillingAccountsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetIamPolicyBillingAccountsRequest,
   output: GetIamPolicyBillingAccountsResponse,
   errors: [],
@@ -608,32 +600,21 @@ export interface SetIamPolicyBillingAccountsRequest {
   body?: SetIamPolicyRequest;
 }
 
-export const SetIamPolicyBillingAccountsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    resource: Schema.String.pipe(T.HttpPath("resource")),
-    body: Schema.optional(SetIamPolicyRequest).pipe(T.HttpBody()),
-  }).pipe(
-    T.Http({
-      method: "POST",
-      path: "v1/{+resource}:setIamPolicy",
-      hasBody: true,
-    }),
-    svc,
-  ) as unknown as Schema.Schema<SetIamPolicyBillingAccountsRequest>;
+export const SetIamPolicyBillingAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  resource: Schema.String.pipe(T.HttpPath("resource")),
+  body: Schema.optional(SetIamPolicyRequest).pipe(T.HttpBody()),
+}).pipe(
+  T.Http({ method: "POST", path: "v1/{+resource}:setIamPolicy", hasBody: true }),
+  svc,
+) as unknown as Schema.Schema<SetIamPolicyBillingAccountsRequest>;
 
 export type SetIamPolicyBillingAccountsResponse = Policy;
-export const SetIamPolicyBillingAccountsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Policy;
+export const SetIamPolicyBillingAccountsResponse = /*@__PURE__*/ /*#__PURE__*/ Policy;
 
 export type SetIamPolicyBillingAccountsError = DefaultErrors;
 
 /** Sets the access control policy for a billing account. Replaces any existing policy. The caller must have the `billing.accounts.setIamPolicy` permission on the account, which is often given to billing account [administrators](https://cloud.google.com/billing/docs/how-to/billing-access). */
-export const setIamPolicyBillingAccounts: API.OperationMethod<
-  SetIamPolicyBillingAccountsRequest,
-  SetIamPolicyBillingAccountsResponse,
-  SetIamPolicyBillingAccountsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const setIamPolicyBillingAccounts: API.OperationMethod<SetIamPolicyBillingAccountsRequest, SetIamPolicyBillingAccountsResponse, SetIamPolicyBillingAccountsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetIamPolicyBillingAccountsRequest,
   output: SetIamPolicyBillingAccountsResponse,
   errors: [],
@@ -646,33 +627,21 @@ export interface TestIamPermissionsBillingAccountsRequest {
   body?: TestIamPermissionsRequest;
 }
 
-export const TestIamPermissionsBillingAccountsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    resource: Schema.String.pipe(T.HttpPath("resource")),
-    body: Schema.optional(TestIamPermissionsRequest).pipe(T.HttpBody()),
-  }).pipe(
-    T.Http({
-      method: "POST",
-      path: "v1/{+resource}:testIamPermissions",
-      hasBody: true,
-    }),
-    svc,
-  ) as unknown as Schema.Schema<TestIamPermissionsBillingAccountsRequest>;
+export const TestIamPermissionsBillingAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  resource: Schema.String.pipe(T.HttpPath("resource")),
+  body: Schema.optional(TestIamPermissionsRequest).pipe(T.HttpBody()),
+}).pipe(
+  T.Http({ method: "POST", path: "v1/{+resource}:testIamPermissions", hasBody: true }),
+  svc,
+) as unknown as Schema.Schema<TestIamPermissionsBillingAccountsRequest>;
 
-export type TestIamPermissionsBillingAccountsResponse =
-  TestIamPermissionsResponse;
-export const TestIamPermissionsBillingAccountsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ TestIamPermissionsResponse;
+export type TestIamPermissionsBillingAccountsResponse = TestIamPermissionsResponse;
+export const TestIamPermissionsBillingAccountsResponse = /*@__PURE__*/ /*#__PURE__*/ TestIamPermissionsResponse;
 
 export type TestIamPermissionsBillingAccountsError = DefaultErrors;
 
 /** Tests the access control policy for a billing account. This method takes the resource and a set of permissions as input and returns the subset of the input permissions that the caller is allowed for that resource. */
-export const testIamPermissionsBillingAccounts: API.OperationMethod<
-  TestIamPermissionsBillingAccountsRequest,
-  TestIamPermissionsBillingAccountsResponse,
-  TestIamPermissionsBillingAccountsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const testIamPermissionsBillingAccounts: API.OperationMethod<TestIamPermissionsBillingAccountsRequest, TestIamPermissionsBillingAccountsResponse, TestIamPermissionsBillingAccountsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: TestIamPermissionsBillingAccountsRequest,
   output: TestIamPermissionsBillingAccountsResponse,
   errors: [],
@@ -685,28 +654,21 @@ export interface MoveBillingAccountsRequest {
   body?: MoveBillingAccountRequest;
 }
 
-export const MoveBillingAccountsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    name: Schema.String.pipe(T.HttpPath("name")),
-    body: Schema.optional(MoveBillingAccountRequest).pipe(T.HttpBody()),
-  }).pipe(
-    T.Http({ method: "POST", path: "v1/{+name}:move", hasBody: true }),
-    svc,
-  ) as unknown as Schema.Schema<MoveBillingAccountsRequest>;
+export const MoveBillingAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  name: Schema.String.pipe(T.HttpPath("name")),
+  body: Schema.optional(MoveBillingAccountRequest).pipe(T.HttpBody()),
+}).pipe(
+  T.Http({ method: "POST", path: "v1/{+name}:move", hasBody: true }),
+  svc,
+) as unknown as Schema.Schema<MoveBillingAccountsRequest>;
 
 export type MoveBillingAccountsResponse = BillingAccount;
-export const MoveBillingAccountsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ BillingAccount;
+export const MoveBillingAccountsResponse = /*@__PURE__*/ /*#__PURE__*/ BillingAccount;
 
 export type MoveBillingAccountsError = DefaultErrors;
 
 /** Changes which parent organization a billing account belongs to. */
-export const moveBillingAccounts: API.OperationMethod<
-  MoveBillingAccountsRequest,
-  MoveBillingAccountsResponse,
-  MoveBillingAccountsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const moveBillingAccounts: API.OperationMethod<MoveBillingAccountsRequest, MoveBillingAccountsResponse, MoveBillingAccountsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: MoveBillingAccountsRequest,
   output: MoveBillingAccountsResponse,
   errors: [],
@@ -723,31 +685,23 @@ export interface ListBillingAccountsSubAccountsRequest {
   filter?: string;
 }
 
-export const ListBillingAccountsSubAccountsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    parent: Schema.String.pipe(T.HttpPath("parent")),
-    pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
-    pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
-    filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
-  }).pipe(
-    T.Http({ method: "GET", path: "v1/{+parent}/subAccounts" }),
-    svc,
-  ) as unknown as Schema.Schema<ListBillingAccountsSubAccountsRequest>;
+export const ListBillingAccountsSubAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  parent: Schema.String.pipe(T.HttpPath("parent")),
+  pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
+  pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
+  filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
+}).pipe(
+  T.Http({ method: "GET", path: "v1/{+parent}/subAccounts" }),
+  svc,
+) as unknown as Schema.Schema<ListBillingAccountsSubAccountsRequest>;
 
-export type ListBillingAccountsSubAccountsResponse =
-  ListBillingAccountsResponse;
-export const ListBillingAccountsSubAccountsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ ListBillingAccountsResponse;
+export type ListBillingAccountsSubAccountsResponse = ListBillingAccountsResponse;
+export const ListBillingAccountsSubAccountsResponse = /*@__PURE__*/ /*#__PURE__*/ ListBillingAccountsResponse;
 
 export type ListBillingAccountsSubAccountsError = DefaultErrors;
 
 /** Lists the billing accounts that the current authenticated user has permission to [view](https://cloud.google.com/billing/docs/how-to/billing-access). */
-export const listBillingAccountsSubAccounts: API.PaginatedOperationMethod<
-  ListBillingAccountsSubAccountsRequest,
-  ListBillingAccountsSubAccountsResponse,
-  ListBillingAccountsSubAccountsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+export const listBillingAccountsSubAccounts: API.PaginatedOperationMethod<ListBillingAccountsSubAccountsRequest, ListBillingAccountsSubAccountsResponse, ListBillingAccountsSubAccountsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
   input: ListBillingAccountsSubAccountsRequest,
   output: ListBillingAccountsSubAccountsResponse,
   errors: [],
@@ -764,28 +718,21 @@ export interface CreateBillingAccountsSubAccountsRequest {
   body?: BillingAccount;
 }
 
-export const CreateBillingAccountsSubAccountsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    parent: Schema.String.pipe(T.HttpPath("parent")),
-    body: Schema.optional(BillingAccount).pipe(T.HttpBody()),
-  }).pipe(
-    T.Http({ method: "POST", path: "v1/{+parent}/subAccounts", hasBody: true }),
-    svc,
-  ) as unknown as Schema.Schema<CreateBillingAccountsSubAccountsRequest>;
+export const CreateBillingAccountsSubAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  parent: Schema.String.pipe(T.HttpPath("parent")),
+  body: Schema.optional(BillingAccount).pipe(T.HttpBody()),
+}).pipe(
+  T.Http({ method: "POST", path: "v1/{+parent}/subAccounts", hasBody: true }),
+  svc,
+) as unknown as Schema.Schema<CreateBillingAccountsSubAccountsRequest>;
 
 export type CreateBillingAccountsSubAccountsResponse = BillingAccount;
-export const CreateBillingAccountsSubAccountsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ BillingAccount;
+export const CreateBillingAccountsSubAccountsResponse = /*@__PURE__*/ /*#__PURE__*/ BillingAccount;
 
 export type CreateBillingAccountsSubAccountsError = DefaultErrors;
 
 /** This method creates [billing subaccounts](https://cloud.google.com/billing/docs/concepts#subaccounts). Google Cloud resellers should use the Channel Services APIs, [accounts.customers.create](https://cloud.google.com/channel/docs/reference/rest/v1/accounts.customers/create) and [accounts.customers.entitlements.create](https://cloud.google.com/channel/docs/reference/rest/v1/accounts.customers.entitlements/create). When creating a subaccount, the current authenticated user must have the `billing.accounts.update` IAM permission on the parent account, which is typically given to billing account [administrators](https://cloud.google.com/billing/docs/how-to/billing-access). This method will return an error if the parent account has not been provisioned for subaccounts. */
-export const createBillingAccountsSubAccounts: API.OperationMethod<
-  CreateBillingAccountsSubAccountsRequest,
-  CreateBillingAccountsSubAccountsResponse,
-  CreateBillingAccountsSubAccountsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const createBillingAccountsSubAccounts: API.OperationMethod<CreateBillingAccountsSubAccountsRequest, CreateBillingAccountsSubAccountsResponse, CreateBillingAccountsSubAccountsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: CreateBillingAccountsSubAccountsRequest,
   output: CreateBillingAccountsSubAccountsResponse,
   errors: [],
@@ -800,30 +747,22 @@ export interface ListBillingAccountsProjectsRequest {
   pageToken?: string;
 }
 
-export const ListBillingAccountsProjectsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    name: Schema.String.pipe(T.HttpPath("name")),
-    pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
-    pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
-  }).pipe(
-    T.Http({ method: "GET", path: "v1/{+name}/projects" }),
-    svc,
-  ) as unknown as Schema.Schema<ListBillingAccountsProjectsRequest>;
+export const ListBillingAccountsProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  name: Schema.String.pipe(T.HttpPath("name")),
+  pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
+  pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
+}).pipe(
+  T.Http({ method: "GET", path: "v1/{+name}/projects" }),
+  svc,
+) as unknown as Schema.Schema<ListBillingAccountsProjectsRequest>;
 
-export type ListBillingAccountsProjectsResponse =
-  ListProjectBillingInfoResponse;
-export const ListBillingAccountsProjectsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ ListProjectBillingInfoResponse;
+export type ListBillingAccountsProjectsResponse = ListProjectBillingInfoResponse;
+export const ListBillingAccountsProjectsResponse = /*@__PURE__*/ /*#__PURE__*/ ListProjectBillingInfoResponse;
 
 export type ListBillingAccountsProjectsError = DefaultErrors;
 
 /** Lists the projects associated with a billing account. The current authenticated user must have the `billing.resourceAssociations.list` IAM permission, which is often given to billing account [viewers](https://cloud.google.com/billing/docs/how-to/billing-access). */
-export const listBillingAccountsProjects: API.PaginatedOperationMethod<
-  ListBillingAccountsProjectsRequest,
-  ListBillingAccountsProjectsResponse,
-  ListBillingAccountsProjectsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+export const listBillingAccountsProjects: API.PaginatedOperationMethod<ListBillingAccountsProjectsRequest, ListBillingAccountsProjectsResponse, ListBillingAccountsProjectsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
   input: ListBillingAccountsProjectsRequest,
   output: ListBillingAccountsProjectsResponse,
   errors: [],
@@ -844,31 +783,23 @@ export interface ListOrganizationsBillingAccountsRequest {
   filter?: string;
 }
 
-export const ListOrganizationsBillingAccountsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    parent: Schema.String.pipe(T.HttpPath("parent")),
-    pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
-    pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
-    filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
-  }).pipe(
-    T.Http({ method: "GET", path: "v1/{+parent}/billingAccounts" }),
-    svc,
-  ) as unknown as Schema.Schema<ListOrganizationsBillingAccountsRequest>;
+export const ListOrganizationsBillingAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  parent: Schema.String.pipe(T.HttpPath("parent")),
+  pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
+  pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
+  filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
+}).pipe(
+  T.Http({ method: "GET", path: "v1/{+parent}/billingAccounts" }),
+  svc,
+) as unknown as Schema.Schema<ListOrganizationsBillingAccountsRequest>;
 
-export type ListOrganizationsBillingAccountsResponse =
-  ListBillingAccountsResponse;
-export const ListOrganizationsBillingAccountsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ ListBillingAccountsResponse;
+export type ListOrganizationsBillingAccountsResponse = ListBillingAccountsResponse;
+export const ListOrganizationsBillingAccountsResponse = /*@__PURE__*/ /*#__PURE__*/ ListBillingAccountsResponse;
 
 export type ListOrganizationsBillingAccountsError = DefaultErrors;
 
 /** Lists the billing accounts that the current authenticated user has permission to [view](https://cloud.google.com/billing/docs/how-to/billing-access). */
-export const listOrganizationsBillingAccounts: API.PaginatedOperationMethod<
-  ListOrganizationsBillingAccountsRequest,
-  ListOrganizationsBillingAccountsResponse,
-  ListOrganizationsBillingAccountsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+export const listOrganizationsBillingAccounts: API.PaginatedOperationMethod<ListOrganizationsBillingAccountsRequest, ListOrganizationsBillingAccountsResponse, ListOrganizationsBillingAccountsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
   input: ListOrganizationsBillingAccountsRequest,
   output: ListOrganizationsBillingAccountsResponse,
   errors: [],
@@ -885,32 +816,21 @@ export interface CreateOrganizationsBillingAccountsRequest {
   body?: BillingAccount;
 }
 
-export const CreateOrganizationsBillingAccountsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    parent: Schema.String.pipe(T.HttpPath("parent")),
-    body: Schema.optional(BillingAccount).pipe(T.HttpBody()),
-  }).pipe(
-    T.Http({
-      method: "POST",
-      path: "v1/{+parent}/billingAccounts",
-      hasBody: true,
-    }),
-    svc,
-  ) as unknown as Schema.Schema<CreateOrganizationsBillingAccountsRequest>;
+export const CreateOrganizationsBillingAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  parent: Schema.String.pipe(T.HttpPath("parent")),
+  body: Schema.optional(BillingAccount).pipe(T.HttpBody()),
+}).pipe(
+  T.Http({ method: "POST", path: "v1/{+parent}/billingAccounts", hasBody: true }),
+  svc,
+) as unknown as Schema.Schema<CreateOrganizationsBillingAccountsRequest>;
 
 export type CreateOrganizationsBillingAccountsResponse = BillingAccount;
-export const CreateOrganizationsBillingAccountsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ BillingAccount;
+export const CreateOrganizationsBillingAccountsResponse = /*@__PURE__*/ /*#__PURE__*/ BillingAccount;
 
 export type CreateOrganizationsBillingAccountsError = DefaultErrors;
 
 /** This method creates [billing subaccounts](https://cloud.google.com/billing/docs/concepts#subaccounts). Google Cloud resellers should use the Channel Services APIs, [accounts.customers.create](https://cloud.google.com/channel/docs/reference/rest/v1/accounts.customers/create) and [accounts.customers.entitlements.create](https://cloud.google.com/channel/docs/reference/rest/v1/accounts.customers.entitlements/create). When creating a subaccount, the current authenticated user must have the `billing.accounts.update` IAM permission on the parent account, which is typically given to billing account [administrators](https://cloud.google.com/billing/docs/how-to/billing-access). This method will return an error if the parent account has not been provisioned for subaccounts. */
-export const createOrganizationsBillingAccounts: API.OperationMethod<
-  CreateOrganizationsBillingAccountsRequest,
-  CreateOrganizationsBillingAccountsResponse,
-  CreateOrganizationsBillingAccountsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const createOrganizationsBillingAccounts: API.OperationMethod<CreateOrganizationsBillingAccountsRequest, CreateOrganizationsBillingAccountsResponse, CreateOrganizationsBillingAccountsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: CreateOrganizationsBillingAccountsRequest,
   output: CreateOrganizationsBillingAccountsResponse,
   errors: [],
@@ -923,28 +843,21 @@ export interface MoveOrganizationsBillingAccountsRequest {
   name: string;
 }
 
-export const MoveOrganizationsBillingAccountsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    destinationParent: Schema.String.pipe(T.HttpPath("destinationParent")),
-    name: Schema.String.pipe(T.HttpPath("name")),
-  }).pipe(
-    T.Http({ method: "GET", path: "v1/{+destinationParent}/{+name}:move" }),
-    svc,
-  ) as unknown as Schema.Schema<MoveOrganizationsBillingAccountsRequest>;
+export const MoveOrganizationsBillingAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  destinationParent: Schema.String.pipe(T.HttpPath("destinationParent")),
+  name: Schema.String.pipe(T.HttpPath("name")),
+}).pipe(
+  T.Http({ method: "GET", path: "v1/{+destinationParent}/{+name}:move" }),
+  svc,
+) as unknown as Schema.Schema<MoveOrganizationsBillingAccountsRequest>;
 
 export type MoveOrganizationsBillingAccountsResponse = BillingAccount;
-export const MoveOrganizationsBillingAccountsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ BillingAccount;
+export const MoveOrganizationsBillingAccountsResponse = /*@__PURE__*/ /*#__PURE__*/ BillingAccount;
 
 export type MoveOrganizationsBillingAccountsError = DefaultErrors;
 
 /** Changes which parent organization a billing account belongs to. */
-export const moveOrganizationsBillingAccounts: API.OperationMethod<
-  MoveOrganizationsBillingAccountsRequest,
-  MoveOrganizationsBillingAccountsResponse,
-  MoveOrganizationsBillingAccountsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const moveOrganizationsBillingAccounts: API.OperationMethod<MoveOrganizationsBillingAccountsRequest, MoveOrganizationsBillingAccountsResponse, MoveOrganizationsBillingAccountsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: MoveOrganizationsBillingAccountsRequest,
   output: MoveOrganizationsBillingAccountsResponse,
   errors: [],
@@ -955,30 +868,23 @@ export interface GetBillingInfoProjectsRequest {
   name: string;
 }
 
-export const GetBillingInfoProjectsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    name: Schema.String.pipe(T.HttpPath("name")),
-  }).pipe(
-    T.Http({ method: "GET", path: "v1/{+name}/billingInfo" }),
-    svc,
-  ) as unknown as Schema.Schema<GetBillingInfoProjectsRequest>;
+export const GetBillingInfoProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  name: Schema.String.pipe(T.HttpPath("name")),
+}).pipe(
+  T.Http({ method: "GET", path: "v1/{+name}/billingInfo" }),
+  svc,
+) as unknown as Schema.Schema<GetBillingInfoProjectsRequest>;
 
 export type GetBillingInfoProjectsResponse = ProjectBillingInfo;
-export const GetBillingInfoProjectsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ ProjectBillingInfo;
+export const GetBillingInfoProjectsResponse = /*@__PURE__*/ /*#__PURE__*/ ProjectBillingInfo;
 
-export type GetBillingInfoProjectsError = DefaultErrors;
+export type GetBillingInfoProjectsError = DefaultErrors | NotFound | Forbidden;
 
 /** Gets the billing information for a project. The current authenticated user must have the `resourcemanager.projects.get` permission for the project, which can be granted by assigning the [Project Viewer](https://cloud.google.com/iam/docs/understanding-roles#predefined_roles) role. */
-export const getBillingInfoProjects: API.OperationMethod<
-  GetBillingInfoProjectsRequest,
-  GetBillingInfoProjectsResponse,
-  GetBillingInfoProjectsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const getBillingInfoProjects: API.OperationMethod<GetBillingInfoProjectsRequest, GetBillingInfoProjectsResponse, GetBillingInfoProjectsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetBillingInfoProjectsRequest,
   output: GetBillingInfoProjectsResponse,
-  errors: [],
+  errors: [NotFound, Forbidden],
 }));
 
 export interface UpdateBillingInfoProjectsRequest {
@@ -988,31 +894,24 @@ export interface UpdateBillingInfoProjectsRequest {
   body?: ProjectBillingInfo;
 }
 
-export const UpdateBillingInfoProjectsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    name: Schema.String.pipe(T.HttpPath("name")),
-    body: Schema.optional(ProjectBillingInfo).pipe(T.HttpBody()),
-  }).pipe(
-    T.Http({ method: "PUT", path: "v1/{+name}/billingInfo", hasBody: true }),
-    svc,
-  ) as unknown as Schema.Schema<UpdateBillingInfoProjectsRequest>;
+export const UpdateBillingInfoProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  name: Schema.String.pipe(T.HttpPath("name")),
+  body: Schema.optional(ProjectBillingInfo).pipe(T.HttpBody()),
+}).pipe(
+  T.Http({ method: "PUT", path: "v1/{+name}/billingInfo", hasBody: true }),
+  svc,
+) as unknown as Schema.Schema<UpdateBillingInfoProjectsRequest>;
 
 export type UpdateBillingInfoProjectsResponse = ProjectBillingInfo;
-export const UpdateBillingInfoProjectsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ ProjectBillingInfo;
+export const UpdateBillingInfoProjectsResponse = /*@__PURE__*/ /*#__PURE__*/ ProjectBillingInfo;
 
-export type UpdateBillingInfoProjectsError = DefaultErrors;
+export type UpdateBillingInfoProjectsError = DefaultErrors | NotFound | BadRequest | Forbidden | Conflict;
 
 /** Sets or updates the billing account associated with a project. You specify the new billing account by setting the `billing_account_name` in the `ProjectBillingInfo` resource to the resource name of a billing account. Associating a project with an open billing account enables billing on the project and allows charges for resource usage. If the project already had a billing account, this method changes the billing account used for resource usage charges. *Note:* Incurred charges that have not yet been reported in the transaction history of the Google Cloud Console might be billed to the new billing account, even if the charge occurred before the new billing account was assigned to the project. The current authenticated user must have ownership privileges for both the [project](https://cloud.google.com/docs/permissions-overview#h.bgs0oxofvnoo ) and the [billing account](https://cloud.google.com/billing/docs/how-to/billing-access). You can disable billing on the project by setting the `billing_account_name` field to empty. This action disassociates the current billing account from the project. Any billable activity of your in-use services will stop, and your application could stop functioning as expected. Any unbilled charges to date will be billed to the previously associated account. The current authenticated user must be either an owner of the project or an owner of the billing account for the project. Note that associating a project with a *closed* billing account will have much the same effect as disabling billing on the project: any paid resources used by the project will be shut down. Thus, unless you wish to disable billing, you should always call this method with the name of an *open* billing account. */
-export const updateBillingInfoProjects: API.OperationMethod<
-  UpdateBillingInfoProjectsRequest,
-  UpdateBillingInfoProjectsResponse,
-  UpdateBillingInfoProjectsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const updateBillingInfoProjects: API.OperationMethod<UpdateBillingInfoProjectsRequest, UpdateBillingInfoProjectsResponse, UpdateBillingInfoProjectsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: UpdateBillingInfoProjectsRequest,
   output: UpdateBillingInfoProjectsResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface ListServicesRequest {
@@ -1031,18 +930,12 @@ export const ListServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 ) as unknown as Schema.Schema<ListServicesRequest>;
 
 export type ListServicesResponse_Op = ListServicesResponse;
-export const ListServicesResponse_Op =
-  /*@__PURE__*/ /*#__PURE__*/ ListServicesResponse;
+export const ListServicesResponse_Op = /*@__PURE__*/ /*#__PURE__*/ ListServicesResponse;
 
 export type ListServicesError = DefaultErrors;
 
 /** Lists all public cloud services. */
-export const listServices: API.PaginatedOperationMethod<
-  ListServicesRequest,
-  ListServicesResponse_Op,
-  ListServicesError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+export const listServices: API.PaginatedOperationMethod<ListServicesRequest, ListServicesResponse_Op, ListServicesError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
   input: ListServicesRequest,
   output: ListServicesResponse_Op,
   errors: [],
@@ -1067,34 +960,25 @@ export interface ListServicesSkusRequest {
   pageToken?: string;
 }
 
-export const ListServicesSkusRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    parent: Schema.String.pipe(T.HttpPath("parent")),
-    startTime: Schema.optional(Schema.String).pipe(T.HttpQuery("startTime")),
-    endTime: Schema.optional(Schema.String).pipe(T.HttpQuery("endTime")),
-    currencyCode: Schema.optional(Schema.String).pipe(
-      T.HttpQuery("currencyCode"),
-    ),
-    pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
-    pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
-  }).pipe(
-    T.Http({ method: "GET", path: "v1/{+parent}/skus" }),
-    svc,
-  ) as unknown as Schema.Schema<ListServicesSkusRequest>;
+export const ListServicesSkusRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  parent: Schema.String.pipe(T.HttpPath("parent")),
+  startTime: Schema.optional(Schema.String).pipe(T.HttpQuery("startTime")),
+  endTime: Schema.optional(Schema.String).pipe(T.HttpQuery("endTime")),
+  currencyCode: Schema.optional(Schema.String).pipe(T.HttpQuery("currencyCode")),
+  pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
+  pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
+}).pipe(
+  T.Http({ method: "GET", path: "v1/{+parent}/skus" }),
+  svc,
+) as unknown as Schema.Schema<ListServicesSkusRequest>;
 
 export type ListServicesSkusResponse = ListSkusResponse;
-export const ListServicesSkusResponse =
-  /*@__PURE__*/ /*#__PURE__*/ ListSkusResponse;
+export const ListServicesSkusResponse = /*@__PURE__*/ /*#__PURE__*/ ListSkusResponse;
 
 export type ListServicesSkusError = DefaultErrors;
 
 /** Lists all publicly available SKUs for a given cloud service. */
-export const listServicesSkus: API.PaginatedOperationMethod<
-  ListServicesSkusRequest,
-  ListServicesSkusResponse,
-  ListServicesSkusError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+export const listServicesSkus: API.PaginatedOperationMethod<ListServicesSkusRequest, ListServicesSkusResponse, ListServicesSkusError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
   input: ListServicesSkusRequest,
   output: ListServicesSkusResponse,
   errors: [],
@@ -1103,3 +987,4 @@ export const listServicesSkus: API.PaginatedOperationMethod<
     outputToken: "nextPageToken",
   },
 }));
+

--- a/packages/gcp/src/services/cloudbilling-v1beta.ts
+++ b/packages/gcp/src/services/cloudbilling-v1beta.ts
@@ -1474,7 +1474,7 @@ export const ListBillingAccountsServicesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/services" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/services" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsServicesRequest>;
 
@@ -1510,7 +1510,7 @@ export const GetBillingAccountsServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsServicesRequest>;
 
@@ -1548,7 +1548,7 @@ export const ListBillingAccountsSkuGroupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/skuGroups" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/skuGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsSkuGroupsRequest>;
 
@@ -1584,7 +1584,7 @@ export const GetBillingAccountsSkuGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsSkuGroupsRequest>;
 
@@ -1622,7 +1622,7 @@ export const ListBillingAccountsSkuGroupsSkusRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/skus" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/skus" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsSkuGroupsSkusRequest>;
 
@@ -1658,7 +1658,7 @@ export const GetBillingAccountsSkuGroupsSkusRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsSkuGroupsSkusRequest>;
 
@@ -1699,7 +1699,7 @@ export const ListBillingAccountsSkusRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/skus" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/skus" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsSkusRequest>;
 
@@ -1735,7 +1735,7 @@ export const GetBillingAccountsSkusRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsSkusRequest>;
 
@@ -1772,7 +1772,7 @@ export const GetBillingAccountsSkusPriceRequest =
       T.HttpQuery("currencyCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsSkusPriceRequest>;
 
@@ -1815,7 +1815,7 @@ export const ListBillingAccountsSkusPricesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/prices" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/prices" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsSkusPricesRequest>;
 
@@ -1855,7 +1855,7 @@ export const GetSkusPriceRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("currencyCode"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta/{name}" }),
+  T.Http({ method: "GET", path: "v1beta/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetSkusPriceRequest>;
 
@@ -1896,7 +1896,7 @@ export const ListSkusPricesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("currencyCode"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta/{parent}/prices" }),
+  T.Http({ method: "GET", path: "v1beta/{+parent}/prices" }),
   svc,
 ) as unknown as Schema.Schema<ListSkusPricesRequest>;
 
@@ -1969,7 +1969,7 @@ export interface GetSkuGroupsRequest {
 export const GetSkuGroupsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta/{name}" }),
+  T.Http({ method: "GET", path: "v1beta/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetSkuGroupsRequest>;
 
@@ -2006,7 +2006,7 @@ export const ListSkuGroupsSkusRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/skus" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/skus" }),
     svc,
   ) as unknown as Schema.Schema<ListSkuGroupsSkusRequest>;
 
@@ -2042,7 +2042,7 @@ export const GetSkuGroupsSkusRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSkuGroupsSkusRequest>;
 

--- a/packages/gcp/src/services/cloudbuild-v1.ts
+++ b/packages/gcp/src/services/cloudbuild-v1.ts
@@ -2398,7 +2398,7 @@ export const ListProjectsGithubEnterpriseConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/githubEnterpriseConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/githubEnterpriseConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsGithubEnterpriseConfigsRequest>;
 
@@ -2436,7 +2436,7 @@ export const PatchProjectsGithubEnterpriseConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GitHubEnterpriseConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsGithubEnterpriseConfigsRequest>;
 
@@ -2473,7 +2473,7 @@ export const DeleteProjectsGithubEnterpriseConfigsRequest =
     configId: Schema.optional(Schema.String).pipe(T.HttpQuery("configId")),
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsGithubEnterpriseConfigsRequest>;
 
@@ -2517,7 +2517,7 @@ export const CreateProjectsGithubEnterpriseConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/githubEnterpriseConfigs",
+      path: "v1/{+parent}/githubEnterpriseConfigs",
       hasBody: true,
     }),
     svc,
@@ -2556,7 +2556,7 @@ export const GetProjectsGithubEnterpriseConfigsRequest =
     configId: Schema.optional(Schema.String).pipe(T.HttpQuery("configId")),
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsGithubEnterpriseConfigsRequest>;
 
@@ -2886,7 +2886,7 @@ export const GetDefaultServiceAccountProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDefaultServiceAccountProjectsLocationsRequest>;
 
@@ -2924,7 +2924,7 @@ export const DeleteProjectsLocationsGithubEnterpriseConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     configId: Schema.optional(Schema.String).pipe(T.HttpQuery("configId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGithubEnterpriseConfigsRequest>;
 
@@ -2968,7 +2968,7 @@ export const CreateProjectsLocationsGithubEnterpriseConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/githubEnterpriseConfigs",
+      path: "v1/{+parent}/githubEnterpriseConfigs",
       hasBody: true,
     }),
     svc,
@@ -3007,7 +3007,7 @@ export const GetProjectsLocationsGithubEnterpriseConfigsRequest =
     configId: Schema.optional(Schema.String).pipe(T.HttpQuery("configId")),
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGithubEnterpriseConfigsRequest>;
 
@@ -3042,7 +3042,7 @@ export const ListProjectsLocationsGithubEnterpriseConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/githubEnterpriseConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/githubEnterpriseConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGithubEnterpriseConfigsRequest>;
 
@@ -3080,7 +3080,7 @@ export const PatchProjectsLocationsGithubEnterpriseConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GitHubEnterpriseConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGithubEnterpriseConfigsRequest>;
 
@@ -3123,7 +3123,7 @@ export const PatchProjectsLocationsTriggersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(BuildTrigger).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{resourceName}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+resourceName}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTriggersRequest>;
 
@@ -3163,7 +3163,7 @@ export const ListProjectsLocationsTriggersRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/triggers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/triggers" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTriggersRequest>;
 
@@ -3201,7 +3201,7 @@ export const RunProjectsLocationsTriggersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RunBuildTriggerRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsTriggersRequest>;
 
@@ -3238,7 +3238,7 @@ export const CreateProjectsLocationsTriggersRequest =
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
     body: Schema.optional(BuildTrigger).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/triggers", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/triggers", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTriggersRequest>;
 
@@ -3275,7 +3275,7 @@ export const GetProjectsLocationsTriggersRequest =
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
     triggerId: Schema.optional(Schema.String).pipe(T.HttpQuery("triggerId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTriggersRequest>;
 
@@ -3318,7 +3318,7 @@ export const WebhookProjectsLocationsTriggersRequest =
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
     body: Schema.optional(HttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:webhook", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:webhook", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WebhookProjectsLocationsTriggersRequest>;
 
@@ -3356,7 +3356,7 @@ export const DeleteProjectsLocationsTriggersRequest =
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTriggersRequest>;
 
@@ -3397,7 +3397,7 @@ export const CreateProjectsLocationsGitLabConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/gitLabConfigs",
+      path: "v1/{+parent}/gitLabConfigs",
       hasBody: true,
     }),
     svc,
@@ -3430,7 +3430,7 @@ export const GetProjectsLocationsGitLabConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGitLabConfigsRequest>;
 
@@ -3461,7 +3461,7 @@ export const DeleteProjectsLocationsGitLabConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGitLabConfigsRequest>;
 
@@ -3499,7 +3499,7 @@ export const RemoveGitLabConnectedRepositoryProjectsLocationsGitLabConfigsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{config}:removeGitLabConnectedRepository",
+      path: "v1/{+config}:removeGitLabConnectedRepository",
       hasBody: true,
     }),
     svc,
@@ -3540,7 +3540,7 @@ export const PatchProjectsLocationsGitLabConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GitLabConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGitLabConfigsRequest>;
 
@@ -3577,7 +3577,7 @@ export const ListProjectsLocationsGitLabConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/gitLabConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/gitLabConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGitLabConfigsRequest>;
 
@@ -3620,7 +3620,7 @@ export const BatchCreateProjectsLocationsGitLabConfigsConnectedRepositoriesReque
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/connectedRepositories:batchCreate",
+      path: "v1/{+parent}/connectedRepositories:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -3662,7 +3662,7 @@ export const ListProjectsLocationsGitLabConfigsReposRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/repos" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/repos" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGitLabConfigsReposRequest>;
 
@@ -3710,7 +3710,7 @@ export const ListProjectsLocationsBuildsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/builds" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/builds" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBuildsRequest>;
 
@@ -3748,7 +3748,7 @@ export const CancelProjectsLocationsBuildsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelBuildRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsBuildsRequest>;
 
@@ -3782,7 +3782,7 @@ export const ApproveProjectsLocationsBuildsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ApproveBuildRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:approve", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:approve", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ApproveProjectsLocationsBuildsRequest>;
 
@@ -3816,7 +3816,7 @@ export const RetryProjectsLocationsBuildsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RetryBuildRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:retry", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:retry", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RetryProjectsLocationsBuildsRequest>;
 
@@ -3853,7 +3853,7 @@ export const CreateProjectsLocationsBuildsRequest =
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
     body: Schema.optional(Build).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/builds", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/builds", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBuildsRequest>;
 
@@ -3890,7 +3890,7 @@ export const GetProjectsLocationsBuildsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     id: Schema.optional(Schema.String).pipe(T.HttpQuery("id")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBuildsRequest>;
 
@@ -3921,7 +3921,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -3955,7 +3955,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -3996,7 +3996,7 @@ export const CreateProjectsLocationsBitbucketServerConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/bitbucketServerConfigs",
+      path: "v1/{+parent}/bitbucketServerConfigs",
       hasBody: true,
     }),
     svc,
@@ -4029,7 +4029,7 @@ export const GetProjectsLocationsBitbucketServerConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBitbucketServerConfigsRequest>;
 
@@ -4061,7 +4061,7 @@ export const DeleteProjectsLocationsBitbucketServerConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBitbucketServerConfigsRequest>;
 
@@ -4099,7 +4099,7 @@ export const RemoveBitbucketServerConnectedRepositoryProjectsLocationsBitbucketS
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{config}:removeBitbucketServerConnectedRepository",
+      path: "v1/{+config}:removeBitbucketServerConnectedRepository",
       hasBody: true,
     }),
     svc,
@@ -4142,7 +4142,7 @@ export const PatchProjectsLocationsBitbucketServerConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(BitbucketServerConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBitbucketServerConfigsRequest>;
 
@@ -4179,7 +4179,7 @@ export const ListProjectsLocationsBitbucketServerConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/bitbucketServerConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/bitbucketServerConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBitbucketServerConfigsRequest>;
 
@@ -4222,7 +4222,7 @@ export const BatchCreateProjectsLocationsBitbucketServerConfigsConnectedReposito
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/connectedRepositories:batchCreate",
+      path: "v1/{+parent}/connectedRepositories:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -4265,7 +4265,7 @@ export const ListProjectsLocationsBitbucketServerConfigsReposRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/repos" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/repos" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBitbucketServerConfigsReposRequest>;
 
@@ -4313,7 +4313,7 @@ export const PatchProjectsLocationsWorkerPoolsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(WorkerPool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsWorkerPoolsRequest>;
 
@@ -4350,7 +4350,7 @@ export const ListProjectsLocationsWorkerPoolsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/workerPools" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/workerPools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkerPoolsRequest>;
 
@@ -4398,7 +4398,7 @@ export const CreateProjectsLocationsWorkerPoolsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(WorkerPool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/workerPools", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/workerPools", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsWorkerPoolsRequest>;
 
@@ -4429,7 +4429,7 @@ export const GetProjectsLocationsWorkerPoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkerPoolsRequest>;
 
@@ -4473,7 +4473,7 @@ export const DeleteProjectsLocationsWorkerPoolsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWorkerPoolsRequest>;
 
@@ -4712,7 +4712,7 @@ export const ApproveProjectsBuildsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ApproveBuildRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:approve", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:approve", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ApproveProjectsBuildsRequest>;
 
@@ -4751,7 +4751,7 @@ export const RegionalWebhookLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{location}/regionalWebhook",
+      path: "v1/{+location}/regionalWebhook",
       hasBody: true,
     }),
     svc,
@@ -4783,7 +4783,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -4816,7 +4816,7 @@ export const CancelOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOperationsRequest>;
 

--- a/packages/gcp/src/services/cloudbuild-v2.ts
+++ b/packages/gcp/src/services/cloudbuild-v2.ts
@@ -1545,7 +1545,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1580,7 +1580,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1611,7 +1611,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1645,7 +1645,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1690,7 +1690,7 @@ export const PatchProjectsLocationsConnectionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Connection).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectionsRequest>;
 
@@ -1732,7 +1732,7 @@ export const ListProjectsLocationsConnectionsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/connections" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/connections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsRequest>;
 
@@ -1775,7 +1775,7 @@ export const CreateProjectsLocationsConnectionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Connection).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/connections", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/connections", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsConnectionsRequest>;
 
@@ -1811,7 +1811,7 @@ export const SetIamPolicyProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1849,7 +1849,7 @@ export const GetIamPolicyProjectsLocationsConnectionsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v2/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsConnectionsRequest>;
 
@@ -1888,7 +1888,7 @@ export const ProcessWebhookProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/connections:processWebhook",
+      path: "v2/{+parent}/connections:processWebhook",
       hasBody: true,
     }),
     svc,
@@ -1921,7 +1921,7 @@ export const GetProjectsLocationsConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionsRequest>;
 
@@ -1960,7 +1960,7 @@ export const FetchLinkableRepositoriesProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/{connection}:fetchLinkableRepositories",
+      path: "v2/{+connection}:fetchLinkableRepositories",
     }),
     svc,
   ) as unknown as Schema.Schema<FetchLinkableRepositoriesProjectsLocationsConnectionsRequest>;
@@ -2003,7 +2003,7 @@ export const TestIamPermissionsProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2045,7 +2045,7 @@ export const DeleteProjectsLocationsConnectionsRequest =
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectionsRequest>;
 
@@ -2084,7 +2084,7 @@ export const DeleteProjectsLocationsConnectionsRepositoriesRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectionsRepositoriesRequest>;
 
@@ -2123,7 +2123,11 @@ export const CreateProjectsLocationsConnectionsRepositoriesRequest =
     ),
     body: Schema.optional(Repository).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/repositories", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+parent}/repositories",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsConnectionsRepositoriesRequest>;
 
@@ -2159,7 +2163,7 @@ export const BatchCreateProjectsLocationsConnectionsRepositoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/repositories:batchCreate",
+      path: "v2/{+parent}/repositories:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -2194,7 +2198,7 @@ export const GetProjectsLocationsConnectionsRepositoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionsRepositoriesRequest>;
 
@@ -2239,7 +2243,7 @@ export const ListProjectsLocationsConnectionsRepositoriesRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/repositories" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/repositories" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsRepositoriesRequest>;
 
@@ -2280,7 +2284,7 @@ export const AccessReadWriteTokenProjectsLocationsConnectionsRepositoriesRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{repository}:accessReadWriteToken",
+      path: "v2/{+repository}:accessReadWriteToken",
       hasBody: true,
     }),
     svc,
@@ -2320,7 +2324,7 @@ export const AccessReadTokenProjectsLocationsConnectionsRepositoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{repository}:accessReadToken",
+      path: "v2/{+repository}:accessReadToken",
       hasBody: true,
     }),
     svc,
@@ -2364,7 +2368,7 @@ export const FetchGitRefsProjectsLocationsConnectionsRepositoriesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     refType: Schema.optional(Schema.String).pipe(T.HttpQuery("refType")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{repository}:fetchGitRefs" }),
+    T.Http({ method: "GET", path: "v2/{+repository}:fetchGitRefs" }),
     svc,
   ) as unknown as Schema.Schema<FetchGitRefsProjectsLocationsConnectionsRepositoriesRequest>;
 

--- a/packages/gcp/src/services/cloudchannel-v1.ts
+++ b/packages/gcp/src/services/cloudchannel-v1.ts
@@ -2821,7 +2821,7 @@ export const ListOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<ListOperationsRequest>;
 
@@ -2856,7 +2856,7 @@ export const DeleteOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOperationsRequest>;
 
@@ -2886,7 +2886,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -2922,7 +2922,7 @@ export const CancelOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOperationsRequest>;
 
@@ -2960,7 +2960,7 @@ export const CheckCloudIdentityAccountsExistAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:checkCloudIdentityAccountsExist",
+      path: "v1/{+parent}:checkCloudIdentityAccountsExist",
       hasBody: true,
     }),
     svc,
@@ -2999,7 +2999,7 @@ export const UnregisterAccountsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{account}:unregister", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+account}:unregister", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UnregisterAccountsRequest>;
 
@@ -3040,7 +3040,7 @@ export const ListSubscribersAccountsRequest =
     integrator: Schema.optional(Schema.String).pipe(T.HttpQuery("integrator")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{account}:listSubscribers" }),
+    T.Http({ method: "GET", path: "v1/{+account}:listSubscribers" }),
     svc,
   ) as unknown as Schema.Schema<ListSubscribersAccountsRequest>;
 
@@ -3081,7 +3081,7 @@ export const RegisterAccountsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{account}:register", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+account}:register", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RegisterAccountsRequest>;
 
@@ -3120,7 +3120,7 @@ export const ListTransferableOffersAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:listTransferableOffers",
+      path: "v1/{+parent}:listTransferableOffers",
       hasBody: true,
     }),
     svc,
@@ -3161,7 +3161,7 @@ export const ListTransferableSkusAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:listTransferableSkus",
+      path: "v1/{+parent}:listTransferableSkus",
       hasBody: true,
     }),
     svc,
@@ -3202,7 +3202,7 @@ export const FetchReportResultsAccountsReportJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{reportJob}:fetchReportResults",
+      path: "v1/{+reportJob}:fetchReportResults",
       hasBody: true,
     }),
     svc,
@@ -3236,7 +3236,7 @@ export const DeleteAccountsCustomersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsCustomersRequest>;
 
@@ -3273,7 +3273,7 @@ export const PatchAccountsCustomersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudChannelV1Customer).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsCustomersRequest>;
 
@@ -3311,7 +3311,7 @@ export const ImportAccountsCustomersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/customers:import",
+      path: "v1/{+parent}/customers:import",
       hasBody: true,
     }),
     svc,
@@ -3351,7 +3351,7 @@ export const TransferEntitlementsToGoogleAccountsCustomersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:transferEntitlementsToGoogle",
+      path: "v1/{+parent}:transferEntitlementsToGoogle",
       hasBody: true,
     }),
     svc,
@@ -3388,7 +3388,7 @@ export const CreateAccountsCustomersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudChannelV1Customer).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/customers", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/customers", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateAccountsCustomersRequest>;
 
@@ -3426,7 +3426,7 @@ export const ProvisionCloudIdentityAccountsCustomersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{customer}:provisionCloudIdentity",
+      path: "v1/{+customer}:provisionCloudIdentity",
       hasBody: true,
     }),
     svc,
@@ -3467,7 +3467,7 @@ export const QueryEligibleBillingAccountsAccountsCustomersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{customer}:queryEligibleBillingAccounts",
+      path: "v1/{+customer}:queryEligibleBillingAccounts",
     }),
     svc,
   ) as unknown as Schema.Schema<QueryEligibleBillingAccountsAccountsCustomersRequest>;
@@ -3507,7 +3507,7 @@ export const TransferEntitlementsAccountsCustomersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:transferEntitlements",
+      path: "v1/{+parent}:transferEntitlements",
       hasBody: true,
     }),
     svc,
@@ -3577,7 +3577,7 @@ export const ListPurchasableOffersAccountsCustomersRequest =
       T.HttpQuery("changeOfferPurchase.newSku"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{customer}:listPurchasableOffers" }),
+    T.Http({ method: "GET", path: "v1/{+customer}:listPurchasableOffers" }),
     svc,
   ) as unknown as Schema.Schema<ListPurchasableOffersAccountsCustomersRequest>;
 
@@ -3622,7 +3622,7 @@ export const ListAccountsCustomersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/customers" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsCustomersRequest>;
 
@@ -3688,7 +3688,7 @@ export const ListPurchasableSkusAccountsCustomersRequest =
       T.HttpQuery("changeOfferPurchase.changeType"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{customer}:listPurchasableSkus" }),
+    T.Http({ method: "GET", path: "v1/{+customer}:listPurchasableSkus" }),
     svc,
   ) as unknown as Schema.Schema<ListPurchasableSkusAccountsCustomersRequest>;
 
@@ -3724,7 +3724,7 @@ export const GetAccountsCustomersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsCustomersRequest>;
 
@@ -3762,7 +3762,7 @@ export const CreateAccountsCustomersCustomerRepricingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/customerRepricingConfigs",
+      path: "v1/{+parent}/customerRepricingConfigs",
       hasBody: true,
     }),
     svc,
@@ -3797,7 +3797,7 @@ export const DeleteAccountsCustomersCustomerRepricingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsCustomersCustomerRepricingConfigsRequest>;
 
@@ -3835,7 +3835,7 @@ export const PatchAccountsCustomersCustomerRepricingConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsCustomersCustomerRepricingConfigsRequest>;
 
@@ -3867,7 +3867,7 @@ export const GetAccountsCustomersCustomerRepricingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsCustomersCustomerRepricingConfigsRequest>;
 
@@ -3908,7 +3908,7 @@ export const ListAccountsCustomersCustomerRepricingConfigsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customerRepricingConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/customerRepricingConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsCustomersCustomerRepricingConfigsRequest>;
 
@@ -3949,7 +3949,7 @@ export const SuspendAccountsCustomersEntitlementsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:suspend", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:suspend", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SuspendAccountsCustomersEntitlementsRequest>;
 
@@ -3988,7 +3988,7 @@ export const ChangeRenewalSettingsAccountsCustomersEntitlementsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:changeRenewalSettings",
+      path: "v1/{+name}:changeRenewalSettings",
       hasBody: true,
     }),
     svc,
@@ -4023,7 +4023,7 @@ export const LookupOfferAccountsCustomersEntitlementsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     entitlement: Schema.String.pipe(T.HttpPath("entitlement")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{entitlement}:lookupOffer" }),
+    T.Http({ method: "GET", path: "v1/{+entitlement}:lookupOffer" }),
     svc,
   ) as unknown as Schema.Schema<LookupOfferAccountsCustomersEntitlementsRequest>;
 
@@ -4060,7 +4060,7 @@ export const ChangeOfferAccountsCustomersEntitlementsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:changeOffer", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:changeOffer", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ChangeOfferAccountsCustomersEntitlementsRequest>;
 
@@ -4097,7 +4097,7 @@ export const CancelAccountsCustomersEntitlementsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelAccountsCustomersEntitlementsRequest>;
 
@@ -4134,7 +4134,7 @@ export const ActivateAccountsCustomersEntitlementsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:activate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:activate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ActivateAccountsCustomersEntitlementsRequest>;
 
@@ -4166,7 +4166,7 @@ export const GetAccountsCustomersEntitlementsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsCustomersEntitlementsRequest>;
 
@@ -4207,7 +4207,7 @@ export const ListEntitlementChangesAccountsCustomersEntitlementsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}:listEntitlementChanges" }),
+    T.Http({ method: "GET", path: "v1/{+parent}:listEntitlementChanges" }),
     svc,
   ) as unknown as Schema.Schema<ListEntitlementChangesAccountsCustomersEntitlementsRequest>;
 
@@ -4250,7 +4250,7 @@ export const ListAccountsCustomersEntitlementsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/entitlements" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/entitlements" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsCustomersEntitlementsRequest>;
 
@@ -4293,7 +4293,7 @@ export const ChangeParametersAccountsCustomersEntitlementsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:changeParameters",
+      path: "v1/{+name}:changeParameters",
       hasBody: true,
     }),
     svc,
@@ -4332,7 +4332,11 @@ export const CreateAccountsCustomersEntitlementsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/entitlements", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/entitlements",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateAccountsCustomersEntitlementsRequest>;
 
@@ -4371,7 +4375,7 @@ export const StartPaidServiceAccountsCustomersEntitlementsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:startPaidService",
+      path: "v1/{+name}:startPaidService",
       hasBody: true,
     }),
     svc,
@@ -4410,7 +4414,7 @@ export const RunAccountsReportsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunAccountsReportsRequest>;
 
@@ -4452,7 +4456,7 @@ export const ListAccountsReportsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/reports" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/reports" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsReportsRequest>;
 
@@ -4507,7 +4511,7 @@ export const ListAccountsOffersRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/offers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/offers" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsOffersRequest>;
 
@@ -4551,7 +4555,7 @@ export const ListAccountsChannelPartnerLinksRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/channelPartnerLinks" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/channelPartnerLinks" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsChannelPartnerLinksRequest>;
 
@@ -4594,7 +4598,7 @@ export const CreateAccountsChannelPartnerLinksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/channelPartnerLinks",
+      path: "v1/{+parent}/channelPartnerLinks",
       hasBody: true,
     }),
     svc,
@@ -4631,7 +4635,7 @@ export const GetAccountsChannelPartnerLinksRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsChannelPartnerLinksRequest>;
 
@@ -4668,7 +4672,7 @@ export const PatchAccountsChannelPartnerLinksRequest =
       GoogleCloudChannelV1UpdateChannelPartnerLinkRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsChannelPartnerLinksRequest>;
 
@@ -4706,7 +4710,7 @@ export const PatchAccountsChannelPartnerLinksCustomersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudChannelV1Customer).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsChannelPartnerLinksCustomersRequest>;
 
@@ -4745,7 +4749,7 @@ export const ImportAccountsChannelPartnerLinksCustomersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/customers:import",
+      path: "v1/{+parent}/customers:import",
       hasBody: true,
     }),
     svc,
@@ -4788,7 +4792,7 @@ export const ListAccountsChannelPartnerLinksCustomersRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/customers" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsChannelPartnerLinksCustomersRequest>;
 
@@ -4824,7 +4828,7 @@ export const GetAccountsChannelPartnerLinksCustomersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsChannelPartnerLinksCustomersRequest>;
 
@@ -4859,7 +4863,7 @@ export const CreateAccountsChannelPartnerLinksCustomersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudChannelV1Customer).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/customers", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/customers", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateAccountsChannelPartnerLinksCustomersRequest>;
 
@@ -4891,7 +4895,7 @@ export const DeleteAccountsChannelPartnerLinksCustomersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsChannelPartnerLinksCustomersRequest>;
 
@@ -4930,7 +4934,7 @@ export const CreateAccountsChannelPartnerLinksChannelPartnerRepricingConfigsRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/channelPartnerRepricingConfigs",
+      path: "v1/{+parent}/channelPartnerRepricingConfigs",
       hasBody: true,
     }),
     svc,
@@ -4966,7 +4970,7 @@ export const DeleteAccountsChannelPartnerLinksChannelPartnerRepricingConfigsRequ
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsChannelPartnerLinksChannelPartnerRepricingConfigsRequest>;
 
@@ -5000,7 +5004,7 @@ export const GetAccountsChannelPartnerLinksChannelPartnerRepricingConfigsRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsChannelPartnerLinksChannelPartnerRepricingConfigsRequest>;
 
@@ -5044,7 +5048,7 @@ export const ListAccountsChannelPartnerLinksChannelPartnerRepricingConfigsReques
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/channelPartnerRepricingConfigs",
+      path: "v1/{+parent}/channelPartnerRepricingConfigs",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsChannelPartnerLinksChannelPartnerRepricingConfigsRequest>;
@@ -5087,7 +5091,7 @@ export const PatchAccountsChannelPartnerLinksChannelPartnerRepricingConfigsReque
       GoogleCloudChannelV1ChannelPartnerRepricingConfig,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsChannelPartnerLinksChannelPartnerRepricingConfigsRequest>;
 
@@ -5127,7 +5131,7 @@ export const ListAccountsSkuGroupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/skuGroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/skuGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsSkuGroupsRequest>;
 
@@ -5169,7 +5173,7 @@ export const ListAccountsSkuGroupsBillableSkusRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/billableSkus" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/billableSkus" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsSkuGroupsBillableSkusRequest>;
 
@@ -5264,7 +5268,7 @@ export const ListProductsSkusRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/skus" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/skus" }),
     svc,
   ) as unknown as Schema.Schema<ListProductsSkusRequest>;
 
@@ -5306,7 +5310,7 @@ export const RegisterSubscriberIntegratorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{integrator}:registerSubscriber",
+      path: "v1/{+integrator}:registerSubscriber",
       hasBody: true,
     }),
     svc,
@@ -5349,7 +5353,7 @@ export const ListSubscribersIntegratorsRequest =
     account: Schema.optional(Schema.String).pipe(T.HttpQuery("account")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{integrator}:listSubscribers" }),
+    T.Http({ method: "GET", path: "v1/{+integrator}:listSubscribers" }),
     svc,
   ) as unknown as Schema.Schema<ListSubscribersIntegratorsRequest>;
 
@@ -5392,7 +5396,7 @@ export const UnregisterSubscriberIntegratorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{integrator}:unregisterSubscriber",
+      path: "v1/{+integrator}:unregisterSubscriber",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/cloudcommerceprocurement-v1.ts
+++ b/packages/gcp/src/services/cloudcommerceprocurement-v1.ts
@@ -321,7 +321,7 @@ export const ApproveProvidersEntitlementsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ApproveEntitlementRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:approve", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:approve", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ApproveProvidersEntitlementsRequest>;
 
@@ -359,7 +359,7 @@ export const RejectPlanChangeProvidersEntitlementsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:rejectPlanChange",
+      path: "v1/{+name}:rejectPlanChange",
       hasBody: true,
     }),
     svc,
@@ -392,7 +392,7 @@ export const GetProvidersEntitlementsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProvidersEntitlementsRequest>;
 
@@ -429,7 +429,7 @@ export const PatchProvidersEntitlementsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Entitlement).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProvidersEntitlementsRequest>;
 
@@ -463,7 +463,7 @@ export const RejectProvidersEntitlementsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RejectEntitlementRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:reject", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:reject", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RejectProvidersEntitlementsRequest>;
 
@@ -503,7 +503,7 @@ export const ListProvidersEntitlementsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/entitlements" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/entitlements" }),
     svc,
   ) as unknown as Schema.Schema<ListProvidersEntitlementsRequest>;
 
@@ -545,7 +545,7 @@ export const ApprovePlanChangeProvidersEntitlementsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:approvePlanChange",
+      path: "v1/{+name}:approvePlanChange",
       hasBody: true,
     }),
     svc,
@@ -581,7 +581,7 @@ export const SuspendProvidersEntitlementsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SuspendEntitlementRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:suspend", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:suspend", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SuspendProvidersEntitlementsRequest>;
 
@@ -615,7 +615,7 @@ export const RejectProvidersAccountsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RejectAccountRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:reject", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:reject", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RejectProvidersAccountsRequest>;
 
@@ -652,7 +652,7 @@ export const ListProvidersAccountsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/accounts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/accounts" }),
     svc,
   ) as unknown as Schema.Schema<ListProvidersAccountsRequest>;
 
@@ -690,7 +690,7 @@ export const ApproveProvidersAccountsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ApproveAccountRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:approve", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:approve", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ApproveProvidersAccountsRequest>;
 
@@ -728,7 +728,7 @@ export const GetProvidersAccountsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProvidersAccountsRequest>;
 
@@ -761,7 +761,7 @@ export const ResetProvidersAccountsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResetAccountRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:reset", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:reset", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResetProvidersAccountsRequest>;
 

--- a/packages/gcp/src/services/cloudcontrolspartner-v1.ts
+++ b/packages/gcp/src/services/cloudcontrolspartner-v1.ts
@@ -541,7 +541,7 @@ export const GetPartnerOrganizationsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPartnerOrganizationsLocationsRequest>;
 
@@ -578,7 +578,7 @@ export const PatchOrganizationsLocationsCustomersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Customer).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsCustomersRequest>;
 
@@ -609,7 +609,7 @@ export const DeleteOrganizationsLocationsCustomersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsCustomersRequest>;
 
@@ -640,7 +640,7 @@ export const GetOrganizationsLocationsCustomersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsCustomersRequest>;
 
@@ -683,7 +683,7 @@ export const ListOrganizationsLocationsCustomersRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/customers" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsCustomersRequest>;
 
@@ -724,7 +724,7 @@ export const CreateOrganizationsLocationsCustomersRequest =
     customerId: Schema.optional(Schema.String).pipe(T.HttpQuery("customerId")),
     body: Schema.optional(Customer).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/customers", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/customers", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsLocationsCustomersRequest>;
 
@@ -767,7 +767,7 @@ export const ListOrganizationsLocationsCustomersWorkloadsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/workloads" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/workloads" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsCustomersWorkloadsRequest>;
 
@@ -803,7 +803,7 @@ export const GetPartnerPermissionsOrganizationsLocationsCustomersWorkloadsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPartnerPermissionsOrganizationsLocationsCustomersWorkloadsRequest>;
 
@@ -836,7 +836,7 @@ export const GetOrganizationsLocationsCustomersWorkloadsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsCustomersWorkloadsRequest>;
 
@@ -867,7 +867,7 @@ export const GetEkmConnectionsOrganizationsLocationsCustomersWorkloadsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEkmConnectionsOrganizationsLocationsCustomersWorkloadsRequest>;
 
@@ -912,7 +912,7 @@ export const ListOrganizationsLocationsCustomersWorkloadsAccessApprovalRequestsR
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/accessApprovalRequests" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/accessApprovalRequests" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsCustomersWorkloadsAccessApprovalRequestsRequest>;
 
@@ -973,7 +973,7 @@ export const ListOrganizationsLocationsCustomersWorkloadsViolationsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/violations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/violations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsCustomersWorkloadsViolationsRequest>;
 
@@ -1010,7 +1010,7 @@ export const GetOrganizationsLocationsCustomersWorkloadsViolationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsCustomersWorkloadsViolationsRequest>;
 

--- a/packages/gcp/src/services/cloudcontrolspartner-v1beta.ts
+++ b/packages/gcp/src/services/cloudcontrolspartner-v1beta.ts
@@ -541,7 +541,7 @@ export const GetPartnerOrganizationsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPartnerOrganizationsLocationsRequest>;
 
@@ -578,7 +578,7 @@ export const PatchOrganizationsLocationsCustomersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Customer).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsCustomersRequest>;
 
@@ -609,7 +609,7 @@ export const DeleteOrganizationsLocationsCustomersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsCustomersRequest>;
 
@@ -640,7 +640,7 @@ export const GetOrganizationsLocationsCustomersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsCustomersRequest>;
 
@@ -683,7 +683,7 @@ export const ListOrganizationsLocationsCustomersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/customers" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/customers" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsCustomersRequest>;
 
@@ -726,7 +726,7 @@ export const CreateOrganizationsLocationsCustomersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/customers",
+      path: "v1beta/{+parent}/customers",
       hasBody: true,
     }),
     svc,
@@ -759,7 +759,7 @@ export const GetOrganizationsLocationsCustomersWorkloadsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsCustomersWorkloadsRequest>;
 
@@ -790,7 +790,7 @@ export const GetEkmConnectionsOrganizationsLocationsCustomersWorkloadsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEkmConnectionsOrganizationsLocationsCustomersWorkloadsRequest>;
 
@@ -835,7 +835,7 @@ export const ListOrganizationsLocationsCustomersWorkloadsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/workloads" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/workloads" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsCustomersWorkloadsRequest>;
 
@@ -871,7 +871,7 @@ export const GetPartnerPermissionsOrganizationsLocationsCustomersWorkloadsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPartnerPermissionsOrganizationsLocationsCustomersWorkloadsRequest>;
 
@@ -916,7 +916,7 @@ export const ListOrganizationsLocationsCustomersWorkloadsAccessApprovalRequestsR
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/accessApprovalRequests" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/accessApprovalRequests" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsCustomersWorkloadsAccessApprovalRequestsRequest>;
 
@@ -955,7 +955,7 @@ export const GetOrganizationsLocationsCustomersWorkloadsViolationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsCustomersWorkloadsViolationsRequest>;
 
@@ -1010,7 +1010,7 @@ export const ListOrganizationsLocationsCustomersWorkloadsViolationsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/violations" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/violations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsCustomersWorkloadsViolationsRequest>;
 

--- a/packages/gcp/src/services/clouddeploy-v1.ts
+++ b/packages/gcp/src/services/clouddeploy-v1.ts
@@ -3608,7 +3608,7 @@ export const ListProjectsLocationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -3643,7 +3643,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -3674,7 +3674,7 @@ export const GetConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigProjectsLocationsRequest>;
 
@@ -3724,7 +3724,7 @@ export const PatchProjectsLocationsDeployPoliciesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(DeployPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDeployPoliciesRequest>;
 
@@ -3760,7 +3760,7 @@ export const GetIamPolicyProjectsLocationsDeployPoliciesRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDeployPoliciesRequest>;
 
@@ -3791,7 +3791,7 @@ export const GetProjectsLocationsDeployPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeployPoliciesRequest>;
 
@@ -3827,7 +3827,7 @@ export const SetIamPolicyProjectsLocationsDeployPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3876,7 +3876,7 @@ export const DeleteProjectsLocationsDeployPoliciesRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDeployPoliciesRequest>;
 
@@ -3919,7 +3919,7 @@ export const ListProjectsLocationsDeployPoliciesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deployPolicies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deployPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeployPoliciesRequest>;
 
@@ -3973,7 +3973,7 @@ export const CreateProjectsLocationsDeployPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/deployPolicies",
+      path: "v1/{+parent}/deployPolicies",
       hasBody: true,
     }),
     svc,
@@ -4011,7 +4011,7 @@ export const TestIamPermissionsProjectsLocationsDeliveryPipelinesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4046,7 +4046,7 @@ export const GetProjectsLocationsDeliveryPipelinesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeliveryPipelinesRequest>;
 
@@ -4082,7 +4082,7 @@ export const GetIamPolicyProjectsLocationsDeliveryPipelinesRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDeliveryPipelinesRequest>;
 
@@ -4132,7 +4132,7 @@ export const DeleteProjectsLocationsDeliveryPipelinesRequest =
       T.HttpQuery("allowMissing"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDeliveryPipelinesRequest>;
 
@@ -4181,7 +4181,7 @@ export const CreateProjectsLocationsDeliveryPipelinesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/deliveryPipelines",
+      path: "v1/{+parent}/deliveryPipelines",
       hasBody: true,
     }),
     svc,
@@ -4233,7 +4233,7 @@ export const PatchProjectsLocationsDeliveryPipelinesRequest =
     ),
     body: Schema.optional(DeliveryPipeline).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDeliveryPipelinesRequest>;
 
@@ -4267,7 +4267,11 @@ export const RollbackTargetProjectsLocationsDeliveryPipelinesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RollbackTargetRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:rollbackTarget", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+name}:rollbackTarget",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<RollbackTargetProjectsLocationsDeliveryPipelinesRequest>;
 
@@ -4312,7 +4316,7 @@ export const ListProjectsLocationsDeliveryPipelinesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deliveryPipelines" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deliveryPipelines" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeliveryPipelinesRequest>;
 
@@ -4353,7 +4357,7 @@ export const SetIamPolicyProjectsLocationsDeliveryPipelinesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4398,7 +4402,7 @@ export const ListProjectsLocationsDeliveryPipelinesReleasesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/releases" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/releases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeliveryPipelinesReleasesRequest>;
 
@@ -4437,7 +4441,7 @@ export const AbandonProjectsLocationsDeliveryPipelinesReleasesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AbandonReleaseRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:abandon", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:abandon", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AbandonProjectsLocationsDeliveryPipelinesReleasesRequest>;
 
@@ -4489,7 +4493,7 @@ export const CreateProjectsLocationsDeliveryPipelinesReleasesRequest =
     releaseId: Schema.optional(Schema.String).pipe(T.HttpQuery("releaseId")),
     body: Schema.optional(Release).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/releases", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/releases", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDeliveryPipelinesReleasesRequest>;
 
@@ -4522,7 +4526,7 @@ export const GetProjectsLocationsDeliveryPipelinesReleasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeliveryPipelinesReleasesRequest>;
 
@@ -4556,7 +4560,7 @@ export const ApproveProjectsLocationsDeliveryPipelinesReleasesRolloutsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ApproveRolloutRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:approve", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:approve", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ApproveProjectsLocationsDeliveryPipelinesReleasesRolloutsRequest>;
 
@@ -4592,7 +4596,7 @@ export const CancelProjectsLocationsDeliveryPipelinesReleasesRolloutsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelRolloutRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDeliveryPipelinesReleasesRolloutsRequest>;
 
@@ -4625,7 +4629,7 @@ export const GetProjectsLocationsDeliveryPipelinesReleasesRolloutsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeliveryPipelinesReleasesRolloutsRequest>;
 
@@ -4661,7 +4665,7 @@ export const IgnoreJobProjectsLocationsDeliveryPipelinesReleasesRolloutsRequest 
     rollout: Schema.String.pipe(T.HttpPath("rollout")),
     body: Schema.optional(IgnoreJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{rollout}:ignoreJob", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+rollout}:ignoreJob", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<IgnoreJobProjectsLocationsDeliveryPipelinesReleasesRolloutsRequest>;
 
@@ -4706,7 +4710,7 @@ export const ListProjectsLocationsDeliveryPipelinesReleasesRolloutsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/rollouts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/rollouts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeliveryPipelinesReleasesRolloutsRequest>;
 
@@ -4746,7 +4750,7 @@ export const RetryJobProjectsLocationsDeliveryPipelinesReleasesRolloutsRequest =
     rollout: Schema.String.pipe(T.HttpPath("rollout")),
     body: Schema.optional(RetryJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{rollout}:retryJob", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+rollout}:retryJob", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RetryJobProjectsLocationsDeliveryPipelinesReleasesRolloutsRequest>;
 
@@ -4782,7 +4786,7 @@ export const AdvanceProjectsLocationsDeliveryPipelinesReleasesRolloutsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AdvanceRolloutRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:advance", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:advance", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AdvanceProjectsLocationsDeliveryPipelinesReleasesRolloutsRequest>;
 
@@ -4839,7 +4843,7 @@ export const CreateProjectsLocationsDeliveryPipelinesReleasesRolloutsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Rollout).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/rollouts", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/rollouts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDeliveryPipelinesReleasesRolloutsRequest>;
 
@@ -4884,7 +4888,7 @@ export const ListProjectsLocationsDeliveryPipelinesReleasesRolloutsJobRunsReques
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/jobRuns" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/jobRuns" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeliveryPipelinesReleasesRolloutsJobRunsRequest>;
 
@@ -4921,7 +4925,7 @@ export const GetProjectsLocationsDeliveryPipelinesReleasesRolloutsJobRunsRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeliveryPipelinesReleasesRolloutsJobRunsRequest>;
 
@@ -4957,7 +4961,7 @@ export const TerminateProjectsLocationsDeliveryPipelinesReleasesRolloutsJobRunsR
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(TerminateJobRunRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:terminate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:terminate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TerminateProjectsLocationsDeliveryPipelinesReleasesRolloutsJobRunsRequest>;
 
@@ -4992,7 +4996,7 @@ export const GetProjectsLocationsDeliveryPipelinesAutomationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeliveryPipelinesAutomationsRequest>;
 
@@ -5041,7 +5045,7 @@ export const DeleteProjectsLocationsDeliveryPipelinesAutomationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDeliveryPipelinesAutomationsRequest>;
 
@@ -5090,7 +5094,7 @@ export const CreateProjectsLocationsDeliveryPipelinesAutomationsRequest =
     ),
     body: Schema.optional(Automation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/automations", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/automations", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDeliveryPipelinesAutomationsRequest>;
 
@@ -5142,7 +5146,7 @@ export const PatchProjectsLocationsDeliveryPipelinesAutomationsRequest =
     ),
     body: Schema.optional(Automation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDeliveryPipelinesAutomationsRequest>;
 
@@ -5187,7 +5191,7 @@ export const ListProjectsLocationsDeliveryPipelinesAutomationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/automations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/automations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeliveryPipelinesAutomationsRequest>;
 
@@ -5227,7 +5231,7 @@ export const CancelProjectsLocationsDeliveryPipelinesAutomationRunsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelAutomationRunRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDeliveryPipelinesAutomationRunsRequest>;
 
@@ -5260,7 +5264,7 @@ export const GetProjectsLocationsDeliveryPipelinesAutomationRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeliveryPipelinesAutomationRunsRequest>;
 
@@ -5305,7 +5309,7 @@ export const ListProjectsLocationsDeliveryPipelinesAutomationRunsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/automationRuns" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/automationRuns" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeliveryPipelinesAutomationRunsRequest>;
 
@@ -5361,7 +5365,7 @@ export const PatchProjectsLocationsCustomTargetTypesRequest =
     ),
     body: Schema.optional(CustomTargetType).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCustomTargetTypesRequest>;
 
@@ -5397,7 +5401,7 @@ export const SetIamPolicyProjectsLocationsCustomTargetTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5448,7 +5452,7 @@ export const CreateProjectsLocationsCustomTargetTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/customTargetTypes",
+      path: "v1/{+parent}/customTargetTypes",
       hasBody: true,
     }),
     svc,
@@ -5481,7 +5485,7 @@ export const GetProjectsLocationsCustomTargetTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCustomTargetTypesRequest>;
 
@@ -5528,7 +5532,7 @@ export const DeleteProjectsLocationsCustomTargetTypesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCustomTargetTypesRequest>;
 
@@ -5571,7 +5575,7 @@ export const ListProjectsLocationsCustomTargetTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customTargetTypes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/customTargetTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCustomTargetTypesRequest>;
 
@@ -5612,7 +5616,7 @@ export const GetIamPolicyProjectsLocationsCustomTargetTypesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsCustomTargetTypesRequest>;
 
@@ -5659,7 +5663,7 @@ export const DeleteProjectsLocationsTargetsRequest =
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTargetsRequest>;
 
@@ -5704,7 +5708,7 @@ export const CreateProjectsLocationsTargetsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Target).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/targets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/targets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTargetsRequest>;
 
@@ -5740,7 +5744,7 @@ export const TestIamPermissionsProjectsLocationsTargetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5779,7 +5783,7 @@ export const SetIamPolicyProjectsLocationsTargetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5831,7 +5835,7 @@ export const PatchProjectsLocationsTargetsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Target).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTargetsRequest>;
 
@@ -5867,7 +5871,7 @@ export const GetIamPolicyProjectsLocationsTargetsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsTargetsRequest>;
 
@@ -5910,7 +5914,7 @@ export const ListProjectsLocationsTargetsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/targets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/targets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTargetsRequest>;
 
@@ -5945,7 +5949,7 @@ export const GetProjectsLocationsTargetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTargetsRequest>;
 
@@ -5990,7 +5994,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -6025,7 +6029,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -6056,7 +6060,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -6090,7 +6094,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/clouderrorreporting-v1beta1.ts
+++ b/packages/gcp/src/services/clouderrorreporting-v1beta1.ts
@@ -281,7 +281,7 @@ export const DeleteEventsProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     projectName: Schema.String.pipe(T.HttpPath("projectName")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{projectName}/events" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+projectName}/events" }),
     svc,
   ) as unknown as Schema.Schema<DeleteEventsProjectsRequest>;
 
@@ -312,7 +312,7 @@ export const GetProjectsGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     groupName: Schema.String.pipe(T.HttpPath("groupName")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{groupName}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+groupName}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsGroupsRequest>;
 
@@ -345,7 +345,7 @@ export const UpdateProjectsGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ErrorGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsGroupsRequest>;
 
@@ -440,7 +440,7 @@ export const ListProjectsGroupStatsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{projectName}/groupStats" }),
+    T.Http({ method: "GET", path: "v1beta1/{+projectName}/groupStats" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsGroupStatsRequest>;
 
@@ -511,7 +511,7 @@ export const ListProjectsEventsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{projectName}/events" }),
+    T.Http({ method: "GET", path: "v1beta1/{+projectName}/events" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsEventsRequest>;
 
@@ -551,7 +551,7 @@ export const ReportProjectsEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{projectName}/events:report",
+      path: "v1beta1/{+projectName}/events:report",
       hasBody: true,
     }),
     svc,
@@ -584,7 +584,7 @@ export const DeleteEventsProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     projectName: Schema.String.pipe(T.HttpPath("projectName")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{projectName}/events" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+projectName}/events" }),
     svc,
   ) as unknown as Schema.Schema<DeleteEventsProjectsLocationsRequest>;
 
@@ -615,7 +615,7 @@ export const GetProjectsLocationsGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     groupName: Schema.String.pipe(T.HttpPath("groupName")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{groupName}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+groupName}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGroupsRequest>;
 
@@ -649,7 +649,7 @@ export const UpdateProjectsLocationsGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ErrorGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsGroupsRequest>;
 
@@ -744,7 +744,7 @@ export const ListProjectsLocationsGroupStatsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{projectName}/groupStats" }),
+    T.Http({ method: "GET", path: "v1beta1/{+projectName}/groupStats" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGroupStatsRequest>;
 
@@ -815,7 +815,7 @@ export const ListProjectsLocationsEventsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{projectName}/events" }),
+    T.Http({ method: "GET", path: "v1beta1/{+projectName}/events" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEventsRequest>;
 

--- a/packages/gcp/src/services/cloudfunctions-v1.ts
+++ b/packages/gcp/src/services/cloudfunctions-v1.ts
@@ -662,7 +662,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -706,7 +706,7 @@ export const ListProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -746,7 +746,7 @@ export const GenerateDownloadUrlProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:generateDownloadUrl",
+      path: "v1/{+name}:generateDownloadUrl",
       hasBody: true,
     }),
     svc,
@@ -783,7 +783,7 @@ export const CreateProjectsLocationsFunctionsRequest =
     location: Schema.String.pipe(T.HttpPath("location")),
     body: Schema.optional(CloudFunction).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{location}/functions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+location}/functions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsFunctionsRequest>;
 
@@ -820,7 +820,7 @@ export const PatchProjectsLocationsFunctionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(CloudFunction).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFunctionsRequest>;
 
@@ -856,7 +856,7 @@ export const SetIamPolicyProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -894,7 +894,7 @@ export const GetIamPolicyProjectsLocationsFunctionsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsFunctionsRequest>;
 
@@ -928,7 +928,7 @@ export const GetProjectsLocationsFunctionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     versionId: Schema.optional(Schema.String).pipe(T.HttpQuery("versionId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFunctionsRequest>;
 
@@ -964,7 +964,7 @@ export const TestIamPermissionsProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1001,7 +1001,7 @@ export const CallProjectsLocationsFunctionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CallFunctionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:call", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:call", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CallProjectsLocationsFunctionsRequest>;
 
@@ -1038,7 +1038,7 @@ export const ListProjectsLocationsFunctionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/functions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/functions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFunctionsRequest>;
 
@@ -1073,7 +1073,7 @@ export const DeleteProjectsLocationsFunctionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFunctionsRequest>;
 
@@ -1109,7 +1109,7 @@ export const GenerateUploadUrlProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/functions:generateUploadUrl",
+      path: "v1/{+parent}/functions:generateUploadUrl",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/cloudfunctions-v2.ts
+++ b/packages/gcp/src/services/cloudfunctions-v2.ts
@@ -1052,7 +1052,7 @@ export const ListProjectsLocationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1093,7 +1093,7 @@ export const PatchProjectsLocationsFunctionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Cloudfunctions_Function).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFunctionsRequest>;
 
@@ -1127,7 +1127,7 @@ export const GetProjectsLocationsFunctionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     revision: Schema.optional(Schema.String).pipe(T.HttpQuery("revision")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFunctionsRequest>;
 
@@ -1165,7 +1165,7 @@ export const CommitFunctionUpgradeAsGen2ProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:commitFunctionUpgradeAsGen2",
+      path: "v2/{+name}:commitFunctionUpgradeAsGen2",
       hasBody: true,
     }),
     svc,
@@ -1203,7 +1203,11 @@ export const DetachFunctionProjectsLocationsFunctionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DetachFunctionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:detachFunction", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+name}:detachFunction",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<DetachFunctionProjectsLocationsFunctionsRequest>;
 
@@ -1239,7 +1243,7 @@ export const AbortFunctionUpgradeProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:abortFunctionUpgrade",
+      path: "v2/{+name}:abortFunctionUpgrade",
       hasBody: true,
     }),
     svc,
@@ -1272,7 +1276,7 @@ export const DeleteProjectsLocationsFunctionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFunctionsRequest>;
 
@@ -1308,7 +1312,7 @@ export const GenerateUploadUrlProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/functions:generateUploadUrl",
+      path: "v2/{+parent}/functions:generateUploadUrl",
       hasBody: true,
     }),
     svc,
@@ -1347,7 +1351,7 @@ export const GenerateDownloadUrlProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:generateDownloadUrl",
+      path: "v2/{+name}:generateDownloadUrl",
       hasBody: true,
     }),
     svc,
@@ -1387,7 +1391,7 @@ export const CreateProjectsLocationsFunctionsRequest =
     functionId: Schema.optional(Schema.String).pipe(T.HttpQuery("functionId")),
     body: Schema.optional(Cloudfunctions_Function).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/functions", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/functions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsFunctionsRequest>;
 
@@ -1425,7 +1429,7 @@ export const RedirectFunctionUpgradeTrafficProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:redirectFunctionUpgradeTraffic",
+      path: "v2/{+name}:redirectFunctionUpgradeTraffic",
       hasBody: true,
     }),
     svc,
@@ -1465,7 +1469,7 @@ export const CommitFunctionUpgradeProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:commitFunctionUpgrade",
+      path: "v2/{+name}:commitFunctionUpgrade",
       hasBody: true,
     }),
     svc,
@@ -1504,7 +1508,7 @@ export const SetIamPolicyProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1542,7 +1546,7 @@ export const GetIamPolicyProjectsLocationsFunctionsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v2/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsFunctionsRequest>;
 
@@ -1578,7 +1582,7 @@ export const TestIamPermissionsProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1624,7 +1628,7 @@ export const ListProjectsLocationsFunctionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/functions" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/functions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFunctionsRequest>;
 
@@ -1666,7 +1670,7 @@ export const RollbackFunctionUpgradeTrafficProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:rollbackFunctionUpgradeTraffic",
+      path: "v2/{+name}:rollbackFunctionUpgradeTraffic",
       hasBody: true,
     }),
     svc,
@@ -1706,7 +1710,7 @@ export const SetupFunctionUpgradeConfigProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:setupFunctionUpgradeConfig",
+      path: "v2/{+name}:setupFunctionUpgradeConfig",
       hasBody: true,
     }),
     svc,
@@ -1744,7 +1748,7 @@ export const ListProjectsLocationsRuntimesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/runtimes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/runtimes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRuntimesRequest>;
 
@@ -1789,7 +1793,7 @@ export const ListProjectsLocationsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1824,7 +1828,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/cloudfunctions-v2alpha.ts
+++ b/packages/gcp/src/services/cloudfunctions-v2alpha.ts
@@ -1052,7 +1052,7 @@ export const ListProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1101,7 +1101,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1136,7 +1136,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1174,7 +1174,7 @@ export const RedirectFunctionUpgradeTrafficProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{name}:redirectFunctionUpgradeTraffic",
+      path: "v2alpha/{+name}:redirectFunctionUpgradeTraffic",
       hasBody: true,
     }),
     svc,
@@ -1214,7 +1214,7 @@ export const GenerateDownloadUrlProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{name}:generateDownloadUrl",
+      path: "v2alpha/{+name}:generateDownloadUrl",
       hasBody: true,
     }),
     svc,
@@ -1253,7 +1253,7 @@ export const DetachFunctionProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{name}:detachFunction",
+      path: "v2alpha/{+name}:detachFunction",
       hasBody: true,
     }),
     svc,
@@ -1292,7 +1292,7 @@ export const PatchProjectsLocationsFunctionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Cloudfunctions_Function).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFunctionsRequest>;
 
@@ -1328,7 +1328,7 @@ export const GetIamPolicyProjectsLocationsFunctionsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v2alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsFunctionsRequest>;
 
@@ -1364,7 +1364,7 @@ export const SetupFunctionUpgradeConfigProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{name}:setupFunctionUpgradeConfig",
+      path: "v2alpha/{+name}:setupFunctionUpgradeConfig",
       hasBody: true,
     }),
     svc,
@@ -1406,7 +1406,7 @@ export const RollbackFunctionUpgradeTrafficProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{name}:rollbackFunctionUpgradeTraffic",
+      path: "v2alpha/{+name}:rollbackFunctionUpgradeTraffic",
       hasBody: true,
     }),
     svc,
@@ -1446,7 +1446,7 @@ export const SetIamPolicyProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{resource}:setIamPolicy",
+      path: "v2alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1479,7 +1479,7 @@ export const DeleteProjectsLocationsFunctionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFunctionsRequest>;
 
@@ -1515,7 +1515,7 @@ export const GenerateUploadUrlProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{parent}/functions:generateUploadUrl",
+      path: "v2alpha/{+parent}/functions:generateUploadUrl",
       hasBody: true,
     }),
     svc,
@@ -1561,7 +1561,7 @@ export const ListProjectsLocationsFunctionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{parent}/functions" }),
+    T.Http({ method: "GET", path: "v2alpha/{+parent}/functions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFunctionsRequest>;
 
@@ -1604,7 +1604,7 @@ export const CreateProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{parent}/functions",
+      path: "v2alpha/{+parent}/functions",
       hasBody: true,
     }),
     svc,
@@ -1642,7 +1642,7 @@ export const CommitFunctionUpgradeProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{name}:commitFunctionUpgrade",
+      path: "v2alpha/{+name}:commitFunctionUpgrade",
       hasBody: true,
     }),
     svc,
@@ -1681,7 +1681,7 @@ export const AbortFunctionUpgradeProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{name}:abortFunctionUpgrade",
+      path: "v2alpha/{+name}:abortFunctionUpgrade",
       hasBody: true,
     }),
     svc,
@@ -1717,7 +1717,7 @@ export const GetProjectsLocationsFunctionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     revision: Schema.optional(Schema.String).pipe(T.HttpQuery("revision")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFunctionsRequest>;
 
@@ -1755,7 +1755,7 @@ export const CommitFunctionUpgradeAsGen2ProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{name}:commitFunctionUpgradeAsGen2",
+      path: "v2alpha/{+name}:commitFunctionUpgradeAsGen2",
       hasBody: true,
     }),
     svc,
@@ -1795,7 +1795,7 @@ export const TestIamPermissionsProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{resource}:testIamPermissions",
+      path: "v2alpha/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1832,7 +1832,7 @@ export const ListProjectsLocationsRuntimesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{parent}/runtimes" }),
+    T.Http({ method: "GET", path: "v2alpha/{+parent}/runtimes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRuntimesRequest>;
 

--- a/packages/gcp/src/services/cloudfunctions-v2beta.ts
+++ b/packages/gcp/src/services/cloudfunctions-v2beta.ts
@@ -1052,7 +1052,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1090,7 +1090,7 @@ export const ListProjectsLocationsRuntimesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{parent}/runtimes" }),
+    T.Http({ method: "GET", path: "v2beta/{+parent}/runtimes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRuntimesRequest>;
 
@@ -1135,7 +1135,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1170,7 +1170,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1208,7 +1208,7 @@ export const RedirectFunctionUpgradeTrafficProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{name}:redirectFunctionUpgradeTraffic",
+      path: "v2beta/{+name}:redirectFunctionUpgradeTraffic",
       hasBody: true,
     }),
     svc,
@@ -1248,7 +1248,7 @@ export const GenerateDownloadUrlProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{name}:generateDownloadUrl",
+      path: "v2beta/{+name}:generateDownloadUrl",
       hasBody: true,
     }),
     svc,
@@ -1287,7 +1287,7 @@ export const DetachFunctionProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{name}:detachFunction",
+      path: "v2beta/{+name}:detachFunction",
       hasBody: true,
     }),
     svc,
@@ -1326,7 +1326,7 @@ export const PatchProjectsLocationsFunctionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Cloudfunctions_Function).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFunctionsRequest>;
 
@@ -1362,7 +1362,7 @@ export const GetIamPolicyProjectsLocationsFunctionsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v2beta/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsFunctionsRequest>;
 
@@ -1398,7 +1398,7 @@ export const SetupFunctionUpgradeConfigProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{name}:setupFunctionUpgradeConfig",
+      path: "v2beta/{+name}:setupFunctionUpgradeConfig",
       hasBody: true,
     }),
     svc,
@@ -1440,7 +1440,7 @@ export const RollbackFunctionUpgradeTrafficProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{name}:rollbackFunctionUpgradeTraffic",
+      path: "v2beta/{+name}:rollbackFunctionUpgradeTraffic",
       hasBody: true,
     }),
     svc,
@@ -1480,7 +1480,7 @@ export const SetIamPolicyProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{resource}:setIamPolicy",
+      path: "v2beta/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1513,7 +1513,7 @@ export const DeleteProjectsLocationsFunctionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFunctionsRequest>;
 
@@ -1549,7 +1549,7 @@ export const GenerateUploadUrlProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/functions:generateUploadUrl",
+      path: "v2beta/{+parent}/functions:generateUploadUrl",
       hasBody: true,
     }),
     svc,
@@ -1595,7 +1595,7 @@ export const ListProjectsLocationsFunctionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{parent}/functions" }),
+    T.Http({ method: "GET", path: "v2beta/{+parent}/functions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFunctionsRequest>;
 
@@ -1638,7 +1638,7 @@ export const CreateProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/functions",
+      path: "v2beta/{+parent}/functions",
       hasBody: true,
     }),
     svc,
@@ -1676,7 +1676,7 @@ export const CommitFunctionUpgradeProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{name}:commitFunctionUpgrade",
+      path: "v2beta/{+name}:commitFunctionUpgrade",
       hasBody: true,
     }),
     svc,
@@ -1715,7 +1715,7 @@ export const AbortFunctionUpgradeProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{name}:abortFunctionUpgrade",
+      path: "v2beta/{+name}:abortFunctionUpgrade",
       hasBody: true,
     }),
     svc,
@@ -1751,7 +1751,7 @@ export const GetProjectsLocationsFunctionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     revision: Schema.optional(Schema.String).pipe(T.HttpQuery("revision")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFunctionsRequest>;
 
@@ -1789,7 +1789,7 @@ export const CommitFunctionUpgradeAsGen2ProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{name}:commitFunctionUpgradeAsGen2",
+      path: "v2beta/{+name}:commitFunctionUpgradeAsGen2",
       hasBody: true,
     }),
     svc,
@@ -1829,7 +1829,7 @@ export const TestIamPermissionsProjectsLocationsFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{resource}:testIamPermissions",
+      path: "v2beta/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/cloudidentity-v1.ts
+++ b/packages/gcp/src/services/cloudidentity-v1.ts
@@ -1889,7 +1889,7 @@ export const UpdateSecuritySettingsGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SecuritySettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSecuritySettingsGroupsRequest>;
 
@@ -1968,7 +1968,7 @@ export const PatchGroupsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(Group).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchGroupsRequest>;
 
@@ -2040,7 +2040,7 @@ export interface DeleteGroupsRequest {
 export const DeleteGroupsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v1/{name}" }),
+  T.Http({ method: "DELETE", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteGroupsRequest>;
 
@@ -2069,7 +2069,7 @@ export interface GetGroupsRequest {
 export const GetGroupsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetGroupsRequest>;
 
@@ -2102,7 +2102,7 @@ export const GetSecuritySettingsGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSecuritySettingsGroupsRequest>;
 
@@ -2218,7 +2218,7 @@ export const LookupGroupsMembershipsRequest =
       T.HttpQuery("memberKey.namespace"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/memberships:lookup" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/memberships:lookup" }),
     svc,
   ) as unknown as Schema.Schema<LookupGroupsMembershipsRequest>;
 
@@ -2254,7 +2254,7 @@ export const GetMembershipGraphGroupsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/memberships:getMembershipGraph",
+      path: "v1/{+parent}/memberships:getMembershipGraph",
     }),
     svc,
   ) as unknown as Schema.Schema<GetMembershipGraphGroupsMembershipsRequest>;
@@ -2289,7 +2289,7 @@ export const CreateGroupsMembershipsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Membership).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/memberships", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/memberships", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateGroupsMembershipsRequest>;
 
@@ -2320,7 +2320,7 @@ export const GetGroupsMembershipsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetGroupsMembershipsRequest>;
 
@@ -2365,7 +2365,7 @@ export const SearchDirectGroupsGroupsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/memberships:searchDirectGroups",
+      path: "v1/{+parent}/memberships:searchDirectGroups",
     }),
     svc,
   ) as unknown as Schema.Schema<SearchDirectGroupsGroupsMembershipsRequest>;
@@ -2410,7 +2410,7 @@ export const SearchTransitiveMembershipsGroupsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/memberships:searchTransitiveMemberships",
+      path: "v1/{+parent}/memberships:searchTransitiveMemberships",
     }),
     svc,
   ) as unknown as Schema.Schema<SearchTransitiveMembershipsGroupsMembershipsRequest>;
@@ -2447,7 +2447,7 @@ export const DeleteGroupsMembershipsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteGroupsMembershipsRequest>;
 
@@ -2483,7 +2483,7 @@ export const CheckTransitiveMembershipGroupsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/memberships:checkTransitiveMembership",
+      path: "v1/{+parent}/memberships:checkTransitiveMembership",
     }),
     svc,
   ) as unknown as Schema.Schema<CheckTransitiveMembershipGroupsMembershipsRequest>;
@@ -2525,7 +2525,7 @@ export const ListGroupsMembershipsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/memberships" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/memberships" }),
     svc,
   ) as unknown as Schema.Schema<ListGroupsMembershipsRequest>;
 
@@ -2571,7 +2571,7 @@ export const SearchTransitiveGroupsGroupsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/memberships:searchTransitiveGroups",
+      path: "v1/{+parent}/memberships:searchTransitiveGroups",
     }),
     svc,
   ) as unknown as Schema.Schema<SearchTransitiveGroupsGroupsMembershipsRequest>;
@@ -2613,7 +2613,7 @@ export const ModifyMembershipRolesGroupsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:modifyMembershipRoles",
+      path: "v1/{+name}:modifyMembershipRoles",
       hasBody: true,
     }),
     svc,
@@ -2650,7 +2650,7 @@ export const CancelCustomersUserinvitationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelUserInvitationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelCustomersUserinvitationsRequest>;
 
@@ -2681,7 +2681,7 @@ export const GetCustomersUserinvitationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersUserinvitationsRequest>;
 
@@ -2724,7 +2724,7 @@ export const ListCustomersUserinvitationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/userinvitations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/userinvitations" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersUserinvitationsRequest>;
 
@@ -2759,7 +2759,7 @@ export const IsInvitableUserCustomersUserinvitationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:isInvitableUser" }),
+    T.Http({ method: "GET", path: "v1/{+name}:isInvitableUser" }),
     svc,
   ) as unknown as Schema.Schema<IsInvitableUserCustomersUserinvitationsRequest>;
 
@@ -2794,7 +2794,7 @@ export const SendCustomersUserinvitationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SendUserInvitationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:send", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:send", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SendCustomersUserinvitationsRequest>;
 
@@ -2831,7 +2831,7 @@ export const PatchInboundSamlSsoProfilesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(InboundSamlSsoProfile).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchInboundSamlSsoProfilesRequest>;
 
@@ -2862,7 +2862,7 @@ export const GetInboundSamlSsoProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetInboundSamlSsoProfilesRequest>;
 
@@ -2970,7 +2970,7 @@ export const DeleteInboundSamlSsoProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteInboundSamlSsoProfilesRequest>;
 
@@ -3001,7 +3001,7 @@ export const DeleteInboundSamlSsoProfilesIdpCredentialsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteInboundSamlSsoProfilesIdpCredentialsRequest>;
 
@@ -3037,7 +3037,7 @@ export const AddInboundSamlSsoProfilesIdpCredentialsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/idpCredentials:add",
+      path: "v1/{+parent}/idpCredentials:add",
       hasBody: true,
     }),
     svc,
@@ -3070,7 +3070,7 @@ export const GetInboundSamlSsoProfilesIdpCredentialsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetInboundSamlSsoProfilesIdpCredentialsRequest>;
 
@@ -3107,7 +3107,7 @@ export const ListInboundSamlSsoProfilesIdpCredentialsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/idpCredentials" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/idpCredentials" }),
     svc,
   ) as unknown as Schema.Schema<ListInboundSamlSsoProfilesIdpCredentialsRequest>;
 
@@ -3143,7 +3143,7 @@ export const DeleteInboundSsoAssignmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteInboundSsoAssignmentsRequest>;
 
@@ -3205,7 +3205,7 @@ export const GetInboundSsoAssignmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetInboundSsoAssignmentsRequest>;
 
@@ -3284,7 +3284,7 @@ export const PatchInboundSsoAssignmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(InboundSsoAssignment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchInboundSsoAssignmentsRequest>;
 
@@ -3350,7 +3350,7 @@ export const DeleteInboundOidcSsoProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteInboundOidcSsoProfilesRequest>;
 
@@ -3387,7 +3387,7 @@ export const PatchInboundOidcSsoProfilesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(InboundOidcSsoProfile).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchInboundOidcSsoProfilesRequest>;
 
@@ -3418,7 +3418,7 @@ export const GetInboundOidcSsoProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetInboundOidcSsoProfilesRequest>;
 
@@ -3527,7 +3527,7 @@ export const DeleteDevicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   customer: Schema.optional(Schema.String).pipe(T.HttpQuery("customer")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v1/{name}" }),
+  T.Http({ method: "DELETE", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteDevicesRequest>;
 
@@ -3562,7 +3562,7 @@ export const CancelWipeDevicesRequest =
       GoogleAppsCloudidentityDevicesV1CancelWipeDeviceRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancelWipe", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancelWipe", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelWipeDevicesRequest>;
 
@@ -3594,7 +3594,7 @@ export const GetDevicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   customer: Schema.optional(Schema.String).pipe(T.HttpQuery("customer")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetDevicesRequest>;
 
@@ -3683,7 +3683,7 @@ export const WipeDevicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpBody(),
   ),
 }).pipe(
-  T.Http({ method: "POST", path: "v1/{name}:wipe", hasBody: true }),
+  T.Http({ method: "POST", path: "v1/{+name}:wipe", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<WipeDevicesRequest>;
 
@@ -3718,7 +3718,7 @@ export const CancelWipeDevicesDeviceUsersRequest =
       GoogleAppsCloudidentityDevicesV1CancelWipeDeviceUserRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancelWipe", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancelWipe", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelWipeDevicesDeviceUsersRequest>;
 
@@ -3752,7 +3752,7 @@ export const GetDevicesDeviceUsersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     customer: Schema.optional(Schema.String).pipe(T.HttpQuery("customer")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDevicesDeviceUsersRequest>;
 
@@ -3799,7 +3799,7 @@ export const ListDevicesDeviceUsersRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deviceUsers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deviceUsers" }),
     svc,
   ) as unknown as Schema.Schema<ListDevicesDeviceUsersRequest>;
 
@@ -3840,7 +3840,7 @@ export const ApproveDevicesDeviceUsersRequest =
       GoogleAppsCloudidentityDevicesV1ApproveDeviceUserRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:approve", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:approve", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ApproveDevicesDeviceUsersRequest>;
 
@@ -3876,7 +3876,7 @@ export const WipeDevicesDeviceUsersRequest =
       GoogleAppsCloudidentityDevicesV1WipeDeviceUserRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wipe", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wipe", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WipeDevicesDeviceUsersRequest>;
 
@@ -3910,7 +3910,7 @@ export const DeleteDevicesDeviceUsersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     customer: Schema.optional(Schema.String).pipe(T.HttpQuery("customer")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDevicesDeviceUsersRequest>;
 
@@ -3966,7 +3966,7 @@ export const LookupDevicesDeviceUsersRequest =
       T.HttpQuery("rawResourceId"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}:lookup" }),
+    T.Http({ method: "GET", path: "v1/{+parent}:lookup" }),
     svc,
   ) as unknown as Schema.Schema<LookupDevicesDeviceUsersRequest>;
 
@@ -4007,7 +4007,7 @@ export const BlockDevicesDeviceUsersRequest =
       GoogleAppsCloudidentityDevicesV1BlockDeviceUserRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:block", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:block", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<BlockDevicesDeviceUsersRequest>;
 
@@ -4049,7 +4049,7 @@ export const PatchDevicesDeviceUsersClientStatesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchDevicesDeviceUsersClientStatesRequest>;
 
@@ -4083,7 +4083,7 @@ export const GetDevicesDeviceUsersClientStatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     customer: Schema.optional(Schema.String).pipe(T.HttpQuery("customer")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDevicesDeviceUsersClientStatesRequest>;
 
@@ -4127,7 +4127,7 @@ export const ListDevicesDeviceUsersClientStatesRequest =
     customer: Schema.optional(Schema.String).pipe(T.HttpQuery("customer")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/clientStates" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/clientStates" }),
     svc,
   ) as unknown as Schema.Schema<ListDevicesDeviceUsersClientStatesRequest>;
 
@@ -4162,7 +4162,7 @@ export interface GetPoliciesRequest {
 export const GetPoliciesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetPoliciesRequest>;
 

--- a/packages/gcp/src/services/cloudidentity-v1beta1.ts
+++ b/packages/gcp/src/services/cloudidentity-v1beta1.ts
@@ -2472,7 +2472,7 @@ export const GetDevicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   customer: Schema.optional(Schema.String).pipe(T.HttpQuery("customer")),
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta1/{name}" }),
+  T.Http({ method: "GET", path: "v1beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetDevicesRequest>;
 
@@ -2557,7 +2557,7 @@ export const DeleteDevicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   customer: Schema.optional(Schema.String).pipe(T.HttpQuery("customer")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+  T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteDevicesRequest>;
 
@@ -2589,7 +2589,7 @@ export const WipeDevicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(WipeDeviceRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v1beta1/{name}:wipe", hasBody: true }),
+  T.Http({ method: "POST", path: "v1beta1/{+name}:wipe", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<WipeDevicesRequest>;
 
@@ -2653,7 +2653,7 @@ export const CancelWipeDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:cancelWipe",
+      path: "v1beta1/{+name}:cancelWipe",
       hasBody: true,
     }),
     svc,
@@ -2688,7 +2688,7 @@ export const GetDevicesDeviceUsersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     customer: Schema.optional(Schema.String).pipe(T.HttpQuery("customer")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDevicesDeviceUsersRequest>;
 
@@ -2734,7 +2734,7 @@ export const ListDevicesDeviceUsersRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/deviceUsers" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/deviceUsers" }),
     svc,
   ) as unknown as Schema.Schema<ListDevicesDeviceUsersRequest>;
 
@@ -2772,7 +2772,7 @@ export const DeleteDevicesDeviceUsersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     customer: Schema.optional(Schema.String).pipe(T.HttpQuery("customer")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDevicesDeviceUsersRequest>;
 
@@ -2828,7 +2828,7 @@ export const LookupDevicesDeviceUsersRequest =
       T.HttpQuery("rawResourceId"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}:lookup" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}:lookup" }),
     svc,
   ) as unknown as Schema.Schema<LookupDevicesDeviceUsersRequest>;
 
@@ -2866,7 +2866,7 @@ export const WipeDevicesDeviceUsersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(WipeDeviceUserRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wipe", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wipe", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WipeDevicesDeviceUsersRequest>;
 
@@ -2900,7 +2900,7 @@ export const ApproveDevicesDeviceUsersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ApproveDeviceUserRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:approve", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:approve", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ApproveDevicesDeviceUsersRequest>;
 
@@ -2934,7 +2934,7 @@ export const BlockDevicesDeviceUsersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(BlockDeviceUserRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:block", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:block", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<BlockDevicesDeviceUsersRequest>;
 
@@ -2970,7 +2970,7 @@ export const CancelWipeDevicesDeviceUsersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:cancelWipe",
+      path: "v1beta1/{+name}:cancelWipe",
       hasBody: true,
     }),
     svc,
@@ -3006,7 +3006,7 @@ export const GetDevicesDeviceUsersClientStatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     customer: Schema.optional(Schema.String).pipe(T.HttpQuery("customer")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDevicesDeviceUsersClientStatesRequest>;
 
@@ -3046,7 +3046,7 @@ export const PatchDevicesDeviceUsersClientStatesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ClientState).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchDevicesDeviceUsersClientStatesRequest>;
 
@@ -3077,7 +3077,7 @@ export const GetInboundOidcSsoProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetInboundOidcSsoProfilesRequest>;
 
@@ -3114,7 +3114,7 @@ export const PatchInboundOidcSsoProfilesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(InboundOidcSsoProfile).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchInboundOidcSsoProfilesRequest>;
 
@@ -3145,7 +3145,7 @@ export const DeleteInboundOidcSsoProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteInboundOidcSsoProfilesRequest>;
 
@@ -3259,7 +3259,7 @@ export const PatchInboundSamlSsoProfilesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(InboundSamlSsoProfile).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchInboundSamlSsoProfilesRequest>;
 
@@ -3290,7 +3290,7 @@ export const GetInboundSamlSsoProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetInboundSamlSsoProfilesRequest>;
 
@@ -3321,7 +3321,7 @@ export const DeleteInboundSamlSsoProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteInboundSamlSsoProfilesRequest>;
 
@@ -3429,7 +3429,7 @@ export const DeleteInboundSamlSsoProfilesIdpCredentialsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteInboundSamlSsoProfilesIdpCredentialsRequest>;
 
@@ -3466,7 +3466,7 @@ export const ListInboundSamlSsoProfilesIdpCredentialsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/idpCredentials" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/idpCredentials" }),
     svc,
   ) as unknown as Schema.Schema<ListInboundSamlSsoProfilesIdpCredentialsRequest>;
 
@@ -3507,7 +3507,7 @@ export const AddInboundSamlSsoProfilesIdpCredentialsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/idpCredentials:add",
+      path: "v1beta1/{+parent}/idpCredentials:add",
       hasBody: true,
     }),
     svc,
@@ -3540,7 +3540,7 @@ export const GetInboundSamlSsoProfilesIdpCredentialsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetInboundSamlSsoProfilesIdpCredentialsRequest>;
 
@@ -3583,7 +3583,7 @@ export const ListCustomersUserinvitationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/userinvitations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/userinvitations" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersUserinvitationsRequest>;
 
@@ -3621,7 +3621,7 @@ export const CancelCustomersUserinvitationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelUserInvitationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelCustomersUserinvitationsRequest>;
 
@@ -3652,7 +3652,7 @@ export const GetCustomersUserinvitationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersUserinvitationsRequest>;
 
@@ -3686,7 +3686,7 @@ export const SendCustomersUserinvitationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SendUserInvitationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:send", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:send", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SendCustomersUserinvitationsRequest>;
 
@@ -3717,7 +3717,7 @@ export const IsInvitableUserCustomersUserinvitationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:isInvitableUser" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:isInvitableUser" }),
     svc,
   ) as unknown as Schema.Schema<IsInvitableUserCustomersUserinvitationsRequest>;
 
@@ -3790,7 +3790,7 @@ export const PatchInboundSsoAssignmentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(InboundSsoAssignment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchInboundSsoAssignmentsRequest>;
 
@@ -3821,7 +3821,7 @@ export const GetInboundSsoAssignmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetInboundSsoAssignmentsRequest>;
 
@@ -3852,7 +3852,7 @@ export const DeleteInboundSsoAssignmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteInboundSsoAssignmentsRequest>;
 
@@ -3937,7 +3937,7 @@ export const ListOrgUnitsMembershipsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/memberships" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/memberships" }),
     svc,
   ) as unknown as Schema.Schema<ListOrgUnitsMembershipsRequest>;
 
@@ -3975,7 +3975,7 @@ export const MoveOrgUnitsMembershipsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MoveOrgMembershipRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveOrgUnitsMembershipsRequest>;
 
@@ -4034,7 +4034,7 @@ export interface GetPoliciesRequest {
 export const GetPoliciesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta1/{name}" }),
+  T.Http({ method: "GET", path: "v1beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetPoliciesRequest>;
 
@@ -4066,7 +4066,7 @@ export const PatchPoliciesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(Policy).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchPoliciesRequest>;
 
@@ -4135,7 +4135,7 @@ export interface DeletePoliciesRequest {
 export const DeletePoliciesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+  T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeletePoliciesRequest>;
 
@@ -4168,7 +4168,7 @@ export const GetSecuritySettingsGroupsRequest =
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSecuritySettingsGroupsRequest>;
 
@@ -4236,7 +4236,7 @@ export interface DeleteGroupsRequest {
 export const DeleteGroupsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+  T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteGroupsRequest>;
 
@@ -4309,7 +4309,7 @@ export const UpdateSecuritySettingsGroupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SecuritySettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSecuritySettingsGroupsRequest>;
 
@@ -4345,7 +4345,7 @@ export const PatchGroupsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(Group).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchGroupsRequest>;
 
@@ -4420,7 +4420,7 @@ export interface GetGroupsRequest {
 export const GetGroupsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta1/{name}" }),
+  T.Http({ method: "GET", path: "v1beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetGroupsRequest>;
 
@@ -4498,7 +4498,7 @@ export const ModifyMembershipRolesGroupsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:modifyMembershipRoles",
+      path: "v1beta1/{+name}:modifyMembershipRoles",
       hasBody: true,
     }),
     svc,
@@ -4540,7 +4540,7 @@ export const SearchTransitiveMembershipsGroupsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/memberships:searchTransitiveMemberships",
+      path: "v1beta1/{+parent}/memberships:searchTransitiveMemberships",
     }),
     svc,
   ) as unknown as Schema.Schema<SearchTransitiveMembershipsGroupsMembershipsRequest>;
@@ -4577,7 +4577,7 @@ export const GetGroupsMembershipsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetGroupsMembershipsRequest>;
 
@@ -4617,7 +4617,7 @@ export const ListGroupsMembershipsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/memberships" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/memberships" }),
     svc,
   ) as unknown as Schema.Schema<ListGroupsMembershipsRequest>;
 
@@ -4666,7 +4666,7 @@ export const SearchDirectGroupsGroupsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/memberships:searchDirectGroups",
+      path: "v1beta1/{+parent}/memberships:searchDirectGroups",
     }),
     svc,
   ) as unknown as Schema.Schema<SearchDirectGroupsGroupsMembershipsRequest>;
@@ -4708,7 +4708,7 @@ export const CheckTransitiveMembershipGroupsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/memberships:checkTransitiveMembership",
+      path: "v1beta1/{+parent}/memberships:checkTransitiveMembership",
     }),
     svc,
   ) as unknown as Schema.Schema<CheckTransitiveMembershipGroupsMembershipsRequest>;
@@ -4746,7 +4746,7 @@ export const CreateGroupsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/memberships",
+      path: "v1beta1/{+parent}/memberships",
       hasBody: true,
     }),
     svc,
@@ -4790,7 +4790,7 @@ export const SearchTransitiveGroupsGroupsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/memberships:searchTransitiveGroups",
+      path: "v1beta1/{+parent}/memberships:searchTransitiveGroups",
     }),
     svc,
   ) as unknown as Schema.Schema<SearchTransitiveGroupsGroupsMembershipsRequest>;
@@ -4827,7 +4827,7 @@ export const DeleteGroupsMembershipsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteGroupsMembershipsRequest>;
 
@@ -4868,7 +4868,7 @@ export const LookupGroupsMembershipsRequest =
       T.HttpQuery("memberKey.id"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/memberships:lookup" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/memberships:lookup" }),
     svc,
   ) as unknown as Schema.Schema<LookupGroupsMembershipsRequest>;
 
@@ -4904,7 +4904,7 @@ export const GetMembershipGraphGroupsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/memberships:getMembershipGraph",
+      path: "v1beta1/{+parent}/memberships:getMembershipGraph",
     }),
     svc,
   ) as unknown as Schema.Schema<GetMembershipGraphGroupsMembershipsRequest>;

--- a/packages/gcp/src/services/cloudkms-v1.ts
+++ b/packages/gcp/src/services/cloudkms-v1.ts
@@ -1999,7 +1999,7 @@ export const UpdateKajPolicyConfigProjectsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateKajPolicyConfigProjectsRequest>;
 
@@ -2031,7 +2031,7 @@ export const ShowEffectiveAutokeyConfigProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}:showEffectiveAutokeyConfig" }),
+    T.Http({ method: "GET", path: "v1/{+parent}:showEffectiveAutokeyConfig" }),
     svc,
   ) as unknown as Schema.Schema<ShowEffectiveAutokeyConfigProjectsRequest>;
 
@@ -2063,7 +2063,7 @@ export const GetKajPolicyConfigProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetKajPolicyConfigProjectsRequest>;
 
@@ -2101,7 +2101,7 @@ export const UpdateAutokeyConfigProjectsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AutokeyConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAutokeyConfigProjectsRequest>;
 
@@ -2132,7 +2132,7 @@ export const GetAutokeyConfigProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAutokeyConfigProjectsRequest>;
 
@@ -2165,7 +2165,7 @@ export const ShowEffectiveKeyAccessJustificationsPolicyConfigProjectsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{project}:showEffectiveKeyAccessJustificationsPolicyConfig",
+      path: "v1/{+project}:showEffectiveKeyAccessJustificationsPolicyConfig",
     }),
     svc,
   ) as unknown as Schema.Schema<ShowEffectiveKeyAccessJustificationsPolicyConfigProjectsRequest>;
@@ -2201,7 +2201,7 @@ export const ShowEffectiveKeyAccessJustificationsEnrollmentConfigProjectsRequest
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{project}:showEffectiveKeyAccessJustificationsEnrollmentConfig",
+      path: "v1/{+project}:showEffectiveKeyAccessJustificationsEnrollmentConfig",
     }),
     svc,
   ) as unknown as Schema.Schema<ShowEffectiveKeyAccessJustificationsEnrollmentConfigProjectsRequest>;
@@ -2241,7 +2241,7 @@ export const UpdateEkmConfigProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EkmConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateEkmConfigProjectsLocationsRequest>;
 
@@ -2277,7 +2277,7 @@ export const GenerateRandomBytesProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{location}:generateRandomBytes",
+      path: "v1/{+location}:generateRandomBytes",
       hasBody: true,
     }),
     svc,
@@ -2311,7 +2311,7 @@ export const GetEkmConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEkmConfigProjectsLocationsRequest>;
 
@@ -2342,7 +2342,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2387,7 +2387,7 @@ export const ListProjectsLocationsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2430,7 +2430,7 @@ export const CreateProjectsLocationsKeyHandlesRequest =
     ),
     body: Schema.optional(KeyHandle).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/keyHandles", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/keyHandles", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsKeyHandlesRequest>;
 
@@ -2461,7 +2461,7 @@ export const GetProjectsLocationsKeyHandlesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsKeyHandlesRequest>;
 
@@ -2501,7 +2501,7 @@ export const ListProjectsLocationsKeyHandlesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/keyHandles" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/keyHandles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsKeyHandlesRequest>;
 
@@ -2542,7 +2542,7 @@ export const CreateProjectsLocationsKeyRingsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(KeyRing).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/keyRings", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/keyRings", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsKeyRingsRequest>;
 
@@ -2585,7 +2585,7 @@ export const ListProjectsLocationsKeyRingsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/keyRings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/keyRings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsKeyRingsRequest>;
 
@@ -2625,7 +2625,7 @@ export const GetIamPolicyProjectsLocationsKeyRingsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsKeyRingsRequest>;
 
@@ -2661,7 +2661,7 @@ export const TestIamPermissionsProjectsLocationsKeyRingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2695,7 +2695,7 @@ export const GetProjectsLocationsKeyRingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsKeyRingsRequest>;
 
@@ -2731,7 +2731,7 @@ export const SetIamPolicyProjectsLocationsKeyRingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2764,7 +2764,7 @@ export const GetProjectsLocationsKeyRingsImportJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsKeyRingsImportJobsRequest>;
 
@@ -2800,7 +2800,7 @@ export const SetIamPolicyProjectsLocationsKeyRingsImportJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2842,7 +2842,7 @@ export const CreateProjectsLocationsKeyRingsImportJobsRequest =
     ),
     body: Schema.optional(ImportJob).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/importJobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/importJobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsKeyRingsImportJobsRequest>;
 
@@ -2885,7 +2885,7 @@ export const ListProjectsLocationsKeyRingsImportJobsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/importJobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/importJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsKeyRingsImportJobsRequest>;
 
@@ -2926,7 +2926,7 @@ export const GetIamPolicyProjectsLocationsKeyRingsImportJobsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsKeyRingsImportJobsRequest>;
 
@@ -2963,7 +2963,7 @@ export const TestIamPermissionsProjectsLocationsKeyRingsImportJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3004,7 +3004,7 @@ export const PatchProjectsLocationsKeyRingsCryptoKeysRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(CryptoKey).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsKeyRingsCryptoKeysRequest>;
 
@@ -3040,7 +3040,7 @@ export const SetIamPolicyProjectsLocationsKeyRingsCryptoKeysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3077,7 +3077,7 @@ export const EncryptProjectsLocationsKeyRingsCryptoKeysRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EncryptRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:encrypt", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:encrypt", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EncryptProjectsLocationsKeyRingsCryptoKeysRequest>;
 
@@ -3126,7 +3126,7 @@ export const ListProjectsLocationsKeyRingsCryptoKeysRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/cryptoKeys" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/cryptoKeys" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsKeyRingsCryptoKeysRequest>;
 
@@ -3167,7 +3167,7 @@ export const TestIamPermissionsProjectsLocationsKeyRingsCryptoKeysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3215,7 +3215,7 @@ export const CreateProjectsLocationsKeyRingsCryptoKeysRequest =
     ),
     body: Schema.optional(CryptoKey).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/cryptoKeys", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/cryptoKeys", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsKeyRingsCryptoKeysRequest>;
 
@@ -3249,7 +3249,7 @@ export const DecryptProjectsLocationsKeyRingsCryptoKeysRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DecryptRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:decrypt", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:decrypt", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DecryptProjectsLocationsKeyRingsCryptoKeysRequest>;
 
@@ -3288,7 +3288,7 @@ export const UpdatePrimaryVersionProjectsLocationsKeyRingsCryptoKeysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:updatePrimaryVersion",
+      path: "v1/{+name}:updatePrimaryVersion",
       hasBody: true,
     }),
     svc,
@@ -3323,7 +3323,7 @@ export const GetProjectsLocationsKeyRingsCryptoKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsKeyRingsCryptoKeysRequest>;
 
@@ -3354,7 +3354,7 @@ export const DeleteProjectsLocationsKeyRingsCryptoKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsKeyRingsCryptoKeysRequest>;
 
@@ -3390,7 +3390,7 @@ export const GetIamPolicyProjectsLocationsKeyRingsCryptoKeysRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsKeyRingsCryptoKeysRequest>;
 
@@ -3425,7 +3425,7 @@ export const DestroyProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest 
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DestroyCryptoKeyVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:destroy", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:destroy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DestroyProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest>;
 
@@ -3461,7 +3461,7 @@ export const RawEncryptProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsReque
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RawEncryptRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:rawEncrypt", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:rawEncrypt", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RawEncryptProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest>;
 
@@ -3498,7 +3498,7 @@ export const MacVerifyProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsReques
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MacVerifyRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:macVerify", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:macVerify", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MacVerifyProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest>;
 
@@ -3536,7 +3536,7 @@ export const AsymmetricDecryptProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersio
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:asymmetricDecrypt",
+      path: "v1/{+name}:asymmetricDecrypt",
       hasBody: true,
     }),
     svc,
@@ -3576,7 +3576,7 @@ export const RestoreProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest 
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestoreCryptoKeyVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest>;
 
@@ -3609,7 +3609,7 @@ export const DeleteProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest>;
 
@@ -3645,7 +3645,7 @@ export const DecapsulateProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequ
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DecapsulateRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:decapsulate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:decapsulate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DecapsulateProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest>;
 
@@ -3684,7 +3684,7 @@ export const CreateProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/cryptoKeyVersions",
+      path: "v1/{+parent}/cryptoKeyVersions",
       hasBody: true,
     }),
     svc,
@@ -3734,7 +3734,7 @@ export const ListProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/cryptoKeyVersions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/cryptoKeyVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest>;
 
@@ -3774,7 +3774,7 @@ export const RawDecryptProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsReque
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RawDecryptRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:rawDecrypt", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:rawDecrypt", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RawDecryptProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest>;
 
@@ -3814,7 +3814,7 @@ export const PatchProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CryptoKeyVersion).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest>;
 
@@ -3850,7 +3850,11 @@ export const AsymmetricSignProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsR
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AsymmetricSignRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:asymmetricSign", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+name}:asymmetricSign",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<AsymmetricSignProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest>;
 
@@ -3888,7 +3892,7 @@ export const MacSignProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest 
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MacSignRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:macSign", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:macSign", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MacSignProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest>;
 
@@ -3926,7 +3930,7 @@ export const ImportProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/cryptoKeyVersions:import",
+      path: "v1/{+parent}/cryptoKeyVersions:import",
       hasBody: true,
     }),
     svc,
@@ -3961,7 +3965,7 @@ export const GetProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest>;
 
@@ -4005,7 +4009,7 @@ export const GetPublicKeyProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsReq
       T.HttpQuery("publicKeyFormat"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/publicKey" }),
+    T.Http({ method: "GET", path: "v1/{+name}/publicKey" }),
     svc,
   ) as unknown as Schema.Schema<GetPublicKeyProjectsLocationsKeyRingsCryptoKeysCryptoKeyVersionsRequest>;
 
@@ -4045,7 +4049,7 @@ export const SetIamPolicyProjectsLocationsEkmConfigRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4083,7 +4087,7 @@ export const GetIamPolicyProjectsLocationsEkmConfigRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsEkmConfigRequest>;
 
@@ -4119,7 +4123,7 @@ export const TestIamPermissionsProjectsLocationsEkmConfigRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4153,7 +4157,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -4184,7 +4188,7 @@ export const GetProjectsLocationsRetiredResourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRetiredResourcesRequest>;
 
@@ -4221,7 +4225,7 @@ export const ListProjectsLocationsRetiredResourcesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/retiredResources" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/retiredResources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRetiredResourcesRequest>;
 
@@ -4267,7 +4271,7 @@ export const CreateProjectsLocationsEkmConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/ekmConnections",
+      path: "v1/{+parent}/ekmConnections",
       hasBody: true,
     }),
     svc,
@@ -4312,7 +4316,7 @@ export const ListProjectsLocationsEkmConnectionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/ekmConnections" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/ekmConnections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEkmConnectionsRequest>;
 
@@ -4353,7 +4357,7 @@ export const GetIamPolicyProjectsLocationsEkmConnectionsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsEkmConnectionsRequest>;
 
@@ -4389,7 +4393,7 @@ export const TestIamPermissionsProjectsLocationsEkmConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4424,7 +4428,7 @@ export const GetProjectsLocationsEkmConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEkmConnectionsRequest>;
 
@@ -4461,7 +4465,7 @@ export const PatchProjectsLocationsEkmConnectionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(EkmConnection).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEkmConnectionsRequest>;
 
@@ -4492,7 +4496,7 @@ export const VerifyConnectivityProjectsLocationsEkmConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:verifyConnectivity" }),
+    T.Http({ method: "GET", path: "v1/{+name}:verifyConnectivity" }),
     svc,
   ) as unknown as Schema.Schema<VerifyConnectivityProjectsLocationsEkmConnectionsRequest>;
 
@@ -4530,7 +4534,7 @@ export const SetIamPolicyProjectsLocationsEkmConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4580,7 +4584,7 @@ export const ListProjectsLocationsSingleTenantHsmInstancesRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/singleTenantHsmInstances" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/singleTenantHsmInstances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSingleTenantHsmInstancesRequest>;
 
@@ -4626,7 +4630,7 @@ export const CreateProjectsLocationsSingleTenantHsmInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/singleTenantHsmInstances",
+      path: "v1/{+parent}/singleTenantHsmInstances",
       hasBody: true,
     }),
     svc,
@@ -4660,7 +4664,7 @@ export const GetProjectsLocationsSingleTenantHsmInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSingleTenantHsmInstancesRequest>;
 
@@ -4709,7 +4713,7 @@ export const ListProjectsLocationsSingleTenantHsmInstancesProposalsRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/proposals" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/proposals" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSingleTenantHsmInstancesProposalsRequest>;
 
@@ -4754,7 +4758,7 @@ export const CreateProjectsLocationsSingleTenantHsmInstancesProposalsRequest =
     ),
     body: Schema.optional(SingleTenantHsmInstanceProposal).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/proposals", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/proposals", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSingleTenantHsmInstancesProposalsRequest>;
 
@@ -4792,7 +4796,7 @@ export const ExecuteProjectsLocationsSingleTenantHsmInstancesProposalsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:execute", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:execute", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteProjectsLocationsSingleTenantHsmInstancesProposalsRequest>;
 
@@ -4825,7 +4829,7 @@ export const GetProjectsLocationsSingleTenantHsmInstancesProposalsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSingleTenantHsmInstancesProposalsRequest>;
 
@@ -4858,7 +4862,7 @@ export const DeleteProjectsLocationsSingleTenantHsmInstancesProposalsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSingleTenantHsmInstancesProposalsRequest>;
 
@@ -4896,7 +4900,7 @@ export const ApproveProjectsLocationsSingleTenantHsmInstancesProposalsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:approve", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:approve", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ApproveProjectsLocationsSingleTenantHsmInstancesProposalsRequest>;
 
@@ -4935,7 +4939,7 @@ export const UpdateAutokeyConfigFoldersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AutokeyConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAutokeyConfigFoldersRequest>;
 
@@ -4974,7 +4978,7 @@ export const UpdateKajPolicyConfigFoldersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateKajPolicyConfigFoldersRequest>;
 
@@ -5006,7 +5010,7 @@ export const GetAutokeyConfigFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAutokeyConfigFoldersRequest>;
 
@@ -5037,7 +5041,7 @@ export const GetKajPolicyConfigFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetKajPolicyConfigFoldersRequest>;
 
@@ -5069,7 +5073,7 @@ export const GetKajPolicyConfigOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetKajPolicyConfigOrganizationsRequest>;
 
@@ -5109,7 +5113,7 @@ export const UpdateKajPolicyConfigOrganizationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateKajPolicyConfigOrganizationsRequest>;
 

--- a/packages/gcp/src/services/cloudlocationfinder-v1.ts
+++ b/packages/gcp/src/services/cloudlocationfinder-v1.ts
@@ -133,7 +133,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -178,7 +178,7 @@ export const ListProjectsLocationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -222,7 +222,7 @@ export const ListProjectsLocationsCloudLocationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/cloudLocations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/cloudLocations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCloudLocationsRequest>;
 
@@ -258,7 +258,7 @@ export const GetProjectsLocationsCloudLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCloudLocationsRequest>;
 
@@ -303,7 +303,7 @@ export const SearchProjectsLocationsCloudLocationsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/cloudLocations:search" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/cloudLocations:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsLocationsCloudLocationsRequest>;
 

--- a/packages/gcp/src/services/cloudlocationfinder-v1alpha.ts
+++ b/packages/gcp/src/services/cloudlocationfinder-v1alpha.ts
@@ -147,7 +147,7 @@ export const ListProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -182,7 +182,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -213,7 +213,7 @@ export const GetProjectsLocationsCloudLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCloudLocationsRequest>;
 
@@ -253,7 +253,7 @@ export const ListProjectsLocationsCloudLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/cloudLocations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/cloudLocations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCloudLocationsRequest>;
 
@@ -303,7 +303,7 @@ export const SearchProjectsLocationsCloudLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     query: Schema.optional(Schema.String).pipe(T.HttpQuery("query")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/cloudLocations:search" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/cloudLocations:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsLocationsCloudLocationsRequest>;
 

--- a/packages/gcp/src/services/cloudprofiler-v2.ts
+++ b/packages/gcp/src/services/cloudprofiler-v2.ts
@@ -126,7 +126,7 @@ export const CreateProjectsProfilesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateProfileRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/profiles", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/profiles", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsProfilesRequest>;
 
@@ -162,7 +162,7 @@ export const CreateOfflineProjectsProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/profiles:createOffline",
+      path: "v2/{+parent}/profiles:createOffline",
       hasBody: true,
     }),
     svc,
@@ -201,7 +201,7 @@ export const PatchProjectsProfilesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Profile).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsProfilesRequest>;
 
@@ -238,7 +238,7 @@ export const ListProjectsProfilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/profiles" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/profiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsProfilesRequest>;
 

--- a/packages/gcp/src/services/cloudresourcemanager-v1.ts
+++ b/packages/gcp/src/services/cloudresourcemanager-v1.ts
@@ -949,7 +949,7 @@ export interface GetLiensRequest {
 export const GetLiensRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetLiensRequest>;
 
@@ -1007,7 +1007,7 @@ export interface DeleteLiensRequest {
 export const DeleteLiensRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v1/{name}" }),
+  T.Http({ method: "DELETE", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteLiensRequest>;
 
@@ -1042,7 +1042,7 @@ export const ListOrgPoliciesProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:listOrgPolicies",
+      path: "v1/{+resource}:listOrgPolicies",
       hasBody: true,
     }),
     svc,
@@ -1080,7 +1080,7 @@ export const SetOrgPolicyProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setOrgPolicy",
+      path: "v1/{+resource}:setOrgPolicy",
       hasBody: true,
     }),
     svc,
@@ -1266,7 +1266,7 @@ export const ClearOrgPolicyProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:clearOrgPolicy",
+      path: "v1/{+resource}:clearOrgPolicy",
       hasBody: true,
     }),
     svc,
@@ -1335,7 +1335,7 @@ export const GetEffectiveOrgPolicyProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getEffectiveOrgPolicy",
+      path: "v1/{+resource}:getEffectiveOrgPolicy",
       hasBody: true,
     }),
     svc,
@@ -1375,7 +1375,7 @@ export const ListAvailableOrgPolicyConstraintsProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:listAvailableOrgPolicyConstraints",
+      path: "v1/{+resource}:listAvailableOrgPolicyConstraints",
       hasBody: true,
     }),
     svc,
@@ -1550,7 +1550,7 @@ export const GetOrgPolicyProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getOrgPolicy",
+      path: "v1/{+resource}:getOrgPolicy",
       hasBody: true,
     }),
     svc,
@@ -1620,7 +1620,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -1655,7 +1655,7 @@ export const GetIamPolicyOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1695,7 +1695,7 @@ export const ListAvailableOrgPolicyConstraintsOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:listAvailableOrgPolicyConstraints",
+      path: "v1/{+resource}:listAvailableOrgPolicyConstraints",
       hasBody: true,
     }),
     svc,
@@ -1734,7 +1734,7 @@ export const GetEffectiveOrgPolicyOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getEffectiveOrgPolicy",
+      path: "v1/{+resource}:getEffectiveOrgPolicy",
       hasBody: true,
     }),
     svc,
@@ -1772,7 +1772,7 @@ export const SetOrgPolicyOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setOrgPolicy",
+      path: "v1/{+resource}:setOrgPolicy",
       hasBody: true,
     }),
     svc,
@@ -1810,7 +1810,7 @@ export const TestIamPermissionsOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1849,7 +1849,7 @@ export const ListOrgPoliciesOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:listOrgPolicies",
+      path: "v1/{+resource}:listOrgPolicies",
       hasBody: true,
     }),
     svc,
@@ -1887,7 +1887,7 @@ export const ClearOrgPolicyOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:clearOrgPolicy",
+      path: "v1/{+resource}:clearOrgPolicy",
       hasBody: true,
     }),
     svc,
@@ -1956,7 +1956,7 @@ export const GetOrgPolicyOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getOrgPolicy",
+      path: "v1/{+resource}:getOrgPolicy",
       hasBody: true,
     }),
     svc,
@@ -1994,7 +1994,7 @@ export const SetIamPolicyOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2027,7 +2027,7 @@ export const GetOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsRequest>;
 
@@ -2065,7 +2065,7 @@ export const ListAvailableOrgPolicyConstraintsFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:listAvailableOrgPolicyConstraints",
+      path: "v1/{+resource}:listAvailableOrgPolicyConstraints",
       hasBody: true,
     }),
     svc,
@@ -2104,7 +2104,7 @@ export const GetOrgPolicyFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getOrgPolicy",
+      path: "v1/{+resource}:getOrgPolicy",
       hasBody: true,
     }),
     svc,
@@ -2142,7 +2142,7 @@ export const ClearOrgPolicyFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:clearOrgPolicy",
+      path: "v1/{+resource}:clearOrgPolicy",
       hasBody: true,
     }),
     svc,
@@ -2179,7 +2179,7 @@ export const ListOrgPoliciesFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:listOrgPolicies",
+      path: "v1/{+resource}:listOrgPolicies",
       hasBody: true,
     }),
     svc,
@@ -2217,7 +2217,7 @@ export const GetEffectiveOrgPolicyFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getEffectiveOrgPolicy",
+      path: "v1/{+resource}:getEffectiveOrgPolicy",
       hasBody: true,
     }),
     svc,
@@ -2255,7 +2255,7 @@ export const SetOrgPolicyFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setOrgPolicy",
+      path: "v1/{+resource}:setOrgPolicy",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/cloudresourcemanager-v1beta1.ts
+++ b/packages/gcp/src/services/cloudresourcemanager-v1beta1.ts
@@ -983,7 +983,7 @@ export const GetIamPolicyOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1021,7 +1021,7 @@ export const TestIamPermissionsOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1060,7 +1060,7 @@ export const GetOrganizationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsRequest>;
 
@@ -1094,7 +1094,7 @@ export const UpdateOrganizationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Organization).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsRequest>;
 
@@ -1171,7 +1171,7 @@ export const SetIamPolicyOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/cloudresourcemanager-v2.ts
+++ b/packages/gcp/src/services/cloudresourcemanager-v2.ts
@@ -595,7 +595,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -630,7 +630,7 @@ export const SetIamPolicyFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -661,7 +661,7 @@ export interface DeleteFoldersRequest {
 export const DeleteFoldersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v2/{name}" }),
+  T.Http({ method: "DELETE", path: "v2/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteFoldersRequest>;
 
@@ -727,7 +727,7 @@ export const TestIamPermissionsFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -762,7 +762,7 @@ export const MoveFoldersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(MoveFolderRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v2/{name}:move", hasBody: true }),
+  T.Http({ method: "POST", path: "v2/{+name}:move", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<MoveFoldersRequest>;
 
@@ -872,7 +872,7 @@ export const PatchFoldersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(Folder).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchFoldersRequest>;
 
@@ -907,7 +907,7 @@ export const GetIamPolicyFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:getIamPolicy",
+      path: "v2/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -938,7 +938,7 @@ export interface GetFoldersRequest {
 export const GetFoldersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{name}" }),
+  T.Http({ method: "GET", path: "v2/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetFoldersRequest>;
 
@@ -972,7 +972,7 @@ export const UndeleteFoldersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     body: Schema.optional(UndeleteFolderRequest).pipe(T.HttpBody()),
   },
 ).pipe(
-  T.Http({ method: "POST", path: "v2/{name}:undelete", hasBody: true }),
+  T.Http({ method: "POST", path: "v2/{+name}:undelete", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<UndeleteFoldersRequest>;
 

--- a/packages/gcp/src/services/cloudresourcemanager-v2beta1.ts
+++ b/packages/gcp/src/services/cloudresourcemanager-v2beta1.ts
@@ -595,7 +595,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -673,7 +673,7 @@ export const TestIamPermissionsFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -711,7 +711,7 @@ export const SetIamPolicyFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -742,7 +742,7 @@ export interface DeleteFoldersRequest {
 export const DeleteFoldersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v2/{name}" }),
+  T.Http({ method: "DELETE", path: "v2/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteFoldersRequest>;
 
@@ -806,7 +806,7 @@ export const MoveFoldersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(MoveFolderRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v2/{name}:move", hasBody: true }),
+  T.Http({ method: "POST", path: "v2/{+name}:move", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<MoveFoldersRequest>;
 
@@ -835,7 +835,7 @@ export interface GetFoldersRequest {
 export const GetFoldersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{name}" }),
+  T.Http({ method: "GET", path: "v2/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetFoldersRequest>;
 
@@ -870,7 +870,7 @@ export const PatchFoldersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(Folder).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchFoldersRequest>;
 
@@ -904,7 +904,7 @@ export const UndeleteFoldersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     body: Schema.optional(UndeleteFolderRequest).pipe(T.HttpBody()),
   },
 ).pipe(
-  T.Http({ method: "POST", path: "v2/{name}:undelete", hasBody: true }),
+  T.Http({ method: "POST", path: "v2/{+name}:undelete", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<UndeleteFoldersRequest>;
 
@@ -939,7 +939,7 @@ export const GetIamPolicyFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:getIamPolicy",
+      path: "v2/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/cloudresourcemanager-v3.ts
+++ b/packages/gcp/src/services/cloudresourcemanager-v3.ts
@@ -1026,7 +1026,7 @@ export interface GetLiensRequest {
 export const GetLiensRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v3/{name}" }),
+  T.Http({ method: "GET", path: "v3/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetLiensRequest>;
 
@@ -1055,7 +1055,7 @@ export interface DeleteLiensRequest {
 export const DeleteLiensRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v3/{name}" }),
+  T.Http({ method: "DELETE", path: "v3/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteLiensRequest>;
 
@@ -1129,7 +1129,7 @@ export const UndeleteFoldersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     body: Schema.optional(UndeleteFolderRequest).pipe(T.HttpBody()),
   },
 ).pipe(
-  T.Http({ method: "POST", path: "v3/{name}:undelete", hasBody: true }),
+  T.Http({ method: "POST", path: "v3/{+name}:undelete", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<UndeleteFoldersRequest>;
 
@@ -1161,7 +1161,7 @@ export const MoveFoldersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(MoveFolderRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v3/{name}:move", hasBody: true }),
+  T.Http({ method: "POST", path: "v3/{+name}:move", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<MoveFoldersRequest>;
 
@@ -1196,7 +1196,7 @@ export const GetIamPolicyFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{resource}:getIamPolicy",
+      path: "v3/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1227,7 +1227,7 @@ export interface GetFoldersRequest {
 export const GetFoldersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v3/{name}" }),
+  T.Http({ method: "GET", path: "v3/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetFoldersRequest>;
 
@@ -1256,7 +1256,7 @@ export interface DeleteFoldersRequest {
 export const DeleteFoldersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v3/{name}" }),
+  T.Http({ method: "DELETE", path: "v3/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteFoldersRequest>;
 
@@ -1291,7 +1291,7 @@ export const PatchFoldersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(Folder).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchFoldersRequest>;
 
@@ -1326,7 +1326,7 @@ export const SetIamPolicyFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{resource}:setIamPolicy",
+      path: "v3/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1363,7 +1363,7 @@ export const TestIamPermissionsFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{resource}:testIamPermissions",
+      path: "v3/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1514,7 +1514,7 @@ export const PatchFoldersCapabilitiesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Capability).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersCapabilitiesRequest>;
 
@@ -1545,7 +1545,7 @@ export const GetFoldersCapabilitiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersCapabilitiesRequest>;
 
@@ -1617,7 +1617,7 @@ export const GetLocationsTagBindingCollectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLocationsTagBindingCollectionsRequest>;
 
@@ -1654,7 +1654,7 @@ export const PatchLocationsTagBindingCollectionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(TagBindingCollection).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchLocationsTagBindingCollectionsRequest>;
 
@@ -1685,7 +1685,7 @@ export const GetLocationsEffectiveTagBindingCollectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLocationsEffectiveTagBindingCollectionsRequest>;
 
@@ -1716,7 +1716,7 @@ export interface GetProjectsRequest {
 export const GetProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v3/{name}" }),
+  T.Http({ method: "GET", path: "v3/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetProjectsRequest>;
 
@@ -1745,7 +1745,7 @@ export interface DeleteProjectsRequest {
 export const DeleteProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v3/{name}" }),
+  T.Http({ method: "DELETE", path: "v3/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteProjectsRequest>;
 
@@ -1784,7 +1784,7 @@ export const PatchProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(Project).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchProjectsRequest>;
 
@@ -1823,7 +1823,7 @@ export const SetIamPolicyProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{resource}:setIamPolicy",
+      path: "v3/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1858,7 +1858,7 @@ export const UndeleteProjectsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndeleteProjectRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsRequest>;
 
@@ -1890,7 +1890,7 @@ export const MoveProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(MoveProjectRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v3/{name}:move", hasBody: true }),
+  T.Http({ method: "POST", path: "v3/{+name}:move", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<MoveProjectsRequest>;
 
@@ -1925,7 +1925,7 @@ export const GetIamPolicyProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{resource}:getIamPolicy",
+      path: "v3/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2045,7 +2045,7 @@ export const TestIamPermissionsProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{resource}:testIamPermissions",
+      path: "v3/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2116,7 +2116,7 @@ export const SetIamPolicyOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{resource}:setIamPolicy",
+      path: "v3/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2149,7 +2149,7 @@ export const GetOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsRequest>;
 
@@ -2226,7 +2226,7 @@ export const GetIamPolicyOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{resource}:getIamPolicy",
+      path: "v3/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2264,7 +2264,7 @@ export const TestIamPermissionsOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{resource}:testIamPermissions",
+      path: "v3/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2337,7 +2337,7 @@ export const TestIamPermissionsTagKeysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{resource}:testIamPermissions",
+      path: "v3/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2415,7 +2415,7 @@ export const GetIamPolicyTagKeysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{resource}:getIamPolicy",
+      path: "v3/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2487,7 +2487,7 @@ export const PatchTagKeysRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   ),
   body: Schema.optional(TagKey).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchTagKeysRequest>;
 
@@ -2522,7 +2522,7 @@ export const SetIamPolicyTagKeysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{resource}:setIamPolicy",
+      path: "v3/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2553,7 +2553,7 @@ export interface GetTagKeysRequest {
 export const GetTagKeysRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v3/{name}" }),
+  T.Http({ method: "GET", path: "v3/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetTagKeysRequest>;
 
@@ -2590,7 +2590,7 @@ export const DeleteTagKeysRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("validateOnly"),
   ),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v3/{name}" }),
+  T.Http({ method: "DELETE", path: "v3/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteTagKeysRequest>;
 
@@ -2619,7 +2619,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v3/{name}" }),
+  T.Http({ method: "GET", path: "v3/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -2730,7 +2730,7 @@ export const TestIamPermissionsTagValuesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{resource}:testIamPermissions",
+      path: "v3/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2768,7 +2768,7 @@ export const GetIamPolicyTagValuesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{resource}:getIamPolicy",
+      path: "v3/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2841,7 +2841,7 @@ export const PatchTagValuesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(TagValue).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchTagValuesRequest>;
 
@@ -2876,7 +2876,7 @@ export const SetIamPolicyTagValuesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{resource}:setIamPolicy",
+      path: "v3/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2907,7 +2907,7 @@ export interface GetTagValuesRequest {
 export const GetTagValuesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v3/{name}" }),
+  T.Http({ method: "GET", path: "v3/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetTagValuesRequest>;
 
@@ -2946,7 +2946,7 @@ export const DeleteTagValuesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     ),
   },
 ).pipe(
-  T.Http({ method: "DELETE", path: "v3/{name}" }),
+  T.Http({ method: "DELETE", path: "v3/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteTagValuesRequest>;
 
@@ -2981,7 +2981,7 @@ export const DeleteTagValuesTagHoldsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteTagValuesTagHoldsRequest>;
 
@@ -3021,7 +3021,7 @@ export const ListTagValuesTagHoldsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/tagHolds" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/tagHolds" }),
     svc,
   ) as unknown as Schema.Schema<ListTagValuesTagHoldsRequest>;
 
@@ -3064,7 +3064,7 @@ export const CreateTagValuesTagHoldsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(TagHold).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/tagHolds", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/tagHolds", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateTagValuesTagHoldsRequest>;
 
@@ -3095,7 +3095,7 @@ export const DeleteTagBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteTagBindingsRequest>;
 

--- a/packages/gcp/src/services/cloudscheduler-v1.ts
+++ b/packages/gcp/src/services/cloudscheduler-v1.ts
@@ -437,7 +437,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -472,7 +472,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -509,7 +509,7 @@ export const UpdateCmekConfigProjectsLocationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(CmekConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateCmekConfigProjectsLocationsRequest>;
 
@@ -540,7 +540,7 @@ export const GetCmekConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCmekConfigProjectsLocationsRequest>;
 
@@ -585,7 +585,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -620,7 +620,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -651,7 +651,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -685,7 +685,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -722,7 +722,7 @@ export const ListProjectsLocationsJobsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/jobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/jobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsJobsRequest>;
 
@@ -757,7 +757,7 @@ export const GetProjectsLocationsJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsJobsRequest>;
 
@@ -790,7 +790,7 @@ export const CreateProjectsLocationsJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Job).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/jobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/jobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsJobsRequest>;
 
@@ -827,7 +827,7 @@ export const PatchProjectsLocationsJobsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Job).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsJobsRequest>;
 
@@ -858,7 +858,7 @@ export const DeleteProjectsLocationsJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsJobsRequest>;
 
@@ -892,7 +892,7 @@ export const PauseProjectsLocationsJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PauseJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsLocationsJobsRequest>;
 
@@ -926,7 +926,7 @@ export const ResumeProjectsLocationsJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResumeJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsJobsRequest>;
 
@@ -960,7 +960,7 @@ export const RunProjectsLocationsJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RunJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsJobsRequest>;
 

--- a/packages/gcp/src/services/cloudscheduler-v1beta1.ts
+++ b/packages/gcp/src/services/cloudscheduler-v1beta1.ts
@@ -431,7 +431,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -466,7 +466,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -511,7 +511,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -546,7 +546,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -577,7 +577,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -611,7 +611,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -656,7 +656,7 @@ export const ListProjectsLocationsJobsRequest =
       T.HttpQuery("legacyAppEngineCron"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/jobs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/jobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsJobsRequest>;
 
@@ -691,7 +691,7 @@ export const GetProjectsLocationsJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsJobsRequest>;
 
@@ -724,7 +724,7 @@ export const CreateProjectsLocationsJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Job).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/jobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+parent}/jobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsJobsRequest>;
 
@@ -761,7 +761,7 @@ export const PatchProjectsLocationsJobsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Job).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsJobsRequest>;
 
@@ -797,7 +797,7 @@ export const DeleteProjectsLocationsJobsRequest =
       T.HttpQuery("legacyAppEngineCron"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsJobsRequest>;
 
@@ -831,7 +831,7 @@ export const PauseProjectsLocationsJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PauseJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsLocationsJobsRequest>;
 
@@ -865,7 +865,7 @@ export const ResumeProjectsLocationsJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResumeJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsJobsRequest>;
 
@@ -899,7 +899,7 @@ export const RunProjectsLocationsJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RunJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsJobsRequest>;
 

--- a/packages/gcp/src/services/cloudsearch-v1.ts
+++ b/packages/gcp/src/services/cloudsearch-v1.ts
@@ -4118,7 +4118,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -4162,7 +4162,7 @@ export const ListOperationsLroRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/lro" }),
+    T.Http({ method: "GET", path: "v1/{+name}/lro" }),
     svc,
   ) as unknown as Schema.Schema<ListOperationsLroRequest>;
 
@@ -4207,7 +4207,7 @@ export const CheckAccessDebugDatasourcesItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/debug/{name}:checkAccess",
+      path: "v1/debug/{+name}:checkAccess",
       hasBody: true,
     }),
     svc,
@@ -4245,7 +4245,7 @@ export const SearchByViewUrlDebugDatasourcesItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/debug/{name}/items:searchByViewUrl",
+      path: "v1/debug/{+name}/items:searchByViewUrl",
       hasBody: true,
     }),
     svc,
@@ -4290,7 +4290,7 @@ export const ListDebugDatasourcesItemsUnmappedidsRequest =
       T.HttpQuery("debugOptions.enableDebugging"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/debug/{parent}/unmappedids" }),
+    T.Http({ method: "GET", path: "v1/debug/{+parent}/unmappedids" }),
     svc,
   ) as unknown as Schema.Schema<ListDebugDatasourcesItemsUnmappedidsRequest>;
 
@@ -4349,7 +4349,7 @@ export const ListDebugIdentitysourcesUnmappedidsRequest =
       T.HttpQuery("debugOptions.enableDebugging"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/debug/{parent}/unmappedids" }),
+    T.Http({ method: "GET", path: "v1/debug/{+parent}/unmappedids" }),
     svc,
   ) as unknown as Schema.Schema<ListDebugIdentitysourcesUnmappedidsRequest>;
 
@@ -4406,7 +4406,7 @@ export const ListForunmappedidentityDebugIdentitysourcesItemsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/debug/{parent}/items:forunmappedidentity",
+      path: "v1/debug/{+parent}/items:forunmappedidentity",
     }),
     svc,
   ) as unknown as Schema.Schema<ListForunmappedidentityDebugIdentitysourcesItemsRequest>;
@@ -4553,7 +4553,7 @@ export const GetSettingsSearchapplicationsRequest =
       T.HttpQuery("debugOptions.enableDebugging"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/settings/{name}" }),
+    T.Http({ method: "GET", path: "v1/settings/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSettingsSearchapplicationsRequest>;
 
@@ -4625,7 +4625,7 @@ export const UpdateSettingsSearchapplicationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SearchApplication).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/settings/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/settings/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSettingsSearchapplicationsRequest>;
 
@@ -4662,7 +4662,7 @@ export const PatchSettingsSearchapplicationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SearchApplication).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/settings/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/settings/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchSettingsSearchapplicationsRequest>;
 
@@ -4698,7 +4698,7 @@ export const DeleteSettingsSearchapplicationsRequest =
       T.HttpQuery("debugOptions.enableDebugging"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/settings/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/settings/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteSettingsSearchapplicationsRequest>;
 
@@ -4732,7 +4732,11 @@ export const ResetSettingsSearchapplicationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResetSearchApplicationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/settings/{name}:reset", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/settings/{+name}:reset",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<ResetSettingsSearchapplicationsRequest>;
 
@@ -4799,7 +4803,7 @@ export const DeleteSettingsDatasourcesRequest =
       T.HttpQuery("debugOptions.enableDebugging"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/settings/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/settings/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteSettingsDatasourcesRequest>;
 
@@ -4835,7 +4839,7 @@ export const GetSettingsDatasourcesRequest =
       T.HttpQuery("debugOptions.enableDebugging"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/settings/{name}" }),
+    T.Http({ method: "GET", path: "v1/settings/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSettingsDatasourcesRequest>;
 
@@ -4869,7 +4873,7 @@ export const UpdateSettingsDatasourcesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateDataSourceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/settings/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/settings/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSettingsDatasourcesRequest>;
 
@@ -4911,7 +4915,7 @@ export const PatchSettingsDatasourcesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(DataSource).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/settings/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/settings/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchSettingsDatasourcesRequest>;
 
@@ -5019,7 +5023,11 @@ export const UpdateSchemaIndexingDatasourcesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateSchemaRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/indexing/{name}/schema", hasBody: true }),
+    T.Http({
+      method: "PUT",
+      path: "v1/indexing/{+name}/schema",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<UpdateSchemaIndexingDatasourcesRequest>;
 
@@ -5055,7 +5063,7 @@ export const GetSchemaIndexingDatasourcesRequest =
       T.HttpQuery("debugOptions.enableDebugging"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/indexing/{name}/schema" }),
+    T.Http({ method: "GET", path: "v1/indexing/{+name}/schema" }),
     svc,
   ) as unknown as Schema.Schema<GetSchemaIndexingDatasourcesRequest>;
 
@@ -5091,7 +5099,7 @@ export const DeleteSchemaIndexingDatasourcesRequest =
       T.HttpQuery("debugOptions.enableDebugging"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/indexing/{name}/schema" }),
+    T.Http({ method: "DELETE", path: "v1/indexing/{+name}/schema" }),
     svc,
   ) as unknown as Schema.Schema<DeleteSchemaIndexingDatasourcesRequest>;
 
@@ -5138,7 +5146,7 @@ export const DeleteIndexingDatasourcesItemsRequest =
       T.HttpQuery("debugOptions.enableDebugging"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/indexing/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/indexing/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteIndexingDatasourcesItemsRequest>;
 
@@ -5179,7 +5187,7 @@ export const GetIndexingDatasourcesItemsRequest =
       T.HttpQuery("debugOptions.enableDebugging"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/indexing/{name}" }),
+    T.Http({ method: "GET", path: "v1/indexing/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetIndexingDatasourcesItemsRequest>;
 
@@ -5229,7 +5237,7 @@ export const ListIndexingDatasourcesItemsRequest =
       T.HttpQuery("debugOptions.enableDebugging"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/indexing/{name}/items" }),
+    T.Http({ method: "GET", path: "v1/indexing/{+name}/items" }),
     svc,
   ) as unknown as Schema.Schema<ListIndexingDatasourcesItemsRequest>;
 
@@ -5268,7 +5276,11 @@ export const IndexIndexingDatasourcesItemsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(IndexItemRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/indexing/{name}:index", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/indexing/{+name}:index",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<IndexIndexingDatasourcesItemsRequest>;
 
@@ -5304,7 +5316,7 @@ export const UploadIndexingDatasourcesItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/indexing/{name}:upload",
+      path: "v1/indexing/{+name}:upload",
       hasBody: true,
     }),
     svc,
@@ -5342,7 +5354,7 @@ export const PollIndexingDatasourcesItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/indexing/{name}/items:poll",
+      path: "v1/indexing/{+name}/items:poll",
       hasBody: true,
     }),
     svc,
@@ -5378,7 +5390,7 @@ export const PushIndexingDatasourcesItemsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PushItemRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/indexing/{name}:push", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/indexing/{+name}:push", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PushIndexingDatasourcesItemsRequest>;
 
@@ -5414,7 +5426,7 @@ export const UnreserveIndexingDatasourcesItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/indexing/{name}/items:unreserve",
+      path: "v1/indexing/{+name}/items:unreserve",
       hasBody: true,
     }),
     svc,
@@ -5452,7 +5464,7 @@ export const DeleteQueueItemsIndexingDatasourcesItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/indexing/{name}/items:deleteQueueItems",
+      path: "v1/indexing/{+name}/items:deleteQueueItems",
       hasBody: true,
     }),
     svc,
@@ -5942,7 +5954,7 @@ export const GetStatsIndexDatasourcesRequest =
       T.HttpQuery("toDate.day"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/stats/index/{name}" }),
+    T.Http({ method: "GET", path: "v1/stats/index/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetStatsIndexDatasourcesRequest>;
 
@@ -6003,7 +6015,7 @@ export const GetStatsQuerySearchapplicationsRequest =
       T.HttpQuery("toDate.day"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/stats/query/{name}" }),
+    T.Http({ method: "GET", path: "v1/stats/query/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetStatsQuerySearchapplicationsRequest>;
 
@@ -6065,7 +6077,7 @@ export const GetStatsUserSearchapplicationsRequest =
       T.HttpQuery("toDate.day"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/stats/user/{name}" }),
+    T.Http({ method: "GET", path: "v1/stats/user/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetStatsUserSearchapplicationsRequest>;
 
@@ -6127,7 +6139,7 @@ export const GetStatsSessionSearchapplicationsRequest =
       T.HttpQuery("toDate.day"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/stats/session/{name}" }),
+    T.Http({ method: "GET", path: "v1/stats/session/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetStatsSessionSearchapplicationsRequest>;
 
@@ -6161,7 +6173,7 @@ export const UploadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   resourceName: Schema.String.pipe(T.HttpPath("resourceName")),
   body: Schema.optional(Media).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v1/media/{resourceName}", hasBody: true }),
+  T.Http({ method: "POST", path: "v1/media/{+resourceName}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<UploadMediaRequest>;
 

--- a/packages/gcp/src/services/cloudshell-v1.ts
+++ b/packages/gcp/src/services/cloudshell-v1.ts
@@ -296,7 +296,7 @@ export const ListOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("returnPartialSuccess"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<ListOperationsRequest>;
 
@@ -330,7 +330,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -360,7 +360,7 @@ export const DeleteOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOperationsRequest>;
 
@@ -393,7 +393,7 @@ export const CancelOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOperationsRequest>;
 
@@ -429,7 +429,7 @@ export const GenerateAccessTokenUsersEnvironmentsRequest =
     expireTime: Schema.optional(Schema.String).pipe(T.HttpQuery("expireTime")),
     ttl: Schema.optional(Schema.String).pipe(T.HttpQuery("ttl")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{environment}:generateAccessToken" }),
+    T.Http({ method: "GET", path: "v1/{+environment}:generateAccessToken" }),
     svc,
   ) as unknown as Schema.Schema<GenerateAccessTokenUsersEnvironmentsRequest>;
 
@@ -461,7 +461,7 @@ export const GetUsersEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetUsersEnvironmentsRequest>;
 
@@ -495,7 +495,7 @@ export const StartUsersEnvironmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StartEnvironmentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartUsersEnvironmentsRequest>;
 
@@ -529,7 +529,7 @@ export const AuthorizeUsersEnvironmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AuthorizeEnvironmentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:authorize", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:authorize", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AuthorizeUsersEnvironmentsRequest>;
 
@@ -565,7 +565,7 @@ export const AddPublicKeyUsersEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{environment}:addPublicKey",
+      path: "v1/{+environment}:addPublicKey",
       hasBody: true,
     }),
     svc,
@@ -603,7 +603,7 @@ export const RemovePublicKeyUsersEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{environment}:removePublicKey",
+      path: "v1/{+environment}:removePublicKey",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/cloudsupport-v2.ts
+++ b/packages/gcp/src/services/cloudsupport-v2.ts
@@ -586,7 +586,7 @@ export const UploadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   parent: Schema.String.pipe(T.HttpPath("parent")),
   body: Schema.optional(CreateAttachmentRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v2/{parent}/attachments", hasBody: true }),
+  T.Http({ method: "POST", path: "v2/{+parent}/attachments", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<UploadMediaRequest>;
 
@@ -615,7 +615,7 @@ export interface DownloadMediaRequest {
 export const DownloadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{name}:download" }),
+  T.Http({ method: "GET", path: "v2/{+name}:download" }),
   svc,
 ) as unknown as Schema.Schema<DownloadMediaRequest>;
 
@@ -653,7 +653,7 @@ export const SearchCasesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   query: Schema.optional(Schema.String).pipe(T.HttpQuery("query")),
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{parent}/cases:search" }),
+  T.Http({ method: "GET", path: "v2/{+parent}/cases:search" }),
   svc,
 ) as unknown as Schema.Schema<SearchCasesRequest>;
 
@@ -693,7 +693,7 @@ export const PatchCasesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(Case).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchCasesRequest>;
 
@@ -725,7 +725,7 @@ export const CloseCasesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(CloseCaseRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v2/{name}:close", hasBody: true }),
+  T.Http({ method: "POST", path: "v2/{+name}:close", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<CloseCasesRequest>;
 
@@ -757,7 +757,7 @@ export const CreateCasesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   parent: Schema.String.pipe(T.HttpPath("parent")),
   body: Schema.optional(Case).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v2/{parent}/cases", hasBody: true }),
+  T.Http({ method: "POST", path: "v2/{+parent}/cases", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<CreateCasesRequest>;
 
@@ -789,7 +789,7 @@ export const EscalateCasesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(EscalateCaseRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v2/{name}:escalate", hasBody: true }),
+  T.Http({ method: "POST", path: "v2/{+name}:escalate", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<EscalateCasesRequest>;
 
@@ -818,7 +818,7 @@ export interface GetCasesRequest {
 export const GetCasesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{name}" }),
+  T.Http({ method: "GET", path: "v2/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetCasesRequest>;
 
@@ -856,7 +856,7 @@ export const ListCasesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{parent}/cases" }),
+  T.Http({ method: "GET", path: "v2/{+parent}/cases" }),
   svc,
 ) as unknown as Schema.Schema<ListCasesRequest>;
 
@@ -897,7 +897,7 @@ export const ListCasesCommentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/comments" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/comments" }),
     svc,
   ) as unknown as Schema.Schema<ListCasesCommentsRequest>;
 
@@ -935,7 +935,7 @@ export const CreateCasesCommentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Comment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/comments", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/comments", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateCasesCommentsRequest>;
 
@@ -971,7 +971,7 @@ export const ListCasesAttachmentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/attachments" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/attachments" }),
     svc,
   ) as unknown as Schema.Schema<ListCasesAttachmentsRequest>;
 

--- a/packages/gcp/src/services/cloudsupport-v2beta.ts
+++ b/packages/gcp/src/services/cloudsupport-v2beta.ts
@@ -683,7 +683,7 @@ export const UploadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "v2beta/{parent}/attachments",
+    path: "v2beta/{+parent}/attachments",
     hasBody: true,
   }),
   svc,
@@ -714,7 +714,7 @@ export interface DownloadMediaRequest {
 export const DownloadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2beta/{name}:download" }),
+  T.Http({ method: "GET", path: "v2beta/{+name}:download" }),
   svc,
 ) as unknown as Schema.Schema<DownloadMediaRequest>;
 
@@ -752,7 +752,7 @@ export const ShowFeedCasesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2beta/{parent}:showFeed" }),
+  T.Http({ method: "GET", path: "v2beta/{+parent}:showFeed" }),
   svc,
 ) as unknown as Schema.Schema<ShowFeedCasesRequest>;
 
@@ -786,7 +786,7 @@ export interface GetCasesRequest {
 export const GetCasesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2beta/{name}" }),
+  T.Http({ method: "GET", path: "v2beta/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetCasesRequest>;
 
@@ -831,7 +831,7 @@ export const ListCasesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   parent: Schema.String.pipe(T.HttpPath("parent")),
   filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2beta/{parent}/cases" }),
+  T.Http({ method: "GET", path: "v2beta/{+parent}/cases" }),
   svc,
 ) as unknown as Schema.Schema<ListCasesRequest>;
 
@@ -914,7 +914,7 @@ export const PatchCasesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(Case).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v2beta/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v2beta/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchCasesRequest>;
 
@@ -946,7 +946,7 @@ export const CloseCasesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(CloseCaseRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v2beta/{name}:close", hasBody: true }),
+  T.Http({ method: "POST", path: "v2beta/{+name}:close", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<CloseCasesRequest>;
 
@@ -978,7 +978,7 @@ export const CreateCasesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   parent: Schema.String.pipe(T.HttpPath("parent")),
   body: Schema.optional(Case).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v2beta/{parent}/cases", hasBody: true }),
+  T.Http({ method: "POST", path: "v2beta/{+parent}/cases", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<CreateCasesRequest>;
 
@@ -1010,7 +1010,7 @@ export const EscalateCasesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(EscalateCaseRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v2beta/{name}:escalate", hasBody: true }),
+  T.Http({ method: "POST", path: "v2beta/{+name}:escalate", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<EscalateCasesRequest>;
 
@@ -1046,7 +1046,7 @@ export const ListCasesAttachmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{parent}/attachments" }),
+    T.Http({ method: "GET", path: "v2beta/{+parent}/attachments" }),
     svc,
   ) as unknown as Schema.Schema<ListCasesAttachmentsRequest>;
 
@@ -1081,7 +1081,7 @@ export const GetCasesAttachmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCasesAttachmentsRequest>;
 
@@ -1112,7 +1112,7 @@ export const GetCasesCommentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCasesCommentsRequest>;
 
@@ -1148,7 +1148,7 @@ export const ListCasesCommentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{parent}/comments" }),
+    T.Http({ method: "GET", path: "v2beta/{+parent}/comments" }),
     svc,
   ) as unknown as Schema.Schema<ListCasesCommentsRequest>;
 
@@ -1186,7 +1186,11 @@ export const CreateCasesCommentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Comment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta/{parent}/comments", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2beta/{+parent}/comments",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateCasesCommentsRequest>;
 

--- a/packages/gcp/src/services/cloudtasks-v2.ts
+++ b/packages/gcp/src/services/cloudtasks-v2.ts
@@ -650,7 +650,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -685,7 +685,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -722,7 +722,7 @@ export const UpdateCmekConfigProjectsLocationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(CmekConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateCmekConfigProjectsLocationsRequest>;
 
@@ -753,7 +753,7 @@ export const GetCmekConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCmekConfigProjectsLocationsRequest>;
 
@@ -793,7 +793,7 @@ export const ListProjectsLocationsQueuesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/queues" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/queues" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsQueuesRequest>;
 
@@ -828,7 +828,7 @@ export const GetProjectsLocationsQueuesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsQueuesRequest>;
 
@@ -862,7 +862,7 @@ export const CreateProjectsLocationsQueuesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Queue).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/queues", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/queues", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsQueuesRequest>;
 
@@ -899,7 +899,7 @@ export const PatchProjectsLocationsQueuesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Queue).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsQueuesRequest>;
 
@@ -930,7 +930,7 @@ export const DeleteProjectsLocationsQueuesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsQueuesRequest>;
 
@@ -964,7 +964,7 @@ export const PurgeProjectsLocationsQueuesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PurgeQueueRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:purge", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:purge", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PurgeProjectsLocationsQueuesRequest>;
 
@@ -998,7 +998,7 @@ export const PauseProjectsLocationsQueuesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PauseQueueRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsLocationsQueuesRequest>;
 
@@ -1032,7 +1032,7 @@ export const ResumeProjectsLocationsQueuesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResumeQueueRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsQueuesRequest>;
 
@@ -1068,7 +1068,7 @@ export const GetIamPolicyProjectsLocationsQueuesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:getIamPolicy",
+      path: "v2/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1106,7 +1106,7 @@ export const SetIamPolicyProjectsLocationsQueuesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1144,7 +1144,7 @@ export const TestIamPermissionsProjectsLocationsQueuesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1189,7 +1189,7 @@ export const ListProjectsLocationsQueuesTasksRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/tasks" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/tasks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsQueuesTasksRequest>;
 
@@ -1229,7 +1229,7 @@ export const GetProjectsLocationsQueuesTasksRequest =
       T.HttpQuery("responseView"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsQueuesTasksRequest>;
 
@@ -1263,7 +1263,7 @@ export const CreateProjectsLocationsQueuesTasksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateTaskRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/tasks", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/tasks", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsQueuesTasksRequest>;
 
@@ -1294,7 +1294,7 @@ export const DeleteProjectsLocationsQueuesTasksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsQueuesTasksRequest>;
 
@@ -1328,7 +1328,7 @@ export const RunProjectsLocationsQueuesTasksRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RunTaskRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsQueuesTasksRequest>;
 
@@ -1367,7 +1367,7 @@ export const BufferProjectsLocationsQueuesTasksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{queue}/tasks/{taskId}:buffer",
+      path: "v2/{+queue}/tasks/{taskId}:buffer",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/cloudtasks-v2beta2.ts
+++ b/packages/gcp/src/services/cloudtasks-v2beta2.ts
@@ -795,7 +795,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta2/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2beta2/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -830,7 +830,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta2/{name}" }),
+    T.Http({ method: "GET", path: "v2beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -867,7 +867,7 @@ export const UpdateCmekConfigProjectsLocationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(CmekConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateCmekConfigProjectsLocationsRequest>;
 
@@ -898,7 +898,7 @@ export const GetCmekConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta2/{name}" }),
+    T.Http({ method: "GET", path: "v2beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCmekConfigProjectsLocationsRequest>;
 
@@ -929,7 +929,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta2/{name}" }),
+    T.Http({ method: "GET", path: "v2beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -972,7 +972,7 @@ export const ListProjectsLocationsQueuesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta2/{parent}/queues" }),
+    T.Http({ method: "GET", path: "v2beta2/{+parent}/queues" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsQueuesRequest>;
 
@@ -1010,7 +1010,7 @@ export const GetProjectsLocationsQueuesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta2/{name}" }),
+    T.Http({ method: "GET", path: "v2beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsQueuesRequest>;
 
@@ -1044,7 +1044,7 @@ export const CreateProjectsLocationsQueuesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Queue).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta2/{parent}/queues", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta2/{+parent}/queues", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsQueuesRequest>;
 
@@ -1081,7 +1081,7 @@ export const PatchProjectsLocationsQueuesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Queue).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsQueuesRequest>;
 
@@ -1112,7 +1112,7 @@ export const DeleteProjectsLocationsQueuesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsQueuesRequest>;
 
@@ -1146,7 +1146,7 @@ export const PurgeProjectsLocationsQueuesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PurgeQueueRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta2/{name}:purge", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta2/{+name}:purge", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PurgeProjectsLocationsQueuesRequest>;
 
@@ -1180,7 +1180,7 @@ export const PauseProjectsLocationsQueuesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PauseQueueRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta2/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta2/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsLocationsQueuesRequest>;
 
@@ -1214,7 +1214,7 @@ export const ResumeProjectsLocationsQueuesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResumeQueueRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta2/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta2/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsQueuesRequest>;
 
@@ -1250,7 +1250,7 @@ export const GetIamPolicyProjectsLocationsQueuesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta2/{resource}:getIamPolicy",
+      path: "v2beta2/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1288,7 +1288,7 @@ export const SetIamPolicyProjectsLocationsQueuesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta2/{resource}:setIamPolicy",
+      path: "v2beta2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1326,7 +1326,7 @@ export const TestIamPermissionsProjectsLocationsQueuesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta2/{resource}:testIamPermissions",
+      path: "v2beta2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1371,7 +1371,7 @@ export const ListProjectsLocationsQueuesTasksRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta2/{parent}/tasks" }),
+    T.Http({ method: "GET", path: "v2beta2/{+parent}/tasks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsQueuesTasksRequest>;
 
@@ -1411,7 +1411,7 @@ export const GetProjectsLocationsQueuesTasksRequest =
       T.HttpQuery("responseView"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta2/{name}" }),
+    T.Http({ method: "GET", path: "v2beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsQueuesTasksRequest>;
 
@@ -1445,7 +1445,7 @@ export const CreateProjectsLocationsQueuesTasksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateTaskRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta2/{parent}/tasks", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta2/{+parent}/tasks", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsQueuesTasksRequest>;
 
@@ -1476,7 +1476,7 @@ export const DeleteProjectsLocationsQueuesTasksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsQueuesTasksRequest>;
 
@@ -1512,7 +1512,7 @@ export const LeaseProjectsLocationsQueuesTasksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta2/{parent}/tasks:lease",
+      path: "v2beta2/{+parent}/tasks:lease",
       hasBody: true,
     }),
     svc,
@@ -1550,7 +1550,7 @@ export const AcknowledgeProjectsLocationsQueuesTasksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta2/{name}:acknowledge",
+      path: "v2beta2/{+name}:acknowledge",
       hasBody: true,
     }),
     svc,
@@ -1588,7 +1588,7 @@ export const RenewLeaseProjectsLocationsQueuesTasksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta2/{name}:renewLease",
+      path: "v2beta2/{+name}:renewLease",
       hasBody: true,
     }),
     svc,
@@ -1626,7 +1626,7 @@ export const CancelLeaseProjectsLocationsQueuesTasksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta2/{name}:cancelLease",
+      path: "v2beta2/{+name}:cancelLease",
       hasBody: true,
     }),
     svc,
@@ -1662,7 +1662,7 @@ export const RunProjectsLocationsQueuesTasksRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RunTaskRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta2/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta2/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsQueuesTasksRequest>;
 
@@ -1701,7 +1701,7 @@ export const BufferProjectsLocationsQueuesTasksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta2/{queue}/tasks/{taskId}:buffer",
+      path: "v2beta2/{+queue}/tasks/{taskId}:buffer",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/cloudtasks-v2beta3.ts
+++ b/packages/gcp/src/services/cloudtasks-v2beta3.ts
@@ -707,7 +707,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta3/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2beta3/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -742,7 +742,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta3/{name}" }),
+    T.Http({ method: "GET", path: "v2beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -779,7 +779,7 @@ export const UpdateCmekConfigProjectsLocationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(CmekConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateCmekConfigProjectsLocationsRequest>;
 
@@ -810,7 +810,7 @@ export const GetCmekConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta3/{name}" }),
+    T.Http({ method: "GET", path: "v2beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCmekConfigProjectsLocationsRequest>;
 
@@ -853,7 +853,7 @@ export const ListProjectsLocationsQueuesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta3/{parent}/queues" }),
+    T.Http({ method: "GET", path: "v2beta3/{+parent}/queues" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsQueuesRequest>;
 
@@ -891,7 +891,7 @@ export const GetProjectsLocationsQueuesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta3/{name}" }),
+    T.Http({ method: "GET", path: "v2beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsQueuesRequest>;
 
@@ -925,7 +925,7 @@ export const CreateProjectsLocationsQueuesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Queue).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta3/{parent}/queues", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta3/{+parent}/queues", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsQueuesRequest>;
 
@@ -962,7 +962,7 @@ export const PatchProjectsLocationsQueuesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Queue).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsQueuesRequest>;
 
@@ -993,7 +993,7 @@ export const DeleteProjectsLocationsQueuesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta3/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsQueuesRequest>;
 
@@ -1027,7 +1027,7 @@ export const PurgeProjectsLocationsQueuesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PurgeQueueRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta3/{name}:purge", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta3/{+name}:purge", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PurgeProjectsLocationsQueuesRequest>;
 
@@ -1061,7 +1061,7 @@ export const PauseProjectsLocationsQueuesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PauseQueueRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta3/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta3/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsLocationsQueuesRequest>;
 
@@ -1095,7 +1095,7 @@ export const ResumeProjectsLocationsQueuesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResumeQueueRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta3/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta3/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsQueuesRequest>;
 
@@ -1131,7 +1131,7 @@ export const GetIamPolicyProjectsLocationsQueuesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta3/{resource}:getIamPolicy",
+      path: "v2beta3/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1169,7 +1169,7 @@ export const SetIamPolicyProjectsLocationsQueuesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta3/{resource}:setIamPolicy",
+      path: "v2beta3/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1207,7 +1207,7 @@ export const TestIamPermissionsProjectsLocationsQueuesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta3/{resource}:testIamPermissions",
+      path: "v2beta3/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1252,7 +1252,7 @@ export const ListProjectsLocationsQueuesTasksRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta3/{parent}/tasks" }),
+    T.Http({ method: "GET", path: "v2beta3/{+parent}/tasks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsQueuesTasksRequest>;
 
@@ -1292,7 +1292,7 @@ export const GetProjectsLocationsQueuesTasksRequest =
       T.HttpQuery("responseView"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta3/{name}" }),
+    T.Http({ method: "GET", path: "v2beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsQueuesTasksRequest>;
 
@@ -1326,7 +1326,7 @@ export const CreateProjectsLocationsQueuesTasksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateTaskRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta3/{parent}/tasks", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta3/{+parent}/tasks", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsQueuesTasksRequest>;
 
@@ -1357,7 +1357,7 @@ export const DeleteProjectsLocationsQueuesTasksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta3/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsQueuesTasksRequest>;
 
@@ -1391,7 +1391,7 @@ export const RunProjectsLocationsQueuesTasksRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RunTaskRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta3/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta3/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsQueuesTasksRequest>;
 
@@ -1430,7 +1430,7 @@ export const BufferProjectsLocationsQueuesTasksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta3/{queue}/tasks/{taskId}:buffer",
+      path: "v2beta3/{+queue}/tasks/{taskId}:buffer",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/cloudtrace-v2.ts
+++ b/packages/gcp/src/services/cloudtrace-v2.ts
@@ -325,7 +325,7 @@ export const BatchWriteProjectsTracesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}/traces:batchWrite",
+      path: "v2/{+name}/traces:batchWrite",
       hasBody: true,
     }),
     svc,
@@ -361,7 +361,7 @@ export const CreateSpanProjectsTracesSpansRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Span).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateSpanProjectsTracesSpansRequest>;
 

--- a/packages/gcp/src/services/cloudtrace-v2beta1.ts
+++ b/packages/gcp/src/services/cloudtrace-v2beta1.ts
@@ -85,7 +85,7 @@ export const ListProjectsTraceSinksRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/traceSinks" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/traceSinks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTraceSinksRequest>;
 
@@ -125,7 +125,7 @@ export const CreateProjectsTraceSinksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/traceSinks",
+      path: "v2beta1/{+parent}/traceSinks",
       hasBody: true,
     }),
     svc,
@@ -158,7 +158,7 @@ export const DeleteProjectsTraceSinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsTraceSinksRequest>;
 
@@ -189,7 +189,7 @@ export const GetProjectsTraceSinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsTraceSinksRequest>;
 
@@ -226,7 +226,7 @@ export const PatchProjectsTraceSinksRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(TraceSink).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsTraceSinksRequest>;
 

--- a/packages/gcp/src/services/composer-v1.ts
+++ b/packages/gcp/src/services/composer-v1.ts
@@ -1178,7 +1178,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1213,7 +1213,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1244,7 +1244,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1278,7 +1278,11 @@ export const CreateProjectsLocationsEnvironmentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Environment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/environments", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/environments",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsEnvironmentsRequest>;
 
@@ -1309,7 +1313,7 @@ export const GetProjectsLocationsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEnvironmentsRequest>;
 
@@ -1346,7 +1350,7 @@ export const ListProjectsLocationsEnvironmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/environments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/environments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEnvironmentsRequest>;
 
@@ -1388,7 +1392,7 @@ export const PatchProjectsLocationsEnvironmentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Environment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEnvironmentsRequest>;
 
@@ -1419,7 +1423,7 @@ export const DeleteProjectsLocationsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEnvironmentsRequest>;
 
@@ -1455,7 +1459,7 @@ export const RestartWebServerProjectsLocationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:restartWebServer",
+      path: "v1/{+name}:restartWebServer",
       hasBody: true,
     }),
     svc,
@@ -1493,7 +1497,7 @@ export const ExecuteAirflowCommandProjectsLocationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{environment}:executeAirflowCommand",
+      path: "v1/{+environment}:executeAirflowCommand",
       hasBody: true,
     }),
     svc,
@@ -1533,7 +1537,7 @@ export const StopAirflowCommandProjectsLocationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{environment}:stopAirflowCommand",
+      path: "v1/{+environment}:stopAirflowCommand",
       hasBody: true,
     }),
     svc,
@@ -1573,7 +1577,7 @@ export const PollAirflowCommandProjectsLocationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{environment}:pollAirflowCommand",
+      path: "v1/{+environment}:pollAirflowCommand",
       hasBody: true,
     }),
     svc,
@@ -1613,7 +1617,7 @@ export const CheckUpgradeProjectsLocationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{environment}:checkUpgrade",
+      path: "v1/{+environment}:checkUpgrade",
       hasBody: true,
     }),
     svc,
@@ -1651,7 +1655,7 @@ export const SaveSnapshotProjectsLocationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{environment}:saveSnapshot",
+      path: "v1/{+environment}:saveSnapshot",
       hasBody: true,
     }),
     svc,
@@ -1689,7 +1693,7 @@ export const LoadSnapshotProjectsLocationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{environment}:loadSnapshot",
+      path: "v1/{+environment}:loadSnapshot",
       hasBody: true,
     }),
     svc,
@@ -1727,7 +1731,7 @@ export const DatabaseFailoverProjectsLocationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{environment}:databaseFailover",
+      path: "v1/{+environment}:databaseFailover",
       hasBody: true,
     }),
     svc,
@@ -1760,7 +1764,10 @@ export const FetchDatabasePropertiesProjectsLocationsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     environment: Schema.String.pipe(T.HttpPath("environment")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{environment}:fetchDatabaseProperties" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+environment}:fetchDatabaseProperties",
+    }),
     svc,
   ) as unknown as Schema.Schema<FetchDatabasePropertiesProjectsLocationsEnvironmentsRequest>;
 
@@ -1802,7 +1809,7 @@ export const ListProjectsLocationsEnvironmentsWorkloadsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/workloads" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/workloads" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEnvironmentsWorkloadsRequest>;
 
@@ -1843,7 +1850,7 @@ export const CreateProjectsLocationsEnvironmentsUserWorkloadsSecretsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/userWorkloadsSecrets",
+      path: "v1/{+parent}/userWorkloadsSecrets",
       hasBody: true,
     }),
     svc,
@@ -1878,7 +1885,7 @@ export const GetProjectsLocationsEnvironmentsUserWorkloadsSecretsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEnvironmentsUserWorkloadsSecretsRequest>;
 
@@ -1917,7 +1924,7 @@ export const ListProjectsLocationsEnvironmentsUserWorkloadsSecretsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/userWorkloadsSecrets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/userWorkloadsSecrets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEnvironmentsUserWorkloadsSecretsRequest>;
 
@@ -1957,7 +1964,7 @@ export const UpdateProjectsLocationsEnvironmentsUserWorkloadsSecretsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UserWorkloadsSecret).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsEnvironmentsUserWorkloadsSecretsRequest>;
 
@@ -1990,7 +1997,7 @@ export const DeleteProjectsLocationsEnvironmentsUserWorkloadsSecretsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEnvironmentsUserWorkloadsSecretsRequest>;
 
@@ -2028,7 +2035,7 @@ export const CreateProjectsLocationsEnvironmentsUserWorkloadsConfigMapsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/userWorkloadsConfigMaps",
+      path: "v1/{+parent}/userWorkloadsConfigMaps",
       hasBody: true,
     }),
     svc,
@@ -2063,7 +2070,7 @@ export const GetProjectsLocationsEnvironmentsUserWorkloadsConfigMapsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEnvironmentsUserWorkloadsConfigMapsRequest>;
 
@@ -2102,7 +2109,7 @@ export const ListProjectsLocationsEnvironmentsUserWorkloadsConfigMapsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/userWorkloadsConfigMaps" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/userWorkloadsConfigMaps" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEnvironmentsUserWorkloadsConfigMapsRequest>;
 
@@ -2142,7 +2149,7 @@ export const UpdateProjectsLocationsEnvironmentsUserWorkloadsConfigMapsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UserWorkloadsConfigMap).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsEnvironmentsUserWorkloadsConfigMapsRequest>;
 
@@ -2175,7 +2182,7 @@ export const DeleteProjectsLocationsEnvironmentsUserWorkloadsConfigMapsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEnvironmentsUserWorkloadsConfigMapsRequest>;
 
@@ -2219,7 +2226,7 @@ export const ListProjectsLocationsImageVersionsRequest =
       T.HttpQuery("includePastReleases"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/imageVersions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/imageVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsImageVersionsRequest>;
 

--- a/packages/gcp/src/services/composer-v1beta1.ts
+++ b/packages/gcp/src/services/composer-v1beta1.ts
@@ -1183,7 +1183,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1218,7 +1218,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1249,7 +1249,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1285,7 +1285,7 @@ export const CreateProjectsLocationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/environments",
+      path: "v1beta1/{+parent}/environments",
       hasBody: true,
     }),
     svc,
@@ -1318,7 +1318,7 @@ export const GetProjectsLocationsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEnvironmentsRequest>;
 
@@ -1355,7 +1355,7 @@ export const ListProjectsLocationsEnvironmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/environments" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/environments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEnvironmentsRequest>;
 
@@ -1397,7 +1397,7 @@ export const PatchProjectsLocationsEnvironmentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Environment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEnvironmentsRequest>;
 
@@ -1428,7 +1428,7 @@ export const DeleteProjectsLocationsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEnvironmentsRequest>;
 
@@ -1464,7 +1464,7 @@ export const RestartWebServerProjectsLocationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:restartWebServer",
+      path: "v1beta1/{+name}:restartWebServer",
       hasBody: true,
     }),
     svc,
@@ -1502,7 +1502,7 @@ export const CheckUpgradeProjectsLocationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{environment}:checkUpgrade",
+      path: "v1beta1/{+environment}:checkUpgrade",
       hasBody: true,
     }),
     svc,
@@ -1540,7 +1540,7 @@ export const ExecuteAirflowCommandProjectsLocationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{environment}:executeAirflowCommand",
+      path: "v1beta1/{+environment}:executeAirflowCommand",
       hasBody: true,
     }),
     svc,
@@ -1580,7 +1580,7 @@ export const StopAirflowCommandProjectsLocationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{environment}:stopAirflowCommand",
+      path: "v1beta1/{+environment}:stopAirflowCommand",
       hasBody: true,
     }),
     svc,
@@ -1620,7 +1620,7 @@ export const PollAirflowCommandProjectsLocationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{environment}:pollAirflowCommand",
+      path: "v1beta1/{+environment}:pollAirflowCommand",
       hasBody: true,
     }),
     svc,
@@ -1660,7 +1660,7 @@ export const SaveSnapshotProjectsLocationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{environment}:saveSnapshot",
+      path: "v1beta1/{+environment}:saveSnapshot",
       hasBody: true,
     }),
     svc,
@@ -1698,7 +1698,7 @@ export const LoadSnapshotProjectsLocationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{environment}:loadSnapshot",
+      path: "v1beta1/{+environment}:loadSnapshot",
       hasBody: true,
     }),
     svc,
@@ -1736,7 +1736,7 @@ export const DatabaseFailoverProjectsLocationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{environment}:databaseFailover",
+      path: "v1beta1/{+environment}:databaseFailover",
       hasBody: true,
     }),
     svc,
@@ -1771,7 +1771,7 @@ export const FetchDatabasePropertiesProjectsLocationsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{environment}:fetchDatabaseProperties",
+      path: "v1beta1/{+environment}:fetchDatabaseProperties",
     }),
     svc,
   ) as unknown as Schema.Schema<FetchDatabasePropertiesProjectsLocationsEnvironmentsRequest>;
@@ -1814,7 +1814,7 @@ export const ListProjectsLocationsEnvironmentsWorkloadsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/workloads" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/workloads" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEnvironmentsWorkloadsRequest>;
 
@@ -1855,7 +1855,7 @@ export const CreateProjectsLocationsEnvironmentsUserWorkloadsSecretsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/userWorkloadsSecrets",
+      path: "v1beta1/{+parent}/userWorkloadsSecrets",
       hasBody: true,
     }),
     svc,
@@ -1890,7 +1890,7 @@ export const GetProjectsLocationsEnvironmentsUserWorkloadsSecretsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEnvironmentsUserWorkloadsSecretsRequest>;
 
@@ -1929,7 +1929,7 @@ export const ListProjectsLocationsEnvironmentsUserWorkloadsSecretsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/userWorkloadsSecrets" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/userWorkloadsSecrets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEnvironmentsUserWorkloadsSecretsRequest>;
 
@@ -1969,7 +1969,7 @@ export const UpdateProjectsLocationsEnvironmentsUserWorkloadsSecretsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UserWorkloadsSecret).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsEnvironmentsUserWorkloadsSecretsRequest>;
 
@@ -2002,7 +2002,7 @@ export const DeleteProjectsLocationsEnvironmentsUserWorkloadsSecretsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEnvironmentsUserWorkloadsSecretsRequest>;
 
@@ -2040,7 +2040,7 @@ export const CreateProjectsLocationsEnvironmentsUserWorkloadsConfigMapsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/userWorkloadsConfigMaps",
+      path: "v1beta1/{+parent}/userWorkloadsConfigMaps",
       hasBody: true,
     }),
     svc,
@@ -2075,7 +2075,7 @@ export const GetProjectsLocationsEnvironmentsUserWorkloadsConfigMapsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEnvironmentsUserWorkloadsConfigMapsRequest>;
 
@@ -2114,7 +2114,10 @@ export const ListProjectsLocationsEnvironmentsUserWorkloadsConfigMapsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/userWorkloadsConfigMaps" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/userWorkloadsConfigMaps",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEnvironmentsUserWorkloadsConfigMapsRequest>;
 
@@ -2154,7 +2157,7 @@ export const UpdateProjectsLocationsEnvironmentsUserWorkloadsConfigMapsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UserWorkloadsConfigMap).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsEnvironmentsUserWorkloadsConfigMapsRequest>;
 
@@ -2187,7 +2190,7 @@ export const DeleteProjectsLocationsEnvironmentsUserWorkloadsConfigMapsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEnvironmentsUserWorkloadsConfigMapsRequest>;
 
@@ -2231,7 +2234,7 @@ export const ListProjectsLocationsImageVersionsRequest =
       T.HttpQuery("includePastReleases"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/imageVersions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/imageVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsImageVersionsRequest>;
 

--- a/packages/gcp/src/services/compute-alpha.ts
+++ b/packages/gcp/src/services/compute-alpha.ts
@@ -41676,7 +41676,7 @@ export const ListZoneOrganizationOperationsRequest =
     ),
     zone: Schema.String.pipe(T.HttpPath("zone")),
   }).pipe(
-    T.Http({ method: "GET", path: "{organization}/zones/{zone}/operations" }),
+    T.Http({ method: "GET", path: "{+organization}/zones/{zone}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListZoneOrganizationOperationsRequest>;
 
@@ -41720,7 +41720,7 @@ export const GetZoneOrganizationOperationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "{organization}/zones/{zone}/operations/{operation}",
+      path: "{+organization}/zones/{zone}/operations/{operation}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetZoneOrganizationOperationsRequest>;
@@ -41769,7 +41769,7 @@ export const ListGlobalFolderOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "{folder}/global/operations" }),
+    T.Http({ method: "GET", path: "{+folder}/global/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListGlobalFolderOperationsRequest>;
 
@@ -41808,7 +41808,7 @@ export const GetGlobalFolderOperationsRequest =
     folder: Schema.String.pipe(T.HttpPath("folder")),
     operation: Schema.String.pipe(T.HttpPath("operation")),
   }).pipe(
-    T.Http({ method: "GET", path: "{folder}/global/operations/{operation}" }),
+    T.Http({ method: "GET", path: "{+folder}/global/operations/{operation}" }),
     svc,
   ) as unknown as Schema.Schema<GetGlobalFolderOperationsRequest>;
 
@@ -41847,7 +41847,7 @@ export const GetZoneFolderOperationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "{folder}/zones/{zone}/operations/{operation}",
+      path: "{+folder}/zones/{zone}/operations/{operation}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetZoneFolderOperationsRequest>;
@@ -41899,7 +41899,7 @@ export const ListZoneFolderOperationsRequest =
     ),
     zone: Schema.String.pipe(T.HttpPath("zone")),
   }).pipe(
-    T.Http({ method: "GET", path: "{folder}/zones/{zone}/operations" }),
+    T.Http({ method: "GET", path: "{+folder}/zones/{zone}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListZoneFolderOperationsRequest>;
 
@@ -81826,7 +81826,7 @@ export const GetReservationSlotsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSlots/{reservationSlot}",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSlots/{reservationSlot}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetReservationSlotsRequest>;
@@ -81883,7 +81883,7 @@ export const ListReservationSlotsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSlots",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSlots",
     }),
     svc,
   ) as unknown as Schema.Schema<ListReservationSlotsRequest>;
@@ -81937,7 +81937,7 @@ export const GetVersionReservationSlotsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSlots/{reservationSlot}/getVersion",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSlots/{reservationSlot}/getVersion",
       hasBody: true,
     }),
     svc,
@@ -81987,7 +81987,7 @@ export const UpdateReservationSlotsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSlots/{reservationSlot}",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSlots/{reservationSlot}",
       hasBody: true,
     }),
     svc,
@@ -82038,7 +82038,7 @@ export const GetReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks/{reservationSubBlock}",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSubBlocks/{reservationSubBlock}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetReservationSubBlocksRequest>;
@@ -82095,7 +82095,7 @@ export const ListReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSubBlocks",
     }),
     svc,
   ) as unknown as Schema.Schema<ListReservationSubBlocksRequest>;
@@ -82146,7 +82146,7 @@ export const PerformMaintenanceReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks/{reservationSubBlock}/performMaintenance",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSubBlocks/{reservationSubBlock}/performMaintenance",
       hasBody: true,
     }),
     svc,
@@ -82198,7 +82198,7 @@ export const ReportFaultyReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks/{reservationSubBlock}/reportFaulty",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSubBlocks/{reservationSubBlock}/reportFaulty",
       hasBody: true,
     }),
     svc,
@@ -82250,7 +82250,7 @@ export const GetVersionReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks/{reservationSubBlock}/getVersion",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSubBlocks/{reservationSubBlock}/getVersion",
       hasBody: true,
     }),
     svc,
@@ -85339,7 +85339,7 @@ export const GetOrganizationSnapshotRecycleBinPolicyRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "{organization}/global/snapshotRecycleBinPolicy",
+      path: "{+organization}/global/snapshotRecycleBinPolicy",
     }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationSnapshotRecycleBinPolicyRequest>;
@@ -85380,7 +85380,7 @@ export const PatchOrganizationSnapshotRecycleBinPolicyRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "{organization}/global/snapshotRecycleBinPolicy",
+      path: "{+organization}/global/snapshotRecycleBinPolicy",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/compute-beta.ts
+++ b/packages/gcp/src/services/compute-beta.ts
@@ -75248,7 +75248,7 @@ export const GetReservationSlotsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSlots/{reservationSlot}",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSlots/{reservationSlot}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetReservationSlotsRequest>;
@@ -75305,7 +75305,7 @@ export const ListReservationSlotsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSlots",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSlots",
     }),
     svc,
   ) as unknown as Schema.Schema<ListReservationSlotsRequest>;
@@ -75359,7 +75359,7 @@ export const GetVersionReservationSlotsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSlots/{reservationSlot}/getVersion",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSlots/{reservationSlot}/getVersion",
       hasBody: true,
     }),
     svc,
@@ -75409,7 +75409,7 @@ export const UpdateReservationSlotsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSlots/{reservationSlot}",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSlots/{reservationSlot}",
       hasBody: true,
     }),
     svc,
@@ -75460,7 +75460,7 @@ export const GetReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks/{reservationSubBlock}",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSubBlocks/{reservationSubBlock}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetReservationSubBlocksRequest>;
@@ -75517,7 +75517,7 @@ export const ListReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSubBlocks",
     }),
     svc,
   ) as unknown as Schema.Schema<ListReservationSubBlocksRequest>;
@@ -75570,7 +75570,7 @@ export const GetIamPolicyReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "projects/{project}/zones/{zone}/{parentResource}/reservationSubBlocks/{resource}/getIamPolicy",
+      path: "projects/{project}/zones/{zone}/{+parentResource}/reservationSubBlocks/{resource}/getIamPolicy",
     }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyReservationSubBlocksRequest>;
@@ -75616,7 +75616,7 @@ export const SetIamPolicyReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentResource}/reservationSubBlocks/{resource}/setIamPolicy",
+      path: "projects/{project}/zones/{zone}/{+parentResource}/reservationSubBlocks/{resource}/setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -75663,7 +75663,7 @@ export const TestIamPermissionsReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentResource}/reservationSubBlocks/{resource}/testIamPermissions",
+      path: "projects/{project}/zones/{zone}/{+parentResource}/reservationSubBlocks/{resource}/testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -75711,7 +75711,7 @@ export const PerformMaintenanceReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks/{reservationSubBlock}/performMaintenance",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSubBlocks/{reservationSubBlock}/performMaintenance",
       hasBody: true,
     }),
     svc,
@@ -75763,7 +75763,7 @@ export const ReportFaultyReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks/{reservationSubBlock}/reportFaulty",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSubBlocks/{reservationSubBlock}/reportFaulty",
       hasBody: true,
     }),
     svc,
@@ -75815,7 +75815,7 @@ export const GetVersionReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks/{reservationSubBlock}/getVersion",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSubBlocks/{reservationSubBlock}/getVersion",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/compute-v1.ts
+++ b/packages/gcp/src/services/compute-v1.ts
@@ -69041,7 +69041,7 @@ export const GetReservationSlotsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSlots/{reservationSlot}",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSlots/{reservationSlot}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetReservationSlotsRequest>;
@@ -69098,7 +69098,7 @@ export const ListReservationSlotsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSlots",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSlots",
     }),
     svc,
   ) as unknown as Schema.Schema<ListReservationSlotsRequest>;
@@ -69152,7 +69152,7 @@ export const GetVersionReservationSlotsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSlots/{reservationSlot}/getVersion",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSlots/{reservationSlot}/getVersion",
       hasBody: true,
     }),
     svc,
@@ -69202,7 +69202,7 @@ export const UpdateReservationSlotsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSlots/{reservationSlot}",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSlots/{reservationSlot}",
       hasBody: true,
     }),
     svc,
@@ -69253,7 +69253,7 @@ export const GetReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks/{reservationSubBlock}",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSubBlocks/{reservationSubBlock}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetReservationSubBlocksRequest>;
@@ -69310,7 +69310,7 @@ export const ListReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSubBlocks",
     }),
     svc,
   ) as unknown as Schema.Schema<ListReservationSubBlocksRequest>;
@@ -69363,7 +69363,7 @@ export const GetIamPolicyReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "projects/{project}/zones/{zone}/{parentResource}/reservationSubBlocks/{resource}/getIamPolicy",
+      path: "projects/{project}/zones/{zone}/{+parentResource}/reservationSubBlocks/{resource}/getIamPolicy",
     }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyReservationSubBlocksRequest>;
@@ -69409,7 +69409,7 @@ export const SetIamPolicyReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentResource}/reservationSubBlocks/{resource}/setIamPolicy",
+      path: "projects/{project}/zones/{zone}/{+parentResource}/reservationSubBlocks/{resource}/setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -69456,7 +69456,7 @@ export const TestIamPermissionsReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentResource}/reservationSubBlocks/{resource}/testIamPermissions",
+      path: "projects/{project}/zones/{zone}/{+parentResource}/reservationSubBlocks/{resource}/testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -69504,7 +69504,7 @@ export const PerformMaintenanceReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks/{reservationSubBlock}/performMaintenance",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSubBlocks/{reservationSubBlock}/performMaintenance",
       hasBody: true,
     }),
     svc,
@@ -69556,7 +69556,7 @@ export const ReportFaultyReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks/{reservationSubBlock}/reportFaulty",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSubBlocks/{reservationSubBlock}/reportFaulty",
       hasBody: true,
     }),
     svc,
@@ -69608,7 +69608,7 @@ export const GetVersionReservationSubBlocksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "projects/{project}/zones/{zone}/{parentName}/reservationSubBlocks/{reservationSubBlock}/getVersion",
+      path: "projects/{project}/zones/{zone}/{+parentName}/reservationSubBlocks/{reservationSubBlock}/getVersion",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/config-v1.ts
+++ b/packages/gcp/src/services/config-v1.ts
@@ -1492,7 +1492,7 @@ export const GetAutoMigrationConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAutoMigrationConfigProjectsLocationsRequest>;
 
@@ -1530,7 +1530,7 @@ export const UpdateAutoMigrationConfigProjectsLocationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AutoMigrationConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAutoMigrationConfigProjectsLocationsRequest>;
 
@@ -1575,7 +1575,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1610,7 +1610,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1655,7 +1655,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1690,7 +1690,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1721,7 +1721,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1755,7 +1755,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1798,7 +1798,7 @@ export const ListProjectsLocationsDeploymentsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeploymentsRequest>;
 
@@ -1833,7 +1833,7 @@ export const GetProjectsLocationsDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeploymentsRequest>;
 
@@ -1875,7 +1875,7 @@ export const CreateProjectsLocationsDeploymentsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Deployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/deployments", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/deployments", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDeploymentsRequest>;
 
@@ -1915,7 +1915,7 @@ export const PatchProjectsLocationsDeploymentsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Deployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDeploymentsRequest>;
 
@@ -1961,7 +1961,7 @@ export const DeleteProjectsLocationsDeploymentsRequest =
       T.HttpQuery("deletePolicy"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDeploymentsRequest>;
 
@@ -1995,7 +1995,7 @@ export const ExportStateProjectsLocationsDeploymentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(ExportDeploymentStatefileRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:exportState", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}:exportState", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportStateProjectsLocationsDeploymentsRequest>;
 
@@ -2029,7 +2029,7 @@ export const ImportStateProjectsLocationsDeploymentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(ImportStatefileRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:importState", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}:importState", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportStateProjectsLocationsDeploymentsRequest>;
 
@@ -2063,7 +2063,7 @@ export const DeleteStateProjectsLocationsDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DeleteStatefileRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:deleteState", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:deleteState", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeleteStateProjectsLocationsDeploymentsRequest>;
 
@@ -2097,7 +2097,7 @@ export const LockProjectsLocationsDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(LockDeploymentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:lock", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:lock", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<LockProjectsLocationsDeploymentsRequest>;
 
@@ -2131,7 +2131,7 @@ export const UnlockProjectsLocationsDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UnlockDeploymentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:unlock", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:unlock", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UnlockProjectsLocationsDeploymentsRequest>;
 
@@ -2162,7 +2162,7 @@ export const ExportLockProjectsLocationsDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:exportLock" }),
+    T.Http({ method: "GET", path: "v1/{+name}:exportLock" }),
     svc,
   ) as unknown as Schema.Schema<ExportLockProjectsLocationsDeploymentsRequest>;
 
@@ -2198,7 +2198,7 @@ export const SetIamPolicyProjectsLocationsDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2236,7 +2236,7 @@ export const GetIamPolicyProjectsLocationsDeploymentsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDeploymentsRequest>;
 
@@ -2272,7 +2272,7 @@ export const TestIamPermissionsProjectsLocationsDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2318,7 +2318,7 @@ export const ListProjectsLocationsDeploymentsRevisionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/revisions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/revisions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeploymentsRevisionsRequest>;
 
@@ -2354,7 +2354,7 @@ export const GetProjectsLocationsDeploymentsRevisionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeploymentsRevisionsRequest>;
 
@@ -2388,7 +2388,7 @@ export const ExportStateProjectsLocationsDeploymentsRevisionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(ExportRevisionStatefileRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:exportState", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}:exportState", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportStateProjectsLocationsDeploymentsRevisionsRequest>;
 
@@ -2421,7 +2421,7 @@ export const GetProjectsLocationsDeploymentsRevisionsResourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeploymentsRevisionsResourcesRequest>;
 
@@ -2466,7 +2466,7 @@ export const ListProjectsLocationsDeploymentsRevisionsResourcesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/resources" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/resources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeploymentsRevisionsResourcesRequest>;
 
@@ -2512,7 +2512,7 @@ export const CreateProjectsLocationsPreviewsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Preview).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/previews", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/previews", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsPreviewsRequest>;
 
@@ -2543,7 +2543,7 @@ export const GetProjectsLocationsPreviewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPreviewsRequest>;
 
@@ -2586,7 +2586,7 @@ export const ListProjectsLocationsPreviewsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/previews" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/previews" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPreviewsRequest>;
 
@@ -2624,7 +2624,7 @@ export const DeleteProjectsLocationsPreviewsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPreviewsRequest>;
 
@@ -2658,7 +2658,7 @@ export const ExportProjectsLocationsPreviewsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(ExportPreviewResultRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsPreviewsRequest>;
 
@@ -2702,7 +2702,7 @@ export const ListProjectsLocationsPreviewsResourceChangesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/resourceChanges" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/resourceChanges" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPreviewsResourceChangesRequest>;
 
@@ -2738,7 +2738,7 @@ export const GetProjectsLocationsPreviewsResourceChangesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPreviewsResourceChangesRequest>;
 
@@ -2782,7 +2782,7 @@ export const ListProjectsLocationsPreviewsResourceDriftsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/resourceDrifts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/resourceDrifts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPreviewsResourceDriftsRequest>;
 
@@ -2818,7 +2818,7 @@ export const GetProjectsLocationsPreviewsResourceDriftsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPreviewsResourceDriftsRequest>;
 
@@ -2861,7 +2861,7 @@ export const ListProjectsLocationsTerraformVersionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/terraformVersions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/terraformVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTerraformVersionsRequest>;
 
@@ -2897,7 +2897,7 @@ export const GetProjectsLocationsTerraformVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTerraformVersionsRequest>;
 
@@ -2928,7 +2928,7 @@ export const GetProjectsLocationsDeploymentGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeploymentGroupsRequest>;
 
@@ -2972,7 +2972,7 @@ export const CreateProjectsLocationsDeploymentGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/deploymentGroups",
+      path: "v1/{+parent}/deploymentGroups",
       hasBody: true,
     }),
     svc,
@@ -3014,7 +3014,7 @@ export const PatchProjectsLocationsDeploymentGroupsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(DeploymentGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDeploymentGroupsRequest>;
 
@@ -3061,7 +3061,7 @@ export const DeleteProjectsLocationsDeploymentGroupsRequest =
       T.HttpQuery("deploymentReferencePolicy"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDeploymentGroupsRequest>;
 
@@ -3104,7 +3104,7 @@ export const ListProjectsLocationsDeploymentGroupsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deploymentGroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deploymentGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeploymentGroupsRequest>;
 
@@ -3143,7 +3143,7 @@ export const ProvisionProjectsLocationsDeploymentGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ProvisionDeploymentGroupRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:provision", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:provision", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ProvisionProjectsLocationsDeploymentGroupsRequest>;
 
@@ -3177,7 +3177,7 @@ export const DeprovisionProjectsLocationsDeploymentGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DeprovisionDeploymentGroupRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:deprovision", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:deprovision", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeprovisionProjectsLocationsDeploymentGroupsRequest>;
 
@@ -3208,7 +3208,7 @@ export const GetProjectsLocationsDeploymentGroupsRevisionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeploymentGroupsRevisionsRequest>;
 
@@ -3246,7 +3246,7 @@ export const ListProjectsLocationsDeploymentGroupsRevisionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/revisions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/revisions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeploymentGroupsRevisionsRequest>;
 

--- a/packages/gcp/src/services/connectors-v1.ts
+++ b/packages/gcp/src/services/connectors-v1.ts
@@ -4074,7 +4074,7 @@ export const GetRuntimeConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetRuntimeConfigProjectsLocationsRequest>;
 
@@ -4105,7 +4105,7 @@ export const GetRegionalSettingsProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetRegionalSettingsProjectsLocationsRequest>;
 
@@ -4136,7 +4136,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -4173,7 +4173,7 @@ export const UpdateRegionalSettingsProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RegionalSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateRegionalSettingsProjectsLocationsRequest>;
 
@@ -4218,7 +4218,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -4259,7 +4259,7 @@ export const UpdateSettingsProjectsLocationsGlobalRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Settings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSettingsProjectsLocationsGlobalRequest>;
 
@@ -4290,7 +4290,7 @@ export const GetSettingsProjectsLocationsGlobalRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSettingsProjectsLocationsGlobalRequest>;
 
@@ -4327,7 +4327,7 @@ export const PatchProjectsLocationsGlobalManagedZonesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ManagedZone).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlobalManagedZonesRequest>;
 
@@ -4358,7 +4358,7 @@ export const GetProjectsLocationsGlobalManagedZonesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalManagedZonesRequest>;
 
@@ -4397,7 +4397,11 @@ export const CreateProjectsLocationsGlobalManagedZonesRequest =
     ),
     body: Schema.optional(ManagedZone).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/managedZones", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/managedZones",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGlobalManagedZonesRequest>;
 
@@ -4445,7 +4449,7 @@ export const ListProjectsLocationsGlobalManagedZonesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/managedZones" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/managedZones" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalManagedZonesRequest>;
 
@@ -4481,7 +4485,7 @@ export const DeleteProjectsLocationsGlobalManagedZonesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalManagedZonesRequest>;
 
@@ -4518,7 +4522,7 @@ export const PatchProjectsLocationsGlobalCustomConnectorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CustomConnector).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlobalCustomConnectorsRequest>;
 
@@ -4549,7 +4553,7 @@ export const GetProjectsLocationsGlobalCustomConnectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalCustomConnectorsRequest>;
 
@@ -4584,7 +4588,7 @@ export const DeleteProjectsLocationsGlobalCustomConnectorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalCustomConnectorsRequest>;
 
@@ -4624,7 +4628,7 @@ export const ListProjectsLocationsGlobalCustomConnectorsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customConnectors" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/customConnectors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalCustomConnectorsRequest>;
 
@@ -4670,7 +4674,7 @@ export const CreateProjectsLocationsGlobalCustomConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/customConnectors",
+      path: "v1/{+parent}/customConnectors",
       hasBody: true,
     }),
     svc,
@@ -4703,7 +4707,7 @@ export const GetProjectsLocationsGlobalCustomConnectorsCustomConnectorVersionsRe
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalCustomConnectorsCustomConnectorVersionsRequest>;
 
@@ -4748,7 +4752,7 @@ export const CreateProjectsLocationsGlobalCustomConnectorsCustomConnectorVersion
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/customConnectorVersions",
+      path: "v1/{+parent}/customConnectorVersions",
       hasBody: true,
     }),
     svc,
@@ -4791,7 +4795,7 @@ export const ListProjectsLocationsGlobalCustomConnectorsCustomConnectorVersionsR
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customConnectorVersions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/customConnectorVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalCustomConnectorsCustomConnectorVersionsRequest>;
 
@@ -4830,7 +4834,7 @@ export const GetProjectsLocationsProvidersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProvidersRequest>;
 
@@ -4866,7 +4870,7 @@ export const SetIamPolicyProjectsLocationsProvidersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4904,7 +4908,7 @@ export const GetIamPolicyProjectsLocationsProvidersRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsProvidersRequest>;
 
@@ -4940,7 +4944,7 @@ export const TestIamPermissionsProjectsLocationsProvidersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4980,7 +4984,7 @@ export const ListProjectsLocationsProvidersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/providers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/providers" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProvidersRequest>;
 
@@ -5024,7 +5028,7 @@ export const ListProjectsLocationsProvidersConnectorsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/connectors" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/connectors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProvidersConnectorsRequest>;
 
@@ -5060,7 +5064,7 @@ export const GetProjectsLocationsProvidersConnectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProvidersConnectorsRequest>;
 
@@ -5098,7 +5102,7 @@ export const GetProjectsLocationsProvidersConnectorsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProvidersConnectorsVersionsRequest>;
 
@@ -5143,7 +5147,7 @@ export const ListProjectsLocationsProvidersConnectorsVersionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProvidersConnectorsVersionsRequest>;
 
@@ -5188,7 +5192,7 @@ export const FetchAuthSchemaProjectsLocationsProvidersConnectorsVersionsRequest 
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:fetchAuthSchema" }),
+    T.Http({ method: "GET", path: "v1/{+name}:fetchAuthSchema" }),
     svc,
   ) as unknown as Schema.Schema<FetchAuthSchemaProjectsLocationsProvidersConnectorsVersionsRequest>;
 
@@ -5227,7 +5231,7 @@ export const ListProjectsLocationsProvidersConnectorsVersionsEventtypesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/eventtypes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/eventtypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProvidersConnectorsVersionsEventtypesRequest>;
 
@@ -5264,7 +5268,7 @@ export const GetProjectsLocationsProvidersConnectorsVersionsEventtypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProvidersConnectorsVersionsEventtypesRequest>;
 
@@ -5307,7 +5311,7 @@ export const CreateProjectsLocationsEndpointAttachmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/endpointAttachments",
+      path: "v1/{+parent}/endpointAttachments",
       hasBody: true,
     }),
     svc,
@@ -5359,7 +5363,7 @@ export const ListProjectsLocationsEndpointAttachmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/endpointAttachments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/endpointAttachments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEndpointAttachmentsRequest>;
 
@@ -5395,7 +5399,7 @@ export const DeleteProjectsLocationsEndpointAttachmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEndpointAttachmentsRequest>;
 
@@ -5433,7 +5437,7 @@ export const GetProjectsLocationsEndpointAttachmentsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEndpointAttachmentsRequest>;
 
@@ -5471,7 +5475,7 @@ export const PatchProjectsLocationsEndpointAttachmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EndpointAttachment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEndpointAttachmentsRequest>;
 
@@ -5507,7 +5511,7 @@ export const SetIamPolicyProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5547,7 +5551,7 @@ export const GenerateToolspecOverrideProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:generateToolspecOverride",
+      path: "v1/{+name}:generateToolspecOverride",
       hasBody: true,
     }),
     svc,
@@ -5591,7 +5595,7 @@ export const SearchProjectsLocationsConnectionsRequest =
     query: Schema.optional(Schema.String).pipe(T.HttpQuery("query")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:search" }),
+    T.Http({ method: "GET", path: "v1/{+name}:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsLocationsConnectionsRequest>;
 
@@ -5633,7 +5637,7 @@ export const PatchProjectsLocationsConnectionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Connection).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectionsRequest>;
 
@@ -5669,7 +5673,7 @@ export const GetIamPolicyProjectsLocationsConnectionsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsConnectionsRequest>;
 
@@ -5715,7 +5719,7 @@ export const ListProjectsLocationsConnectionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/connections" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/connections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsRequest>;
 
@@ -5758,7 +5762,7 @@ export const CreateProjectsLocationsConnectionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Connection).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/connections", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/connections", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsConnectionsRequest>;
 
@@ -5796,7 +5800,7 @@ export const FetchToolspecOverrideProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:fetchToolspecOverride",
+      path: "v1/{+name}:fetchToolspecOverride",
       hasBody: true,
     }),
     svc,
@@ -5834,7 +5838,7 @@ export const GetProjectsLocationsConnectionsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionsRequest>;
 
@@ -5865,7 +5869,7 @@ export const GetConnectionSchemaMetadataProjectsLocationsConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConnectionSchemaMetadataProjectsLocationsConnectionsRequest>;
 
@@ -5905,7 +5909,7 @@ export const RemoveToolspecOverrideProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:removeToolspecOverride",
+      path: "v1/{+name}:removeToolspecOverride",
       hasBody: true,
     }),
     svc,
@@ -5944,7 +5948,7 @@ export const TestIamPermissionsProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5985,7 +5989,7 @@ export const ModifyToolspecOverrideProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:modifyToolspecOverride",
+      path: "v1/{+name}:modifyToolspecOverride",
       hasBody: true,
     }),
     svc,
@@ -6023,7 +6027,11 @@ export const RepairEventingProjectsLocationsConnectionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RepairEventingRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:repairEventing", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+name}:repairEventing",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<RepairEventingProjectsLocationsConnectionsRequest>;
 
@@ -6059,7 +6067,7 @@ export const ListenEventProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resourcePath}:listenEvent",
+      path: "v1/{+resourcePath}:listenEvent",
       hasBody: true,
     }),
     svc,
@@ -6096,7 +6104,7 @@ export const DeleteProjectsLocationsConnectionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectionsRequest>;
 
@@ -6139,7 +6147,7 @@ export const ListActionsProjectsLocationsConnectionsConnectionSchemaMetadataRequ
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:listActions" }),
+    T.Http({ method: "GET", path: "v1/{+name}:listActions" }),
     svc,
   ) as unknown as Schema.Schema<ListActionsProjectsLocationsConnectionsConnectionSchemaMetadataRequest>;
 
@@ -6182,7 +6190,7 @@ export const RefreshProjectsLocationsConnectionsConnectionSchemaMetadataRequest 
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:refresh", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:refresh", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RefreshProjectsLocationsConnectionsConnectionSchemaMetadataRequest>;
 
@@ -6227,7 +6235,7 @@ export const ListEntityTypesProjectsLocationsConnectionsConnectionSchemaMetadata
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:listEntityTypes" }),
+    T.Http({ method: "GET", path: "v1/{+name}:listEntityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListEntityTypesProjectsLocationsConnectionsConnectionSchemaMetadataRequest>;
 
@@ -6269,7 +6277,7 @@ export const GetEntityTypeProjectsLocationsConnectionsConnectionSchemaMetadataRe
     name: Schema.String.pipe(T.HttpPath("name")),
     entityId: Schema.optional(Schema.String).pipe(T.HttpQuery("entityId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getEntityType" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getEntityType" }),
     svc,
   ) as unknown as Schema.Schema<GetEntityTypeProjectsLocationsConnectionsConnectionSchemaMetadataRequest>;
 
@@ -6307,7 +6315,7 @@ export const GetActionProjectsLocationsConnectionsConnectionSchemaMetadataReques
     actionId: Schema.optional(Schema.String).pipe(T.HttpQuery("actionId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getAction" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getAction" }),
     svc,
   ) as unknown as Schema.Schema<GetActionProjectsLocationsConnectionsConnectionSchemaMetadataRequest>;
 
@@ -6346,7 +6354,7 @@ export const PatchProjectsLocationsConnectionsEndUserAuthenticationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EndUserAuthentication).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectionsEndUserAuthenticationsRequest>;
 
@@ -6389,7 +6397,7 @@ export const CreateProjectsLocationsConnectionsEndUserAuthenticationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/endUserAuthentications",
+      path: "v1/{+parent}/endUserAuthentications",
       hasBody: true,
     }),
     svc,
@@ -6436,7 +6444,7 @@ export const ListProjectsLocationsConnectionsEndUserAuthenticationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/endUserAuthentications" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/endUserAuthentications" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsEndUserAuthenticationsRequest>;
 
@@ -6473,7 +6481,7 @@ export const DeleteProjectsLocationsConnectionsEndUserAuthenticationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectionsEndUserAuthenticationsRequest>;
 
@@ -6513,7 +6521,7 @@ export const GetProjectsLocationsConnectionsEndUserAuthenticationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionsEndUserAuthenticationsRequest>;
 
@@ -6560,7 +6568,7 @@ export const ListProjectsLocationsConnectionsRuntimeActionSchemasRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/runtimeActionSchemas" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/runtimeActionSchemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsRuntimeActionSchemasRequest>;
 
@@ -6603,7 +6611,7 @@ export const PatchProjectsLocationsConnectionsEventSubscriptionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(EventSubscription).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectionsEventSubscriptionsRequest>;
 
@@ -6639,7 +6647,7 @@ export const RetryProjectsLocationsConnectionsEventSubscriptionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RetryEventSubscriptionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:retry", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:retry", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RetryProjectsLocationsConnectionsEventSubscriptionsRequest>;
 
@@ -6672,7 +6680,7 @@ export const GetProjectsLocationsConnectionsEventSubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionsEventSubscriptionsRequest>;
 
@@ -6715,7 +6723,7 @@ export const CreateProjectsLocationsConnectionsEventSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/eventSubscriptions",
+      path: "v1/{+parent}/eventSubscriptions",
       hasBody: true,
     }),
     svc,
@@ -6762,7 +6770,7 @@ export const ListProjectsLocationsConnectionsEventSubscriptionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/eventSubscriptions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/eventSubscriptions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsEventSubscriptionsRequest>;
 
@@ -6799,7 +6807,7 @@ export const DeleteProjectsLocationsConnectionsEventSubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectionsEventSubscriptionsRequest>;
 
@@ -6841,7 +6849,7 @@ export const ListProjectsLocationsConnectionsRuntimeEntitySchemasRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/runtimeEntitySchemas" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/runtimeEntitySchemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsRuntimeEntitySchemasRequest>;
 
@@ -6885,7 +6893,7 @@ export const ValidateCustomConnectorSpecProjectsLocationsCustomConnectorsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/customConnectors:validateCustomConnectorSpec",
+      path: "v1/{+parent}/customConnectors:validateCustomConnectorSpec",
       hasBody: true,
     }),
     svc,
@@ -6920,7 +6928,7 @@ export const DeleteProjectsLocationsCustomConnectorsCustomConnectorVersionsReque
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCustomConnectorsCustomConnectorVersionsRequest>;
 
@@ -6959,7 +6967,7 @@ export const DeprecateProjectsLocationsCustomConnectorsCustomConnectorVersionsRe
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:deprecate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:deprecate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeprecateProjectsLocationsCustomConnectorsCustomConnectorVersionsRequest>;
 
@@ -6999,7 +7007,7 @@ export const PublishProjectsLocationsCustomConnectorsCustomConnectorVersionsRequ
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:publish", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:publish", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PublishProjectsLocationsCustomConnectorsCustomConnectorVersionsRequest>;
 
@@ -7038,7 +7046,7 @@ export const WithdrawProjectsLocationsCustomConnectorsCustomConnectorVersionsReq
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:withdraw", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:withdraw", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WithdrawProjectsLocationsCustomConnectorsCustomConnectorVersionsRequest>;
 
@@ -7087,7 +7095,7 @@ export const ListProjectsLocationsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -7122,7 +7130,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -7156,7 +7164,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -7187,7 +7195,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/connectors-v2.ts
+++ b/packages/gcp/src/services/connectors-v2.ts
@@ -1434,7 +1434,7 @@ export const ListCustomToolNamesProjectsLocationsConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}:listCustomToolNames" }),
+    T.Http({ method: "GET", path: "v2/{+name}:listCustomToolNames" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomToolNamesProjectsLocationsConnectionsRequest>;
 
@@ -1471,7 +1471,7 @@ export const RefreshAccessTokenProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:refreshAccessToken",
+      path: "v2/{+name}:refreshAccessToken",
       hasBody: true,
     }),
     svc,
@@ -1509,7 +1509,7 @@ export const CheckStatusProjectsLocationsConnectionsRequest =
       T.HttpQuery("executionConfig.headers"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}:checkStatus" }),
+    T.Http({ method: "GET", path: "v2/{+name}:checkStatus" }),
     svc,
   ) as unknown as Schema.Schema<CheckStatusProjectsLocationsConnectionsRequest>;
 
@@ -1546,7 +1546,7 @@ export const GenerateConnectionToolspecOverrideProjectsLocationsConnectionsReque
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:generateConnectionToolspecOverride",
+      path: "v2/{+name}:generateConnectionToolspecOverride",
       hasBody: true,
     }),
     svc,
@@ -1587,7 +1587,7 @@ export const ExecuteSqlQueryProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{connection}:executeSqlQuery",
+      path: "v2/{+connection}:executeSqlQuery",
       hasBody: true,
     }),
     svc,
@@ -1620,7 +1620,7 @@ export const CheckReadinessProjectsLocationsConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}:checkReadiness" }),
+    T.Http({ method: "GET", path: "v2/{+name}:checkReadiness" }),
     svc,
   ) as unknown as Schema.Schema<CheckReadinessProjectsLocationsConnectionsRequest>;
 
@@ -1656,7 +1656,7 @@ export const ExchangeAuthCodeProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:exchangeAuthCode",
+      path: "v2/{+name}:exchangeAuthCode",
       hasBody: true,
     }),
     svc,
@@ -1693,7 +1693,7 @@ export const ToolsProjectsLocationsConnectionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(ListToolsPostRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/tools", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/tools", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ToolsProjectsLocationsConnectionsRequest>;
 
@@ -1742,7 +1742,7 @@ export const ListProjectsLocationsConnectionsActionsRequest =
       T.HttpQuery("executionConfig.headers"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/actions" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/actions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsActionsRequest>;
 
@@ -1790,7 +1790,7 @@ export const GetProjectsLocationsConnectionsActionsRequest =
       T.HttpQuery("executionConfig.headers"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionsActionsRequest>;
 
@@ -1824,7 +1824,7 @@ export const ExecuteProjectsLocationsConnectionsActionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExecuteActionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:execute", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:execute", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteProjectsLocationsConnectionsActionsRequest>;
 
@@ -1867,7 +1867,7 @@ export const ListProjectsLocationsConnectionsToolsRequest =
       T.HttpQuery("executionConfig.headers"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/tools" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/tools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsToolsRequest>;
 
@@ -1905,7 +1905,7 @@ export const ExecuteProjectsLocationsConnectionsToolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExecuteToolRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:execute", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:execute", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteProjectsLocationsConnectionsToolsRequest>;
 
@@ -1940,7 +1940,7 @@ export const GetResourcePostProjectsLocationsConnectionsResourcesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GetResourcePostRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<GetResourcePostProjectsLocationsConnectionsResourcesRequest>;
 
@@ -1984,7 +1984,7 @@ export const ListProjectsLocationsConnectionsResourcesRequest =
       T.HttpQuery("executionConfig.headers"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/resources" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/resources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsResourcesRequest>;
 
@@ -2025,7 +2025,7 @@ export const GetProjectsLocationsConnectionsResourcesRequest =
       T.HttpQuery("executionConfig.headers"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionsResourcesRequest>;
 
@@ -2074,7 +2074,7 @@ export const GetProjectsLocationsConnectionsEntityTypesRequest =
       T.HttpQuery("executionConfig.headers"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionsEntityTypesRequest>;
 
@@ -2123,7 +2123,7 @@ export const ListProjectsLocationsConnectionsEntityTypesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsEntityTypesRequest>;
 
@@ -2172,7 +2172,7 @@ export const UpdateEntitiesWithConditionsProjectsLocationsConnectionsEntityTypes
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{entityType}/entities:updateEntitiesWithConditions",
+      path: "v2/{+entityType}/entities:updateEntitiesWithConditions",
       hasBody: true,
     }),
     svc,
@@ -2214,7 +2214,7 @@ export const DeleteProjectsLocationsConnectionsEntityTypesEntitiesRequest =
       T.HttpQuery("executionConfig.headers"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectionsEntityTypesEntitiesRequest>;
 
@@ -2252,7 +2252,7 @@ export const GetProjectsLocationsConnectionsEntityTypesEntitiesRequest =
       T.HttpQuery("executionConfig.headers"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionsEntityTypesEntitiesRequest>;
 
@@ -2294,7 +2294,7 @@ export const DeleteEntitiesWithConditionsProjectsLocationsConnectionsEntityTypes
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{entityType}/entities:deleteEntitiesWithConditions",
+      path: "v2/{+entityType}/entities:deleteEntitiesWithConditions",
       hasBody: true,
     }),
     svc,
@@ -2355,7 +2355,7 @@ export const ListProjectsLocationsConnectionsEntityTypesEntitiesRequest =
       T.HttpQuery("executionConfig.headers"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/entities" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/entities" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsEntityTypesEntitiesRequest>;
 
@@ -2400,7 +2400,7 @@ export const CreateProjectsLocationsConnectionsEntityTypesEntitiesRequest =
     ),
     body: Schema.optional(Entity).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/entities", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/entities", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsConnectionsEntityTypesEntitiesRequest>;
 
@@ -2441,7 +2441,7 @@ export const PatchProjectsLocationsConnectionsEntityTypesEntitiesRequest =
     ),
     body: Schema.optional(Entity).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectionsEntityTypesEntitiesRequest>;
 

--- a/packages/gcp/src/services/contactcenteraiplatform-v1alpha1.ts
+++ b/packages/gcp/src/services/contactcenteraiplatform-v1alpha1.ts
@@ -807,7 +807,7 @@ export const QueryContactCenterQuotaProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha1/{parent}:queryContactCenterQuota",
+      path: "v1alpha1/{+parent}:queryContactCenterQuota",
     }),
     svc,
   ) as unknown as Schema.Schema<QueryContactCenterQuotaProjectsLocationsRequest>;
@@ -845,7 +845,7 @@ export const GenerateShiftsProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}:generateShifts",
+      path: "v1alpha1/{+parent}:generateShifts",
       hasBody: true,
     }),
     svc,
@@ -878,7 +878,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -923,7 +923,7 @@ export const ListProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -958,7 +958,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -989,7 +989,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1034,7 +1034,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1072,7 +1072,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1103,7 +1103,7 @@ export const GetProjectsLocationsContactCentersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsContactCentersRequest>;
 
@@ -1137,7 +1137,7 @@ export const DeleteProjectsLocationsContactCentersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsContactCentersRequest>;
 
@@ -1180,7 +1180,7 @@ export const ListProjectsLocationsContactCentersRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/contactCenters" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/contactCenters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsContactCentersRequest>;
 
@@ -1229,7 +1229,7 @@ export const CreateProjectsLocationsContactCentersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/contactCenters",
+      path: "v1alpha1/{+parent}/contactCenters",
       hasBody: true,
     }),
     svc,
@@ -1271,7 +1271,7 @@ export const PatchProjectsLocationsContactCentersRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(ContactCenter).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsContactCentersRequest>;
 

--- a/packages/gcp/src/services/contactcenterinsights-v1.ts
+++ b/packages/gcp/src/services/contactcenterinsights-v1.ts
@@ -13993,7 +13993,7 @@ export const TestCorrelationConfigProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{location}:testCorrelationConfig",
+      path: "v1/{+location}:testCorrelationConfig",
       hasBody: true,
     }),
     svc,
@@ -14027,7 +14027,7 @@ export const GetCorrelationConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCorrelationConfigProjectsLocationsRequest>;
 
@@ -14067,7 +14067,7 @@ export const UpdateCorrelationConfigProjectsLocationsRequest =
       GoogleCloudContactcenterinsightsV1CorrelationConfig,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateCorrelationConfigProjectsLocationsRequest>;
 
@@ -14106,7 +14106,7 @@ export const GenerativeInsightsProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{location}:generativeInsights",
+      path: "v1/{+location}:generativeInsights",
       hasBody: true,
     }),
     svc,
@@ -14140,7 +14140,7 @@ export const GetEncryptionSpecProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEncryptionSpecProjectsLocationsRequest>;
 
@@ -14179,7 +14179,7 @@ export const BulkDeleteFeedbackLabelsProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:bulkDeleteFeedbackLabels",
+      path: "v1/{+parent}:bulkDeleteFeedbackLabels",
       hasBody: true,
     }),
     svc,
@@ -14222,7 +14222,7 @@ export const ListAllFeedbackLabelsProjectsLocationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}:listAllFeedbackLabels" }),
+    T.Http({ method: "GET", path: "v1/{+parent}:listAllFeedbackLabels" }),
     svc,
   ) as unknown as Schema.Schema<ListAllFeedbackLabelsProjectsLocationsRequest>;
 
@@ -14265,7 +14265,7 @@ export const BulkUploadFeedbackLabelsProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:bulkUploadFeedbackLabels",
+      path: "v1/{+parent}:bulkUploadFeedbackLabels",
       hasBody: true,
     }),
     svc,
@@ -14306,7 +14306,7 @@ export const BulkDownloadFeedbackLabelsProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:bulkDownloadFeedbackLabels",
+      path: "v1/{+parent}:bulkDownloadFeedbackLabels",
       hasBody: true,
     }),
     svc,
@@ -14340,7 +14340,7 @@ export const GetSettingsProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSettingsProjectsLocationsRequest>;
 
@@ -14379,7 +14379,7 @@ export const QueryMetricsProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{location}:queryMetrics",
+      path: "v1/{+location}:queryMetrics",
       hasBody: true,
     }),
     svc,
@@ -14419,7 +14419,7 @@ export const QueryPerformanceOverviewProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:queryPerformanceOverview",
+      path: "v1/{+parent}:queryPerformanceOverview",
       hasBody: true,
     }),
     svc,
@@ -14461,7 +14461,7 @@ export const UpdateSettingsProjectsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSettingsProjectsLocationsRequest>;
 
@@ -14499,7 +14499,7 @@ export const ListProjectsLocationsAutoLabelingRulesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/autoLabelingRules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/autoLabelingRules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAutoLabelingRulesRequest>;
 
@@ -14543,7 +14543,7 @@ export const PatchProjectsLocationsAutoLabelingRulesRequest =
       GoogleCloudContactcenterinsightsV1AutoLabelingRule,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAutoLabelingRulesRequest>;
 
@@ -14575,7 +14575,7 @@ export const DeleteProjectsLocationsAutoLabelingRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAutoLabelingRulesRequest>;
 
@@ -14619,7 +14619,7 @@ export const CreateProjectsLocationsAutoLabelingRulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/autoLabelingRules",
+      path: "v1/{+parent}/autoLabelingRules",
       hasBody: true,
     }),
     svc,
@@ -14653,7 +14653,7 @@ export const GetProjectsLocationsAutoLabelingRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAutoLabelingRulesRequest>;
 
@@ -14692,7 +14692,7 @@ export const TestProjectsLocationsAutoLabelingRulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/autoLabelingRules:test",
+      path: "v1/{+parent}/autoLabelingRules:test",
       hasBody: true,
     }),
     svc,
@@ -14732,7 +14732,7 @@ export const ListProjectsLocationsAssessmentRulesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/assessmentRules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/assessmentRules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAssessmentRulesRequest>;
 
@@ -14780,7 +14780,7 @@ export const CreateProjectsLocationsAssessmentRulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/assessmentRules",
+      path: "v1/{+parent}/assessmentRules",
       hasBody: true,
     }),
     svc,
@@ -14822,7 +14822,7 @@ export const PatchProjectsLocationsAssessmentRulesRequest =
       GoogleCloudContactcenterinsightsV1AssessmentRule,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAssessmentRulesRequest>;
 
@@ -14854,7 +14854,7 @@ export const DeleteProjectsLocationsAssessmentRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAssessmentRulesRequest>;
 
@@ -14886,7 +14886,7 @@ export const GetProjectsLocationsAssessmentRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAssessmentRulesRequest>;
 
@@ -14918,7 +14918,7 @@ export const GetProjectsLocationsDashboardsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDashboardsRequest>;
 
@@ -14958,7 +14958,7 @@ export const PatchProjectsLocationsDashboardsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDashboardsRequest>;
 
@@ -14990,7 +14990,7 @@ export const DeleteProjectsLocationsDashboardsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDashboardsRequest>;
 
@@ -15031,7 +15031,7 @@ export const CreateProjectsLocationsDashboardsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/dashboards", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/dashboards", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDashboardsRequest>;
 
@@ -15075,7 +15075,7 @@ export const ListProjectsLocationsDashboardsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dashboards" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dashboards" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDashboardsRequest>;
 
@@ -15111,7 +15111,7 @@ export const GetProjectsLocationsDashboardsChartsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDashboardsChartsRequest>;
 
@@ -15151,7 +15151,7 @@ export const PatchProjectsLocationsDashboardsChartsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDashboardsChartsRequest>;
 
@@ -15183,7 +15183,7 @@ export const DeleteProjectsLocationsDashboardsChartsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDashboardsChartsRequest>;
 
@@ -15223,7 +15223,7 @@ export const CreateProjectsLocationsDashboardsChartsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/charts", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/charts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDashboardsChartsRequest>;
 
@@ -15255,7 +15255,7 @@ export const ListProjectsLocationsDashboardsChartsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/charts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/charts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDashboardsChartsRequest>;
 
@@ -15302,7 +15302,7 @@ export const ListProjectsLocationsConversationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConversationsRequest>;
 
@@ -15345,7 +15345,7 @@ export const BulkAnalyzeProjectsLocationsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/conversations:bulkAnalyze",
+      path: "v1/{+parent}/conversations:bulkAnalyze",
       hasBody: true,
     }),
     svc,
@@ -15391,7 +15391,7 @@ export const CreateProjectsLocationsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/conversations",
+      path: "v1/{+parent}/conversations",
       hasBody: true,
     }),
     svc,
@@ -15446,7 +15446,7 @@ export const PatchProjectsLocationsConversationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConversationsRequest>;
 
@@ -15478,7 +15478,7 @@ export const GenerateSignedAudioProjectsLocationsConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:generateSignedAudio" }),
+    T.Http({ method: "GET", path: "v1/{+name}:generateSignedAudio" }),
     svc,
   ) as unknown as Schema.Schema<GenerateSignedAudioProjectsLocationsConversationsRequest>;
 
@@ -15514,7 +15514,7 @@ export const DeleteProjectsLocationsConversationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConversationsRequest>;
 
@@ -15548,7 +15548,7 @@ export const GetProjectsLocationsConversationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConversationsRequest>;
 
@@ -15587,7 +15587,7 @@ export const IngestProjectsLocationsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/conversations:ingest",
+      path: "v1/{+parent}/conversations:ingest",
       hasBody: true,
     }),
     svc,
@@ -15628,7 +15628,7 @@ export const UploadProjectsLocationsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/conversations:upload",
+      path: "v1/{+parent}/conversations:upload",
       hasBody: true,
     }),
     svc,
@@ -15669,7 +15669,7 @@ export const SampleProjectsLocationsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/conversations:sample",
+      path: "v1/{+parent}/conversations:sample",
       hasBody: true,
     }),
     svc,
@@ -15708,7 +15708,7 @@ export const CalculateStatsProjectsLocationsConversationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{location}/conversations:calculateStats",
+      path: "v1/{+location}/conversations:calculateStats",
     }),
     svc,
   ) as unknown as Schema.Schema<CalculateStatsProjectsLocationsConversationsRequest>;
@@ -15748,7 +15748,7 @@ export const BulkDeleteProjectsLocationsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/conversations:bulkDelete",
+      path: "v1/{+parent}/conversations:bulkDelete",
       hasBody: true,
     }),
     svc,
@@ -15782,7 +15782,7 @@ export const GetProjectsLocationsConversationsFeedbackLabelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConversationsFeedbackLabelsRequest>;
 
@@ -15824,7 +15824,7 @@ export const ListProjectsLocationsConversationsFeedbackLabelsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/feedbackLabels" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/feedbackLabels" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConversationsFeedbackLabelsRequest>;
 
@@ -15873,7 +15873,7 @@ export const CreateProjectsLocationsConversationsFeedbackLabelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/feedbackLabels",
+      path: "v1/{+parent}/feedbackLabels",
       hasBody: true,
     }),
     svc,
@@ -15916,7 +15916,7 @@ export const PatchProjectsLocationsConversationsFeedbackLabelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConversationsFeedbackLabelsRequest>;
 
@@ -15949,7 +15949,7 @@ export const DeleteProjectsLocationsConversationsFeedbackLabelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConversationsFeedbackLabelsRequest>;
 
@@ -15985,7 +15985,7 @@ export const DeleteProjectsLocationsConversationsAssessmentsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConversationsAssessmentsRequest>;
 
@@ -16023,7 +16023,7 @@ export const CreateProjectsLocationsConversationsAssessmentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/assessments", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/assessments", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsConversationsAssessmentsRequest>;
 
@@ -16065,7 +16065,7 @@ export const ListProjectsLocationsConversationsAssessmentsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/assessments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/assessments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConversationsAssessmentsRequest>;
 
@@ -16106,7 +16106,7 @@ export const PublishProjectsLocationsConversationsAssessmentsRequest =
       GoogleCloudContactcenterinsightsV1PublishAssessmentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:publish", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:publish", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PublishProjectsLocationsConversationsAssessmentsRequest>;
 
@@ -16144,7 +16144,7 @@ export const AppealProjectsLocationsConversationsAssessmentsRequest =
       GoogleCloudContactcenterinsightsV1AppealAssessmentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:appeal", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:appeal", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AppealProjectsLocationsConversationsAssessmentsRequest>;
 
@@ -16177,7 +16177,7 @@ export const GetProjectsLocationsConversationsAssessmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConversationsAssessmentsRequest>;
 
@@ -16214,7 +16214,7 @@ export const FinalizeProjectsLocationsConversationsAssessmentsRequest =
       GoogleCloudContactcenterinsightsV1FinalizeAssessmentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:finalize", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:finalize", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<FinalizeProjectsLocationsConversationsAssessmentsRequest>;
 
@@ -16253,7 +16253,7 @@ export const ListProjectsLocationsConversationsAssessmentsNotesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/notes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/notes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConversationsAssessmentsNotesRequest>;
 
@@ -16298,7 +16298,7 @@ export const PatchProjectsLocationsConversationsAssessmentsNotesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConversationsAssessmentsNotesRequest>;
 
@@ -16331,7 +16331,7 @@ export const DeleteProjectsLocationsConversationsAssessmentsNotesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConversationsAssessmentsNotesRequest>;
 
@@ -16369,7 +16369,7 @@ export const CreateProjectsLocationsConversationsAssessmentsNotesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/notes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/notes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsConversationsAssessmentsNotesRequest>;
 
@@ -16402,7 +16402,7 @@ export const GetProjectsLocationsConversationsAnalysesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConversationsAnalysesRequest>;
 
@@ -16443,7 +16443,7 @@ export const ListProjectsLocationsConversationsAnalysesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/analyses" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/analyses" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConversationsAnalysesRequest>;
 
@@ -16479,7 +16479,7 @@ export const DeleteProjectsLocationsConversationsAnalysesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConversationsAnalysesRequest>;
 
@@ -16516,7 +16516,7 @@ export const CreateProjectsLocationsConversationsAnalysesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/analyses", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/analyses", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsConversationsAnalysesRequest>;
 
@@ -16555,7 +16555,7 @@ export const BulkAnalyzeProjectsLocationsConversationsSegmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/segments:bulkAnalyze",
+      path: "v1/{+parent}/segments:bulkAnalyze",
       hasBody: true,
     }),
     svc,
@@ -16590,7 +16590,7 @@ export const GetProjectsLocationsQaQuestionTagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsQaQuestionTagsRequest>;
 
@@ -16634,7 +16634,7 @@ export const CreateProjectsLocationsQaQuestionTagsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/qaQuestionTags",
+      path: "v1/{+parent}/qaQuestionTags",
       hasBody: true,
     }),
     svc,
@@ -16676,7 +16676,7 @@ export const PatchProjectsLocationsQaQuestionTagsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsQaQuestionTagsRequest>;
 
@@ -16708,7 +16708,7 @@ export const DeleteProjectsLocationsQaQuestionTagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsQaQuestionTagsRequest>;
 
@@ -16743,7 +16743,7 @@ export const ListProjectsLocationsQaQuestionTagsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/qaQuestionTags" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/qaQuestionTags" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsQaQuestionTagsRequest>;
 
@@ -16782,7 +16782,7 @@ export const CreateProjectsLocationsPhraseMatchersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/phraseMatchers",
+      path: "v1/{+parent}/phraseMatchers",
       hasBody: true,
     }),
     svc,
@@ -16816,7 +16816,7 @@ export const DeleteProjectsLocationsPhraseMatchersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPhraseMatchersRequest>;
 
@@ -16855,7 +16855,7 @@ export const PatchProjectsLocationsPhraseMatchersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPhraseMatchersRequest>;
 
@@ -16896,7 +16896,7 @@ export const ListProjectsLocationsPhraseMatchersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/phraseMatchers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/phraseMatchers" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPhraseMatchersRequest>;
 
@@ -16932,7 +16932,7 @@ export const GetProjectsLocationsPhraseMatchersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPhraseMatchersRequest>;
 
@@ -16979,7 +16979,7 @@ export const ListProjectsLocationsQaScorecardsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/qaScorecards" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/qaScorecards" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsQaScorecardsRequest>;
 
@@ -17025,7 +17025,11 @@ export const CreateProjectsLocationsQaScorecardsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/qaScorecards", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/qaScorecards",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsQaScorecardsRequest>;
 
@@ -17065,7 +17069,7 @@ export const PatchProjectsLocationsQaScorecardsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsQaScorecardsRequest>;
 
@@ -17100,7 +17104,7 @@ export const DeleteProjectsLocationsQaScorecardsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsQaScorecardsRequest>;
 
@@ -17131,7 +17135,7 @@ export const GetProjectsLocationsQaScorecardsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsQaScorecardsRequest>;
 
@@ -17163,7 +17167,7 @@ export const GetProjectsLocationsQaScorecardsRevisionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsQaScorecardsRevisionsRequest>;
 
@@ -17200,7 +17204,7 @@ export const UndeployProjectsLocationsQaScorecardsRevisionsRequest =
       GoogleCloudContactcenterinsightsV1UndeployQaScorecardRevisionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undeploy", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undeploy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeployProjectsLocationsQaScorecardsRevisionsRequest>;
 
@@ -17239,7 +17243,7 @@ export const TuneQaScorecardRevisionProjectsLocationsQaScorecardsRevisionsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:tuneQaScorecardRevision",
+      path: "v1/{+parent}:tuneQaScorecardRevision",
       hasBody: true,
     }),
     svc,
@@ -17292,7 +17296,7 @@ export const ListProjectsLocationsQaScorecardsRevisionsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/revisions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/revisions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsQaScorecardsRevisionsRequest>;
 
@@ -17338,7 +17342,7 @@ export const CreateProjectsLocationsQaScorecardsRevisionsRequest =
       GoogleCloudContactcenterinsightsV1QaScorecardRevision,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/revisions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/revisions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsQaScorecardsRevisionsRequest>;
 
@@ -17375,7 +17379,7 @@ export const DeployProjectsLocationsQaScorecardsRevisionsRequest =
       GoogleCloudContactcenterinsightsV1DeployQaScorecardRevisionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:deploy", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:deploy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeployProjectsLocationsQaScorecardsRevisionsRequest>;
 
@@ -17410,7 +17414,7 @@ export const DeleteProjectsLocationsQaScorecardsRevisionsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsQaScorecardsRevisionsRequest>;
 
@@ -17442,7 +17446,7 @@ export const GetProjectsLocationsQaScorecardsRevisionsQaQuestionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsQaScorecardsRevisionsQaQuestionsRequest>;
 
@@ -17485,7 +17489,7 @@ export const CreateProjectsLocationsQaScorecardsRevisionsQaQuestionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/qaQuestions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/qaQuestions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsQaScorecardsRevisionsQaQuestionsRequest>;
 
@@ -17526,7 +17530,7 @@ export const PatchProjectsLocationsQaScorecardsRevisionsQaQuestionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsQaScorecardsRevisionsQaQuestionsRequest>;
 
@@ -17559,7 +17563,7 @@ export const DeleteProjectsLocationsQaScorecardsRevisionsQaQuestionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsQaScorecardsRevisionsQaQuestionsRequest>;
 
@@ -17598,7 +17602,7 @@ export const ListProjectsLocationsQaScorecardsRevisionsQaQuestionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/qaQuestions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/qaQuestions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsQaScorecardsRevisionsQaQuestionsRequest>;
 
@@ -17647,7 +17651,7 @@ export const CreateProjectsLocationsAuthorizedViewSetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/authorizedViewSets",
+      path: "v1/{+parent}/authorizedViewSets",
       hasBody: true,
     }),
     svc,
@@ -17689,7 +17693,7 @@ export const PatchProjectsLocationsAuthorizedViewSetsRequest =
       GoogleCloudContactcenterinsightsV1AuthorizedViewSet,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAuthorizedViewSetsRequest>;
 
@@ -17724,7 +17728,7 @@ export const DeleteProjectsLocationsAuthorizedViewSetsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAuthorizedViewSetsRequest>;
 
@@ -17768,7 +17772,7 @@ export const ListProjectsLocationsAuthorizedViewSetsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/authorizedViewSets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/authorizedViewSets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAuthorizedViewSetsRequest>;
 
@@ -17804,7 +17808,7 @@ export const GetProjectsLocationsAuthorizedViewSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAuthorizedViewSetsRequest>;
 
@@ -17843,7 +17847,7 @@ export const TestIamPermissionsProjectsLocationsAuthorizedViewSetsAuthorizedView
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -17892,7 +17896,7 @@ export const ListProjectsLocationsAuthorizedViewSetsAuthorizedViewsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/authorizedViews" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/authorizedViews" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAuthorizedViewSetsAuthorizedViewsRequest>;
 
@@ -17936,7 +17940,7 @@ export const QueryMetricsProjectsLocationsAuthorizedViewSetsAuthorizedViewsReque
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{location}:queryMetrics",
+      path: "v1/{+location}:queryMetrics",
       hasBody: true,
     }),
     svc,
@@ -17984,7 +17988,7 @@ export const SearchProjectsLocationsAuthorizedViewSetsAuthorizedViewsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/authorizedViews:search" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/authorizedViews:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsLocationsAuthorizedViewSetsAuthorizedViewsRequest>;
 
@@ -18029,7 +18033,7 @@ export const PatchProjectsLocationsAuthorizedViewSetsAuthorizedViewsRequest =
       GoogleCloudContactcenterinsightsV1AuthorizedView,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAuthorizedViewSetsAuthorizedViewsRequest>;
 
@@ -18062,7 +18066,7 @@ export const DeleteProjectsLocationsAuthorizedViewSetsAuthorizedViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAuthorizedViewSetsAuthorizedViewsRequest>;
 
@@ -18107,7 +18111,7 @@ export const CreateProjectsLocationsAuthorizedViewSetsAuthorizedViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/authorizedViews",
+      path: "v1/{+parent}/authorizedViews",
       hasBody: true,
     }),
     svc,
@@ -18149,7 +18153,7 @@ export const GenerativeInsightsProjectsLocationsAuthorizedViewSetsAuthorizedView
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{location}:generativeInsights",
+      path: "v1/{+location}:generativeInsights",
       hasBody: true,
     }),
     svc,
@@ -18186,7 +18190,7 @@ export const GetProjectsLocationsAuthorizedViewSetsAuthorizedViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAuthorizedViewSetsAuthorizedViewsRequest>;
 
@@ -18224,7 +18228,7 @@ export const GetIamPolicyProjectsLocationsAuthorizedViewSetsAuthorizedViewsReque
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsAuthorizedViewSetsAuthorizedViewsRequest>;
 
@@ -18263,7 +18267,7 @@ export const SetIamPolicyProjectsLocationsAuthorizedViewSetsAuthorizedViewsReque
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -18306,7 +18310,7 @@ export const QueryPerformanceOverviewProjectsLocationsAuthorizedViewSetsAuthoriz
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:queryPerformanceOverview",
+      path: "v1/{+parent}:queryPerformanceOverview",
       hasBody: true,
     }),
     svc,
@@ -18343,7 +18347,7 @@ export const CancelProjectsLocationsAuthorizedViewSetsAuthorizedViewsOperationsR
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsAuthorizedViewSetsAuthorizedViewsOperationsRequest>;
 
@@ -18392,7 +18396,7 @@ export const ListProjectsLocationsAuthorizedViewSetsAuthorizedViewsOperationsReq
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAuthorizedViewSetsAuthorizedViewsOperationsRequest>;
 
@@ -18431,7 +18435,7 @@ export const GetProjectsLocationsAuthorizedViewSetsAuthorizedViewsOperationsRequ
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAuthorizedViewSetsAuthorizedViewsOperationsRequest>;
 
@@ -18465,7 +18469,7 @@ export const GenerateSignedAudioProjectsLocationsAuthorizedViewSetsAuthorizedVie
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:generateSignedAudio" }),
+    T.Http({ method: "GET", path: "v1/{+name}:generateSignedAudio" }),
     svc,
   ) as unknown as Schema.Schema<GenerateSignedAudioProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsRequest>;
 
@@ -18503,7 +18507,7 @@ export const DeleteProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversatio
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsRequest>;
 
@@ -18553,7 +18557,7 @@ export const ListProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversations
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsRequest>;
 
@@ -18595,7 +18599,7 @@ export const GetProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsR
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsRequest>;
 
@@ -18635,7 +18639,7 @@ export const CalculateStatsProjectsLocationsAuthorizedViewSetsAuthorizedViewsCon
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{location}/conversations:calculateStats",
+      path: "v1/{+location}/conversations:calculateStats",
     }),
     svc,
   ) as unknown as Schema.Schema<CalculateStatsProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsRequest>;
@@ -18676,7 +18680,7 @@ export const PublishProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversati
       GoogleCloudContactcenterinsightsV1PublishAssessmentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:publish", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:publish", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PublishProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsAssessmentsRequest>;
 
@@ -18716,7 +18720,7 @@ export const AppealProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversatio
       GoogleCloudContactcenterinsightsV1AppealAssessmentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:appeal", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:appeal", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AppealProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsAssessmentsRequest>;
 
@@ -18751,7 +18755,7 @@ export const GetProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsA
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsAssessmentsRequest>;
 
@@ -18791,7 +18795,7 @@ export const FinalizeProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversat
       GoogleCloudContactcenterinsightsV1FinalizeAssessmentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:finalize", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:finalize", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<FinalizeProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsAssessmentsRequest>;
 
@@ -18829,7 +18833,7 @@ export const DeleteProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversatio
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsAssessmentsRequest>;
 
@@ -18869,7 +18873,7 @@ export const CreateProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversatio
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/assessments", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/assessments", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsAssessmentsRequest>;
 
@@ -18913,7 +18917,7 @@ export const ListProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversations
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/assessments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/assessments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsAssessmentsRequest>;
 
@@ -18958,7 +18962,7 @@ export const ListProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversations
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/notes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/notes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsAssessmentsNotesRequest>;
 
@@ -19005,7 +19009,7 @@ export const PatchProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversation
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsAssessmentsNotesRequest>;
 
@@ -19040,7 +19044,7 @@ export const DeleteProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversatio
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsAssessmentsNotesRequest>;
 
@@ -19080,7 +19084,7 @@ export const CreateProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversatio
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/notes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/notes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsAssessmentsNotesRequest>;
 
@@ -19115,7 +19119,7 @@ export const GetProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsF
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsFeedbackLabelsRequest>;
 
@@ -19162,7 +19166,7 @@ export const CreateProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversatio
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/feedbackLabels",
+      path: "v1/{+parent}/feedbackLabels",
       hasBody: true,
     }),
     svc,
@@ -19207,7 +19211,7 @@ export const PatchProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversation
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsFeedbackLabelsRequest>;
 
@@ -19242,7 +19246,7 @@ export const DeleteProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversatio
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsFeedbackLabelsRequest>;
 
@@ -19286,7 +19290,7 @@ export const ListProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversations
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/feedbackLabels" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/feedbackLabels" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAuthorizedViewSetsAuthorizedViewsConversationsFeedbackLabelsRequest>;
 
@@ -19332,7 +19336,7 @@ export const ExportProjectsLocationsInsightsdataRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/insightsdata:export",
+      path: "v1/{+parent}/insightsdata:export",
       hasBody: true,
     }),
     svc,
@@ -19366,7 +19370,7 @@ export const GetProjectsLocationsDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsRequest>;
 
@@ -19405,7 +19409,7 @@ export const BulkDeleteFeedbackLabelsProjectsLocationsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:bulkDeleteFeedbackLabels",
+      path: "v1/{+parent}:bulkDeleteFeedbackLabels",
       hasBody: true,
     }),
     svc,
@@ -19449,7 +19453,7 @@ export const ListProjectsLocationsDatasetsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/datasets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/datasets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsRequest>;
 
@@ -19494,7 +19498,7 @@ export const ListAllFeedbackLabelsProjectsLocationsDatasetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}:listAllFeedbackLabels" }),
+    T.Http({ method: "GET", path: "v1/{+parent}:listAllFeedbackLabels" }),
     svc,
   ) as unknown as Schema.Schema<ListAllFeedbackLabelsProjectsLocationsDatasetsRequest>;
 
@@ -19538,7 +19542,7 @@ export const PatchProjectsLocationsDatasetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsRequest>;
 
@@ -19570,7 +19574,7 @@ export const DeleteProjectsLocationsDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsRequest>;
 
@@ -19610,7 +19614,7 @@ export const CreateProjectsLocationsDatasetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/datasets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/datasets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDatasetsRequest>;
 
@@ -19649,7 +19653,7 @@ export const BulkUploadFeedbackLabelsProjectsLocationsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:bulkUploadFeedbackLabels",
+      path: "v1/{+parent}:bulkUploadFeedbackLabels",
       hasBody: true,
     }),
     svc,
@@ -19691,7 +19695,7 @@ export const BulkDownloadFeedbackLabelsProjectsLocationsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:bulkDownloadFeedbackLabels",
+      path: "v1/{+parent}:bulkDownloadFeedbackLabels",
       hasBody: true,
     }),
     svc,
@@ -19741,7 +19745,7 @@ export const ListProjectsLocationsDatasetsConversationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsConversationsRequest>;
 
@@ -19784,7 +19788,7 @@ export const IngestProjectsLocationsDatasetsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/conversations:ingest",
+      path: "v1/{+parent}/conversations:ingest",
       hasBody: true,
     }),
     svc,
@@ -19818,7 +19822,7 @@ export const GenerateSignedAudioProjectsLocationsDatasetsConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:generateSignedAudio" }),
+    T.Http({ method: "GET", path: "v1/{+name}:generateSignedAudio" }),
     svc,
   ) as unknown as Schema.Schema<GenerateSignedAudioProjectsLocationsDatasetsConversationsRequest>;
 
@@ -19854,7 +19858,7 @@ export const DeleteProjectsLocationsDatasetsConversationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsConversationsRequest>;
 
@@ -19889,7 +19893,7 @@ export const GetProjectsLocationsDatasetsConversationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsConversationsRequest>;
 
@@ -19928,7 +19932,7 @@ export const SampleProjectsLocationsDatasetsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/conversations:sample",
+      path: "v1/{+parent}/conversations:sample",
       hasBody: true,
     }),
     svc,
@@ -19969,7 +19973,7 @@ export const CalculateStatsProjectsLocationsDatasetsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{location}/conversations:calculateStats",
+      path: "v1/{+location}/conversations:calculateStats",
       hasBody: true,
     }),
     svc,
@@ -20011,7 +20015,7 @@ export const BulkDeleteProjectsLocationsDatasetsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/conversations:bulkDelete",
+      path: "v1/{+parent}/conversations:bulkDelete",
       hasBody: true,
     }),
     svc,
@@ -20055,7 +20059,7 @@ export const ListProjectsLocationsDatasetsConversationsFeedbackLabelsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/feedbackLabels" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/feedbackLabels" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsConversationsFeedbackLabelsRequest>;
 
@@ -20100,7 +20104,7 @@ export const PatchProjectsLocationsDatasetsConversationsFeedbackLabelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsConversationsFeedbackLabelsRequest>;
 
@@ -20133,7 +20137,7 @@ export const DeleteProjectsLocationsDatasetsConversationsFeedbackLabelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsConversationsFeedbackLabelsRequest>;
 
@@ -20178,7 +20182,7 @@ export const CreateProjectsLocationsDatasetsConversationsFeedbackLabelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/feedbackLabels",
+      path: "v1/{+parent}/feedbackLabels",
       hasBody: true,
     }),
     svc,
@@ -20213,7 +20217,7 @@ export const GetProjectsLocationsDatasetsConversationsFeedbackLabelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsConversationsFeedbackLabelsRequest>;
 
@@ -20253,7 +20257,7 @@ export const ExportProjectsLocationsDatasetsInsightsdataRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/insightsdata:export",
+      path: "v1/{+parent}/insightsdata:export",
       hasBody: true,
     }),
     svc,
@@ -20295,7 +20299,7 @@ export const PatchProjectsLocationsIssueModelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsIssueModelsRequest>;
 
@@ -20327,7 +20331,7 @@ export const DeleteProjectsLocationsIssueModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsIssueModelsRequest>;
 
@@ -20364,7 +20368,7 @@ export const DeployProjectsLocationsIssueModelsRequest =
       GoogleCloudContactcenterinsightsV1DeployIssueModelRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:deploy", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:deploy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeployProjectsLocationsIssueModelsRequest>;
 
@@ -20401,7 +20405,7 @@ export const CreateProjectsLocationsIssueModelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/issueModels", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/issueModels", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsIssueModelsRequest>;
 
@@ -20433,7 +20437,7 @@ export const ListProjectsLocationsIssueModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/issueModels" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/issueModels" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIssueModelsRequest>;
 
@@ -20470,7 +20474,7 @@ export const UndeployProjectsLocationsIssueModelsRequest =
       GoogleCloudContactcenterinsightsV1UndeployIssueModelRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undeploy", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undeploy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeployProjectsLocationsIssueModelsRequest>;
 
@@ -20502,7 +20506,10 @@ export const CalculateIssueModelStatsProjectsLocationsIssueModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     issueModel: Schema.String.pipe(T.HttpPath("issueModel")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{issueModel}:calculateIssueModelStats" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+issueModel}:calculateIssueModelStats",
+    }),
     svc,
   ) as unknown as Schema.Schema<CalculateIssueModelStatsProjectsLocationsIssueModelsRequest>;
 
@@ -20535,7 +20542,7 @@ export const GetProjectsLocationsIssueModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIssueModelsRequest>;
 
@@ -20572,7 +20579,7 @@ export const ExportProjectsLocationsIssueModelsRequest =
       GoogleCloudContactcenterinsightsV1ExportIssueModelRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsIssueModelsRequest>;
 
@@ -20611,7 +20618,7 @@ export const ImportProjectsLocationsIssueModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/issueModels:import",
+      path: "v1/{+parent}/issueModels:import",
       hasBody: true,
     }),
     svc,
@@ -20645,7 +20652,7 @@ export const ListProjectsLocationsIssueModelsIssuesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/issues" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/issues" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIssueModelsIssuesRequest>;
 
@@ -20685,7 +20692,7 @@ export const PatchProjectsLocationsIssueModelsIssuesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsIssueModelsIssuesRequest>;
 
@@ -20717,7 +20724,7 @@ export const DeleteProjectsLocationsIssueModelsIssuesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsIssueModelsIssuesRequest>;
 
@@ -20754,7 +20761,7 @@ export const CreateProjectsLocationsIssueModelsIssuesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/issues", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/issues", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsIssueModelsIssuesRequest>;
 
@@ -20786,7 +20793,7 @@ export const GetProjectsLocationsIssueModelsIssuesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIssueModelsIssuesRequest>;
 
@@ -20818,7 +20825,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -20863,7 +20870,7 @@ export const ListProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -20899,7 +20906,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -20935,7 +20942,7 @@ export const InitializeProjectsLocationsEncryptionSpecRequest =
       GoogleCloudContactcenterinsightsV1InitializeEncryptionSpecRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:initialize", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:initialize", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<InitializeProjectsLocationsEncryptionSpecRequest>;
 
@@ -20967,7 +20974,7 @@ export const GetProjectsLocationsViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsViewsRequest>;
 
@@ -21005,7 +21012,7 @@ export const ListProjectsLocationsViewsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/views" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/views" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsViewsRequest>;
 
@@ -21049,7 +21056,7 @@ export const PatchProjectsLocationsViewsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsViewsRequest>;
 
@@ -21081,7 +21088,7 @@ export const DeleteProjectsLocationsViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsViewsRequest>;
 
@@ -21117,7 +21124,7 @@ export const CreateProjectsLocationsViewsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/views", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/views", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsViewsRequest>;
 
@@ -21149,7 +21156,7 @@ export const GetProjectsLocationsAnalysisRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAnalysisRulesRequest>;
 
@@ -21189,7 +21196,7 @@ export const PatchProjectsLocationsAnalysisRulesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAnalysisRulesRequest>;
 
@@ -21221,7 +21228,7 @@ export const DeleteProjectsLocationsAnalysisRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAnalysisRulesRequest>;
 
@@ -21259,7 +21266,7 @@ export const CreateProjectsLocationsAnalysisRulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/analysisRules",
+      path: "v1/{+parent}/analysisRules",
       hasBody: true,
     }),
     svc,
@@ -21299,7 +21306,7 @@ export const ListProjectsLocationsAnalysisRulesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/analysisRules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/analysisRules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAnalysisRulesRequest>;
 

--- a/packages/gcp/src/services/container-v1.ts
+++ b/packages/gcp/src/services/container-v1.ts
@@ -5053,6 +5053,52 @@ export const SetMonitoringServiceRequest =
   }).annotate({ identifier: "SetMonitoringServiceRequest" });
 
 // ==========================================================================
+// Errors
+// ==========================================================================
+
+export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
+  code: Schema.optional(Schema.Number),
+  message: Schema.String,
+  status: Schema.optional(Schema.String),
+  reason: Schema.optional(Schema.String),
+  domain: Schema.optional(Schema.String),
+}) {}
+T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
+
+export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
+  "BadRequest",
+  {
+    code: Schema.optional(Schema.Number),
+    message: Schema.String,
+    status: Schema.optional(Schema.String),
+    reason: Schema.optional(Schema.String),
+    domain: Schema.optional(Schema.String),
+  },
+) {}
+T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
+
+export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
+  "Forbidden",
+  {
+    code: Schema.optional(Schema.Number),
+    message: Schema.String,
+    status: Schema.optional(Schema.String),
+    reason: Schema.optional(Schema.String),
+    domain: Schema.optional(Schema.String),
+  },
+) {}
+T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
+
+export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
+  code: Schema.optional(Schema.Number),
+  message: Schema.String,
+  status: Schema.optional(Schema.String),
+  reason: Schema.optional(Schema.String),
+  domain: Schema.optional(Schema.String),
+}) {}
+T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
+
+// ==========================================================================
 // Operations
 // ==========================================================================
 
@@ -5161,7 +5207,12 @@ export type SetAddonsProjectsLocationsClustersResponse = Operation;
 export const SetAddonsProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetAddonsProjectsLocationsClustersError = DefaultErrors;
+export type SetAddonsProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Sets the addons for a specific cluster. */
 export const setAddonsProjectsLocationsClusters: API.OperationMethod<
@@ -5172,7 +5223,7 @@ export const setAddonsProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetAddonsProjectsLocationsClustersRequest,
   output: SetAddonsProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface SetMasterAuthProjectsLocationsClustersRequest {
@@ -5195,7 +5246,11 @@ export type SetMasterAuthProjectsLocationsClustersResponse = Operation;
 export const SetMasterAuthProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetMasterAuthProjectsLocationsClustersError = DefaultErrors;
+export type SetMasterAuthProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden;
 
 /** Sets master auth materials. Currently supports changing the admin password or a specific cluster, either via password generation or explicitly setting the password. */
 export const setMasterAuthProjectsLocationsClusters: API.OperationMethod<
@@ -5206,7 +5261,7 @@ export const setMasterAuthProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetMasterAuthProjectsLocationsClustersRequest,
   output: SetMasterAuthProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden],
 }));
 
 export interface SetMonitoringProjectsLocationsClustersRequest {
@@ -5229,7 +5284,12 @@ export type SetMonitoringProjectsLocationsClustersResponse = Operation;
 export const SetMonitoringProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetMonitoringProjectsLocationsClustersError = DefaultErrors;
+export type SetMonitoringProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Sets the monitoring service for a specific cluster. */
 export const setMonitoringProjectsLocationsClusters: API.OperationMethod<
@@ -5240,7 +5300,7 @@ export const setMonitoringProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetMonitoringProjectsLocationsClustersRequest,
   output: SetMonitoringProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface SetResourceLabelsProjectsLocationsClustersRequest {
@@ -5267,7 +5327,12 @@ export type SetResourceLabelsProjectsLocationsClustersResponse = Operation;
 export const SetResourceLabelsProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetResourceLabelsProjectsLocationsClustersError = DefaultErrors;
+export type SetResourceLabelsProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Sets labels on a cluster. */
 export const setResourceLabelsProjectsLocationsClusters: API.OperationMethod<
@@ -5278,7 +5343,7 @@ export const setResourceLabelsProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetResourceLabelsProjectsLocationsClustersRequest,
   output: SetResourceLabelsProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface SetLocationsProjectsLocationsClustersRequest {
@@ -5301,7 +5366,12 @@ export type SetLocationsProjectsLocationsClustersResponse = Operation;
 export const SetLocationsProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetLocationsProjectsLocationsClustersError = DefaultErrors;
+export type SetLocationsProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Sets the locations for a specific cluster. Deprecated. Use [projects.locations.clusters.update](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters/update) instead. */
 export const setLocationsProjectsLocationsClusters: API.OperationMethod<
@@ -5312,7 +5382,7 @@ export const setLocationsProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetLocationsProjectsLocationsClustersRequest,
   output: SetLocationsProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface GetProjectsLocationsClustersRequest {
@@ -5341,7 +5411,10 @@ export type GetProjectsLocationsClustersResponse = Cluster;
 export const GetProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Cluster;
 
-export type GetProjectsLocationsClustersError = DefaultErrors;
+export type GetProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | Forbidden;
 
 /** Gets the details of a specific cluster. */
 export const getProjectsLocationsClusters: API.OperationMethod<
@@ -5352,7 +5425,7 @@ export const getProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetProjectsLocationsClustersRequest,
   output: GetProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, Forbidden],
 }));
 
 export interface FetchClusterUpgradeInfoProjectsLocationsClustersRequest {
@@ -5411,7 +5484,11 @@ export type CreateProjectsLocationsClustersResponse = Operation;
 export const CreateProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type CreateProjectsLocationsClustersError = DefaultErrors;
+export type CreateProjectsLocationsClustersError =
+  | DefaultErrors
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Creates a cluster, consisting of the specified number and type of Google Compute Engine instances. By default, the cluster is created in the project's [default network](https://cloud.google.com/compute/docs/networks-and-firewalls#networks). One firewall is added for the cluster. After cluster creation, the kubelet creates routes for each node to allow the containers on that node to communicate with all other instances in the cluster. Finally, an entry is added to the project's global metadata indicating which CIDR range the cluster is using. */
 export const createProjectsLocationsClusters: API.OperationMethod<
@@ -5422,7 +5499,7 @@ export const createProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: CreateProjectsLocationsClustersRequest,
   output: CreateProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [BadRequest, Forbidden, Conflict],
 }));
 
 export interface ListProjectsLocationsClustersRequest {
@@ -5488,7 +5565,12 @@ export type DeleteProjectsLocationsClustersResponse = Operation;
 export const DeleteProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type DeleteProjectsLocationsClustersError = DefaultErrors;
+export type DeleteProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Deletes the cluster, including the Kubernetes endpoint and all worker nodes. Firewalls and routes that were configured during cluster creation are also deleted. Other Google Compute Engine resources that might be in use by the cluster, such as load balancer resources, are not deleted if they weren't present when the cluster was initially created. */
 export const deleteProjectsLocationsClusters: API.OperationMethod<
@@ -5499,7 +5581,7 @@ export const deleteProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: DeleteProjectsLocationsClustersRequest,
   output: DeleteProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface CheckAutopilotCompatibilityProjectsLocationsClustersRequest {
@@ -5559,7 +5641,12 @@ export type SetNetworkPolicyProjectsLocationsClustersResponse = Operation;
 export const SetNetworkPolicyProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetNetworkPolicyProjectsLocationsClustersError = DefaultErrors;
+export type SetNetworkPolicyProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Enables or disables Network Policy for a cluster. */
 export const setNetworkPolicyProjectsLocationsClusters: API.OperationMethod<
@@ -5570,7 +5657,7 @@ export const setNetworkPolicyProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetNetworkPolicyProjectsLocationsClustersRequest,
   output: SetNetworkPolicyProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface CompleteIpRotationProjectsLocationsClustersRequest {
@@ -5631,7 +5718,12 @@ export type SetLoggingProjectsLocationsClustersResponse = Operation;
 export const SetLoggingProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetLoggingProjectsLocationsClustersError = DefaultErrors;
+export type SetLoggingProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Sets the logging service for a specific cluster. */
 export const setLoggingProjectsLocationsClusters: API.OperationMethod<
@@ -5642,7 +5734,7 @@ export const setLoggingProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetLoggingProjectsLocationsClustersRequest,
   output: SetLoggingProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface UpdateProjectsLocationsClustersRequest {
@@ -5665,7 +5757,12 @@ export type UpdateProjectsLocationsClustersResponse = Operation;
 export const UpdateProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type UpdateProjectsLocationsClustersError = DefaultErrors;
+export type UpdateProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Updates the settings of a specific cluster. */
 export const updateProjectsLocationsClusters: API.OperationMethod<
@@ -5676,7 +5773,7 @@ export const updateProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: UpdateProjectsLocationsClustersRequest,
   output: UpdateProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface GetJwksProjectsLocationsClustersRequest {
@@ -5768,7 +5865,12 @@ export type SetMaintenancePolicyProjectsLocationsClustersResponse = Operation;
 export const SetMaintenancePolicyProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetMaintenancePolicyProjectsLocationsClustersError = DefaultErrors;
+export type SetMaintenancePolicyProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Sets the maintenance policy for a cluster. */
 export const setMaintenancePolicyProjectsLocationsClusters: API.OperationMethod<
@@ -5779,7 +5881,7 @@ export const setMaintenancePolicyProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetMaintenancePolicyProjectsLocationsClustersRequest,
   output: SetMaintenancePolicyProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface StartIpRotationProjectsLocationsClustersRequest {
@@ -5840,7 +5942,11 @@ export type SetLegacyAbacProjectsLocationsClustersResponse = Operation;
 export const SetLegacyAbacProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetLegacyAbacProjectsLocationsClustersError = DefaultErrors;
+export type SetLegacyAbacProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden;
 
 /** Enables or disables the ABAC authorization mechanism on a cluster. */
 export const setLegacyAbacProjectsLocationsClusters: API.OperationMethod<
@@ -5851,7 +5957,7 @@ export const setLegacyAbacProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetLegacyAbacProjectsLocationsClustersRequest,
   output: SetLegacyAbacProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden],
 }));
 
 export interface GetProjectsLocationsClustersNodePoolsRequest {
@@ -5883,7 +5989,10 @@ export type GetProjectsLocationsClustersNodePoolsResponse = NodePool;
 export const GetProjectsLocationsClustersNodePoolsResponse =
   /*@__PURE__*/ /*#__PURE__*/ NodePool;
 
-export type GetProjectsLocationsClustersNodePoolsError = DefaultErrors;
+export type GetProjectsLocationsClustersNodePoolsError =
+  | DefaultErrors
+  | NotFound
+  | Forbidden;
 
 /** Retrieves the requested node pool. */
 export const getProjectsLocationsClustersNodePools: API.OperationMethod<
@@ -5894,7 +6003,7 @@ export const getProjectsLocationsClustersNodePools: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetProjectsLocationsClustersNodePoolsRequest,
   output: GetProjectsLocationsClustersNodePoolsResponse,
-  errors: [],
+  errors: [NotFound, Forbidden],
 }));
 
 export interface UpdateProjectsLocationsClustersNodePoolsRequest {
@@ -5917,7 +6026,12 @@ export type UpdateProjectsLocationsClustersNodePoolsResponse = Operation;
 export const UpdateProjectsLocationsClustersNodePoolsResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type UpdateProjectsLocationsClustersNodePoolsError = DefaultErrors;
+export type UpdateProjectsLocationsClustersNodePoolsError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Updates the version and/or image type for the specified node pool. */
 export const updateProjectsLocationsClustersNodePools: API.OperationMethod<
@@ -5928,7 +6042,7 @@ export const updateProjectsLocationsClustersNodePools: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: UpdateProjectsLocationsClustersNodePoolsRequest,
   output: UpdateProjectsLocationsClustersNodePoolsResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface CreateProjectsLocationsClustersNodePoolsRequest {
@@ -5951,7 +6065,11 @@ export type CreateProjectsLocationsClustersNodePoolsResponse = Operation;
 export const CreateProjectsLocationsClustersNodePoolsResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type CreateProjectsLocationsClustersNodePoolsError = DefaultErrors;
+export type CreateProjectsLocationsClustersNodePoolsError =
+  | DefaultErrors
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Creates a node pool for a cluster. */
 export const createProjectsLocationsClustersNodePools: API.OperationMethod<
@@ -5962,7 +6080,7 @@ export const createProjectsLocationsClustersNodePools: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: CreateProjectsLocationsClustersNodePoolsRequest,
   output: CreateProjectsLocationsClustersNodePoolsResponse,
-  errors: [],
+  errors: [BadRequest, Forbidden, Conflict],
 }));
 
 export interface SetManagementProjectsLocationsClustersNodePoolsRequest {
@@ -5986,7 +6104,11 @@ export const SetManagementProjectsLocationsClustersNodePoolsResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
 export type SetManagementProjectsLocationsClustersNodePoolsError =
-  DefaultErrors;
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Sets the NodeManagement options for a node pool. */
 export const setManagementProjectsLocationsClustersNodePools: API.OperationMethod<
@@ -5997,7 +6119,7 @@ export const setManagementProjectsLocationsClustersNodePools: API.OperationMetho
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetManagementProjectsLocationsClustersNodePoolsRequest,
   output: SetManagementProjectsLocationsClustersNodePoolsResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface ListProjectsLocationsClustersNodePoolsRequest {
@@ -6131,7 +6253,12 @@ export type SetSizeProjectsLocationsClustersNodePoolsResponse = Operation;
 export const SetSizeProjectsLocationsClustersNodePoolsResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetSizeProjectsLocationsClustersNodePoolsError = DefaultErrors;
+export type SetSizeProjectsLocationsClustersNodePoolsError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Sets the size for a specific node pool. The new size will be used for all replicas, including future replicas created by modifying NodePool.locations. */
 export const setSizeProjectsLocationsClustersNodePools: API.OperationMethod<
@@ -6142,7 +6269,7 @@ export const setSizeProjectsLocationsClustersNodePools: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetSizeProjectsLocationsClustersNodePoolsRequest,
   output: SetSizeProjectsLocationsClustersNodePoolsResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface DeleteProjectsLocationsClustersNodePoolsRequest {
@@ -6174,7 +6301,12 @@ export type DeleteProjectsLocationsClustersNodePoolsResponse = Operation;
 export const DeleteProjectsLocationsClustersNodePoolsResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type DeleteProjectsLocationsClustersNodePoolsError = DefaultErrors;
+export type DeleteProjectsLocationsClustersNodePoolsError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Deletes a node pool from a cluster. */
 export const deleteProjectsLocationsClustersNodePools: API.OperationMethod<
@@ -6185,7 +6317,7 @@ export const deleteProjectsLocationsClustersNodePools: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: DeleteProjectsLocationsClustersNodePoolsRequest,
   output: DeleteProjectsLocationsClustersNodePoolsResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface CompleteUpgradeProjectsLocationsClustersNodePoolsRequest {
@@ -6253,7 +6385,11 @@ export const SetAutoscalingProjectsLocationsClustersNodePoolsResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
 export type SetAutoscalingProjectsLocationsClustersNodePoolsError =
-  DefaultErrors;
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Sets the autoscaling settings for the specified node pool. */
 export const setAutoscalingProjectsLocationsClustersNodePools: API.OperationMethod<
@@ -6264,7 +6400,7 @@ export const setAutoscalingProjectsLocationsClustersNodePools: API.OperationMeth
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetAutoscalingProjectsLocationsClustersNodePoolsRequest,
   output: SetAutoscalingProjectsLocationsClustersNodePoolsResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface GetOpenid_configurationProjectsLocationsClustersWell_knownRequest {
@@ -6402,7 +6538,10 @@ export type GetProjectsLocationsOperationsResponse = Operation;
 export const GetProjectsLocationsOperationsResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type GetProjectsLocationsOperationsError = DefaultErrors;
+export type GetProjectsLocationsOperationsError =
+  | DefaultErrors
+  | NotFound
+  | Forbidden;
 
 /** Gets the specified operation. */
 export const getProjectsLocationsOperations: API.OperationMethod<
@@ -6413,7 +6552,7 @@ export const getProjectsLocationsOperations: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetProjectsLocationsOperationsRequest,
   output: GetProjectsLocationsOperationsResponse,
-  errors: [],
+  errors: [NotFound, Forbidden],
 }));
 
 export interface GetServerconfigProjectsZonesRequest {

--- a/packages/gcp/src/services/container-v1.ts
+++ b/packages/gcp/src/services/container-v1.ts
@@ -5074,7 +5074,10 @@ export const ListProjectsAggregatedUsableSubnetworksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/aggregated/usableSubnetworks" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+parent}/aggregated/usableSubnetworks",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAggregatedUsableSubnetworksRequest>;
 
@@ -5116,7 +5119,7 @@ export const GetServerConfigProjectsLocationsRequest =
     zone: Schema.optional(Schema.String).pipe(T.HttpQuery("zone")),
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/serverConfig" }),
+    T.Http({ method: "GET", path: "v1/{+name}/serverConfig" }),
     svc,
   ) as unknown as Schema.Schema<GetServerConfigProjectsLocationsRequest>;
 
@@ -5150,7 +5153,7 @@ export const SetAddonsProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetAddonsConfigRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setAddons", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setAddons", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetAddonsProjectsLocationsClustersRequest>;
 
@@ -5184,7 +5187,7 @@ export const SetMasterAuthProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetMasterAuthRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setMasterAuth", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setMasterAuth", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetMasterAuthProjectsLocationsClustersRequest>;
 
@@ -5218,7 +5221,7 @@ export const SetMonitoringProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetMonitoringServiceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setMonitoring", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setMonitoring", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetMonitoringProjectsLocationsClustersRequest>;
 
@@ -5254,7 +5257,7 @@ export const SetResourceLabelsProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:setResourceLabels",
+      path: "v1/{+name}:setResourceLabels",
       hasBody: true,
     }),
     svc,
@@ -5290,7 +5293,7 @@ export const SetLocationsProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetLocationsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setLocations", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setLocations", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetLocationsProjectsLocationsClustersRequest>;
 
@@ -5330,7 +5333,7 @@ export const GetProjectsLocationsClustersRequest =
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
     clusterId: Schema.optional(Schema.String).pipe(T.HttpQuery("clusterId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersRequest>;
 
@@ -5364,7 +5367,7 @@ export const FetchClusterUpgradeInfoProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     version: Schema.optional(Schema.String).pipe(T.HttpQuery("version")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:fetchClusterUpgradeInfo" }),
+    T.Http({ method: "GET", path: "v1/{+name}:fetchClusterUpgradeInfo" }),
     svc,
   ) as unknown as Schema.Schema<FetchClusterUpgradeInfoProjectsLocationsClustersRequest>;
 
@@ -5400,7 +5403,7 @@ export const CreateProjectsLocationsClustersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/clusters", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/clusters", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsClustersRequest>;
 
@@ -5437,7 +5440,7 @@ export const ListProjectsLocationsClustersRequest =
     zone: Schema.optional(Schema.String).pipe(T.HttpQuery("zone")),
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/clusters" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/clusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersRequest>;
 
@@ -5477,7 +5480,7 @@ export const DeleteProjectsLocationsClustersRequest =
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
     zone: Schema.optional(Schema.String).pipe(T.HttpQuery("zone")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersRequest>;
 
@@ -5508,7 +5511,7 @@ export const CheckAutopilotCompatibilityProjectsLocationsClustersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:checkAutopilotCompatibility" }),
+    T.Http({ method: "GET", path: "v1/{+name}:checkAutopilotCompatibility" }),
     svc,
   ) as unknown as Schema.Schema<CheckAutopilotCompatibilityProjectsLocationsClustersRequest>;
 
@@ -5546,7 +5549,7 @@ export const SetNetworkPolicyProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:setNetworkPolicy",
+      path: "v1/{+name}:setNetworkPolicy",
       hasBody: true,
     }),
     svc,
@@ -5584,7 +5587,7 @@ export const CompleteIpRotationProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:completeIpRotation",
+      path: "v1/{+name}:completeIpRotation",
       hasBody: true,
     }),
     svc,
@@ -5620,7 +5623,7 @@ export const SetLoggingProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetLoggingServiceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setLogging", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setLogging", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetLoggingProjectsLocationsClustersRequest>;
 
@@ -5654,7 +5657,7 @@ export const UpdateProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsClustersRequest>;
 
@@ -5685,7 +5688,7 @@ export const GetJwksProjectsLocationsClustersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/jwks" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/jwks" }),
     svc,
   ) as unknown as Schema.Schema<GetJwksProjectsLocationsClustersRequest>;
 
@@ -5719,7 +5722,7 @@ export const UpdateMasterProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateMasterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:updateMaster", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:updateMaster", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateMasterProjectsLocationsClustersRequest>;
 
@@ -5755,7 +5758,7 @@ export const SetMaintenancePolicyProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:setMaintenancePolicy",
+      path: "v1/{+name}:setMaintenancePolicy",
       hasBody: true,
     }),
     svc,
@@ -5793,7 +5796,7 @@ export const StartIpRotationProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:startIpRotation",
+      path: "v1/{+name}:startIpRotation",
       hasBody: true,
     }),
     svc,
@@ -5829,7 +5832,7 @@ export const SetLegacyAbacProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetLegacyAbacRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setLegacyAbac", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setLegacyAbac", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetLegacyAbacProjectsLocationsClustersRequest>;
 
@@ -5872,7 +5875,7 @@ export const GetProjectsLocationsClustersNodePoolsRequest =
     zone: Schema.optional(Schema.String).pipe(T.HttpQuery("zone")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersNodePoolsRequest>;
 
@@ -5906,7 +5909,7 @@ export const UpdateProjectsLocationsClustersNodePoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateNodePoolRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsClustersNodePoolsRequest>;
 
@@ -5940,7 +5943,7 @@ export const CreateProjectsLocationsClustersNodePoolsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateNodePoolRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/nodePools", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/nodePools", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsClustersNodePoolsRequest>;
 
@@ -5974,7 +5977,7 @@ export const SetManagementProjectsLocationsClustersNodePoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetNodePoolManagementRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setManagement", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setManagement", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetManagementProjectsLocationsClustersNodePoolsRequest>;
 
@@ -6015,7 +6018,7 @@ export const ListProjectsLocationsClustersNodePoolsRequest =
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
     zone: Schema.optional(Schema.String).pipe(T.HttpQuery("zone")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/nodePools" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/nodePools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersNodePoolsRequest>;
 
@@ -6050,7 +6053,7 @@ export const RollbackProjectsLocationsClustersNodePoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RollbackNodePoolUpgradeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:rollback", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:rollback", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RollbackProjectsLocationsClustersNodePoolsRequest>;
 
@@ -6084,7 +6087,7 @@ export const FetchNodePoolUpgradeInfoProjectsLocationsClustersNodePoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     version: Schema.optional(Schema.String).pipe(T.HttpQuery("version")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:fetchNodePoolUpgradeInfo" }),
+    T.Http({ method: "GET", path: "v1/{+name}:fetchNodePoolUpgradeInfo" }),
     svc,
   ) as unknown as Schema.Schema<FetchNodePoolUpgradeInfoProjectsLocationsClustersNodePoolsRequest>;
 
@@ -6120,7 +6123,7 @@ export const SetSizeProjectsLocationsClustersNodePoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetNodePoolSizeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setSize", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setSize", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetSizeProjectsLocationsClustersNodePoolsRequest>;
 
@@ -6163,7 +6166,7 @@ export const DeleteProjectsLocationsClustersNodePoolsRequest =
     zone: Schema.optional(Schema.String).pipe(T.HttpQuery("zone")),
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersNodePoolsRequest>;
 
@@ -6199,7 +6202,7 @@ export const CompleteUpgradeProjectsLocationsClustersNodePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:completeUpgrade",
+      path: "v1/{+name}:completeUpgrade",
       hasBody: true,
     }),
     svc,
@@ -6236,7 +6239,11 @@ export const SetAutoscalingProjectsLocationsClustersNodePoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetNodePoolAutoscalingRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setAutoscaling", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+name}:setAutoscaling",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<SetAutoscalingProjectsLocationsClustersNodePoolsRequest>;
 
@@ -6271,7 +6278,7 @@ export const GetOpenid_configurationProjectsLocationsClustersWell_knownRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/.well-known/openid-configuration",
+      path: "v1/{+parent}/.well-known/openid-configuration",
     }),
     svc,
   ) as unknown as Schema.Schema<GetOpenid_configurationProjectsLocationsClustersWell_knownRequest>;
@@ -6308,7 +6315,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -6345,7 +6352,7 @@ export const ListProjectsLocationsOperationsRequest =
     zone: Schema.optional(Schema.String).pipe(T.HttpQuery("zone")),
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -6387,7 +6394,7 @@ export const GetProjectsLocationsOperationsRequest =
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -6676,7 +6683,7 @@ export const FetchClusterUpgradeInfoProjectsZonesClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     version: Schema.optional(Schema.String).pipe(T.HttpQuery("version")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:fetchClusterUpgradeInfo" }),
+    T.Http({ method: "GET", path: "v1/{+name}:fetchClusterUpgradeInfo" }),
     svc,
   ) as unknown as Schema.Schema<FetchClusterUpgradeInfoProjectsZonesClustersRequest>;
 
@@ -7776,7 +7783,7 @@ export const FetchNodePoolUpgradeInfoProjectsZonesClustersNodePoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     version: Schema.optional(Schema.String).pipe(T.HttpQuery("version")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:fetchNodePoolUpgradeInfo" }),
+    T.Http({ method: "GET", path: "v1/{+name}:fetchNodePoolUpgradeInfo" }),
     svc,
   ) as unknown as Schema.Schema<FetchNodePoolUpgradeInfoProjectsZonesClustersNodePoolsRequest>;
 

--- a/packages/gcp/src/services/container-v1beta1.ts
+++ b/packages/gcp/src/services/container-v1beta1.ts
@@ -5542,7 +5542,7 @@ export const ListProjectsAggregatedUsableSubnetworksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/aggregated/usableSubnetworks",
+      path: "v1beta1/{+parent}/aggregated/usableSubnetworks",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAggregatedUsableSubnetworksRequest>;
@@ -5749,7 +5749,7 @@ export const FetchClusterUpgradeInfoProjectsZonesClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     version: Schema.optional(Schema.String).pipe(T.HttpQuery("version")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:fetchClusterUpgradeInfo" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:fetchClusterUpgradeInfo" }),
     svc,
   ) as unknown as Schema.Schema<FetchClusterUpgradeInfoProjectsZonesClustersRequest>;
 
@@ -6527,7 +6527,7 @@ export const CompleteControlPlaneUpgradeProjectsZonesClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:completeControlPlaneUpgrade",
+      path: "v1beta1/{+name}:completeControlPlaneUpgrade",
       hasBody: true,
     }),
     svc,
@@ -6749,7 +6749,7 @@ export const FetchNodePoolUpgradeInfoProjectsZonesClustersNodePoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     version: Schema.optional(Schema.String).pipe(T.HttpQuery("version")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:fetchNodePoolUpgradeInfo" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:fetchNodePoolUpgradeInfo" }),
     svc,
   ) as unknown as Schema.Schema<FetchNodePoolUpgradeInfoProjectsZonesClustersNodePoolsRequest>;
 
@@ -7018,7 +7018,7 @@ export const GetServerConfigProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     zone: Schema.optional(Schema.String).pipe(T.HttpQuery("zone")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/serverConfig" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/serverConfig" }),
     svc,
   ) as unknown as Schema.Schema<GetServerConfigProjectsLocationsRequest>;
 
@@ -7049,7 +7049,7 @@ export const ListProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -7083,7 +7083,11 @@ export const SetAddonsProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetAddonsConfigRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:setAddons", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+name}:setAddons",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<SetAddonsProjectsLocationsClustersRequest>;
 
@@ -7119,7 +7123,7 @@ export const UpdateMasterProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:updateMaster",
+      path: "v1beta1/{+name}:updateMaster",
       hasBody: true,
     }),
     svc,
@@ -7157,7 +7161,7 @@ export const SetResourceLabelsProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:setResourceLabels",
+      path: "v1beta1/{+name}:setResourceLabels",
       hasBody: true,
     }),
     svc,
@@ -7193,7 +7197,7 @@ export const UpdateProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsClustersRequest>;
 
@@ -7229,7 +7233,7 @@ export const SetMasterAuthProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:setMasterAuth",
+      path: "v1beta1/{+name}:setMasterAuth",
       hasBody: true,
     }),
     svc,
@@ -7269,7 +7273,7 @@ export const CompleteControlPlaneUpgradeProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:completeControlPlaneUpgrade",
+      path: "v1beta1/{+name}:completeControlPlaneUpgrade",
       hasBody: true,
     }),
     svc,
@@ -7309,7 +7313,7 @@ export const SetLocationsProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:setLocations",
+      path: "v1beta1/{+name}:setLocations",
       hasBody: true,
     }),
     svc,
@@ -7347,7 +7351,7 @@ export const CompleteIpRotationProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:completeIpRotation",
+      path: "v1beta1/{+name}:completeIpRotation",
       hasBody: true,
     }),
     svc,
@@ -7385,7 +7389,7 @@ export const CreateProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/clusters",
+      path: "v1beta1/{+parent}/clusters",
       hasBody: true,
     }),
     svc,
@@ -7420,7 +7424,7 @@ export const CheckAutopilotCompatibilityProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{name}:checkAutopilotCompatibility",
+      path: "v1beta1/{+name}:checkAutopilotCompatibility",
     }),
     svc,
   ) as unknown as Schema.Schema<CheckAutopilotCompatibilityProjectsLocationsClustersRequest>;
@@ -7459,7 +7463,7 @@ export const SetLoggingProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:setLogging",
+      path: "v1beta1/{+name}:setLogging",
       hasBody: true,
     }),
     svc,
@@ -7498,7 +7502,7 @@ export const ListProjectsLocationsClustersRequest =
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
     zone: Schema.optional(Schema.String).pipe(T.HttpQuery("zone")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/clusters" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/clusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersRequest>;
 
@@ -7534,7 +7538,7 @@ export const SetLegacyAbacProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:setLegacyAbac",
+      path: "v1beta1/{+name}:setLegacyAbac",
       hasBody: true,
     }),
     svc,
@@ -7570,7 +7574,7 @@ export const FetchClusterUpgradeInfoProjectsLocationsClustersRequest =
     version: Schema.optional(Schema.String).pipe(T.HttpQuery("version")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:fetchClusterUpgradeInfo" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:fetchClusterUpgradeInfo" }),
     svc,
   ) as unknown as Schema.Schema<FetchClusterUpgradeInfoProjectsLocationsClustersRequest>;
 
@@ -7612,7 +7616,7 @@ export const GetProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersRequest>;
 
@@ -7643,7 +7647,7 @@ export const GetJwksProjectsLocationsClustersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/jwks" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/jwks" }),
     svc,
   ) as unknown as Schema.Schema<GetJwksProjectsLocationsClustersRequest>;
 
@@ -7679,7 +7683,7 @@ export const StartIpRotationProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:startIpRotation",
+      path: "v1beta1/{+name}:startIpRotation",
       hasBody: true,
     }),
     svc,
@@ -7717,7 +7721,7 @@ export const SetMonitoringProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:setMonitoring",
+      path: "v1beta1/{+name}:setMonitoring",
       hasBody: true,
     }),
     svc,
@@ -7755,7 +7759,7 @@ export const SetMaintenancePolicyProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:setMaintenancePolicy",
+      path: "v1beta1/{+name}:setMaintenancePolicy",
       hasBody: true,
     }),
     svc,
@@ -7797,7 +7801,7 @@ export const DeleteProjectsLocationsClustersRequest =
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
     clusterId: Schema.optional(Schema.String).pipe(T.HttpQuery("clusterId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersRequest>;
 
@@ -7833,7 +7837,7 @@ export const SetNetworkPolicyProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:setNetworkPolicy",
+      path: "v1beta1/{+name}:setNetworkPolicy",
       hasBody: true,
     }),
     svc,
@@ -7868,7 +7872,7 @@ export const GetOpenid_configurationProjectsLocationsClustersWell_knownRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/.well-known/openid-configuration",
+      path: "v1beta1/{+parent}/.well-known/openid-configuration",
     }),
     svc,
   ) as unknown as Schema.Schema<GetOpenid_configurationProjectsLocationsClustersWell_knownRequest>;
@@ -7905,7 +7909,7 @@ export const RollbackProjectsLocationsClustersNodePoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RollbackNodePoolUpgradeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:rollback", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:rollback", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RollbackProjectsLocationsClustersNodePoolsRequest>;
 
@@ -7945,7 +7949,7 @@ export const ListProjectsLocationsClustersNodePoolsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/nodePools" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/nodePools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersNodePoolsRequest>;
 
@@ -7980,7 +7984,7 @@ export const SetSizeProjectsLocationsClustersNodePoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetNodePoolSizeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:setSize", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:setSize", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetSizeProjectsLocationsClustersNodePoolsRequest>;
 
@@ -8016,7 +8020,7 @@ export const SetAutoscalingProjectsLocationsClustersNodePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:setAutoscaling",
+      path: "v1beta1/{+name}:setAutoscaling",
       hasBody: true,
     }),
     svc,
@@ -8063,7 +8067,7 @@ export const GetProjectsLocationsClustersNodePoolsRequest =
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
     nodePoolId: Schema.optional(Schema.String).pipe(T.HttpQuery("nodePoolId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersNodePoolsRequest>;
 
@@ -8099,7 +8103,7 @@ export const CompleteUpgradeProjectsLocationsClustersNodePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:completeUpgrade",
+      path: "v1beta1/{+name}:completeUpgrade",
       hasBody: true,
     }),
     svc,
@@ -8138,7 +8142,7 @@ export const CreateProjectsLocationsClustersNodePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/nodePools",
+      path: "v1beta1/{+parent}/nodePools",
       hasBody: true,
     }),
     svc,
@@ -8174,7 +8178,7 @@ export const FetchNodePoolUpgradeInfoProjectsLocationsClustersNodePoolsRequest =
     version: Schema.optional(Schema.String).pipe(T.HttpQuery("version")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:fetchNodePoolUpgradeInfo" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:fetchNodePoolUpgradeInfo" }),
     svc,
   ) as unknown as Schema.Schema<FetchNodePoolUpgradeInfoProjectsLocationsClustersNodePoolsRequest>;
 
@@ -8210,7 +8214,7 @@ export const UpdateProjectsLocationsClustersNodePoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateNodePoolRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsClustersNodePoolsRequest>;
 
@@ -8246,7 +8250,7 @@ export const SetManagementProjectsLocationsClustersNodePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:setManagement",
+      path: "v1beta1/{+name}:setManagement",
       hasBody: true,
     }),
     svc,
@@ -8292,7 +8296,7 @@ export const DeleteProjectsLocationsClustersNodePoolsRequest =
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
     nodePoolId: Schema.optional(Schema.String).pipe(T.HttpQuery("nodePoolId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersNodePoolsRequest>;
 
@@ -8334,7 +8338,7 @@ export const GetProjectsLocationsOperationsRequest =
     ),
     zone: Schema.optional(Schema.String).pipe(T.HttpQuery("zone")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -8368,7 +8372,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -8405,7 +8409,7 @@ export const ListProjectsLocationsOperationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/containeranalysis-v1.ts
+++ b/packages/gcp/src/services/containeranalysis-v1.ts
@@ -3953,7 +3953,7 @@ export const GetProjectsOccurrencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOccurrencesRequest>;
 
@@ -3998,7 +3998,7 @@ export const ListProjectsOccurrencesRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/occurrences" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/occurrences" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsOccurrencesRequest>;
 
@@ -4033,7 +4033,7 @@ export const DeleteProjectsOccurrencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsOccurrencesRequest>;
 
@@ -4067,7 +4067,7 @@ export const CreateProjectsOccurrencesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Occurrence).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/occurrences", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/occurrences", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsOccurrencesRequest>;
 
@@ -4103,7 +4103,7 @@ export const BatchCreateProjectsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/occurrences:batchCreate",
+      path: "v1/{+parent}/occurrences:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -4143,7 +4143,7 @@ export const PatchProjectsOccurrencesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Occurrence).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsOccurrencesRequest>;
 
@@ -4174,7 +4174,7 @@ export const GetNotesProjectsOccurrencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/notes" }),
+    T.Http({ method: "GET", path: "v1/{+name}/notes" }),
     svc,
   ) as unknown as Schema.Schema<GetNotesProjectsOccurrencesRequest>;
 
@@ -4210,7 +4210,7 @@ export const SetIamPolicyProjectsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4248,7 +4248,7 @@ export const GetIamPolicyProjectsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4286,7 +4286,7 @@ export const TestIamPermissionsProjectsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4330,7 +4330,7 @@ export const GetVulnerabilitySummaryProjectsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/occurrences:vulnerabilitySummary",
+      path: "v1/{+parent}/occurrences:vulnerabilitySummary",
     }),
     svc,
   ) as unknown as Schema.Schema<GetVulnerabilitySummaryProjectsOccurrencesRequest>;
@@ -4363,7 +4363,7 @@ export const GetProjectsLocationsOccurrencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOccurrencesRequest>;
 
@@ -4408,7 +4408,7 @@ export const ListProjectsLocationsOccurrencesRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/occurrences" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/occurrences" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOccurrencesRequest>;
 
@@ -4443,7 +4443,7 @@ export const DeleteProjectsLocationsOccurrencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOccurrencesRequest>;
 
@@ -4477,7 +4477,7 @@ export const CreateProjectsLocationsOccurrencesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Occurrence).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/occurrences", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/occurrences", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsOccurrencesRequest>;
 
@@ -4513,7 +4513,7 @@ export const BatchCreateProjectsLocationsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/occurrences:batchCreate",
+      path: "v1/{+parent}/occurrences:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -4553,7 +4553,7 @@ export const PatchProjectsLocationsOccurrencesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Occurrence).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsOccurrencesRequest>;
 
@@ -4584,7 +4584,7 @@ export const GetNotesProjectsLocationsOccurrencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/notes" }),
+    T.Http({ method: "GET", path: "v1/{+name}/notes" }),
     svc,
   ) as unknown as Schema.Schema<GetNotesProjectsLocationsOccurrencesRequest>;
 
@@ -4620,7 +4620,7 @@ export const SetIamPolicyProjectsLocationsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4658,7 +4658,7 @@ export const GetIamPolicyProjectsLocationsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4696,7 +4696,7 @@ export const TestIamPermissionsProjectsLocationsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4740,7 +4740,7 @@ export const GetVulnerabilitySummaryProjectsLocationsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/occurrences:vulnerabilitySummary",
+      path: "v1/{+parent}/occurrences:vulnerabilitySummary",
     }),
     svc,
   ) as unknown as Schema.Schema<GetVulnerabilitySummaryProjectsLocationsOccurrencesRequest>;
@@ -4774,7 +4774,7 @@ export const GetProjectsLocationsNotesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNotesRequest>;
 
@@ -4819,7 +4819,7 @@ export const ListProjectsLocationsNotesRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/notes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/notes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNotesRequest>;
 
@@ -4854,7 +4854,7 @@ export const DeleteProjectsLocationsNotesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNotesRequest>;
 
@@ -4891,7 +4891,7 @@ export const CreateProjectsLocationsNotesRequest =
     noteId: Schema.optional(Schema.String).pipe(T.HttpQuery("noteId")),
     body: Schema.optional(Note).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/notes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/notes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsNotesRequest>;
 
@@ -4927,7 +4927,7 @@ export const BatchCreateProjectsLocationsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/notes:batchCreate",
+      path: "v1/{+parent}/notes:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -4967,7 +4967,7 @@ export const PatchProjectsLocationsNotesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Note).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsNotesRequest>;
 
@@ -5003,7 +5003,7 @@ export const SetIamPolicyProjectsLocationsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5041,7 +5041,7 @@ export const GetIamPolicyProjectsLocationsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5079,7 +5079,7 @@ export const TestIamPermissionsProjectsLocationsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5122,7 +5122,7 @@ export const ListProjectsLocationsNotesOccurrencesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/occurrences" }),
+    T.Http({ method: "GET", path: "v1/{+name}/occurrences" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNotesOccurrencesRequest>;
 
@@ -5161,7 +5161,7 @@ export const ExportSBOMProjectsLocationsResourcesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportSBOMRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:exportSBOM", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:exportSBOM", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportSBOMProjectsLocationsResourcesRequest>;
 
@@ -5192,7 +5192,7 @@ export const GetProjectsNotesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsNotesRequest>;
 
@@ -5236,7 +5236,7 @@ export const ListProjectsNotesRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/notes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/notes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsNotesRequest>;
 
@@ -5271,7 +5271,7 @@ export const DeleteProjectsNotesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsNotesRequest>;
 
@@ -5307,7 +5307,7 @@ export const CreateProjectsNotesRequest =
     noteId: Schema.optional(Schema.String).pipe(T.HttpQuery("noteId")),
     body: Schema.optional(Note).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/notes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/notes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsNotesRequest>;
 
@@ -5342,7 +5342,7 @@ export const BatchCreateProjectsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/notes:batchCreate",
+      path: "v1/{+parent}/notes:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -5381,7 +5381,7 @@ export const PatchProjectsNotesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Note).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsNotesRequest>;
 
@@ -5416,7 +5416,7 @@ export const SetIamPolicyProjectsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5454,7 +5454,7 @@ export const GetIamPolicyProjectsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5492,7 +5492,7 @@ export const TestIamPermissionsProjectsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5535,7 +5535,7 @@ export const ListProjectsNotesOccurrencesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/occurrences" }),
+    T.Http({ method: "GET", path: "v1/{+name}/occurrences" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsNotesOccurrencesRequest>;
 
@@ -5573,7 +5573,7 @@ export const ExportSBOMProjectsResourcesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportSBOMRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:exportSBOM", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:exportSBOM", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportSBOMProjectsResourcesRequest>;
 

--- a/packages/gcp/src/services/containeranalysis-v1alpha1.ts
+++ b/packages/gcp/src/services/containeranalysis-v1alpha1.ts
@@ -4399,7 +4399,7 @@ export const GetProjectsOccurrencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOccurrencesRequest>;
 
@@ -4464,7 +4464,7 @@ export const ListProjectsOccurrencesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     kind: Schema.optional(Schema.String).pipe(T.HttpQuery("kind")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/occurrences" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/occurrences" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsOccurrencesRequest>;
 
@@ -4499,7 +4499,7 @@ export const DeleteProjectsOccurrencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsOccurrencesRequest>;
 
@@ -4538,7 +4538,7 @@ export const CreateProjectsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/occurrences",
+      path: "v1alpha1/{+parent}/occurrences",
       hasBody: true,
     }),
     svc,
@@ -4577,7 +4577,7 @@ export const PatchProjectsOccurrencesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Occurrence).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsOccurrencesRequest>;
 
@@ -4608,7 +4608,7 @@ export const GetNotesProjectsOccurrencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/notes" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/notes" }),
     svc,
   ) as unknown as Schema.Schema<GetNotesProjectsOccurrencesRequest>;
 
@@ -4644,7 +4644,7 @@ export const GetVulnerabilitySummaryProjectsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha1/{parent}/occurrences:vulnerabilitySummary",
+      path: "v1alpha1/{+parent}/occurrences:vulnerabilitySummary",
     }),
     svc,
   ) as unknown as Schema.Schema<GetVulnerabilitySummaryProjectsOccurrencesRequest>;
@@ -4682,7 +4682,7 @@ export const SetIamPolicyProjectsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:setIamPolicy",
+      path: "v1alpha1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4720,7 +4720,7 @@ export const GetIamPolicyProjectsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:getIamPolicy",
+      path: "v1alpha1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4758,7 +4758,7 @@ export const TestIamPermissionsProjectsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:testIamPermissions",
+      path: "v1alpha1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4792,7 +4792,7 @@ export const GetProjectsNotesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsNotesRequest>;
 
@@ -4834,7 +4834,7 @@ export const ListProjectsNotesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/notes" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/notes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsNotesRequest>;
 
@@ -4869,7 +4869,7 @@ export const DeleteProjectsNotesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsNotesRequest>;
 
@@ -4908,7 +4908,7 @@ export const CreateProjectsNotesRequest =
     noteId: Schema.optional(Schema.String).pipe(T.HttpQuery("noteId")),
     body: Schema.optional(Note).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{parent}/notes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+parent}/notes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsNotesRequest>;
 
@@ -4944,7 +4944,7 @@ export const PatchProjectsNotesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Note).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsNotesRequest>;
 
@@ -4979,7 +4979,7 @@ export const SetIamPolicyProjectsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:setIamPolicy",
+      path: "v1alpha1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5017,7 +5017,7 @@ export const GetIamPolicyProjectsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:getIamPolicy",
+      path: "v1alpha1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5055,7 +5055,7 @@ export const TestIamPermissionsProjectsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:testIamPermissions",
+      path: "v1alpha1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5098,7 +5098,7 @@ export const ListProjectsNotesOccurrencesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/occurrences" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/occurrences" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsNotesOccurrencesRequest>;
 
@@ -5138,7 +5138,7 @@ export const CreateProjectsOperationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/operations",
+      path: "v1alpha1/{+parent}/operations",
       hasBody: true,
     }),
     svc,
@@ -5174,7 +5174,7 @@ export const PatchProjectsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsOperationsRequest>;
 
@@ -5205,7 +5205,7 @@ export const GetProjectsScanConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsScanConfigsRequest>;
 
@@ -5245,7 +5245,7 @@ export const ListProjectsScanConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/scanConfigs" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/scanConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsScanConfigsRequest>;
 
@@ -5286,7 +5286,7 @@ export const PatchProjectsScanConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ScanConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsScanConfigsRequest>;
 
@@ -5317,7 +5317,7 @@ export const GetProvidersNotesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProvidersNotesRequest>;
 
@@ -5359,7 +5359,7 @@ export const ListProvidersNotesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/notes" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/notes" }),
     svc,
   ) as unknown as Schema.Schema<ListProvidersNotesRequest>;
 
@@ -5394,7 +5394,7 @@ export const DeleteProvidersNotesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProvidersNotesRequest>;
 
@@ -5433,7 +5433,7 @@ export const CreateProvidersNotesRequest =
     noteId: Schema.optional(Schema.String).pipe(T.HttpQuery("noteId")),
     body: Schema.optional(Note).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}/notes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}/notes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProvidersNotesRequest>;
 
@@ -5469,7 +5469,7 @@ export const PatchProvidersNotesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Note).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProvidersNotesRequest>;
 
@@ -5504,7 +5504,7 @@ export const SetIamPolicyProvidersNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:setIamPolicy",
+      path: "v1alpha1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5542,7 +5542,7 @@ export const GetIamPolicyProvidersNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:getIamPolicy",
+      path: "v1alpha1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5580,7 +5580,7 @@ export const TestIamPermissionsProvidersNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:testIamPermissions",
+      path: "v1alpha1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5623,7 +5623,7 @@ export const ListProvidersNotesOccurrencesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/occurrences" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/occurrences" }),
     svc,
   ) as unknown as Schema.Schema<ListProvidersNotesOccurrencesRequest>;
 

--- a/packages/gcp/src/services/containeranalysis-v1beta1.ts
+++ b/packages/gcp/src/services/containeranalysis-v1beta1.ts
@@ -3982,7 +3982,7 @@ export const GetProjectsOccurrencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOccurrencesRequest>;
 
@@ -4027,7 +4027,7 @@ export const ListProjectsOccurrencesRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/occurrences" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/occurrences" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsOccurrencesRequest>;
 
@@ -4062,7 +4062,7 @@ export const DeleteProjectsOccurrencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsOccurrencesRequest>;
 
@@ -4098,7 +4098,7 @@ export const CreateProjectsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/occurrences",
+      path: "v1beta1/{+parent}/occurrences",
       hasBody: true,
     }),
     svc,
@@ -4136,7 +4136,7 @@ export const BatchCreateProjectsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/occurrences:batchCreate",
+      path: "v1beta1/{+parent}/occurrences:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -4176,7 +4176,7 @@ export const PatchProjectsOccurrencesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Occurrence).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsOccurrencesRequest>;
 
@@ -4207,7 +4207,7 @@ export const GetNotesProjectsOccurrencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/notes" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/notes" }),
     svc,
   ) as unknown as Schema.Schema<GetNotesProjectsOccurrencesRequest>;
 
@@ -4248,7 +4248,7 @@ export const GetVulnerabilitySummaryProjectsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/occurrences:vulnerabilitySummary",
+      path: "v1beta1/{+parent}/occurrences:vulnerabilitySummary",
     }),
     svc,
   ) as unknown as Schema.Schema<GetVulnerabilitySummaryProjectsOccurrencesRequest>;
@@ -4286,7 +4286,7 @@ export const SetIamPolicyProjectsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4324,7 +4324,7 @@ export const GetIamPolicyProjectsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4362,7 +4362,7 @@ export const TestIamPermissionsProjectsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4396,7 +4396,7 @@ export const GetProjectsLocationsOccurrencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOccurrencesRequest>;
 
@@ -4441,7 +4441,7 @@ export const ListProjectsLocationsOccurrencesRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/occurrences" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/occurrences" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOccurrencesRequest>;
 
@@ -4476,7 +4476,7 @@ export const DeleteProjectsLocationsOccurrencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOccurrencesRequest>;
 
@@ -4512,7 +4512,7 @@ export const CreateProjectsLocationsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/occurrences",
+      path: "v1beta1/{+parent}/occurrences",
       hasBody: true,
     }),
     svc,
@@ -4550,7 +4550,7 @@ export const BatchCreateProjectsLocationsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/occurrences:batchCreate",
+      path: "v1beta1/{+parent}/occurrences:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -4590,7 +4590,7 @@ export const PatchProjectsLocationsOccurrencesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Occurrence).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsOccurrencesRequest>;
 
@@ -4621,7 +4621,7 @@ export const GetNotesProjectsLocationsOccurrencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/notes" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/notes" }),
     svc,
   ) as unknown as Schema.Schema<GetNotesProjectsLocationsOccurrencesRequest>;
 
@@ -4662,7 +4662,7 @@ export const GetVulnerabilitySummaryProjectsLocationsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/occurrences:vulnerabilitySummary",
+      path: "v1beta1/{+parent}/occurrences:vulnerabilitySummary",
     }),
     svc,
   ) as unknown as Schema.Schema<GetVulnerabilitySummaryProjectsLocationsOccurrencesRequest>;
@@ -4701,7 +4701,7 @@ export const SetIamPolicyProjectsLocationsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4739,7 +4739,7 @@ export const GetIamPolicyProjectsLocationsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4777,7 +4777,7 @@ export const TestIamPermissionsProjectsLocationsOccurrencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4811,7 +4811,7 @@ export const GetProjectsLocationsNotesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNotesRequest>;
 
@@ -4856,7 +4856,7 @@ export const ListProjectsLocationsNotesRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/notes" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/notes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNotesRequest>;
 
@@ -4891,7 +4891,7 @@ export const DeleteProjectsLocationsNotesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNotesRequest>;
 
@@ -4928,7 +4928,7 @@ export const CreateProjectsLocationsNotesRequest =
     noteId: Schema.optional(Schema.String).pipe(T.HttpQuery("noteId")),
     body: Schema.optional(Note).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/notes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+parent}/notes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsNotesRequest>;
 
@@ -4964,7 +4964,7 @@ export const BatchCreateProjectsLocationsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/notes:batchCreate",
+      path: "v1beta1/{+parent}/notes:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -5004,7 +5004,7 @@ export const PatchProjectsLocationsNotesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Note).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsNotesRequest>;
 
@@ -5040,7 +5040,7 @@ export const SetIamPolicyProjectsLocationsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5078,7 +5078,7 @@ export const GetIamPolicyProjectsLocationsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5116,7 +5116,7 @@ export const TestIamPermissionsProjectsLocationsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5159,7 +5159,7 @@ export const ListProjectsLocationsNotesOccurrencesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/occurrences" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/occurrences" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNotesOccurrencesRequest>;
 
@@ -5200,7 +5200,7 @@ export const GeneratePackagesSummaryProjectsLocationsResourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:generatePackagesSummary",
+      path: "v1beta1/{+name}:generatePackagesSummary",
       hasBody: true,
     }),
     svc,
@@ -5240,7 +5240,7 @@ export const ExportSBOMProjectsLocationsResourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:exportSBOM",
+      path: "v1beta1/{+name}:exportSBOM",
       hasBody: true,
     }),
     svc,
@@ -5273,7 +5273,7 @@ export const GetProjectsNotesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsNotesRequest>;
 
@@ -5317,7 +5317,7 @@ export const ListProjectsNotesRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/notes" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/notes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsNotesRequest>;
 
@@ -5352,7 +5352,7 @@ export const DeleteProjectsNotesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsNotesRequest>;
 
@@ -5388,7 +5388,7 @@ export const CreateProjectsNotesRequest =
     noteId: Schema.optional(Schema.String).pipe(T.HttpQuery("noteId")),
     body: Schema.optional(Note).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/notes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+parent}/notes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsNotesRequest>;
 
@@ -5423,7 +5423,7 @@ export const BatchCreateProjectsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/notes:batchCreate",
+      path: "v1beta1/{+parent}/notes:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -5462,7 +5462,7 @@ export const PatchProjectsNotesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Note).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsNotesRequest>;
 
@@ -5497,7 +5497,7 @@ export const SetIamPolicyProjectsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5535,7 +5535,7 @@ export const GetIamPolicyProjectsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5573,7 +5573,7 @@ export const TestIamPermissionsProjectsNotesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5616,7 +5616,7 @@ export const ListProjectsNotesOccurrencesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/occurrences" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/occurrences" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsNotesOccurrencesRequest>;
 
@@ -5656,7 +5656,7 @@ export const GeneratePackagesSummaryProjectsResourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:generatePackagesSummary",
+      path: "v1beta1/{+name}:generatePackagesSummary",
       hasBody: true,
     }),
     svc,
@@ -5695,7 +5695,7 @@ export const ExportSBOMProjectsResourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:exportSBOM",
+      path: "v1beta1/{+name}:exportSBOM",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/contentwarehouse-v1.ts
+++ b/packages/gcp/src/services/contentwarehouse-v1.ts
@@ -3931,7 +3931,7 @@ export const FetchAclProjectsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{resource}:fetchAcl", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+resource}:fetchAcl", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<FetchAclProjectsRequest>;
 
@@ -3967,7 +3967,7 @@ export const SetAclProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpBody(),
   ),
 }).pipe(
-  T.Http({ method: "POST", path: "v1/{resource}:setAcl", hasBody: true }),
+  T.Http({ method: "POST", path: "v1/{+resource}:setAcl", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<SetAclProjectsRequest>;
 
@@ -4004,7 +4004,7 @@ export const RunPipelineProjectsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:runPipeline", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:runPipeline", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunPipelineProjectsLocationsRequest>;
 
@@ -4035,7 +4035,7 @@ export const GetStatusProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     location: Schema.String.pipe(T.HttpPath("location")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{location}:getStatus" }),
+    T.Http({ method: "GET", path: "v1/{+location}:getStatus" }),
     svc,
   ) as unknown as Schema.Schema<GetStatusProjectsLocationsRequest>;
 
@@ -4072,7 +4072,11 @@ export const InitializeProjectsLocationsRequest =
       GoogleCloudContentwarehouseV1InitializeProjectRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{location}:initialize", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+location}:initialize",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<InitializeProjectsLocationsRequest>;
 
@@ -4103,7 +4107,7 @@ export const GetProjectsLocationsDocumentSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDocumentSchemasRequest>;
 
@@ -4140,7 +4144,7 @@ export const PatchProjectsLocationsDocumentSchemasRequest =
       GoogleCloudContentwarehouseV1UpdateDocumentSchemaRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDocumentSchemasRequest>;
 
@@ -4172,7 +4176,7 @@ export const DeleteProjectsLocationsDocumentSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDocumentSchemasRequest>;
 
@@ -4211,7 +4215,7 @@ export const CreateProjectsLocationsDocumentSchemasRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/documentSchemas",
+      path: "v1/{+parent}/documentSchemas",
       hasBody: true,
     }),
     svc,
@@ -4251,7 +4255,7 @@ export const ListProjectsLocationsDocumentSchemasRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/documentSchemas" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/documentSchemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDocumentSchemasRequest>;
 
@@ -4287,7 +4291,7 @@ export const GetProjectsLocationsSynonymSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSynonymSetsRequest>;
 
@@ -4324,7 +4328,7 @@ export const PatchProjectsLocationsSynonymSetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSynonymSetsRequest>;
 
@@ -4362,7 +4366,7 @@ export const ListProjectsLocationsSynonymSetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/synonymSets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/synonymSets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSynonymSetsRequest>;
 
@@ -4398,7 +4402,7 @@ export const DeleteProjectsLocationsSynonymSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSynonymSetsRequest>;
 
@@ -4434,7 +4438,7 @@ export const CreateProjectsLocationsSynonymSetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/synonymSets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/synonymSets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSynonymSetsRequest>;
 
@@ -4466,7 +4470,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -4504,7 +4508,7 @@ export const LinkedTargetsProjectsLocationsDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/linkedTargets",
+      path: "v1/{+parent}/linkedTargets",
       hasBody: true,
     }),
     svc,
@@ -4543,7 +4547,7 @@ export const SetAclProjectsLocationsDocumentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{resource}:setAcl", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+resource}:setAcl", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetAclProjectsLocationsDocumentsRequest>;
 
@@ -4580,7 +4584,7 @@ export const CreateProjectsLocationsDocumentsRequest =
       GoogleCloudContentwarehouseV1CreateDocumentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/documents", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/documents", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDocumentsRequest>;
 
@@ -4619,7 +4623,7 @@ export const LinkedSourcesProjectsLocationsDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/linkedSources",
+      path: "v1/{+parent}/linkedSources",
       hasBody: true,
     }),
     svc,
@@ -4658,7 +4662,7 @@ export const FetchAclProjectsLocationsDocumentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{resource}:fetchAcl", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+resource}:fetchAcl", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<FetchAclProjectsLocationsDocumentsRequest>;
 
@@ -4695,7 +4699,7 @@ export const PatchProjectsLocationsDocumentsRequest =
       GoogleCloudContentwarehouseV1UpdateDocumentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDocumentsRequest>;
 
@@ -4734,7 +4738,7 @@ export const SearchProjectsLocationsDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/documents:search",
+      path: "v1/{+parent}/documents:search",
       hasBody: true,
     }),
     svc,
@@ -4773,7 +4777,7 @@ export const GetProjectsLocationsDocumentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:get", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:get", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDocumentsRequest>;
 
@@ -4810,7 +4814,7 @@ export const DeleteProjectsLocationsDocumentsRequest =
       GoogleCloudContentwarehouseV1DeleteDocumentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:delete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:delete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDocumentsRequest>;
 
@@ -4846,7 +4850,7 @@ export const LockProjectsLocationsDocumentsRequest =
       GoogleCloudContentwarehouseV1LockDocumentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:lock", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:lock", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<LockProjectsLocationsDocumentsRequest>;
 
@@ -4883,7 +4887,7 @@ export const PatchProjectsLocationsDocumentsReferenceIdRequest =
       GoogleCloudContentwarehouseV1UpdateDocumentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDocumentsReferenceIdRequest>;
 
@@ -4920,7 +4924,7 @@ export const DeleteProjectsLocationsDocumentsReferenceIdRequest =
       GoogleCloudContentwarehouseV1DeleteDocumentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:delete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:delete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDocumentsReferenceIdRequest>;
 
@@ -4957,7 +4961,7 @@ export const GetProjectsLocationsDocumentsReferenceIdRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:get", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:get", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDocumentsReferenceIdRequest>;
 
@@ -4994,7 +4998,7 @@ export const DeleteProjectsLocationsDocumentsDocumentLinksRequest =
       GoogleCloudContentwarehouseV1DeleteDocumentLinkRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:delete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:delete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDocumentsDocumentLinksRequest>;
 
@@ -5033,7 +5037,7 @@ export const CreateProjectsLocationsDocumentsDocumentLinksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/documentLinks",
+      path: "v1/{+parent}/documentLinks",
       hasBody: true,
     }),
     svc,
@@ -5072,7 +5076,7 @@ export const CreateProjectsLocationsRuleSetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/ruleSets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/ruleSets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRuleSetsRequest>;
 
@@ -5109,7 +5113,7 @@ export const PatchProjectsLocationsRuleSetsRequest =
       GoogleCloudContentwarehouseV1UpdateRuleSetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRuleSetsRequest>;
 
@@ -5147,7 +5151,7 @@ export const ListProjectsLocationsRuleSetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/ruleSets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/ruleSets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRuleSetsRequest>;
 
@@ -5183,7 +5187,7 @@ export const GetProjectsLocationsRuleSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRuleSetsRequest>;
 
@@ -5215,7 +5219,7 @@ export const DeleteProjectsLocationsRuleSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRuleSetsRequest>;
 

--- a/packages/gcp/src/services/css-v1.ts
+++ b/packages/gcp/src/services/css-v1.ts
@@ -636,7 +636,7 @@ export const ListChildAccountsAccountsRequest =
     fullName: Schema.optional(Schema.String).pipe(T.HttpQuery("fullName")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}:listChildAccounts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}:listChildAccounts" }),
     svc,
   ) as unknown as Schema.Schema<ListChildAccountsAccountsRequest>;
 
@@ -673,7 +673,7 @@ export const GetAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   parent: Schema.optional(Schema.String).pipe(T.HttpQuery("parent")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetAccountsRequest>;
 
@@ -706,7 +706,7 @@ export const UpdateLabelsAccountsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateAccountLabelsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:updateLabels", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:updateLabels", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateLabelsAccountsRequest>;
 
@@ -742,7 +742,7 @@ export const ListAccountsLabelsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/labels" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/labels" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsLabelsRequest>;
 
@@ -780,7 +780,7 @@ export const PatchAccountsLabelsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AccountLabel).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsLabelsRequest>;
 
@@ -811,7 +811,7 @@ export const DeleteAccountsLabelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsLabelsRequest>;
 
@@ -844,7 +844,7 @@ export const CreateAccountsLabelsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(AccountLabel).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/labels", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/labels", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateAccountsLabelsRequest>;
 
@@ -883,7 +883,7 @@ export const InsertAccountsCssProductInputsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/cssProductInputs:insert",
+      path: "v1/{+parent}/cssProductInputs:insert",
       hasBody: true,
     }),
     svc,
@@ -922,7 +922,7 @@ export const PatchAccountsCssProductInputsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(CssProductInput).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsCssProductInputsRequest>;
 
@@ -958,7 +958,7 @@ export const DeleteAccountsCssProductInputsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsCssProductInputsRequest>;
 
@@ -995,7 +995,7 @@ export const ListAccountsQuotasRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/quotas" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/quotas" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsQuotasRequest>;
 
@@ -1030,7 +1030,7 @@ export const GetAccountsCssProductsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsCssProductsRequest>;
 
@@ -1067,7 +1067,7 @@ export const ListAccountsCssProductsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/cssProducts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/cssProducts" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsCssProductsRequest>;
 

--- a/packages/gcp/src/services/datacatalog-v1.ts
+++ b/packages/gcp/src/services/datacatalog-v1.ts
@@ -2271,7 +2271,7 @@ export const SetConfigProjectsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setConfig", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setConfig", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetConfigProjectsLocationsRequest>;
 
@@ -2303,7 +2303,7 @@ export const RetrieveEffectiveConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:retrieveEffectiveConfig" }),
+    T.Http({ method: "GET", path: "v1/{+name}:retrieveEffectiveConfig" }),
     svc,
   ) as unknown as Schema.Schema<RetrieveEffectiveConfigProjectsLocationsRequest>;
 
@@ -2349,7 +2349,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2384,7 +2384,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2415,7 +2415,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2446,7 +2446,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2487,7 +2487,7 @@ export const CreateProjectsLocationsEntryGroupsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/entryGroups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/entryGroups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsEntryGroupsRequest>;
 
@@ -2522,7 +2522,7 @@ export const GetProjectsLocationsEntryGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEntryGroupsRequest>;
 
@@ -2562,7 +2562,7 @@ export const PatchProjectsLocationsEntryGroupsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEntryGroupsRequest>;
 
@@ -2597,7 +2597,7 @@ export const DeleteProjectsLocationsEntryGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEntryGroupsRequest>;
 
@@ -2634,7 +2634,7 @@ export const ListProjectsLocationsEntryGroupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/entryGroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/entryGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEntryGroupsRequest>;
 
@@ -2675,7 +2675,7 @@ export const SetIamPolicyProjectsLocationsEntryGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2713,7 +2713,7 @@ export const GetIamPolicyProjectsLocationsEntryGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2751,7 +2751,7 @@ export const TestIamPermissionsProjectsLocationsEntryGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2791,7 +2791,7 @@ export const CreateProjectsLocationsEntryGroupsEntriesRequest =
     entryId: Schema.optional(Schema.String).pipe(T.HttpQuery("entryId")),
     body: Schema.optional(GoogleCloudDatacatalogV1Entry).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/entries", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/entries", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsEntryGroupsEntriesRequest>;
 
@@ -2829,7 +2829,7 @@ export const PatchProjectsLocationsEntryGroupsEntriesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDatacatalogV1Entry).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEntryGroupsEntriesRequest>;
 
@@ -2861,7 +2861,7 @@ export const DeleteProjectsLocationsEntryGroupsEntriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEntryGroupsEntriesRequest>;
 
@@ -2892,7 +2892,7 @@ export const GetProjectsLocationsEntryGroupsEntriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEntryGroupsEntriesRequest>;
 
@@ -2933,7 +2933,7 @@ export const ListProjectsLocationsEntryGroupsEntriesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/entries" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/entries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEntryGroupsEntriesRequest>;
 
@@ -2976,7 +2976,7 @@ export const ModifyEntryOverviewProjectsLocationsEntryGroupsEntriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:modifyEntryOverview",
+      path: "v1/{+name}:modifyEntryOverview",
       hasBody: true,
     }),
     svc,
@@ -3018,7 +3018,7 @@ export const ModifyEntryContactsProjectsLocationsEntryGroupsEntriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:modifyEntryContacts",
+      path: "v1/{+name}:modifyEntryContacts",
       hasBody: true,
     }),
     svc,
@@ -3058,7 +3058,7 @@ export const StarProjectsLocationsEntryGroupsEntriesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:star", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:star", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StarProjectsLocationsEntryGroupsEntriesRequest>;
 
@@ -3095,7 +3095,7 @@ export const UnstarProjectsLocationsEntryGroupsEntriesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:unstar", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:unstar", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UnstarProjectsLocationsEntryGroupsEntriesRequest>;
 
@@ -3132,7 +3132,7 @@ export const GetIamPolicyProjectsLocationsEntryGroupsEntriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3171,7 +3171,7 @@ export const TestIamPermissionsProjectsLocationsEntryGroupsEntriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3213,7 +3213,7 @@ export const ImportProjectsLocationsEntryGroupsEntriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/entries:import",
+      path: "v1/{+parent}/entries:import",
       hasBody: true,
     }),
     svc,
@@ -3249,7 +3249,7 @@ export const CreateProjectsLocationsEntryGroupsEntriesTagsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDatacatalogV1Tag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/tags", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/tags", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsEntryGroupsEntriesTagsRequest>;
 
@@ -3287,7 +3287,7 @@ export const PatchProjectsLocationsEntryGroupsEntriesTagsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDatacatalogV1Tag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEntryGroupsEntriesTagsRequest>;
 
@@ -3319,7 +3319,7 @@ export const DeleteProjectsLocationsEntryGroupsEntriesTagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEntryGroupsEntriesTagsRequest>;
 
@@ -3356,7 +3356,7 @@ export const ListProjectsLocationsEntryGroupsEntriesTagsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/tags" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/tags" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEntryGroupsEntriesTagsRequest>;
 
@@ -3399,7 +3399,7 @@ export const ReconcileProjectsLocationsEntryGroupsEntriesTagsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/tags:reconcile",
+      path: "v1/{+parent}/tags:reconcile",
       hasBody: true,
     }),
     svc,
@@ -3437,7 +3437,7 @@ export const CreateProjectsLocationsEntryGroupsTagsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDatacatalogV1Tag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/tags", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/tags", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsEntryGroupsTagsRequest>;
 
@@ -3475,7 +3475,7 @@ export const PatchProjectsLocationsEntryGroupsTagsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDatacatalogV1Tag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEntryGroupsTagsRequest>;
 
@@ -3507,7 +3507,7 @@ export const DeleteProjectsLocationsEntryGroupsTagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEntryGroupsTagsRequest>;
 
@@ -3544,7 +3544,7 @@ export const ListProjectsLocationsEntryGroupsTagsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/tags" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/tags" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEntryGroupsTagsRequest>;
 
@@ -3590,7 +3590,11 @@ export const CreateProjectsLocationsTagTemplatesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/tagTemplates", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/tagTemplates",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTagTemplatesRequest>;
 
@@ -3622,7 +3626,7 @@ export const GetProjectsLocationsTagTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTagTemplatesRequest>;
 
@@ -3662,7 +3666,7 @@ export const PatchProjectsLocationsTagTemplatesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTagTemplatesRequest>;
 
@@ -3697,7 +3701,7 @@ export const DeleteProjectsLocationsTagTemplatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTagTemplatesRequest>;
 
@@ -3733,7 +3737,7 @@ export const SetIamPolicyProjectsLocationsTagTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3771,7 +3775,7 @@ export const GetIamPolicyProjectsLocationsTagTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3809,7 +3813,7 @@ export const TestIamPermissionsProjectsLocationsTagTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3854,7 +3858,7 @@ export const CreateProjectsLocationsTagTemplatesFieldsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/fields", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/fields", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTagTemplatesFieldsRequest>;
 
@@ -3894,7 +3898,7 @@ export const PatchProjectsLocationsTagTemplatesFieldsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTagTemplatesFieldsRequest>;
 
@@ -3931,7 +3935,7 @@ export const RenameProjectsLocationsTagTemplatesFieldsRequest =
       GoogleCloudDatacatalogV1RenameTagTemplateFieldRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:rename", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:rename", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RenameProjectsLocationsTagTemplatesFieldsRequest>;
 
@@ -3966,7 +3970,7 @@ export const DeleteProjectsLocationsTagTemplatesFieldsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTagTemplatesFieldsRequest>;
 
@@ -4002,7 +4006,7 @@ export const RenameProjectsLocationsTagTemplatesFieldsEnumValuesRequest =
       GoogleCloudDatacatalogV1RenameTagTemplateFieldEnumValueRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:rename", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:rename", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RenameProjectsLocationsTagTemplatesFieldsEnumValuesRequest>;
 
@@ -4038,7 +4042,7 @@ export const CreateProjectsLocationsTaxonomiesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDatacatalogV1Taxonomy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/taxonomies", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/taxonomies", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTaxonomiesRequest>;
 
@@ -4070,7 +4074,7 @@ export const DeleteProjectsLocationsTaxonomiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTaxonomiesRequest>;
 
@@ -4107,7 +4111,7 @@ export const PatchProjectsLocationsTaxonomiesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDatacatalogV1Taxonomy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTaxonomiesRequest>;
 
@@ -4148,7 +4152,7 @@ export const ListProjectsLocationsTaxonomiesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/taxonomies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/taxonomies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTaxonomiesRequest>;
 
@@ -4184,7 +4188,7 @@ export const GetProjectsLocationsTaxonomiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTaxonomiesRequest>;
 
@@ -4221,7 +4225,7 @@ export const GetIamPolicyProjectsLocationsTaxonomiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4259,7 +4263,7 @@ export const SetIamPolicyProjectsLocationsTaxonomiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4297,7 +4301,7 @@ export const TestIamPermissionsProjectsLocationsTaxonomiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4336,7 +4340,7 @@ export const ReplaceProjectsLocationsTaxonomiesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:replace", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:replace", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReplaceProjectsLocationsTaxonomiesRequest>;
 
@@ -4375,7 +4379,7 @@ export const ImportProjectsLocationsTaxonomiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/taxonomies:import",
+      path: "v1/{+parent}/taxonomies:import",
       hasBody: true,
     }),
     svc,
@@ -4419,7 +4423,7 @@ export const ExportProjectsLocationsTaxonomiesRequest =
       T.HttpQuery("serializedTaxonomies"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/taxonomies:export" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/taxonomies:export" }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsTaxonomiesRequest>;
 
@@ -4454,7 +4458,7 @@ export const CreateProjectsLocationsTaxonomiesPolicyTagsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDatacatalogV1PolicyTag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/policyTags", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/policyTags", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTaxonomiesPolicyTagsRequest>;
 
@@ -4486,7 +4490,7 @@ export const DeleteProjectsLocationsTaxonomiesPolicyTagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTaxonomiesPolicyTagsRequest>;
 
@@ -4523,7 +4527,7 @@ export const PatchProjectsLocationsTaxonomiesPolicyTagsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDatacatalogV1PolicyTag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTaxonomiesPolicyTagsRequest>;
 
@@ -4561,7 +4565,7 @@ export const ListProjectsLocationsTaxonomiesPolicyTagsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/policyTags" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/policyTags" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTaxonomiesPolicyTagsRequest>;
 
@@ -4597,7 +4601,7 @@ export const GetProjectsLocationsTaxonomiesPolicyTagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTaxonomiesPolicyTagsRequest>;
 
@@ -4634,7 +4638,7 @@ export const GetIamPolicyProjectsLocationsTaxonomiesPolicyTagsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4673,7 +4677,7 @@ export const SetIamPolicyProjectsLocationsTaxonomiesPolicyTagsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4712,7 +4716,7 @@ export const TestIamPermissionsProjectsLocationsTaxonomiesPolicyTagsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4831,7 +4835,7 @@ export const SetConfigOrganizationsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setConfig", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setConfig", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetConfigOrganizationsLocationsRequest>;
 
@@ -4863,7 +4867,7 @@ export const RetrieveConfigOrganizationsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:retrieveConfig" }),
+    T.Http({ method: "GET", path: "v1/{+name}:retrieveConfig" }),
     svc,
   ) as unknown as Schema.Schema<RetrieveConfigOrganizationsLocationsRequest>;
 
@@ -4895,7 +4899,7 @@ export const RetrieveEffectiveConfigOrganizationsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:retrieveEffectiveConfig" }),
+    T.Http({ method: "GET", path: "v1/{+name}:retrieveEffectiveConfig" }),
     svc,
   ) as unknown as Schema.Schema<RetrieveEffectiveConfigOrganizationsLocationsRequest>;
 

--- a/packages/gcp/src/services/datacatalog-v1beta1.ts
+++ b/packages/gcp/src/services/datacatalog-v1beta1.ts
@@ -2402,7 +2402,7 @@ export const CreateProjectsLocationsEntryGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/entryGroups",
+      path: "v1beta1/{+parent}/entryGroups",
       hasBody: true,
     }),
     svc,
@@ -2444,7 +2444,7 @@ export const PatchProjectsLocationsEntryGroupsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEntryGroupsRequest>;
 
@@ -2479,7 +2479,7 @@ export const GetProjectsLocationsEntryGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEntryGroupsRequest>;
 
@@ -2514,7 +2514,7 @@ export const DeleteProjectsLocationsEntryGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEntryGroupsRequest>;
 
@@ -2551,7 +2551,7 @@ export const ListProjectsLocationsEntryGroupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/entryGroups" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/entryGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEntryGroupsRequest>;
 
@@ -2592,7 +2592,7 @@ export const SetIamPolicyProjectsLocationsEntryGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2630,7 +2630,7 @@ export const GetIamPolicyProjectsLocationsEntryGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2668,7 +2668,7 @@ export const TestIamPermissionsProjectsLocationsEntryGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2710,7 +2710,11 @@ export const CreateProjectsLocationsEntryGroupsEntriesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/entries", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/entries",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsEntryGroupsEntriesRequest>;
 
@@ -2750,7 +2754,7 @@ export const PatchProjectsLocationsEntryGroupsEntriesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEntryGroupsEntriesRequest>;
 
@@ -2782,7 +2786,7 @@ export const DeleteProjectsLocationsEntryGroupsEntriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEntryGroupsEntriesRequest>;
 
@@ -2813,7 +2817,7 @@ export const GetProjectsLocationsEntryGroupsEntriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEntryGroupsEntriesRequest>;
 
@@ -2854,7 +2858,7 @@ export const ListProjectsLocationsEntryGroupsEntriesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/entries" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/entries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEntryGroupsEntriesRequest>;
 
@@ -2895,7 +2899,7 @@ export const GetIamPolicyProjectsLocationsEntryGroupsEntriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2934,7 +2938,7 @@ export const TestIamPermissionsProjectsLocationsEntryGroupsEntriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2972,7 +2976,7 @@ export const CreateProjectsLocationsEntryGroupsEntriesTagsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDatacatalogV1beta1Tag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/tags", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+parent}/tags", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsEntryGroupsEntriesTagsRequest>;
 
@@ -3010,7 +3014,7 @@ export const PatchProjectsLocationsEntryGroupsEntriesTagsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDatacatalogV1beta1Tag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEntryGroupsEntriesTagsRequest>;
 
@@ -3042,7 +3046,7 @@ export const DeleteProjectsLocationsEntryGroupsEntriesTagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEntryGroupsEntriesTagsRequest>;
 
@@ -3079,7 +3083,7 @@ export const ListProjectsLocationsEntryGroupsEntriesTagsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/tags" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/tags" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEntryGroupsEntriesTagsRequest>;
 
@@ -3118,7 +3122,7 @@ export const CreateProjectsLocationsEntryGroupsTagsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDatacatalogV1beta1Tag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/tags", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+parent}/tags", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsEntryGroupsTagsRequest>;
 
@@ -3156,7 +3160,7 @@ export const PatchProjectsLocationsEntryGroupsTagsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDatacatalogV1beta1Tag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEntryGroupsTagsRequest>;
 
@@ -3188,7 +3192,7 @@ export const DeleteProjectsLocationsEntryGroupsTagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEntryGroupsTagsRequest>;
 
@@ -3225,7 +3229,7 @@ export const ListProjectsLocationsEntryGroupsTagsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/tags" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/tags" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEntryGroupsTagsRequest>;
 
@@ -3273,7 +3277,7 @@ export const CreateProjectsLocationsTagTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/tagTemplates",
+      path: "v1beta1/{+parent}/tagTemplates",
       hasBody: true,
     }),
     svc,
@@ -3307,7 +3311,7 @@ export const GetProjectsLocationsTagTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTagTemplatesRequest>;
 
@@ -3347,7 +3351,7 @@ export const PatchProjectsLocationsTagTemplatesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTagTemplatesRequest>;
 
@@ -3382,7 +3386,7 @@ export const DeleteProjectsLocationsTagTemplatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTagTemplatesRequest>;
 
@@ -3418,7 +3422,7 @@ export const SetIamPolicyProjectsLocationsTagTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3456,7 +3460,7 @@ export const GetIamPolicyProjectsLocationsTagTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3494,7 +3498,7 @@ export const TestIamPermissionsProjectsLocationsTagTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3539,7 +3543,7 @@ export const CreateProjectsLocationsTagTemplatesFieldsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/fields", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+parent}/fields", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTagTemplatesFieldsRequest>;
 
@@ -3579,7 +3583,7 @@ export const PatchProjectsLocationsTagTemplatesFieldsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTagTemplatesFieldsRequest>;
 
@@ -3616,7 +3620,7 @@ export const RenameProjectsLocationsTagTemplatesFieldsRequest =
       GoogleCloudDatacatalogV1beta1RenameTagTemplateFieldRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:rename", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:rename", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RenameProjectsLocationsTagTemplatesFieldsRequest>;
 
@@ -3651,7 +3655,7 @@ export const DeleteProjectsLocationsTagTemplatesFieldsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTagTemplatesFieldsRequest>;
 
@@ -3687,7 +3691,7 @@ export const RenameProjectsLocationsTagTemplatesFieldsEnumValuesRequest =
       GoogleCloudDatacatalogV1beta1RenameTagTemplateFieldEnumValueRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:rename", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:rename", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RenameProjectsLocationsTagTemplatesFieldsEnumValuesRequest>;
 
@@ -3727,7 +3731,7 @@ export const CreateProjectsLocationsTaxonomiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/taxonomies",
+      path: "v1beta1/{+parent}/taxonomies",
       hasBody: true,
     }),
     svc,
@@ -3761,7 +3765,7 @@ export const DeleteProjectsLocationsTaxonomiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTaxonomiesRequest>;
 
@@ -3800,7 +3804,7 @@ export const PatchProjectsLocationsTaxonomiesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTaxonomiesRequest>;
 
@@ -3841,7 +3845,7 @@ export const ListProjectsLocationsTaxonomiesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/taxonomies" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/taxonomies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTaxonomiesRequest>;
 
@@ -3877,7 +3881,7 @@ export const GetProjectsLocationsTaxonomiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTaxonomiesRequest>;
 
@@ -3914,7 +3918,7 @@ export const GetIamPolicyProjectsLocationsTaxonomiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3952,7 +3956,7 @@ export const SetIamPolicyProjectsLocationsTaxonomiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3990,7 +3994,7 @@ export const TestIamPermissionsProjectsLocationsTaxonomiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4031,7 +4035,7 @@ export const ImportProjectsLocationsTaxonomiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/taxonomies:import",
+      path: "v1beta1/{+parent}/taxonomies:import",
       hasBody: true,
     }),
     svc,
@@ -4075,7 +4079,7 @@ export const ExportProjectsLocationsTaxonomiesRequest =
       T.HttpQuery("serializedTaxonomies"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/taxonomies:export" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/taxonomies:export" }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsTaxonomiesRequest>;
 
@@ -4114,7 +4118,7 @@ export const CreateProjectsLocationsTaxonomiesPolicyTagsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/policyTags",
+      path: "v1beta1/{+parent}/policyTags",
       hasBody: true,
     }),
     svc,
@@ -4148,7 +4152,7 @@ export const DeleteProjectsLocationsTaxonomiesPolicyTagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTaxonomiesPolicyTagsRequest>;
 
@@ -4187,7 +4191,7 @@ export const PatchProjectsLocationsTaxonomiesPolicyTagsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTaxonomiesPolicyTagsRequest>;
 
@@ -4225,7 +4229,7 @@ export const ListProjectsLocationsTaxonomiesPolicyTagsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/policyTags" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/policyTags" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTaxonomiesPolicyTagsRequest>;
 
@@ -4261,7 +4265,7 @@ export const GetProjectsLocationsTaxonomiesPolicyTagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTaxonomiesPolicyTagsRequest>;
 
@@ -4298,7 +4302,7 @@ export const GetIamPolicyProjectsLocationsTaxonomiesPolicyTagsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4337,7 +4341,7 @@ export const SetIamPolicyProjectsLocationsTaxonomiesPolicyTagsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4376,7 +4380,7 @@ export const TestIamPermissionsProjectsLocationsTaxonomiesPolicyTagsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/dataform-v1.ts
+++ b/packages/gcp/src/services/dataform-v1.ts
@@ -2046,7 +2046,7 @@ export const QueryUserRootContentsProjectsLocationsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{location}:queryUserRootContents" }),
+    T.Http({ method: "GET", path: "v1/{+location}:queryUserRootContents" }),
     svc,
   ) as unknown as Schema.Schema<QueryUserRootContentsProjectsLocationsRequest>;
 
@@ -2082,7 +2082,7 @@ export const GetConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigProjectsLocationsRequest>;
 
@@ -2119,7 +2119,7 @@ export const UpdateConfigProjectsLocationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Config).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigProjectsLocationsRequest>;
 
@@ -2164,7 +2164,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2199,7 +2199,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2244,7 +2244,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2279,7 +2279,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2310,7 +2310,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2344,7 +2344,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2375,7 +2375,7 @@ export const GetProjectsLocationsTeamFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTeamFoldersRequest>;
 
@@ -2409,7 +2409,7 @@ export const CreateProjectsLocationsTeamFoldersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(TeamFolder).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/teamFolders", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/teamFolders", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTeamFoldersRequest>;
 
@@ -2446,7 +2446,7 @@ export const PatchProjectsLocationsTeamFoldersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(TeamFolder).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTeamFoldersRequest>;
 
@@ -2477,7 +2477,7 @@ export const DeleteProjectsLocationsTeamFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTeamFoldersRequest>;
 
@@ -2511,7 +2511,7 @@ export const DeleteTreeProjectsLocationsTeamFoldersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DeleteTeamFolderTreeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:deleteTree", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:deleteTree", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeleteTreeProjectsLocationsTeamFoldersRequest>;
 
@@ -2554,7 +2554,7 @@ export const QueryContentsProjectsLocationsTeamFoldersRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{teamFolder}:queryContents" }),
+    T.Http({ method: "GET", path: "v1/{+teamFolder}:queryContents" }),
     svc,
   ) as unknown as Schema.Schema<QueryContentsProjectsLocationsTeamFoldersRequest>;
 
@@ -2602,7 +2602,7 @@ export const SearchProjectsLocationsTeamFoldersRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{location}/teamFolders:search" }),
+    T.Http({ method: "GET", path: "v1/{+location}/teamFolders:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsLocationsTeamFoldersRequest>;
 
@@ -2643,7 +2643,7 @@ export const GetIamPolicyProjectsLocationsTeamFoldersRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsTeamFoldersRequest>;
 
@@ -2679,7 +2679,7 @@ export const SetIamPolicyProjectsLocationsTeamFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2717,7 +2717,7 @@ export const TestIamPermissionsProjectsLocationsTeamFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2751,7 +2751,7 @@ export const GetProjectsLocationsFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFoldersRequest>;
 
@@ -2785,7 +2785,7 @@ export const CreateProjectsLocationsFoldersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Folder).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/folders", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/folders", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsFoldersRequest>;
 
@@ -2822,7 +2822,7 @@ export const PatchProjectsLocationsFoldersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Folder).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFoldersRequest>;
 
@@ -2853,7 +2853,7 @@ export const DeleteProjectsLocationsFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFoldersRequest>;
 
@@ -2887,7 +2887,7 @@ export const DeleteTreeProjectsLocationsFoldersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DeleteFolderTreeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:deleteTree", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:deleteTree", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeleteTreeProjectsLocationsFoldersRequest>;
 
@@ -2930,7 +2930,7 @@ export const QueryFolderContentsProjectsLocationsFoldersRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{folder}:queryFolderContents" }),
+    T.Http({ method: "GET", path: "v1/{+folder}:queryFolderContents" }),
     svc,
   ) as unknown as Schema.Schema<QueryFolderContentsProjectsLocationsFoldersRequest>;
 
@@ -2969,7 +2969,7 @@ export const MoveProjectsLocationsFoldersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MoveFolderRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveProjectsLocationsFoldersRequest>;
 
@@ -3005,7 +3005,7 @@ export const GetIamPolicyProjectsLocationsFoldersRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsFoldersRequest>;
 
@@ -3041,7 +3041,7 @@ export const SetIamPolicyProjectsLocationsFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3079,7 +3079,7 @@ export const TestIamPermissionsProjectsLocationsFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3125,7 +3125,7 @@ export const ListProjectsLocationsRepositoriesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/repositories" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/repositories" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesRequest>;
 
@@ -3161,7 +3161,7 @@ export const GetProjectsLocationsRepositoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesRequest>;
 
@@ -3200,7 +3200,11 @@ export const CreateProjectsLocationsRepositoriesRequest =
     ),
     body: Schema.optional(Repository).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/repositories", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/repositories",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRepositoriesRequest>;
 
@@ -3237,7 +3241,7 @@ export const PatchProjectsLocationsRepositoriesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Repository).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesRequest>;
 
@@ -3271,7 +3275,7 @@ export const DeleteProjectsLocationsRepositoriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesRequest>;
 
@@ -3305,7 +3309,7 @@ export const MoveProjectsLocationsRepositoriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MoveRepositoryRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveProjectsLocationsRepositoriesRequest>;
 
@@ -3339,7 +3343,7 @@ export const CommitProjectsLocationsRepositoriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CommitRepositoryChangesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:commit", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:commit", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CommitProjectsLocationsRepositoriesRequest>;
 
@@ -3377,7 +3381,7 @@ export const ReadFileProjectsLocationsRepositoriesRequest =
     commitSha: Schema.optional(Schema.String).pipe(T.HttpQuery("commitSha")),
     path: Schema.optional(Schema.String).pipe(T.HttpQuery("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:readFile" }),
+    T.Http({ method: "GET", path: "v1/{+name}:readFile" }),
     svc,
   ) as unknown as Schema.Schema<ReadFileProjectsLocationsRepositoriesRequest>;
 
@@ -3421,7 +3425,7 @@ export const QueryDirectoryContentsProjectsLocationsRepositoriesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:queryDirectoryContents" }),
+    T.Http({ method: "GET", path: "v1/{+name}:queryDirectoryContents" }),
     svc,
   ) as unknown as Schema.Schema<QueryDirectoryContentsProjectsLocationsRepositoriesRequest>;
 
@@ -3464,7 +3468,7 @@ export const FetchHistoryProjectsLocationsRepositoriesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:fetchHistory" }),
+    T.Http({ method: "GET", path: "v1/{+name}:fetchHistory" }),
     svc,
   ) as unknown as Schema.Schema<FetchHistoryProjectsLocationsRepositoriesRequest>;
 
@@ -3500,7 +3504,7 @@ export const ComputeAccessTokenStatusProjectsLocationsRepositoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:computeAccessTokenStatus" }),
+    T.Http({ method: "GET", path: "v1/{+name}:computeAccessTokenStatus" }),
     svc,
   ) as unknown as Schema.Schema<ComputeAccessTokenStatusProjectsLocationsRepositoriesRequest>;
 
@@ -3533,7 +3537,7 @@ export const FetchRemoteBranchesProjectsLocationsRepositoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:fetchRemoteBranches" }),
+    T.Http({ method: "GET", path: "v1/{+name}:fetchRemoteBranches" }),
     svc,
   ) as unknown as Schema.Schema<FetchRemoteBranchesProjectsLocationsRepositoriesRequest>;
 
@@ -3571,7 +3575,7 @@ export const GetIamPolicyProjectsLocationsRepositoriesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsRepositoriesRequest>;
 
@@ -3607,7 +3611,7 @@ export const SetIamPolicyProjectsLocationsRepositoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3645,7 +3649,7 @@ export const TestIamPermissionsProjectsLocationsRepositoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3692,7 +3696,7 @@ export const ListProjectsLocationsRepositoriesWorkspacesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/workspaces" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/workspaces" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -3728,7 +3732,7 @@ export const GetProjectsLocationsRepositoriesWorkspacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -3767,7 +3771,7 @@ export const CreateProjectsLocationsRepositoriesWorkspacesRequest =
     ),
     body: Schema.optional(Workspace).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/workspaces", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/workspaces", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -3798,7 +3802,7 @@ export const DeleteProjectsLocationsRepositoriesWorkspacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -3834,7 +3838,7 @@ export const InstallNpmPackagesProjectsLocationsRepositoriesWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{workspace}:installNpmPackages",
+      path: "v1/{+workspace}:installNpmPackages",
       hasBody: true,
     }),
     svc,
@@ -3872,7 +3876,7 @@ export const PullProjectsLocationsRepositoriesWorkspacesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PullGitCommitsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:pull", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:pull", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PullProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -3907,7 +3911,7 @@ export const PushProjectsLocationsRepositoriesWorkspacesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PushGitCommitsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:push", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:push", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PushProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -3939,7 +3943,7 @@ export const FetchFileGitStatusesProjectsLocationsRepositoriesWorkspacesRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:fetchFileGitStatuses" }),
+    T.Http({ method: "GET", path: "v1/{+name}:fetchFileGitStatuses" }),
     svc,
   ) as unknown as Schema.Schema<FetchFileGitStatusesProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -3977,7 +3981,7 @@ export const FetchGitAheadBehindProjectsLocationsRepositoriesWorkspacesRequest =
       T.HttpQuery("remoteBranch"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:fetchGitAheadBehind" }),
+    T.Http({ method: "GET", path: "v1/{+name}:fetchGitAheadBehind" }),
     svc,
   ) as unknown as Schema.Schema<FetchGitAheadBehindProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -4013,7 +4017,7 @@ export const CommitProjectsLocationsRepositoriesWorkspacesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CommitWorkspaceChangesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:commit", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:commit", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CommitProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -4048,7 +4052,7 @@ export const ResetProjectsLocationsRepositoriesWorkspacesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResetWorkspaceChangesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:reset", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:reset", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResetProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -4083,7 +4087,7 @@ export const FetchFileDiffProjectsLocationsRepositoriesWorkspacesRequest =
     workspace: Schema.String.pipe(T.HttpPath("workspace")),
     path: Schema.optional(Schema.String).pipe(T.HttpQuery("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{workspace}:fetchFileDiff" }),
+    T.Http({ method: "GET", path: "v1/{+workspace}:fetchFileDiff" }),
     svc,
   ) as unknown as Schema.Schema<FetchFileDiffProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -4132,7 +4136,7 @@ export const QueryDirectoryContentsProjectsLocationsRepositoriesWorkspacesReques
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{workspace}:queryDirectoryContents" }),
+    T.Http({ method: "GET", path: "v1/{+workspace}:queryDirectoryContents" }),
     svc,
   ) as unknown as Schema.Schema<QueryDirectoryContentsProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -4178,7 +4182,7 @@ export const SearchFilesProjectsLocationsRepositoriesWorkspacesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{workspace}:searchFiles" }),
+    T.Http({ method: "GET", path: "v1/{+workspace}:searchFiles" }),
     svc,
   ) as unknown as Schema.Schema<SearchFilesProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -4220,7 +4224,7 @@ export const MakeDirectoryProjectsLocationsRepositoriesWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{workspace}:makeDirectory",
+      path: "v1/{+workspace}:makeDirectory",
       hasBody: true,
     }),
     svc,
@@ -4260,7 +4264,7 @@ export const RemoveDirectoryProjectsLocationsRepositoriesWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{workspace}:removeDirectory",
+      path: "v1/{+workspace}:removeDirectory",
       hasBody: true,
     }),
     svc,
@@ -4300,7 +4304,7 @@ export const MoveDirectoryProjectsLocationsRepositoriesWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{workspace}:moveDirectory",
+      path: "v1/{+workspace}:moveDirectory",
       hasBody: true,
     }),
     svc,
@@ -4341,7 +4345,7 @@ export const ReadFileProjectsLocationsRepositoriesWorkspacesRequest =
     path: Schema.optional(Schema.String).pipe(T.HttpQuery("path")),
     revision: Schema.optional(Schema.String).pipe(T.HttpQuery("revision")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{workspace}:readFile" }),
+    T.Http({ method: "GET", path: "v1/{+workspace}:readFile" }),
     svc,
   ) as unknown as Schema.Schema<ReadFileProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -4379,7 +4383,7 @@ export const RemoveFileProjectsLocationsRepositoriesWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{workspace}:removeFile",
+      path: "v1/{+workspace}:removeFile",
       hasBody: true,
     }),
     svc,
@@ -4417,7 +4421,7 @@ export const MoveFileProjectsLocationsRepositoriesWorkspacesRequest =
     workspace: Schema.String.pipe(T.HttpPath("workspace")),
     body: Schema.optional(MoveFileRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{workspace}:moveFile", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+workspace}:moveFile", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveFileProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -4453,7 +4457,11 @@ export const WriteFileProjectsLocationsRepositoriesWorkspacesRequest =
     workspace: Schema.String.pipe(T.HttpPath("workspace")),
     body: Schema.optional(WriteFileRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{workspace}:writeFile", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+workspace}:writeFile",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<WriteFileProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -4491,7 +4499,7 @@ export const GetIamPolicyProjectsLocationsRepositoriesWorkspacesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -4529,7 +4537,7 @@ export const SetIamPolicyProjectsLocationsRepositoriesWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4569,7 +4577,7 @@ export const TestIamPermissionsProjectsLocationsRepositoriesWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4610,7 +4618,7 @@ export const ListProjectsLocationsRepositoriesReleaseConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/releaseConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/releaseConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesReleaseConfigsRequest>;
 
@@ -4647,7 +4655,7 @@ export const GetProjectsLocationsRepositoriesReleaseConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesReleaseConfigsRequest>;
 
@@ -4689,7 +4697,7 @@ export const CreateProjectsLocationsRepositoriesReleaseConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/releaseConfigs",
+      path: "v1/{+parent}/releaseConfigs",
       hasBody: true,
     }),
     svc,
@@ -4730,7 +4738,7 @@ export const PatchProjectsLocationsRepositoriesReleaseConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ReleaseConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesReleaseConfigsRequest>;
 
@@ -4763,7 +4771,7 @@ export const DeleteProjectsLocationsRepositoriesReleaseConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesReleaseConfigsRequest>;
 
@@ -4807,7 +4815,7 @@ export const ListProjectsLocationsRepositoriesCompilationResultsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/compilationResults" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/compilationResults" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesCompilationResultsRequest>;
 
@@ -4844,7 +4852,7 @@ export const GetProjectsLocationsRepositoriesCompilationResultsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesCompilationResultsRequest>;
 
@@ -4882,7 +4890,7 @@ export const CreateProjectsLocationsRepositoriesCompilationResultsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/compilationResults",
+      path: "v1/{+parent}/compilationResults",
       hasBody: true,
     }),
     svc,
@@ -4926,7 +4934,7 @@ export const QueryProjectsLocationsRepositoriesCompilationResultsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:query" }),
+    T.Http({ method: "GET", path: "v1/{+name}:query" }),
     svc,
   ) as unknown as Schema.Schema<QueryProjectsLocationsRepositoriesCompilationResultsRequest>;
 
@@ -4969,7 +4977,7 @@ export const ListProjectsLocationsRepositoriesWorkflowConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/workflowConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/workflowConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesWorkflowConfigsRequest>;
 
@@ -5006,7 +5014,7 @@ export const GetProjectsLocationsRepositoriesWorkflowConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesWorkflowConfigsRequest>;
 
@@ -5049,7 +5057,7 @@ export const CreateProjectsLocationsRepositoriesWorkflowConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/workflowConfigs",
+      path: "v1/{+parent}/workflowConfigs",
       hasBody: true,
     }),
     svc,
@@ -5090,7 +5098,7 @@ export const PatchProjectsLocationsRepositoriesWorkflowConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(WorkflowConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesWorkflowConfigsRequest>;
 
@@ -5123,7 +5131,7 @@ export const DeleteProjectsLocationsRepositoriesWorkflowConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesWorkflowConfigsRequest>;
 
@@ -5167,7 +5175,7 @@ export const ListProjectsLocationsRepositoriesWorkflowInvocationsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/workflowInvocations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/workflowInvocations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesWorkflowInvocationsRequest>;
 
@@ -5204,7 +5212,7 @@ export const GetProjectsLocationsRepositoriesWorkflowInvocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesWorkflowInvocationsRequest>;
 
@@ -5242,7 +5250,7 @@ export const CreateProjectsLocationsRepositoriesWorkflowInvocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/workflowInvocations",
+      path: "v1/{+parent}/workflowInvocations",
       hasBody: true,
     }),
     svc,
@@ -5277,7 +5285,7 @@ export const DeleteProjectsLocationsRepositoriesWorkflowInvocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesWorkflowInvocationsRequest>;
 
@@ -5313,7 +5321,7 @@ export const CancelProjectsLocationsRepositoriesWorkflowInvocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelWorkflowInvocationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsRepositoriesWorkflowInvocationsRequest>;
 
@@ -5352,7 +5360,7 @@ export const QueryProjectsLocationsRepositoriesWorkflowInvocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:query" }),
+    T.Http({ method: "GET", path: "v1/{+name}:query" }),
     svc,
   ) as unknown as Schema.Schema<QueryProjectsLocationsRepositoriesWorkflowInvocationsRequest>;
 

--- a/packages/gcp/src/services/dataform-v1beta1.ts
+++ b/packages/gcp/src/services/dataform-v1beta1.ts
@@ -2046,7 +2046,10 @@ export const QueryUserRootContentsProjectsLocationsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{location}:queryUserRootContents" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+location}:queryUserRootContents",
+    }),
     svc,
   ) as unknown as Schema.Schema<QueryUserRootContentsProjectsLocationsRequest>;
 
@@ -2082,7 +2085,7 @@ export const GetConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigProjectsLocationsRequest>;
 
@@ -2119,7 +2122,7 @@ export const UpdateConfigProjectsLocationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Config).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigProjectsLocationsRequest>;
 
@@ -2164,7 +2167,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2199,7 +2202,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2244,7 +2247,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2279,7 +2282,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2310,7 +2313,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2344,7 +2347,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2375,7 +2378,7 @@ export const GetProjectsLocationsTeamFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTeamFoldersRequest>;
 
@@ -2416,7 +2419,7 @@ export const CreateProjectsLocationsTeamFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/teamFolders",
+      path: "v1beta1/{+parent}/teamFolders",
       hasBody: true,
     }),
     svc,
@@ -2455,7 +2458,7 @@ export const PatchProjectsLocationsTeamFoldersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(TeamFolder).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTeamFoldersRequest>;
 
@@ -2486,7 +2489,7 @@ export const DeleteProjectsLocationsTeamFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTeamFoldersRequest>;
 
@@ -2522,7 +2525,7 @@ export const DeleteTreeProjectsLocationsTeamFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:deleteTree",
+      path: "v1beta1/{+name}:deleteTree",
       hasBody: true,
     }),
     svc,
@@ -2567,7 +2570,7 @@ export const QueryContentsProjectsLocationsTeamFoldersRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{teamFolder}:queryContents" }),
+    T.Http({ method: "GET", path: "v1beta1/{+teamFolder}:queryContents" }),
     svc,
   ) as unknown as Schema.Schema<QueryContentsProjectsLocationsTeamFoldersRequest>;
 
@@ -2615,7 +2618,7 @@ export const SearchProjectsLocationsTeamFoldersRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{location}/teamFolders:search" }),
+    T.Http({ method: "GET", path: "v1beta1/{+location}/teamFolders:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsLocationsTeamFoldersRequest>;
 
@@ -2656,7 +2659,7 @@ export const GetIamPolicyProjectsLocationsTeamFoldersRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsTeamFoldersRequest>;
 
@@ -2692,7 +2695,7 @@ export const SetIamPolicyProjectsLocationsTeamFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2730,7 +2733,7 @@ export const TestIamPermissionsProjectsLocationsTeamFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2764,7 +2767,7 @@ export const GetProjectsLocationsFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFoldersRequest>;
 
@@ -2801,7 +2804,11 @@ export const CreateProjectsLocationsFoldersRequest =
     folderId: Schema.optional(Schema.String).pipe(T.HttpQuery("folderId")),
     body: Schema.optional(Folder).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/folders", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/folders",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsFoldersRequest>;
 
@@ -2838,7 +2845,7 @@ export const PatchProjectsLocationsFoldersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Folder).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFoldersRequest>;
 
@@ -2869,7 +2876,7 @@ export const DeleteProjectsLocationsFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFoldersRequest>;
 
@@ -2905,7 +2912,7 @@ export const DeleteTreeProjectsLocationsFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:deleteTree",
+      path: "v1beta1/{+name}:deleteTree",
       hasBody: true,
     }),
     svc,
@@ -2950,7 +2957,7 @@ export const QueryFolderContentsProjectsLocationsFoldersRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{folder}:queryFolderContents" }),
+    T.Http({ method: "GET", path: "v1beta1/{+folder}:queryFolderContents" }),
     svc,
   ) as unknown as Schema.Schema<QueryFolderContentsProjectsLocationsFoldersRequest>;
 
@@ -2989,7 +2996,7 @@ export const MoveProjectsLocationsFoldersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MoveFolderRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveProjectsLocationsFoldersRequest>;
 
@@ -3025,7 +3032,7 @@ export const GetIamPolicyProjectsLocationsFoldersRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsFoldersRequest>;
 
@@ -3061,7 +3068,7 @@ export const SetIamPolicyProjectsLocationsFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3099,7 +3106,7 @@ export const TestIamPermissionsProjectsLocationsFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3145,7 +3152,7 @@ export const ListProjectsLocationsRepositoriesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/repositories" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/repositories" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesRequest>;
 
@@ -3181,7 +3188,7 @@ export const GetProjectsLocationsRepositoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesRequest>;
 
@@ -3222,7 +3229,7 @@ export const CreateProjectsLocationsRepositoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/repositories",
+      path: "v1beta1/{+parent}/repositories",
       hasBody: true,
     }),
     svc,
@@ -3261,7 +3268,7 @@ export const PatchProjectsLocationsRepositoriesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Repository).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesRequest>;
 
@@ -3295,7 +3302,7 @@ export const DeleteProjectsLocationsRepositoriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesRequest>;
 
@@ -3329,7 +3336,7 @@ export const MoveProjectsLocationsRepositoriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MoveRepositoryRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveProjectsLocationsRepositoriesRequest>;
 
@@ -3363,7 +3370,7 @@ export const CommitProjectsLocationsRepositoriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CommitRepositoryChangesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:commit", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:commit", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CommitProjectsLocationsRepositoriesRequest>;
 
@@ -3401,7 +3408,7 @@ export const ReadFileProjectsLocationsRepositoriesRequest =
     commitSha: Schema.optional(Schema.String).pipe(T.HttpQuery("commitSha")),
     path: Schema.optional(Schema.String).pipe(T.HttpQuery("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:readFile" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:readFile" }),
     svc,
   ) as unknown as Schema.Schema<ReadFileProjectsLocationsRepositoriesRequest>;
 
@@ -3445,7 +3452,7 @@ export const QueryDirectoryContentsProjectsLocationsRepositoriesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:queryDirectoryContents" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:queryDirectoryContents" }),
     svc,
   ) as unknown as Schema.Schema<QueryDirectoryContentsProjectsLocationsRepositoriesRequest>;
 
@@ -3488,7 +3495,7 @@ export const FetchHistoryProjectsLocationsRepositoriesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:fetchHistory" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:fetchHistory" }),
     svc,
   ) as unknown as Schema.Schema<FetchHistoryProjectsLocationsRepositoriesRequest>;
 
@@ -3524,7 +3531,7 @@ export const ComputeAccessTokenStatusProjectsLocationsRepositoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:computeAccessTokenStatus" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:computeAccessTokenStatus" }),
     svc,
   ) as unknown as Schema.Schema<ComputeAccessTokenStatusProjectsLocationsRepositoriesRequest>;
 
@@ -3557,7 +3564,7 @@ export const FetchRemoteBranchesProjectsLocationsRepositoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:fetchRemoteBranches" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:fetchRemoteBranches" }),
     svc,
   ) as unknown as Schema.Schema<FetchRemoteBranchesProjectsLocationsRepositoriesRequest>;
 
@@ -3595,7 +3602,7 @@ export const GetIamPolicyProjectsLocationsRepositoriesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsRepositoriesRequest>;
 
@@ -3631,7 +3638,7 @@ export const SetIamPolicyProjectsLocationsRepositoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3669,7 +3676,7 @@ export const TestIamPermissionsProjectsLocationsRepositoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3716,7 +3723,7 @@ export const ListProjectsLocationsRepositoriesWorkspacesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/workspaces" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/workspaces" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -3752,7 +3759,7 @@ export const GetProjectsLocationsRepositoriesWorkspacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -3793,7 +3800,7 @@ export const CreateProjectsLocationsRepositoriesWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/workspaces",
+      path: "v1beta1/{+parent}/workspaces",
       hasBody: true,
     }),
     svc,
@@ -3826,7 +3833,7 @@ export const DeleteProjectsLocationsRepositoriesWorkspacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -3862,7 +3869,7 @@ export const InstallNpmPackagesProjectsLocationsRepositoriesWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{workspace}:installNpmPackages",
+      path: "v1beta1/{+workspace}:installNpmPackages",
       hasBody: true,
     }),
     svc,
@@ -3900,7 +3907,7 @@ export const PullProjectsLocationsRepositoriesWorkspacesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PullGitCommitsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:pull", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:pull", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PullProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -3935,7 +3942,7 @@ export const PushProjectsLocationsRepositoriesWorkspacesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PushGitCommitsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:push", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:push", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PushProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -3967,7 +3974,7 @@ export const FetchFileGitStatusesProjectsLocationsRepositoriesWorkspacesRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:fetchFileGitStatuses" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:fetchFileGitStatuses" }),
     svc,
   ) as unknown as Schema.Schema<FetchFileGitStatusesProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -4005,7 +4012,7 @@ export const FetchGitAheadBehindProjectsLocationsRepositoriesWorkspacesRequest =
       T.HttpQuery("remoteBranch"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:fetchGitAheadBehind" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:fetchGitAheadBehind" }),
     svc,
   ) as unknown as Schema.Schema<FetchGitAheadBehindProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -4041,7 +4048,7 @@ export const CommitProjectsLocationsRepositoriesWorkspacesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CommitWorkspaceChangesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:commit", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:commit", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CommitProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -4076,7 +4083,7 @@ export const ResetProjectsLocationsRepositoriesWorkspacesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResetWorkspaceChangesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:reset", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:reset", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResetProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -4111,7 +4118,7 @@ export const FetchFileDiffProjectsLocationsRepositoriesWorkspacesRequest =
     workspace: Schema.String.pipe(T.HttpPath("workspace")),
     path: Schema.optional(Schema.String).pipe(T.HttpQuery("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{workspace}:fetchFileDiff" }),
+    T.Http({ method: "GET", path: "v1beta1/{+workspace}:fetchFileDiff" }),
     svc,
   ) as unknown as Schema.Schema<FetchFileDiffProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -4162,7 +4169,7 @@ export const QueryDirectoryContentsProjectsLocationsRepositoriesWorkspacesReques
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{workspace}:queryDirectoryContents",
+      path: "v1beta1/{+workspace}:queryDirectoryContents",
     }),
     svc,
   ) as unknown as Schema.Schema<QueryDirectoryContentsProjectsLocationsRepositoriesWorkspacesRequest>;
@@ -4209,7 +4216,7 @@ export const SearchFilesProjectsLocationsRepositoriesWorkspacesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{workspace}:searchFiles" }),
+    T.Http({ method: "GET", path: "v1beta1/{+workspace}:searchFiles" }),
     svc,
   ) as unknown as Schema.Schema<SearchFilesProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -4251,7 +4258,7 @@ export const MakeDirectoryProjectsLocationsRepositoriesWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{workspace}:makeDirectory",
+      path: "v1beta1/{+workspace}:makeDirectory",
       hasBody: true,
     }),
     svc,
@@ -4291,7 +4298,7 @@ export const RemoveDirectoryProjectsLocationsRepositoriesWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{workspace}:removeDirectory",
+      path: "v1beta1/{+workspace}:removeDirectory",
       hasBody: true,
     }),
     svc,
@@ -4331,7 +4338,7 @@ export const MoveDirectoryProjectsLocationsRepositoriesWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{workspace}:moveDirectory",
+      path: "v1beta1/{+workspace}:moveDirectory",
       hasBody: true,
     }),
     svc,
@@ -4372,7 +4379,7 @@ export const ReadFileProjectsLocationsRepositoriesWorkspacesRequest =
     path: Schema.optional(Schema.String).pipe(T.HttpQuery("path")),
     revision: Schema.optional(Schema.String).pipe(T.HttpQuery("revision")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{workspace}:readFile" }),
+    T.Http({ method: "GET", path: "v1beta1/{+workspace}:readFile" }),
     svc,
   ) as unknown as Schema.Schema<ReadFileProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -4410,7 +4417,7 @@ export const RemoveFileProjectsLocationsRepositoriesWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{workspace}:removeFile",
+      path: "v1beta1/{+workspace}:removeFile",
       hasBody: true,
     }),
     svc,
@@ -4450,7 +4457,7 @@ export const MoveFileProjectsLocationsRepositoriesWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{workspace}:moveFile",
+      path: "v1beta1/{+workspace}:moveFile",
       hasBody: true,
     }),
     svc,
@@ -4490,7 +4497,7 @@ export const WriteFileProjectsLocationsRepositoriesWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{workspace}:writeFile",
+      path: "v1beta1/{+workspace}:writeFile",
       hasBody: true,
     }),
     svc,
@@ -4530,7 +4537,7 @@ export const GetIamPolicyProjectsLocationsRepositoriesWorkspacesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsRepositoriesWorkspacesRequest>;
 
@@ -4568,7 +4575,7 @@ export const SetIamPolicyProjectsLocationsRepositoriesWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4608,7 +4615,7 @@ export const TestIamPermissionsProjectsLocationsRepositoriesWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4649,7 +4656,7 @@ export const ListProjectsLocationsRepositoriesReleaseConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/releaseConfigs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/releaseConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesReleaseConfigsRequest>;
 
@@ -4686,7 +4693,7 @@ export const GetProjectsLocationsRepositoriesReleaseConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesReleaseConfigsRequest>;
 
@@ -4728,7 +4735,7 @@ export const CreateProjectsLocationsRepositoriesReleaseConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/releaseConfigs",
+      path: "v1beta1/{+parent}/releaseConfigs",
       hasBody: true,
     }),
     svc,
@@ -4769,7 +4776,7 @@ export const PatchProjectsLocationsRepositoriesReleaseConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ReleaseConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesReleaseConfigsRequest>;
 
@@ -4802,7 +4809,7 @@ export const DeleteProjectsLocationsRepositoriesReleaseConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesReleaseConfigsRequest>;
 
@@ -4846,7 +4853,7 @@ export const ListProjectsLocationsRepositoriesCompilationResultsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/compilationResults" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/compilationResults" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesCompilationResultsRequest>;
 
@@ -4883,7 +4890,7 @@ export const GetProjectsLocationsRepositoriesCompilationResultsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesCompilationResultsRequest>;
 
@@ -4921,7 +4928,7 @@ export const CreateProjectsLocationsRepositoriesCompilationResultsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/compilationResults",
+      path: "v1beta1/{+parent}/compilationResults",
       hasBody: true,
     }),
     svc,
@@ -4965,7 +4972,7 @@ export const QueryProjectsLocationsRepositoriesCompilationResultsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:query" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:query" }),
     svc,
   ) as unknown as Schema.Schema<QueryProjectsLocationsRepositoriesCompilationResultsRequest>;
 
@@ -5008,7 +5015,7 @@ export const ListProjectsLocationsRepositoriesWorkflowConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/workflowConfigs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/workflowConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesWorkflowConfigsRequest>;
 
@@ -5045,7 +5052,7 @@ export const GetProjectsLocationsRepositoriesWorkflowConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesWorkflowConfigsRequest>;
 
@@ -5088,7 +5095,7 @@ export const CreateProjectsLocationsRepositoriesWorkflowConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/workflowConfigs",
+      path: "v1beta1/{+parent}/workflowConfigs",
       hasBody: true,
     }),
     svc,
@@ -5129,7 +5136,7 @@ export const PatchProjectsLocationsRepositoriesWorkflowConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(WorkflowConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesWorkflowConfigsRequest>;
 
@@ -5162,7 +5169,7 @@ export const DeleteProjectsLocationsRepositoriesWorkflowConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesWorkflowConfigsRequest>;
 
@@ -5206,7 +5213,7 @@ export const ListProjectsLocationsRepositoriesWorkflowInvocationsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/workflowInvocations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/workflowInvocations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesWorkflowInvocationsRequest>;
 
@@ -5243,7 +5250,7 @@ export const GetProjectsLocationsRepositoriesWorkflowInvocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesWorkflowInvocationsRequest>;
 
@@ -5281,7 +5288,7 @@ export const CreateProjectsLocationsRepositoriesWorkflowInvocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/workflowInvocations",
+      path: "v1beta1/{+parent}/workflowInvocations",
       hasBody: true,
     }),
     svc,
@@ -5316,7 +5323,7 @@ export const DeleteProjectsLocationsRepositoriesWorkflowInvocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesWorkflowInvocationsRequest>;
 
@@ -5352,7 +5359,7 @@ export const CancelProjectsLocationsRepositoriesWorkflowInvocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelWorkflowInvocationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsRepositoriesWorkflowInvocationsRequest>;
 
@@ -5391,7 +5398,7 @@ export const QueryProjectsLocationsRepositoriesWorkflowInvocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:query" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:query" }),
     svc,
   ) as unknown as Schema.Schema<QueryProjectsLocationsRepositoriesWorkflowInvocationsRequest>;
 

--- a/packages/gcp/src/services/datafusion-v1.ts
+++ b/packages/gcp/src/services/datafusion-v1.ts
@@ -704,7 +704,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -739,7 +739,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -773,7 +773,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -818,7 +818,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -853,7 +853,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -884,7 +884,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -926,7 +926,7 @@ export const ListProjectsLocationsVersionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVersionsRequest>;
 
@@ -968,7 +968,7 @@ export const PatchProjectsLocationsInstancesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInstancesRequest>;
 
@@ -999,7 +999,7 @@ export const GetProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesRequest>;
 
@@ -1033,7 +1033,7 @@ export const RestartProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestartInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:restart", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:restart", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestartProjectsLocationsInstancesRequest>;
 
@@ -1067,7 +1067,7 @@ export const DeleteProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesRequest>;
 
@@ -1103,7 +1103,7 @@ export const GetIamPolicyProjectsLocationsInstancesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsInstancesRequest>;
 
@@ -1146,7 +1146,7 @@ export const ListProjectsLocationsInstancesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesRequest>;
 
@@ -1186,7 +1186,7 @@ export const TestIamPermissionsProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1225,7 +1225,7 @@ export const SetIamPolicyProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1264,7 +1264,7 @@ export const CreateProjectsLocationsInstancesRequest =
     instanceId: Schema.optional(Schema.String).pipe(T.HttpQuery("instanceId")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/instances", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/instances", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsInstancesRequest>;
 
@@ -1295,7 +1295,7 @@ export const DeleteProjectsLocationsInstancesDnsPeeringsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesDnsPeeringsRequest>;
 
@@ -1332,7 +1332,7 @@ export const ListProjectsLocationsInstancesDnsPeeringsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dnsPeerings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dnsPeerings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesDnsPeeringsRequest>;
 
@@ -1376,7 +1376,7 @@ export const CreateProjectsLocationsInstancesDnsPeeringsRequest =
     ),
     body: Schema.optional(DnsPeering).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/dnsPeerings", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/dnsPeerings", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsInstancesDnsPeeringsRequest>;
 

--- a/packages/gcp/src/services/datafusion-v1beta1.ts
+++ b/packages/gcp/src/services/datafusion-v1beta1.ts
@@ -761,7 +761,7 @@ export const ListProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -801,7 +801,7 @@ export const RemoveIamPolicyProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:removeIamPolicy",
+      path: "v1beta1/{+resource}:removeIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -834,7 +834,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -876,7 +876,7 @@ export const ListProjectsLocationsVersionsRequest =
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVersionsRequest>;
 
@@ -912,7 +912,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -946,7 +946,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -977,7 +977,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1022,7 +1022,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1057,7 +1057,7 @@ export const GetProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesRequest>;
 
@@ -1093,7 +1093,7 @@ export const SetIamPolicyProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1134,7 +1134,7 @@ export const CreateProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/instances",
+      path: "v1beta1/{+parent}/instances",
       hasBody: true,
     }),
     svc,
@@ -1179,7 +1179,7 @@ export const ListProjectsLocationsInstancesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesRequest>;
 
@@ -1217,7 +1217,7 @@ export const RestartProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestartInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:restart", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:restart", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestartProjectsLocationsInstancesRequest>;
 
@@ -1251,7 +1251,7 @@ export const DeleteProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesRequest>;
 
@@ -1285,7 +1285,7 @@ export const UpgradeProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpgradeInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:upgrade", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:upgrade", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpgradeProjectsLocationsInstancesRequest>;
 
@@ -1322,7 +1322,7 @@ export const PatchProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInstancesRequest>;
 
@@ -1358,7 +1358,7 @@ export const GetIamPolicyProjectsLocationsInstancesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsInstancesRequest>;
 
@@ -1394,7 +1394,7 @@ export const TestIamPermissionsProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1433,7 +1433,7 @@ export const SetIamPolicyProjectsLocationsInstancesNamespacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1472,7 +1472,7 @@ export const GetIamPolicyProjectsLocationsInstancesNamespacesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsInstancesNamespacesRequest>;
 
@@ -1517,7 +1517,7 @@ export const ListProjectsLocationsInstancesNamespacesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/namespaces" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/namespaces" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesNamespacesRequest>;
 
@@ -1558,7 +1558,7 @@ export const TestIamPermissionsProjectsLocationsInstancesNamespacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1593,7 +1593,7 @@ export const DeleteProjectsLocationsInstancesDnsPeeringsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesDnsPeeringsRequest>;
 
@@ -1634,7 +1634,7 @@ export const CreateProjectsLocationsInstancesDnsPeeringsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/dnsPeerings",
+      path: "v1beta1/{+parent}/dnsPeerings",
       hasBody: true,
     }),
     svc,
@@ -1673,7 +1673,7 @@ export const ListProjectsLocationsInstancesDnsPeeringsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dnsPeerings" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/dnsPeerings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesDnsPeeringsRequest>;
 

--- a/packages/gcp/src/services/datalabeling-v1beta1.ts
+++ b/packages/gcp/src/services/datalabeling-v1beta1.ts
@@ -3869,7 +3869,7 @@ export const ListProjectsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsOperationsRequest>;
 
@@ -3905,7 +3905,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 
@@ -3936,7 +3936,7 @@ export const DeleteProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsOperationsRequest>;
 
@@ -3967,7 +3967,7 @@ export const CancelProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:cancel" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:cancel" }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsOperationsRequest>;
 
@@ -4005,7 +4005,7 @@ export const CreateProjectsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/datasets",
+      path: "v1beta1/{+parent}/datasets",
       hasBody: true,
     }),
     svc,
@@ -4039,7 +4039,7 @@ export const GetProjectsDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatasetsRequest>;
 
@@ -4079,7 +4079,7 @@ export const ListProjectsDatasetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/datasets" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/datasets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDatasetsRequest>;
 
@@ -4115,7 +4115,7 @@ export const DeleteProjectsDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsDatasetsRequest>;
 
@@ -4153,7 +4153,7 @@ export const ImportDataProjectsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:importData",
+      path: "v1beta1/{+name}:importData",
       hasBody: true,
     }),
     svc,
@@ -4193,7 +4193,7 @@ export const ExportDataProjectsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:exportData",
+      path: "v1beta1/{+name}:exportData",
       hasBody: true,
     }),
     svc,
@@ -4226,7 +4226,7 @@ export const GetProjectsDatasetsDataItemsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatasetsDataItemsRequest>;
 
@@ -4267,7 +4267,7 @@ export const ListProjectsDatasetsDataItemsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dataItems" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/dataItems" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDatasetsDataItemsRequest>;
 
@@ -4303,7 +4303,7 @@ export const GetProjectsDatasetsAnnotatedDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatasetsAnnotatedDatasetsRequest>;
 
@@ -4344,7 +4344,7 @@ export const ListProjectsDatasetsAnnotatedDatasetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/annotatedDatasets" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/annotatedDatasets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDatasetsAnnotatedDatasetsRequest>;
 
@@ -4380,7 +4380,7 @@ export const DeleteProjectsDatasetsAnnotatedDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsDatasetsAnnotatedDatasetsRequest>;
 
@@ -4412,7 +4412,7 @@ export const GetProjectsDatasetsAnnotatedDatasetsDataItemsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatasetsAnnotatedDatasetsDataItemsRequest>;
 
@@ -4453,7 +4453,7 @@ export const ListProjectsDatasetsAnnotatedDatasetsDataItemsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dataItems" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/dataItems" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDatasetsAnnotatedDatasetsDataItemsRequest>;
 
@@ -4492,7 +4492,7 @@ export const GetProjectsDatasetsAnnotatedDatasetsExamplesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatasetsAnnotatedDatasetsExamplesRequest>;
 
@@ -4533,7 +4533,7 @@ export const ListProjectsDatasetsAnnotatedDatasetsExamplesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/examples" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/examples" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDatasetsAnnotatedDatasetsExamplesRequest>;
 
@@ -4569,7 +4569,7 @@ export const GetProjectsDatasetsAnnotatedDatasetsFeedbackThreadsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatasetsAnnotatedDatasetsFeedbackThreadsRequest>;
 
@@ -4608,7 +4608,7 @@ export const ListProjectsDatasetsAnnotatedDatasetsFeedbackThreadsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/feedbackThreads" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/feedbackThreads" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDatasetsAnnotatedDatasetsFeedbackThreadsRequest>;
 
@@ -4645,7 +4645,7 @@ export const DeleteProjectsDatasetsAnnotatedDatasetsFeedbackThreadsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsDatasetsAnnotatedDatasetsFeedbackThreadsRequest>;
 
@@ -4685,7 +4685,7 @@ export const CreateProjectsDatasetsAnnotatedDatasetsFeedbackThreadsFeedbackMessa
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/feedbackMessages",
+      path: "v1beta1/{+parent}/feedbackMessages",
       hasBody: true,
     }),
     svc,
@@ -4722,7 +4722,7 @@ export const GetProjectsDatasetsAnnotatedDatasetsFeedbackThreadsFeedbackMessages
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatasetsAnnotatedDatasetsFeedbackThreadsFeedbackMessagesRequest>;
 
@@ -4763,7 +4763,7 @@ export const ListProjectsDatasetsAnnotatedDatasetsFeedbackThreadsFeedbackMessage
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/feedbackMessages" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/feedbackMessages" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDatasetsAnnotatedDatasetsFeedbackThreadsFeedbackMessagesRequest>;
 
@@ -4802,7 +4802,7 @@ export const DeleteProjectsDatasetsAnnotatedDatasetsFeedbackThreadsFeedbackMessa
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsDatasetsAnnotatedDatasetsFeedbackThreadsFeedbackMessagesRequest>;
 
@@ -4844,7 +4844,7 @@ export const LabelProjectsDatasetsImageRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/image:label",
+      path: "v1beta1/{+parent}/image:label",
       hasBody: true,
     }),
     svc,
@@ -4884,7 +4884,7 @@ export const LabelProjectsDatasetsVideoRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/video:label",
+      path: "v1beta1/{+parent}/video:label",
       hasBody: true,
     }),
     svc,
@@ -4924,7 +4924,7 @@ export const LabelProjectsDatasetsTextRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/text:label",
+      path: "v1beta1/{+parent}/text:label",
       hasBody: true,
     }),
     svc,
@@ -4957,7 +4957,7 @@ export const GetProjectsDatasetsEvaluationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatasetsEvaluationsRequest>;
 
@@ -4996,7 +4996,7 @@ export const SearchProjectsDatasetsEvaluationsExampleComparisonsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/exampleComparisons:search",
+      path: "v1beta1/{+parent}/exampleComparisons:search",
       hasBody: true,
     }),
     svc,
@@ -5038,7 +5038,7 @@ export const CreateProjectsAnnotationSpecSetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/annotationSpecSets",
+      path: "v1beta1/{+parent}/annotationSpecSets",
       hasBody: true,
     }),
     svc,
@@ -5072,7 +5072,7 @@ export const GetProjectsAnnotationSpecSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAnnotationSpecSetsRequest>;
 
@@ -5113,7 +5113,7 @@ export const ListProjectsAnnotationSpecSetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/annotationSpecSets" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/annotationSpecSets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAnnotationSpecSetsRequest>;
 
@@ -5149,7 +5149,7 @@ export const DeleteProjectsAnnotationSpecSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAnnotationSpecSetsRequest>;
 
@@ -5187,7 +5187,7 @@ export const CreateProjectsInstructionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/instructions",
+      path: "v1beta1/{+parent}/instructions",
       hasBody: true,
     }),
     svc,
@@ -5220,7 +5220,7 @@ export const GetProjectsInstructionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstructionsRequest>;
 
@@ -5261,7 +5261,7 @@ export const ListProjectsInstructionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/instructions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/instructions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstructionsRequest>;
 
@@ -5297,7 +5297,7 @@ export const DeleteProjectsInstructionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstructionsRequest>;
 
@@ -5337,7 +5337,7 @@ export const SearchProjectsEvaluationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/evaluations:search" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/evaluations:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsEvaluationsRequest>;
 
@@ -5380,7 +5380,7 @@ export const CreateProjectsEvaluationJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/evaluationJobs",
+      path: "v1beta1/{+parent}/evaluationJobs",
       hasBody: true,
     }),
     svc,
@@ -5422,7 +5422,7 @@ export const PatchProjectsEvaluationJobsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsEvaluationJobsRequest>;
 
@@ -5454,7 +5454,7 @@ export const GetProjectsEvaluationJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsEvaluationJobsRequest>;
 
@@ -5491,7 +5491,7 @@ export const PauseProjectsEvaluationJobsRequest =
       GoogleCloudDatalabelingV1beta1PauseEvaluationJobRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsEvaluationJobsRequest>;
 
@@ -5527,7 +5527,7 @@ export const ResumeProjectsEvaluationJobsRequest =
       GoogleCloudDatalabelingV1beta1ResumeEvaluationJobRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsEvaluationJobsRequest>;
 
@@ -5558,7 +5558,7 @@ export const DeleteProjectsEvaluationJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsEvaluationJobsRequest>;
 
@@ -5598,7 +5598,7 @@ export const ListProjectsEvaluationJobsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/evaluationJobs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/evaluationJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsEvaluationJobsRequest>;
 

--- a/packages/gcp/src/services/datalineage-v1.ts
+++ b/packages/gcp/src/services/datalineage-v1.ts
@@ -534,7 +534,7 @@ export const GetFoldersLocationsConfigRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsConfigRequest>;
 
@@ -571,7 +571,7 @@ export const PatchFoldersLocationsConfigRequest =
       GoogleCloudDatacatalogLineageConfigmanagementV1Config,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersLocationsConfigRequest>;
 
@@ -608,7 +608,7 @@ export const ProcessOpenLineageRunEventProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:processOpenLineageRunEvent",
+      path: "v1/{+parent}:processOpenLineageRunEvent",
       hasBody: true,
     }),
     svc,
@@ -649,7 +649,7 @@ export const BatchSearchLinkProcessesProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:batchSearchLinkProcesses",
+      path: "v1/{+parent}:batchSearchLinkProcesses",
       hasBody: true,
     }),
     svc,
@@ -688,7 +688,7 @@ export const SearchLinksProjectsLocationsRequest =
       GoogleCloudDatacatalogLineageV1SearchLinksRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:searchLinks", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}:searchLinks", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SearchLinksProjectsLocationsRequest>;
 
@@ -720,7 +720,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -751,7 +751,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -796,7 +796,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -837,7 +837,7 @@ export const CancelProjectsLocationsOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -868,7 +868,7 @@ export const GetProjectsLocationsConfigRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConfigRequest>;
 
@@ -905,7 +905,7 @@ export const PatchProjectsLocationsConfigRequest =
       GoogleCloudDatacatalogLineageConfigmanagementV1Config,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConfigRequest>;
 
@@ -943,7 +943,7 @@ export const ListProjectsLocationsProcessesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/processes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/processes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProcessesRequest>;
 
@@ -987,7 +987,7 @@ export const CreateProjectsLocationsProcessesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/processes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/processes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsProcessesRequest>;
 
@@ -1019,7 +1019,7 @@ export const GetProjectsLocationsProcessesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProcessesRequest>;
 
@@ -1056,7 +1056,7 @@ export const DeleteProjectsLocationsProcessesRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsProcessesRequest>;
 
@@ -1104,7 +1104,7 @@ export const PatchProjectsLocationsProcessesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsProcessesRequest>;
 
@@ -1144,7 +1144,7 @@ export const CreateProjectsLocationsProcessesRunsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/runs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/runs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsProcessesRunsRequest>;
 
@@ -1182,7 +1182,7 @@ export const ListProjectsLocationsProcessesRunsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/runs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/runs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProcessesRunsRequest>;
 
@@ -1218,7 +1218,7 @@ export const GetProjectsLocationsProcessesRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProcessesRunsRequest>;
 
@@ -1255,7 +1255,7 @@ export const DeleteProjectsLocationsProcessesRunsRequest =
       T.HttpQuery("allowMissing"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsProcessesRunsRequest>;
 
@@ -1300,7 +1300,7 @@ export const PatchProjectsLocationsProcessesRunsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsProcessesRunsRequest>;
 
@@ -1338,7 +1338,7 @@ export const ListProjectsLocationsProcessesRunsLineageEventsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/lineageEvents" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/lineageEvents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProcessesRunsLineageEventsRequest>;
 
@@ -1385,7 +1385,7 @@ export const CreateProjectsLocationsProcessesRunsLineageEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/lineageEvents",
+      path: "v1/{+parent}/lineageEvents",
       hasBody: true,
     }),
     svc,
@@ -1425,7 +1425,7 @@ export const DeleteProjectsLocationsProcessesRunsLineageEventsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsProcessesRunsLineageEventsRequest>;
 
@@ -1458,7 +1458,7 @@ export const GetProjectsLocationsProcessesRunsLineageEventsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProcessesRunsLineageEventsRequest>;
 
@@ -1490,7 +1490,7 @@ export const GetOrganizationsLocationsConfigRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsConfigRequest>;
 
@@ -1527,7 +1527,7 @@ export const PatchOrganizationsLocationsConfigRequest =
       GoogleCloudDatacatalogLineageConfigmanagementV1Config,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsConfigRequest>;
 

--- a/packages/gcp/src/services/datamanager-v1.ts
+++ b/packages/gcp/src/services/datamanager-v1.ts
@@ -1642,7 +1642,7 @@ export const GetAccountTypesAccountsUserListDirectLicensesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountTypesAccountsUserListDirectLicensesRequest>;
 
@@ -1683,7 +1683,7 @@ export const ListAccountTypesAccountsUserListDirectLicensesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/userListDirectLicenses" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/userListDirectLicenses" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountTypesAccountsUserListDirectLicensesRequest>;
 
@@ -1724,7 +1724,7 @@ export const CreateAccountTypesAccountsUserListDirectLicensesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/userListDirectLicenses",
+      path: "v1/{+parent}/userListDirectLicenses",
       hasBody: true,
     }),
     svc,
@@ -1765,7 +1765,7 @@ export const PatchAccountTypesAccountsUserListDirectLicensesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(UserListDirectLicense).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountTypesAccountsUserListDirectLicensesRequest>;
 
@@ -1798,7 +1798,7 @@ export const GetAccountTypesAccountsUserListGlobalLicensesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountTypesAccountsUserListGlobalLicensesRequest>;
 
@@ -1839,7 +1839,7 @@ export const ListAccountTypesAccountsUserListGlobalLicensesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/userListGlobalLicenses" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/userListGlobalLicenses" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountTypesAccountsUserListGlobalLicensesRequest>;
 
@@ -1880,7 +1880,7 @@ export const CreateAccountTypesAccountsUserListGlobalLicensesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/userListGlobalLicenses",
+      path: "v1/{+parent}/userListGlobalLicenses",
       hasBody: true,
     }),
     svc,
@@ -1921,7 +1921,7 @@ export const PatchAccountTypesAccountsUserListGlobalLicensesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(UserListGlobalLicense).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountTypesAccountsUserListGlobalLicensesRequest>;
 
@@ -1965,7 +1965,7 @@ export const ListAccountTypesAccountsUserListGlobalLicensesUserListGlobalLicense
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/userListGlobalLicenseCustomerInfos",
+      path: "v1/{+parent}/userListGlobalLicenseCustomerInfos",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountTypesAccountsUserListGlobalLicensesUserListGlobalLicenseCustomerInfosRequest>;
@@ -2010,7 +2010,7 @@ export const RetrieveAccountTypesAccountsInsightsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/insights:retrieve",
+      path: "v1/{+parent}/insights:retrieve",
       hasBody: true,
     }),
     svc,
@@ -2047,7 +2047,11 @@ export const CreateAccountTypesAccountsPartnerLinksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(PartnerLink).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/partnerLinks", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/partnerLinks",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateAccountTypesAccountsPartnerLinksRequest>;
 
@@ -2087,7 +2091,7 @@ export const SearchAccountTypesAccountsPartnerLinksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/partnerLinks:search" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/partnerLinks:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchAccountTypesAccountsPartnerLinksRequest>;
 
@@ -2123,7 +2127,7 @@ export const DeleteAccountTypesAccountsPartnerLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountTypesAccountsPartnerLinksRequest>;
 
@@ -2154,7 +2158,7 @@ export const GetAccountTypesAccountsUserListsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountTypesAccountsUserListsRequest>;
 
@@ -2196,7 +2200,7 @@ export const PatchAccountTypesAccountsUserListsRequest =
     ),
     body: Schema.optional(UserList).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountTypesAccountsUserListsRequest>;
 
@@ -2232,7 +2236,7 @@ export const DeleteAccountTypesAccountsUserListsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountTypesAccountsUserListsRequest>;
 
@@ -2272,7 +2276,7 @@ export const ListAccountTypesAccountsUserListsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/userLists" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/userLists" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountTypesAccountsUserListsRequest>;
 
@@ -2315,7 +2319,7 @@ export const CreateAccountTypesAccountsUserListsRequest =
     ),
     body: Schema.optional(UserList).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/userLists", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/userLists", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateAccountTypesAccountsUserListsRequest>;
 

--- a/packages/gcp/src/services/datamigration-v1.ts
+++ b/packages/gcp/src/services/datamigration-v1.ts
@@ -3498,7 +3498,7 @@ export const FetchStaticIpsProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:fetchStaticIps" }),
+    T.Http({ method: "GET", path: "v1/{+name}:fetchStaticIps" }),
     svc,
   ) as unknown as Schema.Schema<FetchStaticIpsProjectsLocationsRequest>;
 
@@ -3547,7 +3547,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -3582,7 +3582,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -3627,7 +3627,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -3662,7 +3662,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -3693,7 +3693,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -3727,7 +3727,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -3770,7 +3770,7 @@ export const ListProjectsLocationsMigrationJobsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/migrationJobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/migrationJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMigrationJobsRequest>;
 
@@ -3806,7 +3806,7 @@ export const GetProjectsLocationsMigrationJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMigrationJobsRequest>;
 
@@ -3850,7 +3850,7 @@ export const CreateProjectsLocationsMigrationJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/migrationJobs",
+      path: "v1/{+parent}/migrationJobs",
       hasBody: true,
     }),
     svc,
@@ -3892,7 +3892,7 @@ export const PatchProjectsLocationsMigrationJobsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(MigrationJob).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMigrationJobsRequest>;
 
@@ -3929,7 +3929,7 @@ export const DeleteProjectsLocationsMigrationJobsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMigrationJobsRequest>;
 
@@ -3963,7 +3963,7 @@ export const StartProjectsLocationsMigrationJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StartMigrationJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsLocationsMigrationJobsRequest>;
 
@@ -3997,7 +3997,7 @@ export const StopProjectsLocationsMigrationJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopMigrationJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsMigrationJobsRequest>;
 
@@ -4031,7 +4031,7 @@ export const ResumeProjectsLocationsMigrationJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResumeMigrationJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsMigrationJobsRequest>;
 
@@ -4065,7 +4065,7 @@ export const PromoteProjectsLocationsMigrationJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PromoteMigrationJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:promote", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:promote", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PromoteProjectsLocationsMigrationJobsRequest>;
 
@@ -4101,7 +4101,7 @@ export const DemoteDestinationProjectsLocationsMigrationJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:demoteDestination",
+      path: "v1/{+name}:demoteDestination",
       hasBody: true,
     }),
     svc,
@@ -4138,7 +4138,7 @@ export const VerifyProjectsLocationsMigrationJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(VerifyMigrationJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:verify", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:verify", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<VerifyProjectsLocationsMigrationJobsRequest>;
 
@@ -4172,7 +4172,7 @@ export const RestartProjectsLocationsMigrationJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestartMigrationJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:restart", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:restart", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestartProjectsLocationsMigrationJobsRequest>;
 
@@ -4208,7 +4208,7 @@ export const GenerateSshScriptProjectsLocationsMigrationJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{migrationJob}:generateSshScript",
+      path: "v1/{+migrationJob}:generateSshScript",
       hasBody: true,
     }),
     svc,
@@ -4247,7 +4247,7 @@ export const GenerateTcpProxyScriptProjectsLocationsMigrationJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{migrationJob}:generateTcpProxyScript",
+      path: "v1/{+migrationJob}:generateTcpProxyScript",
       hasBody: true,
     }),
     svc,
@@ -4282,7 +4282,7 @@ export const FetchSourceObjectsProjectsLocationsMigrationJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:fetchSourceObjects" }),
+    T.Http({ method: "GET", path: "v1/{+name}:fetchSourceObjects" }),
     svc,
   ) as unknown as Schema.Schema<FetchSourceObjectsProjectsLocationsMigrationJobsRequest>;
 
@@ -4320,7 +4320,7 @@ export const SetIamPolicyProjectsLocationsMigrationJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4358,7 +4358,7 @@ export const GetIamPolicyProjectsLocationsMigrationJobsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsMigrationJobsRequest>;
 
@@ -4394,7 +4394,7 @@ export const TestIamPermissionsProjectsLocationsMigrationJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4429,7 +4429,7 @@ export const GetProjectsLocationsMigrationJobsObjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMigrationJobsObjectsRequest>;
 
@@ -4466,7 +4466,7 @@ export const LookupProjectsLocationsMigrationJobsObjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/objects:lookup",
+      path: "v1/{+parent}/objects:lookup",
       hasBody: true,
     }),
     svc,
@@ -4506,7 +4506,7 @@ export const ListProjectsLocationsMigrationJobsObjectsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/objects" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/objects" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMigrationJobsObjectsRequest>;
 
@@ -4547,7 +4547,7 @@ export const SetIamPolicyProjectsLocationsMigrationJobsObjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4586,7 +4586,7 @@ export const GetIamPolicyProjectsLocationsMigrationJobsObjectsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsMigrationJobsObjectsRequest>;
 
@@ -4623,7 +4623,7 @@ export const TestIamPermissionsProjectsLocationsMigrationJobsObjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4670,7 +4670,7 @@ export const ListProjectsLocationsConnectionProfilesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/connectionProfiles" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/connectionProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionProfilesRequest>;
 
@@ -4706,7 +4706,7 @@ export const GetProjectsLocationsConnectionProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionProfilesRequest>;
 
@@ -4760,7 +4760,7 @@ export const CreateProjectsLocationsConnectionProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/connectionProfiles",
+      path: "v1/{+parent}/connectionProfiles",
       hasBody: true,
     }),
     svc,
@@ -4812,7 +4812,7 @@ export const PatchProjectsLocationsConnectionProfilesRequest =
     ),
     body: Schema.optional(ConnectionProfile).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectionProfilesRequest>;
 
@@ -4849,7 +4849,7 @@ export const DeleteProjectsLocationsConnectionProfilesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectionProfilesRequest>;
 
@@ -4885,7 +4885,7 @@ export const SetIamPolicyProjectsLocationsConnectionProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4924,7 +4924,7 @@ export const GetIamPolicyProjectsLocationsConnectionProfilesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsConnectionProfilesRequest>;
 
@@ -4961,7 +4961,7 @@ export const TestIamPermissionsProjectsLocationsConnectionProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5019,7 +5019,7 @@ export const CreateProjectsLocationsPrivateConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/privateConnections",
+      path: "v1/{+parent}/privateConnections",
       hasBody: true,
     }),
     svc,
@@ -5052,7 +5052,7 @@ export const GetProjectsLocationsPrivateConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPrivateConnectionsRequest>;
 
@@ -5095,7 +5095,7 @@ export const ListProjectsLocationsPrivateConnectionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/privateConnections" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/privateConnections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPrivateConnectionsRequest>;
 
@@ -5134,7 +5134,7 @@ export const DeleteProjectsLocationsPrivateConnectionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPrivateConnectionsRequest>;
 
@@ -5170,7 +5170,7 @@ export const SetIamPolicyProjectsLocationsPrivateConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5209,7 +5209,7 @@ export const GetIamPolicyProjectsLocationsPrivateConnectionsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsPrivateConnectionsRequest>;
 
@@ -5246,7 +5246,7 @@ export const TestIamPermissionsProjectsLocationsPrivateConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5281,7 +5281,7 @@ export const GetProjectsLocationsConversionWorkspacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConversionWorkspacesRequest>;
 
@@ -5322,7 +5322,7 @@ export const ListProjectsLocationsConversionWorkspacesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/conversionWorkspaces" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/conversionWorkspaces" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConversionWorkspacesRequest>;
 
@@ -5371,7 +5371,7 @@ export const CreateProjectsLocationsConversionWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/conversionWorkspaces",
+      path: "v1/{+parent}/conversionWorkspaces",
       hasBody: true,
     }),
     svc,
@@ -5413,7 +5413,7 @@ export const PatchProjectsLocationsConversionWorkspacesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(ConversionWorkspace).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConversionWorkspacesRequest>;
 
@@ -5450,7 +5450,7 @@ export const DeleteProjectsLocationsConversionWorkspacesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConversionWorkspacesRequest>;
 
@@ -5484,7 +5484,7 @@ export const SeedProjectsLocationsConversionWorkspacesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SeedConversionWorkspaceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:seed", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:seed", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SeedProjectsLocationsConversionWorkspacesRequest>;
 
@@ -5518,7 +5518,7 @@ export const ConvertProjectsLocationsConversionWorkspacesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ConvertConversionWorkspaceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:convert", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:convert", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ConvertProjectsLocationsConversionWorkspacesRequest>;
 
@@ -5552,7 +5552,7 @@ export const CommitProjectsLocationsConversionWorkspacesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CommitConversionWorkspaceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:commit", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:commit", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CommitProjectsLocationsConversionWorkspacesRequest>;
 
@@ -5588,7 +5588,7 @@ export const RollbackProjectsLocationsConversionWorkspacesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:rollback", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:rollback", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RollbackProjectsLocationsConversionWorkspacesRequest>;
 
@@ -5622,7 +5622,7 @@ export const ApplyProjectsLocationsConversionWorkspacesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ApplyConversionWorkspaceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:apply", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:apply", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ApplyProjectsLocationsConversionWorkspacesRequest>;
 
@@ -5689,7 +5689,7 @@ export const DescribeDatabaseEntitiesProjectsLocationsConversionWorkspacesReques
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{conversionWorkspace}:describeDatabaseEntities",
+      path: "v1/{+conversionWorkspace}:describeDatabaseEntities",
     }),
     svc,
   ) as unknown as Schema.Schema<DescribeDatabaseEntitiesProjectsLocationsConversionWorkspacesRequest>;
@@ -5742,7 +5742,7 @@ export const SearchBackgroundJobsProjectsLocationsConversionWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{conversionWorkspace}:searchBackgroundJobs",
+      path: "v1/{+conversionWorkspace}:searchBackgroundJobs",
     }),
     svc,
   ) as unknown as Schema.Schema<SearchBackgroundJobsProjectsLocationsConversionWorkspacesRequest>;
@@ -5781,7 +5781,7 @@ export const DescribeConversionWorkspaceRevisionsProjectsLocationsConversionWork
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{conversionWorkspace}:describeConversionWorkspaceRevisions",
+      path: "v1/{+conversionWorkspace}:describeConversionWorkspaceRevisions",
     }),
     svc,
   ) as unknown as Schema.Schema<DescribeConversionWorkspaceRevisionsProjectsLocationsConversionWorkspacesRequest>;
@@ -5822,7 +5822,7 @@ export const SetIamPolicyProjectsLocationsConversionWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5861,7 +5861,7 @@ export const GetIamPolicyProjectsLocationsConversionWorkspacesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsConversionWorkspacesRequest>;
 
@@ -5898,7 +5898,7 @@ export const TestIamPermissionsProjectsLocationsConversionWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5944,7 +5944,11 @@ export const CreateProjectsLocationsConversionWorkspacesMappingRulesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(MappingRule).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/mappingRules", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/mappingRules",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsConversionWorkspacesMappingRulesRequest>;
 
@@ -5980,7 +5984,7 @@ export const DeleteProjectsLocationsConversionWorkspacesMappingRulesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConversionWorkspacesMappingRulesRequest>;
 
@@ -6019,7 +6023,7 @@ export const ListProjectsLocationsConversionWorkspacesMappingRulesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/mappingRules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/mappingRules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConversionWorkspacesMappingRulesRequest>;
 
@@ -6056,7 +6060,7 @@ export const GetProjectsLocationsConversionWorkspacesMappingRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConversionWorkspacesMappingRulesRequest>;
 
@@ -6094,7 +6098,7 @@ export const ImportProjectsLocationsConversionWorkspacesMappingRulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/mappingRules:import",
+      path: "v1/{+parent}/mappingRules:import",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/datamigration-v1beta1.ts
+++ b/packages/gcp/src/services/datamigration-v1beta1.ts
@@ -996,7 +996,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1031,7 +1031,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1076,7 +1076,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1111,7 +1111,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1142,7 +1142,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1176,7 +1176,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1219,7 +1219,7 @@ export const ListProjectsLocationsMigrationJobsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/migrationJobs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/migrationJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMigrationJobsRequest>;
 
@@ -1255,7 +1255,7 @@ export const GetProjectsLocationsMigrationJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMigrationJobsRequest>;
 
@@ -1299,7 +1299,7 @@ export const CreateProjectsLocationsMigrationJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/migrationJobs",
+      path: "v1beta1/{+parent}/migrationJobs",
       hasBody: true,
     }),
     svc,
@@ -1341,7 +1341,7 @@ export const PatchProjectsLocationsMigrationJobsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(MigrationJob).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMigrationJobsRequest>;
 
@@ -1378,7 +1378,7 @@ export const DeleteProjectsLocationsMigrationJobsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMigrationJobsRequest>;
 
@@ -1412,7 +1412,7 @@ export const StartProjectsLocationsMigrationJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StartMigrationJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsLocationsMigrationJobsRequest>;
 
@@ -1446,7 +1446,7 @@ export const StopProjectsLocationsMigrationJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopMigrationJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsMigrationJobsRequest>;
 
@@ -1480,7 +1480,7 @@ export const ResumeProjectsLocationsMigrationJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResumeMigrationJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsMigrationJobsRequest>;
 
@@ -1514,7 +1514,7 @@ export const PromoteProjectsLocationsMigrationJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PromoteMigrationJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:promote", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:promote", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PromoteProjectsLocationsMigrationJobsRequest>;
 
@@ -1548,7 +1548,7 @@ export const VerifyProjectsLocationsMigrationJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(VerifyMigrationJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:verify", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:verify", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<VerifyProjectsLocationsMigrationJobsRequest>;
 
@@ -1582,7 +1582,7 @@ export const RestartProjectsLocationsMigrationJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestartMigrationJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:restart", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:restart", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestartProjectsLocationsMigrationJobsRequest>;
 
@@ -1618,7 +1618,7 @@ export const GenerateSshScriptProjectsLocationsMigrationJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{migrationJob}:generateSshScript",
+      path: "v1beta1/{+migrationJob}:generateSshScript",
       hasBody: true,
     }),
     svc,
@@ -1657,7 +1657,7 @@ export const SetIamPolicyProjectsLocationsMigrationJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1695,7 +1695,7 @@ export const GetIamPolicyProjectsLocationsMigrationJobsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsMigrationJobsRequest>;
 
@@ -1731,7 +1731,7 @@ export const TestIamPermissionsProjectsLocationsMigrationJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1778,7 +1778,7 @@ export const ListProjectsLocationsConnectionProfilesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/connectionProfiles" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/connectionProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionProfilesRequest>;
 
@@ -1814,7 +1814,7 @@ export const GetProjectsLocationsConnectionProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionProfilesRequest>;
 
@@ -1858,7 +1858,7 @@ export const CreateProjectsLocationsConnectionProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/connectionProfiles",
+      path: "v1beta1/{+parent}/connectionProfiles",
       hasBody: true,
     }),
     svc,
@@ -1900,7 +1900,7 @@ export const PatchProjectsLocationsConnectionProfilesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(ConnectionProfile).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectionProfilesRequest>;
 
@@ -1937,7 +1937,7 @@ export const DeleteProjectsLocationsConnectionProfilesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectionProfilesRequest>;
 
@@ -1973,7 +1973,7 @@ export const SetIamPolicyProjectsLocationsConnectionProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2012,7 +2012,7 @@ export const GetIamPolicyProjectsLocationsConnectionProfilesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsConnectionProfilesRequest>;
 
@@ -2049,7 +2049,7 @@ export const TestIamPermissionsProjectsLocationsConnectionProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/datapipelines-v1.ts
+++ b/packages/gcp/src/services/datapipelines-v1.ts
@@ -515,7 +515,7 @@ export const CreateProjectsLocationsPipelinesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/pipelines", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/pipelines", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsPipelinesRequest>;
 
@@ -555,7 +555,7 @@ export const PatchProjectsLocationsPipelinesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPipelinesRequest>;
 
@@ -587,7 +587,7 @@ export const DeleteProjectsLocationsPipelinesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPipelinesRequest>;
 
@@ -627,7 +627,7 @@ export const ListProjectsLocationsPipelinesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/pipelines" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/pipelines" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPipelinesRequest>;
 
@@ -663,7 +663,7 @@ export const GetProjectsLocationsPipelinesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPipelinesRequest>;
 
@@ -700,7 +700,7 @@ export const StopProjectsLocationsPipelinesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsPipelinesRequest>;
 
@@ -737,7 +737,7 @@ export const RunProjectsLocationsPipelinesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsPipelinesRequest>;
 
@@ -775,7 +775,7 @@ export const ListProjectsLocationsPipelinesJobsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/jobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/jobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPipelinesJobsRequest>;
 

--- a/packages/gcp/src/services/dataplex-v1.ts
+++ b/packages/gcp/src/services/dataplex-v1.ts
@@ -5716,7 +5716,7 @@ export const LookupEntryProjectsLocationsRequest =
       T.HttpQuery("paths"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:lookupEntry" }),
+    T.Http({ method: "GET", path: "v1/{+name}:lookupEntry" }),
     svc,
   ) as unknown as Schema.Schema<LookupEntryProjectsLocationsRequest>;
 
@@ -5752,7 +5752,7 @@ export const LookupContextProjectsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:lookupContext", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:lookupContext", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<LookupContextProjectsLocationsRequest>;
 
@@ -5798,7 +5798,7 @@ export const ListProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -5834,7 +5834,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -5882,7 +5882,7 @@ export const LookupEntryLinksProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     entry: Schema.optional(Schema.String).pipe(T.HttpQuery("entry")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:lookupEntryLinks" }),
+    T.Http({ method: "GET", path: "v1/{+name}:lookupEntryLinks" }),
     svc,
   ) as unknown as Schema.Schema<LookupEntryLinksProjectsLocationsRequest>;
 
@@ -5938,7 +5938,7 @@ export const SearchEntriesProjectsLocationsRequest =
     ),
     query: Schema.optional(Schema.String).pipe(T.HttpQuery("query")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:searchEntries", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:searchEntries", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SearchEntriesProjectsLocationsRequest>;
 
@@ -5979,7 +5979,7 @@ export const ModifyEntryProjectsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:modifyEntry", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:modifyEntry", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ModifyEntryProjectsLocationsRequest>;
 
@@ -6017,7 +6017,7 @@ export const TestIamPermissionsProjectsLocationsEntryGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -6062,7 +6062,7 @@ export const PatchProjectsLocationsEntryGroupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDataplexV1EntryGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEntryGroupsRequest>;
 
@@ -6097,7 +6097,7 @@ export const DeleteProjectsLocationsEntryGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEntryGroupsRequest>;
 
@@ -6134,7 +6134,7 @@ export const SetIamPolicyProjectsLocationsEntryGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -6180,7 +6180,7 @@ export const ListProjectsLocationsEntryGroupsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/entryGroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/entryGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEntryGroupsRequest>;
 
@@ -6216,7 +6216,7 @@ export const GetProjectsLocationsEntryGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEntryGroupsRequest>;
 
@@ -6253,7 +6253,7 @@ export const GetIamPolicyProjectsLocationsEntryGroupsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsEntryGroupsRequest>;
 
@@ -6298,7 +6298,7 @@ export const CreateProjectsLocationsEntryGroupsRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1EntryGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/entryGroups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/entryGroups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsEntryGroupsRequest>;
 
@@ -6336,7 +6336,7 @@ export const CreateProjectsLocationsEntryGroupsEntriesRequest =
     entryId: Schema.optional(Schema.String).pipe(T.HttpQuery("entryId")),
     body: Schema.optional(GoogleCloudDataplexV1Entry).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/entries", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/entries", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsEntryGroupsEntriesRequest>;
 
@@ -6377,7 +6377,7 @@ export const ListProjectsLocationsEntryGroupsEntriesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/entries" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/entries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEntryGroupsEntriesRequest>;
 
@@ -6432,7 +6432,7 @@ export const GetProjectsLocationsEntryGroupsEntriesRequest =
       T.HttpQuery("paths"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEntryGroupsEntriesRequest>;
 
@@ -6464,7 +6464,7 @@ export const DeleteProjectsLocationsEntryGroupsEntriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEntryGroupsEntriesRequest>;
 
@@ -6517,7 +6517,7 @@ export const PatchProjectsLocationsEntryGroupsEntriesRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1Entry).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEntryGroupsEntriesRequest>;
 
@@ -6562,7 +6562,7 @@ export const PatchProjectsLocationsEntryGroupsEntryLinksRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1EntryLink).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEntryGroupsEntryLinksRequest>;
 
@@ -6602,7 +6602,7 @@ export const CreateProjectsLocationsEntryGroupsEntryLinksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDataplexV1EntryLink).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/entryLinks", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/entryLinks", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsEntryGroupsEntryLinksRequest>;
 
@@ -6634,7 +6634,7 @@ export const DeleteProjectsLocationsEntryGroupsEntryLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEntryGroupsEntryLinksRequest>;
 
@@ -6666,7 +6666,7 @@ export const GetProjectsLocationsEntryGroupsEntryLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEntryGroupsEntryLinksRequest>;
 
@@ -6703,7 +6703,7 @@ export const GetIamPolicyProjectsLocationsEntryLinkTypesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsEntryLinkTypesRequest>;
 
@@ -6742,7 +6742,7 @@ export const TestIamPermissionsProjectsLocationsEntryLinkTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -6782,7 +6782,7 @@ export const SetIamPolicyProjectsLocationsEntryLinkTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -6819,7 +6819,7 @@ export const DeleteProjectsLocationsGlossariesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlossariesRequest>;
 
@@ -6856,7 +6856,7 @@ export const SetIamPolicyProjectsLocationsGlossariesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -6900,7 +6900,7 @@ export const PatchProjectsLocationsGlossariesRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1Glossary).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlossariesRequest>;
 
@@ -6939,7 +6939,7 @@ export const TestIamPermissionsProjectsLocationsGlossariesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -6984,7 +6984,7 @@ export const CreateProjectsLocationsGlossariesRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1Glossary).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/glossaries", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/glossaries", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGlossariesRequest>;
 
@@ -7021,7 +7021,7 @@ export const GetIamPolicyProjectsLocationsGlossariesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGlossariesRequest>;
 
@@ -7052,7 +7052,7 @@ export const GetProjectsLocationsGlossariesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlossariesRequest>;
 
@@ -7096,7 +7096,7 @@ export const ListProjectsLocationsGlossariesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/glossaries" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/glossaries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlossariesRequest>;
 
@@ -7132,7 +7132,7 @@ export const GetProjectsLocationsGlossariesTermsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlossariesTermsRequest>;
 
@@ -7176,7 +7176,7 @@ export const ListProjectsLocationsGlossariesTermsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/terms" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/terms" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlossariesTermsRequest>;
 
@@ -7217,7 +7217,7 @@ export const GetIamPolicyProjectsLocationsGlossariesTermsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGlossariesTermsRequest>;
 
@@ -7255,7 +7255,7 @@ export const CreateProjectsLocationsGlossariesTermsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDataplexV1GlossaryTerm).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/terms", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/terms", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGlossariesTermsRequest>;
 
@@ -7294,7 +7294,7 @@ export const TestIamPermissionsProjectsLocationsGlossariesTermsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -7335,7 +7335,7 @@ export const PatchProjectsLocationsGlossariesTermsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudDataplexV1GlossaryTerm).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlossariesTermsRequest>;
 
@@ -7367,7 +7367,7 @@ export const DeleteProjectsLocationsGlossariesTermsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlossariesTermsRequest>;
 
@@ -7403,7 +7403,7 @@ export const SetIamPolicyProjectsLocationsGlossariesTermsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -7437,7 +7437,7 @@ export const GetProjectsLocationsGlossariesCategoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlossariesCategoriesRequest>;
 
@@ -7481,7 +7481,7 @@ export const ListProjectsLocationsGlossariesCategoriesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/categories" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/categories" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlossariesCategoriesRequest>;
 
@@ -7522,7 +7522,7 @@ export const GetIamPolicyProjectsLocationsGlossariesCategoriesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGlossariesCategoriesRequest>;
 
@@ -7563,7 +7563,7 @@ export const CreateProjectsLocationsGlossariesCategoriesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/categories", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/categories", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGlossariesCategoriesRequest>;
 
@@ -7602,7 +7602,7 @@ export const TestIamPermissionsProjectsLocationsGlossariesCategoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -7645,7 +7645,7 @@ export const PatchProjectsLocationsGlossariesCategoriesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlossariesCategoriesRequest>;
 
@@ -7677,7 +7677,7 @@ export const DeleteProjectsLocationsGlossariesCategoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlossariesCategoriesRequest>;
 
@@ -7713,7 +7713,7 @@ export const SetIamPolicyProjectsLocationsGlossariesCategoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -7753,7 +7753,7 @@ export const SetIamPolicyProjectsLocationsLakesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -7786,7 +7786,7 @@ export const DeleteProjectsLocationsLakesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsLakesRequest>;
 
@@ -7828,7 +7828,7 @@ export const PatchProjectsLocationsLakesRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1Lake).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsLakesRequest>;
 
@@ -7866,7 +7866,7 @@ export const TestIamPermissionsProjectsLocationsLakesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -7911,7 +7911,7 @@ export const CreateProjectsLocationsLakesRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1Lake).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/lakes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/lakes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsLakesRequest>;
 
@@ -7947,7 +7947,7 @@ export const GetIamPolicyProjectsLocationsLakesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsLakesRequest>;
 
@@ -7990,7 +7990,7 @@ export const ListProjectsLocationsLakesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/lakes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/lakes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsLakesRequest>;
 
@@ -8026,7 +8026,7 @@ export const GetProjectsLocationsLakesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsLakesRequest>;
 
@@ -8063,7 +8063,7 @@ export const ListProjectsLocationsLakesActionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/actions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/actions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsLakesActionsRequest>;
 
@@ -8110,7 +8110,7 @@ export const CreateProjectsLocationsLakesTasksRequest =
     taskId: Schema.optional(Schema.String).pipe(T.HttpQuery("taskId")),
     body: Schema.optional(GoogleCloudDataplexV1Task).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/tasks", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/tasks", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsLakesTasksRequest>;
 
@@ -8154,7 +8154,7 @@ export const ListProjectsLocationsLakesTasksRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/tasks" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/tasks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsLakesTasksRequest>;
 
@@ -8195,7 +8195,7 @@ export const RunProjectsLocationsLakesTasksRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsLakesTasksRequest>;
 
@@ -8238,7 +8238,7 @@ export const PatchProjectsLocationsLakesTasksRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDataplexV1Task).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsLakesTasksRequest>;
 
@@ -8277,7 +8277,7 @@ export const TestIamPermissionsProjectsLocationsLakesTasksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -8311,7 +8311,7 @@ export const GetProjectsLocationsLakesTasksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsLakesTasksRequest>;
 
@@ -8347,7 +8347,7 @@ export const GetIamPolicyProjectsLocationsLakesTasksRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsLakesTasksRequest>;
 
@@ -8383,7 +8383,7 @@ export const SetIamPolicyProjectsLocationsLakesTasksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -8416,7 +8416,7 @@ export const DeleteProjectsLocationsLakesTasksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsLakesTasksRequest>;
 
@@ -8453,7 +8453,7 @@ export const CancelProjectsLocationsLakesTasksJobsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsLakesTasksJobsRequest>;
 
@@ -8490,7 +8490,7 @@ export const ListProjectsLocationsLakesTasksJobsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/jobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/jobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsLakesTasksJobsRequest>;
 
@@ -8526,7 +8526,7 @@ export const GetProjectsLocationsLakesTasksJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsLakesTasksJobsRequest>;
 
@@ -8565,7 +8565,7 @@ export const TestIamPermissionsProjectsLocationsLakesZonesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -8604,7 +8604,7 @@ export const SetIamPolicyProjectsLocationsLakesZonesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -8637,7 +8637,7 @@ export const DeleteProjectsLocationsLakesZonesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsLakesZonesRequest>;
 
@@ -8680,7 +8680,7 @@ export const PatchProjectsLocationsLakesZonesRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1Zone).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsLakesZonesRequest>;
 
@@ -8717,7 +8717,7 @@ export const GetIamPolicyProjectsLocationsLakesZonesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsLakesZonesRequest>;
 
@@ -8760,7 +8760,7 @@ export const ListProjectsLocationsLakesZonesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/zones" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/zones" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsLakesZonesRequest>;
 
@@ -8796,7 +8796,7 @@ export const GetProjectsLocationsLakesZonesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsLakesZonesRequest>;
 
@@ -8838,7 +8838,7 @@ export const CreateProjectsLocationsLakesZonesRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1Zone).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/zones", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/zones", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsLakesZonesRequest>;
 
@@ -8878,7 +8878,7 @@ export const UpdateProjectsLocationsLakesZonesEntitiesRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1Entity).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsLakesZonesEntitiesRequest>;
 
@@ -8913,7 +8913,7 @@ export const DeleteProjectsLocationsLakesZonesEntitiesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsLakesZonesEntitiesRequest>;
 
@@ -8952,7 +8952,7 @@ export const GetProjectsLocationsLakesZonesEntitiesRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsLakesZonesEntitiesRequest>;
 
@@ -8996,7 +8996,7 @@ export const ListProjectsLocationsLakesZonesEntitiesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/entities" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/entities" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsLakesZonesEntitiesRequest>;
 
@@ -9040,7 +9040,7 @@ export const CreateProjectsLocationsLakesZonesEntitiesRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1Entity).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/entities", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/entities", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsLakesZonesEntitiesRequest>;
 
@@ -9080,7 +9080,7 @@ export const CreateProjectsLocationsLakesZonesEntitiesPartitionsRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1Partition).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/partitions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/partitions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsLakesZonesEntitiesPartitionsRequest>;
 
@@ -9116,7 +9116,7 @@ export const DeleteProjectsLocationsLakesZonesEntitiesPartitionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsLakesZonesEntitiesPartitionsRequest>;
 
@@ -9148,7 +9148,7 @@ export const GetProjectsLocationsLakesZonesEntitiesPartitionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsLakesZonesEntitiesPartitionsRequest>;
 
@@ -9190,7 +9190,7 @@ export const ListProjectsLocationsLakesZonesEntitiesPartitionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/partitions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/partitions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsLakesZonesEntitiesPartitionsRequest>;
 
@@ -9238,7 +9238,7 @@ export const PatchProjectsLocationsLakesZonesAssetsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDataplexV1Asset).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsLakesZonesAssetsRequest>;
 
@@ -9275,7 +9275,7 @@ export const SetIamPolicyProjectsLocationsLakesZonesAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -9309,7 +9309,7 @@ export const DeleteProjectsLocationsLakesZonesAssetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsLakesZonesAssetsRequest>;
 
@@ -9348,7 +9348,7 @@ export const TestIamPermissionsProjectsLocationsLakesZonesAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -9394,7 +9394,7 @@ export const CreateProjectsLocationsLakesZonesAssetsRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1Asset).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/assets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/assets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsLakesZonesAssetsRequest>;
 
@@ -9438,7 +9438,7 @@ export const ListProjectsLocationsLakesZonesAssetsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/assets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/assets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsLakesZonesAssetsRequest>;
 
@@ -9474,7 +9474,7 @@ export const GetProjectsLocationsLakesZonesAssetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsLakesZonesAssetsRequest>;
 
@@ -9511,7 +9511,7 @@ export const GetIamPolicyProjectsLocationsLakesZonesAssetsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsLakesZonesAssetsRequest>;
 
@@ -9549,7 +9549,7 @@ export const ListProjectsLocationsLakesZonesAssetsActionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/actions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/actions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsLakesZonesAssetsActionsRequest>;
 
@@ -9591,7 +9591,7 @@ export const ListProjectsLocationsLakesZonesActionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/actions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/actions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsLakesZonesActionsRequest>;
 
@@ -9642,7 +9642,7 @@ export const CreateProjectsLocationsMetadataFeedsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/metadataFeeds",
+      path: "v1/{+parent}/metadataFeeds",
       hasBody: true,
     }),
     svc,
@@ -9676,7 +9676,7 @@ export const GetProjectsLocationsMetadataFeedsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataFeedsRequest>;
 
@@ -9720,7 +9720,7 @@ export const ListProjectsLocationsMetadataFeedsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/metadataFeeds" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/metadataFeeds" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataFeedsRequest>;
 
@@ -9756,7 +9756,7 @@ export const DeleteProjectsLocationsMetadataFeedsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMetadataFeedsRequest>;
 
@@ -9799,7 +9799,7 @@ export const PatchProjectsLocationsMetadataFeedsRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1MetadataFeed).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMetadataFeedsRequest>;
 
@@ -9836,7 +9836,7 @@ export const SetIamPolicyProjectsLocationsChangeRequestsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -9875,7 +9875,7 @@ export const GetIamPolicyProjectsLocationsChangeRequestsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsChangeRequestsRequest>;
 
@@ -9914,7 +9914,7 @@ export const TestIamPermissionsProjectsLocationsChangeRequestsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -9954,7 +9954,7 @@ export const GetIamPolicyProjectsLocationsPolicyIntentsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsPolicyIntentsRequest>;
 
@@ -9993,7 +9993,7 @@ export const TestIamPermissionsProjectsLocationsPolicyIntentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -10033,7 +10033,7 @@ export const SetIamPolicyProjectsLocationsPolicyIntentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -10072,7 +10072,7 @@ export const CancelProjectsLocationsMetadataJobsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsMetadataJobsRequest>;
 
@@ -10103,7 +10103,7 @@ export const GetProjectsLocationsMetadataJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMetadataJobsRequest>;
 
@@ -10147,7 +10147,7 @@ export const ListProjectsLocationsMetadataJobsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/metadataJobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/metadataJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMetadataJobsRequest>;
 
@@ -10196,7 +10196,11 @@ export const CreateProjectsLocationsMetadataJobsRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1MetadataJob).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/metadataJobs", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/metadataJobs",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsMetadataJobsRequest>;
 
@@ -10241,7 +10245,7 @@ export const PatchProjectsLocationsDataAttributeBindingsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataAttributeBindingsRequest>;
 
@@ -10278,7 +10282,7 @@ export const SetIamPolicyProjectsLocationsDataAttributeBindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -10316,7 +10320,7 @@ export const DeleteProjectsLocationsDataAttributeBindingsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataAttributeBindingsRequest>;
 
@@ -10355,7 +10359,7 @@ export const TestIamPermissionsProjectsLocationsDataAttributeBindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -10407,7 +10411,7 @@ export const CreateProjectsLocationsDataAttributeBindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/dataAttributeBindings",
+      path: "v1/{+parent}/dataAttributeBindings",
       hasBody: true,
     }),
     svc,
@@ -10453,7 +10457,7 @@ export const ListProjectsLocationsDataAttributeBindingsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dataAttributeBindings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dataAttributeBindings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataAttributeBindingsRequest>;
 
@@ -10489,7 +10493,7 @@ export const GetProjectsLocationsDataAttributeBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataAttributeBindingsRequest>;
 
@@ -10526,7 +10530,7 @@ export const GetIamPolicyProjectsLocationsDataAttributeBindingsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDataAttributeBindingsRequest>;
 
@@ -10573,7 +10577,7 @@ export const CreateProjectsLocationsDataTaxonomiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/dataTaxonomies",
+      path: "v1/{+parent}/dataTaxonomies",
       hasBody: true,
     }),
     svc,
@@ -10619,7 +10623,7 @@ export const ListProjectsLocationsDataTaxonomiesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dataTaxonomies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dataTaxonomies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataTaxonomiesRequest>;
 
@@ -10654,7 +10658,7 @@ export const GetProjectsLocationsDataTaxonomiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataTaxonomiesRequest>;
 
@@ -10691,7 +10695,7 @@ export const GetIamPolicyProjectsLocationsDataTaxonomiesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDataTaxonomiesRequest>;
 
@@ -10734,7 +10738,7 @@ export const PatchProjectsLocationsDataTaxonomiesRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1DataTaxonomy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataTaxonomiesRequest>;
 
@@ -10771,7 +10775,7 @@ export const SetIamPolicyProjectsLocationsDataTaxonomiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -10808,7 +10812,7 @@ export const DeleteProjectsLocationsDataTaxonomiesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataTaxonomiesRequest>;
 
@@ -10847,7 +10851,7 @@ export const TestIamPermissionsProjectsLocationsDataTaxonomiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -10895,7 +10899,7 @@ export const PatchProjectsLocationsDataTaxonomiesAttributesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataTaxonomiesAttributesRequest>;
 
@@ -10932,7 +10936,7 @@ export const SetIamPolicyProjectsLocationsDataTaxonomiesAttributesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -10970,7 +10974,7 @@ export const DeleteProjectsLocationsDataTaxonomiesAttributesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataTaxonomiesAttributesRequest>;
 
@@ -11010,7 +11014,7 @@ export const TestIamPermissionsProjectsLocationsDataTaxonomiesAttributesRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -11060,7 +11064,7 @@ export const CreateProjectsLocationsDataTaxonomiesAttributesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/attributes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/attributes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataTaxonomiesAttributesRequest>;
 
@@ -11105,7 +11109,7 @@ export const ListProjectsLocationsDataTaxonomiesAttributesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/attributes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/attributes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataTaxonomiesAttributesRequest>;
 
@@ -11141,7 +11145,7 @@ export const GetProjectsLocationsDataTaxonomiesAttributesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataTaxonomiesAttributesRequest>;
 
@@ -11178,7 +11182,7 @@ export const GetIamPolicyProjectsLocationsDataTaxonomiesAttributesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDataTaxonomiesAttributesRequest>;
 
@@ -11218,7 +11222,7 @@ export const TestIamPermissionsProjectsLocationsAspectTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -11263,7 +11267,7 @@ export const PatchProjectsLocationsAspectTypesRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1AspectType).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAspectTypesRequest>;
 
@@ -11298,7 +11302,7 @@ export const DeleteProjectsLocationsAspectTypesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAspectTypesRequest>;
 
@@ -11335,7 +11339,7 @@ export const SetIamPolicyProjectsLocationsAspectTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -11381,7 +11385,7 @@ export const ListProjectsLocationsAspectTypesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/aspectTypes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/aspectTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAspectTypesRequest>;
 
@@ -11417,7 +11421,7 @@ export const GetProjectsLocationsAspectTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAspectTypesRequest>;
 
@@ -11454,7 +11458,7 @@ export const GetIamPolicyProjectsLocationsAspectTypesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsAspectTypesRequest>;
 
@@ -11499,7 +11503,7 @@ export const CreateProjectsLocationsAspectTypesRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1AspectType).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/aspectTypes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/aspectTypes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAspectTypesRequest>;
 
@@ -11545,7 +11549,7 @@ export const ListProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -11581,7 +11585,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -11617,7 +11621,7 @@ export const CancelProjectsLocationsOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -11648,7 +11652,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -11684,7 +11688,7 @@ export const SetIamPolicyProjectsLocationsDataProductsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -11726,7 +11730,7 @@ export const DeleteProjectsLocationsDataProductsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataProductsRequest>;
 
@@ -11769,7 +11773,7 @@ export const PatchProjectsLocationsDataProductsRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1DataProduct).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataProductsRequest>;
 
@@ -11808,7 +11812,7 @@ export const TestIamPermissionsProjectsLocationsDataProductsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -11856,7 +11860,11 @@ export const CreateProjectsLocationsDataProductsRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1DataProduct).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/dataProducts", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/dataProducts",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataProductsRequest>;
 
@@ -11893,7 +11901,7 @@ export const GetIamPolicyProjectsLocationsDataProductsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDataProductsRequest>;
 
@@ -11925,7 +11933,7 @@ export const GetProjectsLocationsDataProductsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataProductsRequest>;
 
@@ -11969,7 +11977,7 @@ export const ListProjectsLocationsDataProductsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dataProducts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dataProducts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataProductsRequest>;
 
@@ -12013,7 +12021,7 @@ export const DeleteProjectsLocationsDataProductsDataAssetsRequest =
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataProductsDataAssetsRequest>;
 
@@ -12056,7 +12064,7 @@ export const PatchProjectsLocationsDataProductsDataAssetsRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1DataAsset).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataProductsDataAssetsRequest>;
 
@@ -12101,7 +12109,7 @@ export const CreateProjectsLocationsDataProductsDataAssetsRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1DataAsset).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/dataAssets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/dataAssets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataProductsDataAssetsRequest>;
 
@@ -12133,7 +12141,7 @@ export const GetProjectsLocationsDataProductsDataAssetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataProductsDataAssetsRequest>;
 
@@ -12177,7 +12185,7 @@ export const ListProjectsLocationsDataProductsDataAssetsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dataAssets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dataAssets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataProductsDataAssetsRequest>;
 
@@ -12218,7 +12226,7 @@ export const GetIamPolicyProjectsLocationsDataDomainsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDataDomainsRequest>;
 
@@ -12257,7 +12265,7 @@ export const TestIamPermissionsProjectsLocationsDataDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -12296,7 +12304,7 @@ export const SetIamPolicyProjectsLocationsDataDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -12337,7 +12345,7 @@ export const GenerateDataQualityRulesProjectsLocationsDataScansRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:generateDataQualityRules",
+      path: "v1/{+name}:generateDataQualityRules",
       hasBody: true,
     }),
     svc,
@@ -12377,7 +12385,7 @@ export const SetIamPolicyProjectsLocationsDataScansRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -12413,7 +12421,7 @@ export const DeleteProjectsLocationsDataScansRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataScansRequest>;
 
@@ -12448,7 +12456,7 @@ export const GetProjectsLocationsDataScansRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataScansRequest>;
 
@@ -12485,7 +12493,7 @@ export const GetIamPolicyProjectsLocationsDataScansRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDataScansRequest>;
 
@@ -12523,7 +12531,7 @@ export const TestIamPermissionsProjectsLocationsDataScansRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -12568,7 +12576,7 @@ export const PatchProjectsLocationsDataScansRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDataplexV1DataScan).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataScansRequest>;
 
@@ -12612,7 +12620,7 @@ export const ListProjectsLocationsDataScansRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dataScans" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dataScans" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataScansRequest>;
 
@@ -12653,7 +12661,7 @@ export const RunProjectsLocationsDataScansRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsDataScansRequest>;
 
@@ -12696,7 +12704,7 @@ export const CreateProjectsLocationsDataScansRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1DataScan).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/dataScans", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/dataScans", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataScansRequest>;
 
@@ -12731,7 +12739,7 @@ export const GetProjectsLocationsDataScansJobsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataScansJobsRequest>;
 
@@ -12772,7 +12780,7 @@ export const ListProjectsLocationsDataScansJobsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/jobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/jobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataScansJobsRequest>;
 
@@ -12815,7 +12823,7 @@ export const GenerateDataQualityRulesProjectsLocationsDataScansJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:generateDataQualityRules",
+      path: "v1/{+name}:generateDataQualityRules",
       hasBody: true,
     }),
     svc,
@@ -12855,7 +12863,7 @@ export const CancelProjectsLocationsDataScansJobsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDataScansJobsRequest>;
 
@@ -12892,7 +12900,7 @@ export const GetIamPolicyProjectsLocationsGovernanceRulesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGovernanceRulesRequest>;
 
@@ -12931,7 +12939,7 @@ export const TestIamPermissionsProjectsLocationsGovernanceRulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -12971,7 +12979,7 @@ export const SetIamPolicyProjectsLocationsGovernanceRulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -13012,7 +13020,7 @@ export const TestIamPermissionsProjectsLocationsEntryTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -13049,7 +13057,7 @@ export const DeleteProjectsLocationsEntryTypesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEntryTypesRequest>;
 
@@ -13086,7 +13094,7 @@ export const SetIamPolicyProjectsLocationsEntryTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -13130,7 +13138,7 @@ export const PatchProjectsLocationsEntryTypesRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1EntryType).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEntryTypesRequest>;
 
@@ -13167,7 +13175,7 @@ export const GetIamPolicyProjectsLocationsEntryTypesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsEntryTypesRequest>;
 
@@ -13210,7 +13218,7 @@ export const ListProjectsLocationsEntryTypesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/entryTypes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/entryTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEntryTypesRequest>;
 
@@ -13246,7 +13254,7 @@ export const GetProjectsLocationsEntryTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEntryTypesRequest>;
 
@@ -13291,7 +13299,7 @@ export const CreateProjectsLocationsEntryTypesRequest =
     ),
     body: Schema.optional(GoogleCloudDataplexV1EntryType).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/entryTypes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/entryTypes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsEntryTypesRequest>;
 
@@ -13337,7 +13345,7 @@ export const ListOrganizationsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsOperationsRequest>;
 
@@ -13373,7 +13381,7 @@ export const GetOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsOperationsRequest>;
 
@@ -13410,7 +13418,7 @@ export const CancelOrganizationsLocationsOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOrganizationsLocationsOperationsRequest>;
 
@@ -13441,7 +13449,7 @@ export const DeleteOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsOperationsRequest>;
 
@@ -13479,7 +13487,7 @@ export const TestIamPermissionsOrganizationsLocationsEncryptionConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -13522,7 +13530,7 @@ export const PatchOrganizationsLocationsEncryptionConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsEncryptionConfigsRequest>;
 
@@ -13557,7 +13565,7 @@ export const DeleteOrganizationsLocationsEncryptionConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsEncryptionConfigsRequest>;
 
@@ -13594,7 +13602,7 @@ export const SetIamPolicyOrganizationsLocationsEncryptionConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -13641,7 +13649,7 @@ export const ListOrganizationsLocationsEncryptionConfigsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/encryptionConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/encryptionConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsEncryptionConfigsRequest>;
 
@@ -13677,7 +13685,7 @@ export const GetOrganizationsLocationsEncryptionConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsEncryptionConfigsRequest>;
 
@@ -13714,7 +13722,7 @@ export const GetIamPolicyOrganizationsLocationsEncryptionConfigsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyOrganizationsLocationsEncryptionConfigsRequest>;
 
@@ -13759,7 +13767,7 @@ export const CreateOrganizationsLocationsEncryptionConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/encryptionConfigs",
+      path: "v1/{+parent}/encryptionConfigs",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/dataportability-v1.ts
+++ b/packages/gcp/src/services/dataportability-v1.ts
@@ -198,7 +198,7 @@ export const CancelArchiveJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelPortabilityArchiveRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelArchiveJobsRequest>;
 
@@ -232,7 +232,7 @@ export const RetryArchiveJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RetryPortabilityArchiveRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:retry", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:retry", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RetryArchiveJobsRequest>;
 
@@ -263,7 +263,7 @@ export const GetPortabilityArchiveStateArchiveJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPortabilityArchiveStateArchiveJobsRequest>;
 

--- a/packages/gcp/src/services/dataportability-v1beta.ts
+++ b/packages/gcp/src/services/dataportability-v1beta.ts
@@ -198,7 +198,7 @@ export const RetryArchiveJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RetryPortabilityArchiveRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:retry", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:retry", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RetryArchiveJobsRequest>;
 
@@ -229,7 +229,7 @@ export const GetPortabilityArchiveStateArchiveJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPortabilityArchiveStateArchiveJobsRequest>;
 
@@ -264,7 +264,7 @@ export const CancelArchiveJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelPortabilityArchiveRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelArchiveJobsRequest>;
 

--- a/packages/gcp/src/services/dataproc-v1.ts
+++ b/packages/gcp/src/services/dataproc-v1.ts
@@ -5380,7 +5380,7 @@ export const ListProjectsRegionsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsRegionsOperationsRequest>;
 
@@ -5415,7 +5415,7 @@ export const GetProjectsRegionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsRegionsOperationsRequest>;
 
@@ -5446,7 +5446,7 @@ export const DeleteProjectsRegionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsRegionsOperationsRequest>;
 
@@ -5477,7 +5477,7 @@ export const CancelProjectsRegionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsRegionsOperationsRequest>;
 
@@ -5513,7 +5513,7 @@ export const SetIamPolicyProjectsRegionsOperationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5551,7 +5551,7 @@ export const GetIamPolicyProjectsRegionsOperationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5589,7 +5589,7 @@ export const TestIamPermissionsProjectsRegionsOperationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -6061,7 +6061,7 @@ export const InjectCredentialsProjectsRegionsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{project}/{region}/{cluster}:injectCredentials",
+      path: "v1/{+project}/{+region}/{+cluster}:injectCredentials",
       hasBody: true,
     }),
     svc,
@@ -6099,7 +6099,7 @@ export const SetIamPolicyProjectsRegionsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -6137,7 +6137,7 @@ export const GetIamPolicyProjectsRegionsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -6175,7 +6175,7 @@ export const TestIamPermissionsProjectsRegionsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -6225,7 +6225,7 @@ export const CreateProjectsRegionsClustersNodeGroupsRequest =
     ),
     body: Schema.optional(NodeGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/nodeGroups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/nodeGroups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsRegionsClustersNodeGroupsRequest>;
 
@@ -6259,7 +6259,7 @@ export const ResizeProjectsRegionsClustersNodeGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResizeNodeGroupRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:resize", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:resize", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResizeProjectsRegionsClustersNodeGroupsRequest>;
 
@@ -6293,7 +6293,7 @@ export const RepairProjectsRegionsClustersNodeGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RepairNodeGroupRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:repair", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:repair", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RepairProjectsRegionsClustersNodeGroupsRequest>;
 
@@ -6324,7 +6324,7 @@ export const GetProjectsRegionsClustersNodeGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsRegionsClustersNodeGroupsRequest>;
 
@@ -6360,7 +6360,7 @@ export const CreateProjectsRegionsAutoscalingPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/autoscalingPolicies",
+      path: "v1/{+parent}/autoscalingPolicies",
       hasBody: true,
     }),
     svc,
@@ -6397,7 +6397,7 @@ export const UpdateProjectsRegionsAutoscalingPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AutoscalingPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsRegionsAutoscalingPoliciesRequest>;
 
@@ -6429,7 +6429,7 @@ export const GetProjectsRegionsAutoscalingPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsRegionsAutoscalingPoliciesRequest>;
 
@@ -6466,7 +6466,7 @@ export const ListProjectsRegionsAutoscalingPoliciesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/autoscalingPolicies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/autoscalingPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsRegionsAutoscalingPoliciesRequest>;
 
@@ -6502,7 +6502,7 @@ export const DeleteProjectsRegionsAutoscalingPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsRegionsAutoscalingPoliciesRequest>;
 
@@ -6538,7 +6538,7 @@ export const SetIamPolicyProjectsRegionsAutoscalingPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -6576,7 +6576,7 @@ export const GetIamPolicyProjectsRegionsAutoscalingPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -6614,7 +6614,7 @@ export const TestIamPermissionsProjectsRegionsAutoscalingPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -6965,7 +6965,7 @@ export const SetIamPolicyProjectsRegionsJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -7003,7 +7003,7 @@ export const GetIamPolicyProjectsRegionsJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -7041,7 +7041,7 @@ export const TestIamPermissionsProjectsRegionsJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -7080,7 +7080,7 @@ export const CreateProjectsRegionsWorkflowTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/workflowTemplates",
+      path: "v1/{+parent}/workflowTemplates",
       hasBody: true,
     }),
     svc,
@@ -7116,7 +7116,7 @@ export const GetProjectsRegionsWorkflowTemplatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     version: Schema.optional(Schema.Number).pipe(T.HttpQuery("version")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsRegionsWorkflowTemplatesRequest>;
 
@@ -7152,7 +7152,7 @@ export const InstantiateProjectsRegionsWorkflowTemplatesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:instantiate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:instantiate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<InstantiateProjectsRegionsWorkflowTemplatesRequest>;
 
@@ -7191,7 +7191,7 @@ export const InstantiateInlineProjectsRegionsWorkflowTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/workflowTemplates:instantiateInline",
+      path: "v1/{+parent}/workflowTemplates:instantiateInline",
       hasBody: true,
     }),
     svc,
@@ -7229,7 +7229,7 @@ export const UpdateProjectsRegionsWorkflowTemplatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(WorkflowTemplate).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsRegionsWorkflowTemplatesRequest>;
 
@@ -7266,7 +7266,7 @@ export const ListProjectsRegionsWorkflowTemplatesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/workflowTemplates" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/workflowTemplates" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsRegionsWorkflowTemplatesRequest>;
 
@@ -7305,7 +7305,7 @@ export const DeleteProjectsRegionsWorkflowTemplatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     version: Schema.optional(Schema.Number).pipe(T.HttpQuery("version")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsRegionsWorkflowTemplatesRequest>;
 
@@ -7341,7 +7341,7 @@ export const SetIamPolicyProjectsRegionsWorkflowTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -7379,7 +7379,7 @@ export const GetIamPolicyProjectsRegionsWorkflowTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -7417,7 +7417,7 @@ export const TestIamPermissionsProjectsRegionsWorkflowTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -7466,7 +7466,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -7501,7 +7501,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -7532,7 +7532,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -7563,7 +7563,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -7603,7 +7603,7 @@ export const CreateProjectsLocationsBatchesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Batch).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/batches", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/batches", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBatchesRequest>;
 
@@ -7634,7 +7634,7 @@ export const GetProjectsLocationsBatchesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBatchesRequest>;
 
@@ -7677,7 +7677,7 @@ export const ListProjectsLocationsBatchesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/batches" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/batches" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBatchesRequest>;
 
@@ -7712,7 +7712,7 @@ export const DeleteProjectsLocationsBatchesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBatchesRequest>;
 
@@ -7746,7 +7746,7 @@ export const AnalyzeProjectsLocationsBatchesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AnalyzeBatchRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:analyze", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:analyze", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AnalyzeProjectsLocationsBatchesRequest>;
 
@@ -7782,7 +7782,7 @@ export const WriteProjectsLocationsBatchesSparkApplicationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:write", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:write", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WriteProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -7841,7 +7841,7 @@ export const SearchProjectsLocationsBatchesSparkApplicationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sparkApplications:search" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sparkApplications:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -7881,7 +7881,7 @@ export const AccessProjectsLocationsBatchesSparkApplicationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     parent: Schema.optional(Schema.String).pipe(T.HttpQuery("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:access" }),
+    T.Http({ method: "GET", path: "v1/{+name}:access" }),
     svc,
   ) as unknown as Schema.Schema<AccessProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -7932,7 +7932,7 @@ export const SearchJobsProjectsLocationsBatchesSparkApplicationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:searchJobs" }),
+    T.Http({ method: "GET", path: "v1/{+name}:searchJobs" }),
     svc,
   ) as unknown as Schema.Schema<SearchJobsProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -7975,7 +7975,7 @@ export const AccessJobProjectsLocationsBatchesSparkApplicationsRequest =
     parent: Schema.optional(Schema.String).pipe(T.HttpQuery("parent")),
     jobId: Schema.optional(Schema.String).pipe(T.HttpQuery("jobId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:accessJob" }),
+    T.Http({ method: "GET", path: "v1/{+name}:accessJob" }),
     svc,
   ) as unknown as Schema.Schema<AccessJobProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -8034,7 +8034,7 @@ export const SearchStagesProjectsLocationsBatchesSparkApplicationsRequest =
       T.HttpQuery("summaryMetricsMask"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:searchStages" }),
+    T.Http({ method: "GET", path: "v1/{+name}:searchStages" }),
     svc,
   ) as unknown as Schema.Schema<SearchStagesProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -8088,7 +8088,7 @@ export const SearchStageAttemptsProjectsLocationsBatchesSparkApplicationsRequest
       T.HttpQuery("summaryMetricsMask"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:searchStageAttempts" }),
+    T.Http({ method: "GET", path: "v1/{+name}:searchStageAttempts" }),
     svc,
   ) as unknown as Schema.Schema<SearchStageAttemptsProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -8141,7 +8141,7 @@ export const AccessStageAttemptProjectsLocationsBatchesSparkApplicationsRequest 
       T.HttpQuery("summaryMetricsMask"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:accessStageAttempt" }),
+    T.Http({ method: "GET", path: "v1/{+name}:accessStageAttempt" }),
     svc,
   ) as unknown as Schema.Schema<AccessStageAttemptProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -8206,7 +8206,7 @@ export const SearchStageAttemptTasksProjectsLocationsBatchesSparkApplicationsReq
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:searchStageAttemptTasks" }),
+    T.Http({ method: "GET", path: "v1/{+name}:searchStageAttemptTasks" }),
     svc,
   ) as unknown as Schema.Schema<SearchStageAttemptTasksProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -8263,7 +8263,7 @@ export const SearchExecutorsProjectsLocationsBatchesSparkApplicationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:searchExecutors" }),
+    T.Http({ method: "GET", path: "v1/{+name}:searchExecutors" }),
     svc,
   ) as unknown as Schema.Schema<SearchExecutorsProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -8317,7 +8317,7 @@ export const SearchExecutorStageSummaryProjectsLocationsBatchesSparkApplications
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:searchExecutorStageSummary" }),
+    T.Http({ method: "GET", path: "v1/{+name}:searchExecutorStageSummary" }),
     svc,
   ) as unknown as Schema.Schema<SearchExecutorStageSummaryProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -8373,7 +8373,7 @@ export const SearchSqlQueriesProjectsLocationsBatchesSparkApplicationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:searchSqlQueries" }),
+    T.Http({ method: "GET", path: "v1/{+name}:searchSqlQueries" }),
     svc,
   ) as unknown as Schema.Schema<SearchSqlQueriesProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -8426,7 +8426,7 @@ export const AccessSqlQueryProjectsLocationsBatchesSparkApplicationsRequest =
       T.HttpQuery("planDescription"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:accessSqlQuery" }),
+    T.Http({ method: "GET", path: "v1/{+name}:accessSqlQuery" }),
     svc,
   ) as unknown as Schema.Schema<AccessSqlQueryProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -8467,7 +8467,7 @@ export const AccessSqlPlanProjectsLocationsBatchesSparkApplicationsRequest =
       T.HttpQuery("executionId"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:accessSqlPlan" }),
+    T.Http({ method: "GET", path: "v1/{+name}:accessSqlPlan" }),
     svc,
   ) as unknown as Schema.Schema<AccessSqlPlanProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -8506,7 +8506,7 @@ export const AccessStageRddGraphProjectsLocationsBatchesSparkApplicationsRequest
     parent: Schema.optional(Schema.String).pipe(T.HttpQuery("parent")),
     stageId: Schema.optional(Schema.String).pipe(T.HttpQuery("stageId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:accessStageRddGraph" }),
+    T.Http({ method: "GET", path: "v1/{+name}:accessStageRddGraph" }),
     svc,
   ) as unknown as Schema.Schema<AccessStageRddGraphProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -8542,7 +8542,7 @@ export const AccessEnvironmentInfoProjectsLocationsBatchesSparkApplicationsReque
     name: Schema.String.pipe(T.HttpPath("name")),
     parent: Schema.optional(Schema.String).pipe(T.HttpQuery("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:accessEnvironmentInfo" }),
+    T.Http({ method: "GET", path: "v1/{+name}:accessEnvironmentInfo" }),
     svc,
   ) as unknown as Schema.Schema<AccessEnvironmentInfoProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -8579,7 +8579,7 @@ export const SummarizeJobsProjectsLocationsBatchesSparkApplicationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     parent: Schema.optional(Schema.String).pipe(T.HttpQuery("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:summarizeJobs" }),
+    T.Http({ method: "GET", path: "v1/{+name}:summarizeJobs" }),
     svc,
   ) as unknown as Schema.Schema<SummarizeJobsProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -8615,7 +8615,7 @@ export const SummarizeStagesProjectsLocationsBatchesSparkApplicationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     parent: Schema.optional(Schema.String).pipe(T.HttpQuery("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:summarizeStages" }),
+    T.Http({ method: "GET", path: "v1/{+name}:summarizeStages" }),
     svc,
   ) as unknown as Schema.Schema<SummarizeStagesProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -8659,7 +8659,7 @@ export const SummarizeStageAttemptTasksProjectsLocationsBatchesSparkApplications
       T.HttpQuery("stageAttemptId"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:summarizeStageAttemptTasks" }),
+    T.Http({ method: "GET", path: "v1/{+name}:summarizeStageAttemptTasks" }),
     svc,
   ) as unknown as Schema.Schema<SummarizeStageAttemptTasksProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -8697,7 +8697,7 @@ export const SummarizeExecutorsProjectsLocationsBatchesSparkApplicationsRequest 
     name: Schema.String.pipe(T.HttpPath("name")),
     parent: Schema.optional(Schema.String).pipe(T.HttpQuery("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:summarizeExecutors" }),
+    T.Http({ method: "GET", path: "v1/{+name}:summarizeExecutors" }),
     svc,
   ) as unknown as Schema.Schema<SummarizeExecutorsProjectsLocationsBatchesSparkApplicationsRequest>;
 
@@ -8739,7 +8739,7 @@ export const CreateProjectsLocationsSessionsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Session).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/sessions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/sessions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSessionsRequest>;
 
@@ -8770,7 +8770,7 @@ export const GetProjectsLocationsSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSessionsRequest>;
 
@@ -8810,7 +8810,7 @@ export const ListProjectsLocationsSessionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sessions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sessions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSessionsRequest>;
 
@@ -8848,7 +8848,7 @@ export const TerminateProjectsLocationsSessionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(TerminateSessionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:terminate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:terminate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TerminateProjectsLocationsSessionsRequest>;
 
@@ -8882,7 +8882,7 @@ export const DeleteProjectsLocationsSessionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSessionsRequest>;
 
@@ -8918,7 +8918,7 @@ export const WriteProjectsLocationsSessionsSparkApplicationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:write", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:write", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WriteProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -8978,7 +8978,7 @@ export const SearchProjectsLocationsSessionsSparkApplicationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sparkApplications:search" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sparkApplications:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9018,7 +9018,7 @@ export const AccessProjectsLocationsSessionsSparkApplicationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     parent: Schema.optional(Schema.String).pipe(T.HttpQuery("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:access" }),
+    T.Http({ method: "GET", path: "v1/{+name}:access" }),
     svc,
   ) as unknown as Schema.Schema<AccessProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9074,7 +9074,7 @@ export const SearchJobsProjectsLocationsSessionsSparkApplicationsRequest =
       T.HttpQuery("jobIds"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:searchJobs" }),
+    T.Http({ method: "GET", path: "v1/{+name}:searchJobs" }),
     svc,
   ) as unknown as Schema.Schema<SearchJobsProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9117,7 +9117,7 @@ export const AccessJobProjectsLocationsSessionsSparkApplicationsRequest =
     parent: Schema.optional(Schema.String).pipe(T.HttpQuery("parent")),
     jobId: Schema.optional(Schema.String).pipe(T.HttpQuery("jobId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:accessJob" }),
+    T.Http({ method: "GET", path: "v1/{+name}:accessJob" }),
     svc,
   ) as unknown as Schema.Schema<AccessJobProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9181,7 +9181,7 @@ export const SearchStagesProjectsLocationsSessionsSparkApplicationsRequest =
       T.HttpQuery("stageIds"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:searchStages" }),
+    T.Http({ method: "GET", path: "v1/{+name}:searchStages" }),
     svc,
   ) as unknown as Schema.Schema<SearchStagesProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9235,7 +9235,7 @@ export const SearchStageAttemptsProjectsLocationsSessionsSparkApplicationsReques
       T.HttpQuery("summaryMetricsMask"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:searchStageAttempts" }),
+    T.Http({ method: "GET", path: "v1/{+name}:searchStageAttempts" }),
     svc,
   ) as unknown as Schema.Schema<SearchStageAttemptsProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9288,7 +9288,7 @@ export const AccessStageAttemptProjectsLocationsSessionsSparkApplicationsRequest
       T.HttpQuery("summaryMetricsMask"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:accessStageAttempt" }),
+    T.Http({ method: "GET", path: "v1/{+name}:accessStageAttempt" }),
     svc,
   ) as unknown as Schema.Schema<AccessStageAttemptProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9353,7 +9353,7 @@ export const SearchStageAttemptTasksProjectsLocationsSessionsSparkApplicationsRe
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:searchStageAttemptTasks" }),
+    T.Http({ method: "GET", path: "v1/{+name}:searchStageAttemptTasks" }),
     svc,
   ) as unknown as Schema.Schema<SearchStageAttemptTasksProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9410,7 +9410,7 @@ export const SearchExecutorsProjectsLocationsSessionsSparkApplicationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:searchExecutors" }),
+    T.Http({ method: "GET", path: "v1/{+name}:searchExecutors" }),
     svc,
   ) as unknown as Schema.Schema<SearchExecutorsProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9464,7 +9464,7 @@ export const SearchExecutorStageSummaryProjectsLocationsSessionsSparkApplication
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:searchExecutorStageSummary" }),
+    T.Http({ method: "GET", path: "v1/{+name}:searchExecutorStageSummary" }),
     svc,
   ) as unknown as Schema.Schema<SearchExecutorStageSummaryProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9525,7 +9525,7 @@ export const SearchSqlQueriesProjectsLocationsSessionsSparkApplicationsRequest =
       T.HttpQuery("operationIds"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:searchSqlQueries" }),
+    T.Http({ method: "GET", path: "v1/{+name}:searchSqlQueries" }),
     svc,
   ) as unknown as Schema.Schema<SearchSqlQueriesProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9578,7 +9578,7 @@ export const AccessSqlQueryProjectsLocationsSessionsSparkApplicationsRequest =
       T.HttpQuery("planDescription"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:accessSqlQuery" }),
+    T.Http({ method: "GET", path: "v1/{+name}:accessSqlQuery" }),
     svc,
   ) as unknown as Schema.Schema<AccessSqlQueryProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9619,7 +9619,7 @@ export const AccessSqlPlanProjectsLocationsSessionsSparkApplicationsRequest =
       T.HttpQuery("executionId"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:accessSqlPlan" }),
+    T.Http({ method: "GET", path: "v1/{+name}:accessSqlPlan" }),
     svc,
   ) as unknown as Schema.Schema<AccessSqlPlanProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9658,7 +9658,7 @@ export const AccessStageRddGraphProjectsLocationsSessionsSparkApplicationsReques
     parent: Schema.optional(Schema.String).pipe(T.HttpQuery("parent")),
     stageId: Schema.optional(Schema.String).pipe(T.HttpQuery("stageId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:accessStageRddGraph" }),
+    T.Http({ method: "GET", path: "v1/{+name}:accessStageRddGraph" }),
     svc,
   ) as unknown as Schema.Schema<AccessStageRddGraphProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9694,7 +9694,7 @@ export const AccessEnvironmentInfoProjectsLocationsSessionsSparkApplicationsRequ
     name: Schema.String.pipe(T.HttpPath("name")),
     parent: Schema.optional(Schema.String).pipe(T.HttpQuery("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:accessEnvironmentInfo" }),
+    T.Http({ method: "GET", path: "v1/{+name}:accessEnvironmentInfo" }),
     svc,
   ) as unknown as Schema.Schema<AccessEnvironmentInfoProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9736,7 +9736,7 @@ export const SummarizeJobsProjectsLocationsSessionsSparkApplicationsRequest =
       T.HttpQuery("jobIds"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:summarizeJobs" }),
+    T.Http({ method: "GET", path: "v1/{+name}:summarizeJobs" }),
     svc,
   ) as unknown as Schema.Schema<SummarizeJobsProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9777,7 +9777,7 @@ export const SummarizeStagesProjectsLocationsSessionsSparkApplicationsRequest =
       T.HttpQuery("stageIds"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:summarizeStages" }),
+    T.Http({ method: "GET", path: "v1/{+name}:summarizeStages" }),
     svc,
   ) as unknown as Schema.Schema<SummarizeStagesProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9821,7 +9821,7 @@ export const SummarizeStageAttemptTasksProjectsLocationsSessionsSparkApplication
       T.HttpQuery("stageAttemptId"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:summarizeStageAttemptTasks" }),
+    T.Http({ method: "GET", path: "v1/{+name}:summarizeStageAttemptTasks" }),
     svc,
   ) as unknown as Schema.Schema<SummarizeStageAttemptTasksProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9859,7 +9859,7 @@ export const SummarizeExecutorsProjectsLocationsSessionsSparkApplicationsRequest
     name: Schema.String.pipe(T.HttpPath("name")),
     parent: Schema.optional(Schema.String).pipe(T.HttpQuery("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:summarizeExecutors" }),
+    T.Http({ method: "GET", path: "v1/{+name}:summarizeExecutors" }),
     svc,
   ) as unknown as Schema.Schema<SummarizeExecutorsProjectsLocationsSessionsSparkApplicationsRequest>;
 
@@ -9897,7 +9897,7 @@ export const CreateProjectsLocationsAutoscalingPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/autoscalingPolicies",
+      path: "v1/{+parent}/autoscalingPolicies",
       hasBody: true,
     }),
     svc,
@@ -9934,7 +9934,7 @@ export const UpdateProjectsLocationsAutoscalingPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AutoscalingPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsAutoscalingPoliciesRequest>;
 
@@ -9966,7 +9966,7 @@ export const GetProjectsLocationsAutoscalingPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAutoscalingPoliciesRequest>;
 
@@ -10003,7 +10003,7 @@ export const ListProjectsLocationsAutoscalingPoliciesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/autoscalingPolicies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/autoscalingPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAutoscalingPoliciesRequest>;
 
@@ -10039,7 +10039,7 @@ export const DeleteProjectsLocationsAutoscalingPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAutoscalingPoliciesRequest>;
 
@@ -10075,7 +10075,7 @@ export const SetIamPolicyProjectsLocationsAutoscalingPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -10114,7 +10114,7 @@ export const GetIamPolicyProjectsLocationsAutoscalingPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -10153,7 +10153,7 @@ export const TestIamPermissionsProjectsLocationsAutoscalingPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -10193,7 +10193,7 @@ export const CreateProjectsLocationsSessionTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/sessionTemplates",
+      path: "v1/{+parent}/sessionTemplates",
       hasBody: true,
     }),
     svc,
@@ -10229,7 +10229,7 @@ export const PatchProjectsLocationsSessionTemplatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SessionTemplate).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSessionTemplatesRequest>;
 
@@ -10260,7 +10260,7 @@ export const GetProjectsLocationsSessionTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSessionTemplatesRequest>;
 
@@ -10300,7 +10300,7 @@ export const ListProjectsLocationsSessionTemplatesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sessionTemplates" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sessionTemplates" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSessionTemplatesRequest>;
 
@@ -10336,7 +10336,7 @@ export const DeleteProjectsLocationsSessionTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSessionTemplatesRequest>;
 
@@ -10372,7 +10372,7 @@ export const CreateProjectsLocationsWorkflowTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/workflowTemplates",
+      path: "v1/{+parent}/workflowTemplates",
       hasBody: true,
     }),
     svc,
@@ -10408,7 +10408,7 @@ export const GetProjectsLocationsWorkflowTemplatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     version: Schema.optional(Schema.Number).pipe(T.HttpQuery("version")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkflowTemplatesRequest>;
 
@@ -10444,7 +10444,7 @@ export const InstantiateProjectsLocationsWorkflowTemplatesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:instantiate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:instantiate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<InstantiateProjectsLocationsWorkflowTemplatesRequest>;
 
@@ -10483,7 +10483,7 @@ export const InstantiateInlineProjectsLocationsWorkflowTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/workflowTemplates:instantiateInline",
+      path: "v1/{+parent}/workflowTemplates:instantiateInline",
       hasBody: true,
     }),
     svc,
@@ -10521,7 +10521,7 @@ export const UpdateProjectsLocationsWorkflowTemplatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(WorkflowTemplate).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsWorkflowTemplatesRequest>;
 
@@ -10558,7 +10558,7 @@ export const ListProjectsLocationsWorkflowTemplatesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/workflowTemplates" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/workflowTemplates" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkflowTemplatesRequest>;
 
@@ -10597,7 +10597,7 @@ export const DeleteProjectsLocationsWorkflowTemplatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     version: Schema.optional(Schema.Number).pipe(T.HttpQuery("version")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWorkflowTemplatesRequest>;
 
@@ -10633,7 +10633,7 @@ export const SetIamPolicyProjectsLocationsWorkflowTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -10671,7 +10671,7 @@ export const GetIamPolicyProjectsLocationsWorkflowTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -10709,7 +10709,7 @@ export const TestIamPermissionsProjectsLocationsWorkflowTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/datastore-v1.ts
+++ b/packages/gcp/src/services/datastore-v1.ts
@@ -1862,7 +1862,7 @@ export const DeleteProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsOperationsRequest>;
 
@@ -1907,7 +1907,7 @@ export const ListProjectsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsOperationsRequest>;
 
@@ -1943,7 +1943,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 
@@ -1974,7 +1974,7 @@ export const CancelProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsOperationsRequest>;
 

--- a/packages/gcp/src/services/datastream-v1.ts
+++ b/packages/gcp/src/services/datastream-v1.ts
@@ -2607,7 +2607,7 @@ export const ListProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2642,7 +2642,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2679,7 +2679,7 @@ export const FetchStaticIpsProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:fetchStaticIps" }),
+    T.Http({ method: "GET", path: "v1/{+name}:fetchStaticIps" }),
     svc,
   ) as unknown as Schema.Schema<FetchStaticIpsProjectsLocationsRequest>;
 
@@ -2728,7 +2728,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2763,7 +2763,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2797,7 +2797,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2828,7 +2828,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2859,7 +2859,7 @@ export const GetProjectsLocationsPrivateConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPrivateConnectionsRequest>;
 
@@ -2902,7 +2902,7 @@ export const ListProjectsLocationsPrivateConnectionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/privateConnections" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/privateConnections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPrivateConnectionsRequest>;
 
@@ -2959,7 +2959,7 @@ export const CreateProjectsLocationsPrivateConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/privateConnections",
+      path: "v1/{+parent}/privateConnections",
       hasBody: true,
     }),
     svc,
@@ -2998,7 +2998,7 @@ export const DeleteProjectsLocationsPrivateConnectionsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPrivateConnectionsRequest>;
 
@@ -3029,7 +3029,7 @@ export const GetProjectsLocationsPrivateConnectionsRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPrivateConnectionsRoutesRequest>;
 
@@ -3072,7 +3072,7 @@ export const ListProjectsLocationsPrivateConnectionsRoutesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/routes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/routes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPrivateConnectionsRoutesRequest>;
 
@@ -3117,7 +3117,7 @@ export const CreateProjectsLocationsPrivateConnectionsRoutesRequest =
     routeId: Schema.optional(Schema.String).pipe(T.HttpQuery("routeId")),
     body: Schema.optional(Route).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/routes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/routes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsPrivateConnectionsRoutesRequest>;
 
@@ -3152,7 +3152,7 @@ export const DeleteProjectsLocationsPrivateConnectionsRoutesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPrivateConnectionsRoutesRequest>;
 
@@ -3189,7 +3189,7 @@ export const DiscoverProjectsLocationsConnectionProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/connectionProfiles:discover",
+      path: "v1/{+parent}/connectionProfiles:discover",
       hasBody: true,
     }),
     svc,
@@ -3226,7 +3226,7 @@ export const DeleteProjectsLocationsConnectionProfilesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectionProfilesRequest>;
 
@@ -3269,7 +3269,7 @@ export const ListProjectsLocationsConnectionProfilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/connectionProfiles" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/connectionProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionProfilesRequest>;
 
@@ -3305,7 +3305,7 @@ export const GetProjectsLocationsConnectionProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionProfilesRequest>;
 
@@ -3353,7 +3353,7 @@ export const PatchProjectsLocationsConnectionProfilesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ConnectionProfile).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectionProfilesRequest>;
 
@@ -3405,7 +3405,7 @@ export const CreateProjectsLocationsConnectionProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/connectionProfiles",
+      path: "v1/{+parent}/connectionProfiles",
       hasBody: true,
     }),
     svc,
@@ -3441,7 +3441,7 @@ export const DeleteProjectsLocationsStreamsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsStreamsRequest>;
 
@@ -3489,7 +3489,7 @@ export const CreateProjectsLocationsStreamsRequest =
     streamId: Schema.optional(Schema.String).pipe(T.HttpQuery("streamId")),
     body: Schema.optional(Stream).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/streams", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/streams", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsStreamsRequest>;
 
@@ -3523,7 +3523,7 @@ export const RunProjectsLocationsStreamsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RunStreamRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsStreamsRequest>;
 
@@ -3566,7 +3566,7 @@ export const ListProjectsLocationsStreamsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/streams" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/streams" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsStreamsRequest>;
 
@@ -3601,7 +3601,7 @@ export const GetProjectsLocationsStreamsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsStreamsRequest>;
 
@@ -3649,7 +3649,7 @@ export const PatchProjectsLocationsStreamsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Stream).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsStreamsRequest>;
 
@@ -3685,7 +3685,7 @@ export const LookupProjectsLocationsStreamsObjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/objects:lookup",
+      path: "v1/{+parent}/objects:lookup",
       hasBody: true,
     }),
     svc,
@@ -3723,7 +3723,7 @@ export const StartBackfillJobProjectsLocationsStreamsObjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{object}:startBackfillJob",
+      path: "v1/{+object}:startBackfillJob",
       hasBody: true,
     }),
     svc,
@@ -3763,7 +3763,7 @@ export const StopBackfillJobProjectsLocationsStreamsObjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{object}:stopBackfillJob",
+      path: "v1/{+object}:stopBackfillJob",
       hasBody: true,
     }),
     svc,
@@ -3797,7 +3797,7 @@ export const GetProjectsLocationsStreamsObjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsStreamsObjectsRequest>;
 
@@ -3834,7 +3834,7 @@ export const ListProjectsLocationsStreamsObjectsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/objects" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/objects" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsStreamsObjectsRequest>;
 

--- a/packages/gcp/src/services/datastream-v1alpha1.ts
+++ b/packages/gcp/src/services/datastream-v1alpha1.ts
@@ -1241,7 +1241,7 @@ export const FetchStaticIpsProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}:fetchStaticIps" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}:fetchStaticIps" }),
     svc,
   ) as unknown as Schema.Schema<FetchStaticIpsProjectsLocationsRequest>;
 
@@ -1276,7 +1276,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1321,7 +1321,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1356,7 +1356,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1387,7 +1387,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1432,7 +1432,7 @@ export const ListProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1470,7 +1470,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1504,7 +1504,7 @@ export const DeleteProjectsLocationsStreamsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsStreamsRequest>;
 
@@ -1535,7 +1535,7 @@ export const GetProjectsLocationsStreamsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsStreamsRequest>;
 
@@ -1571,7 +1571,7 @@ export const FetchErrorsProjectsLocationsStreamsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{stream}:fetchErrors",
+      path: "v1alpha1/{+stream}:fetchErrors",
       hasBody: true,
     }),
     svc,
@@ -1623,7 +1623,7 @@ export const CreateProjectsLocationsStreamsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/streams",
+      path: "v1alpha1/{+parent}/streams",
       hasBody: true,
     }),
     svc,
@@ -1673,7 +1673,7 @@ export const PatchProjectsLocationsStreamsRequest =
     ),
     body: Schema.optional(Stream).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsStreamsRequest>;
 
@@ -1716,7 +1716,7 @@ export const ListProjectsLocationsStreamsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/streams" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/streams" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsStreamsRequest>;
 
@@ -1757,7 +1757,7 @@ export const ListProjectsLocationsStreamsObjectsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/objects" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/objects" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsStreamsObjectsRequest>;
 
@@ -1793,7 +1793,7 @@ export const GetProjectsLocationsStreamsObjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsStreamsObjectsRequest>;
 
@@ -1826,7 +1826,7 @@ export const StartBackfillJobProjectsLocationsStreamsObjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{object}:startBackfillJob",
+      path: "v1alpha1/{+object}:startBackfillJob",
       hasBody: true,
     }),
     svc,
@@ -1863,7 +1863,7 @@ export const StopBackfillJobProjectsLocationsStreamsObjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{object}:stopBackfillJob",
+      path: "v1alpha1/{+object}:stopBackfillJob",
       hasBody: true,
     }),
     svc,
@@ -1903,7 +1903,7 @@ export const DeleteProjectsLocationsPrivateConnectionsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPrivateConnectionsRequest>;
 
@@ -1934,7 +1934,7 @@ export const GetProjectsLocationsPrivateConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPrivateConnectionsRequest>;
 
@@ -1978,7 +1978,7 @@ export const CreateProjectsLocationsPrivateConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/privateConnections",
+      path: "v1alpha1/{+parent}/privateConnections",
       hasBody: true,
     }),
     svc,
@@ -2023,7 +2023,7 @@ export const ListProjectsLocationsPrivateConnectionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/privateConnections" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/privateConnections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPrivateConnectionsRequest>;
 
@@ -2062,7 +2062,7 @@ export const DeleteProjectsLocationsPrivateConnectionsRoutesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPrivateConnectionsRoutesRequest>;
 
@@ -2094,7 +2094,7 @@ export const GetProjectsLocationsPrivateConnectionsRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPrivateConnectionsRoutesRequest>;
 
@@ -2134,7 +2134,11 @@ export const CreateProjectsLocationsPrivateConnectionsRoutesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Route).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{parent}/routes", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1alpha1/{+parent}/routes",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsPrivateConnectionsRoutesRequest>;
 
@@ -2178,7 +2182,7 @@ export const ListProjectsLocationsPrivateConnectionsRoutesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/routes" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/routes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPrivateConnectionsRoutesRequest>;
 
@@ -2226,7 +2230,7 @@ export const ListProjectsLocationsConnectionProfilesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/connectionProfiles" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/connectionProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionProfilesRequest>;
 
@@ -2276,7 +2280,7 @@ export const PatchProjectsLocationsConnectionProfilesRequest =
     ),
     body: Schema.optional(ConnectionProfile).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectionProfilesRequest>;
 
@@ -2320,7 +2324,7 @@ export const CreateProjectsLocationsConnectionProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/connectionProfiles",
+      path: "v1alpha1/{+parent}/connectionProfiles",
       hasBody: true,
     }),
     svc,
@@ -2353,7 +2357,7 @@ export const GetProjectsLocationsConnectionProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionProfilesRequest>;
 
@@ -2387,7 +2391,7 @@ export const DeleteProjectsLocationsConnectionProfilesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectionProfilesRequest>;
 
@@ -2423,7 +2427,7 @@ export const DiscoverProjectsLocationsConnectionProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/connectionProfiles:discover",
+      path: "v1alpha1/{+parent}/connectionProfiles:discover",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/developerconnect-v1.ts
+++ b/packages/gcp/src/services/developerconnect-v1.ts
@@ -1323,7 +1323,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1358,7 +1358,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1403,7 +1403,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1438,7 +1438,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1469,7 +1469,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1503,7 +1503,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1546,7 +1546,7 @@ export const ListProjectsLocationsConnectionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/connections" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/connections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsRequest>;
 
@@ -1581,7 +1581,7 @@ export const GetProjectsLocationsConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionsRequest>;
 
@@ -1628,7 +1628,7 @@ export const CreateProjectsLocationsConnectionsRequest =
     ),
     body: Schema.optional(Connection).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/connections", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/connections", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsConnectionsRequest>;
 
@@ -1678,7 +1678,7 @@ export const PatchProjectsLocationsConnectionsRequest =
     ),
     body: Schema.optional(Connection).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectionsRequest>;
 
@@ -1720,7 +1720,7 @@ export const DeleteProjectsLocationsConnectionsRequest =
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectionsRequest>;
 
@@ -1759,7 +1759,7 @@ export const FetchLinkableGitRepositoriesProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{connection}:fetchLinkableGitRepositories",
+      path: "v1/{+connection}:fetchLinkableGitRepositories",
     }),
     svc,
   ) as unknown as Schema.Schema<FetchLinkableGitRepositoriesProjectsLocationsConnectionsRequest>;
@@ -1797,7 +1797,10 @@ export const FetchGitHubInstallationsProjectsLocationsConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     connection: Schema.String.pipe(T.HttpPath("connection")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{connection}:fetchGitHubInstallations" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+connection}:fetchGitHubInstallations",
+    }),
     svc,
   ) as unknown as Schema.Schema<FetchGitHubInstallationsProjectsLocationsConnectionsRequest>;
 
@@ -1837,7 +1840,7 @@ export const ProcessGitHubEnterpriseWebhookProjectsLocationsConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/connections:processGitHubEnterpriseWebhook",
+      path: "v1/{+parent}/connections:processGitHubEnterpriseWebhook",
       hasBody: true,
     }),
     svc,
@@ -1890,7 +1893,7 @@ export const CreateProjectsLocationsConnectionsGitRepositoryLinksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/gitRepositoryLinks",
+      path: "v1/{+parent}/gitRepositoryLinks",
       hasBody: true,
     }),
     svc,
@@ -1936,7 +1939,7 @@ export const DeleteProjectsLocationsConnectionsGitRepositoryLinksRequest =
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectionsGitRepositoryLinksRequest>;
 
@@ -1981,7 +1984,7 @@ export const ListProjectsLocationsConnectionsGitRepositoryLinksRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/gitRepositoryLinks" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/gitRepositoryLinks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsGitRepositoryLinksRequest>;
 
@@ -2018,7 +2021,7 @@ export const GetProjectsLocationsConnectionsGitRepositoryLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionsGitRepositoryLinksRequest>;
 
@@ -2056,7 +2059,7 @@ export const FetchReadWriteTokenProjectsLocationsConnectionsGitRepositoryLinksRe
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{gitRepositoryLink}:fetchReadWriteToken",
+      path: "v1/{+gitRepositoryLink}:fetchReadWriteToken",
       hasBody: true,
     }),
     svc,
@@ -2098,7 +2101,7 @@ export const FetchReadTokenProjectsLocationsConnectionsGitRepositoryLinksRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{gitRepositoryLink}:fetchReadToken",
+      path: "v1/{+gitRepositoryLink}:fetchReadToken",
       hasBody: true,
     }),
     svc,
@@ -2142,7 +2145,7 @@ export const FetchGitRefsProjectsLocationsConnectionsGitRepositoryLinksRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{gitRepositoryLink}:fetchGitRefs" }),
+    T.Http({ method: "GET", path: "v1/{+gitRepositoryLink}:fetchGitRefs" }),
     svc,
   ) as unknown as Schema.Schema<FetchGitRefsProjectsLocationsConnectionsGitRepositoryLinksRequest>;
 
@@ -2186,7 +2189,7 @@ export const ProcessGitLabEnterpriseWebhookProjectsLocationsConnectionsGitReposi
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:processGitLabEnterpriseWebhook",
+      path: "v1/{+name}:processGitLabEnterpriseWebhook",
       hasBody: true,
     }),
     svc,
@@ -2228,7 +2231,7 @@ export const ProcessGitLabWebhookProjectsLocationsConnectionsGitRepositoryLinksR
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:processGitLabWebhook",
+      path: "v1/{+name}:processGitLabWebhook",
       hasBody: true,
     }),
     svc,
@@ -2272,7 +2275,7 @@ export const ProcessBitbucketDataCenterWebhookProjectsLocationsConnectionsGitRep
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:processBitbucketDataCenterWebhook",
+      path: "v1/{+name}:processBitbucketDataCenterWebhook",
       hasBody: true,
     }),
     svc,
@@ -2316,7 +2319,7 @@ export const ProcessBitbucketCloudWebhookProjectsLocationsConnectionsGitReposito
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:processBitbucketCloudWebhook",
+      path: "v1/{+name}:processBitbucketCloudWebhook",
       hasBody: true,
     }),
     svc,
@@ -2365,7 +2368,7 @@ export const ListProjectsLocationsAccountConnectorsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/accountConnectors" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/accountConnectors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAccountConnectorsRequest>;
 
@@ -2401,7 +2404,7 @@ export const GetProjectsLocationsAccountConnectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAccountConnectorsRequest>;
 
@@ -2450,7 +2453,7 @@ export const CreateProjectsLocationsAccountConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/accountConnectors",
+      path: "v1/{+parent}/accountConnectors",
       hasBody: true,
     }),
     svc,
@@ -2502,7 +2505,7 @@ export const PatchProjectsLocationsAccountConnectorsRequest =
     ),
     body: Schema.optional(AccountConnector).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAccountConnectorsRequest>;
 
@@ -2547,7 +2550,7 @@ export const DeleteProjectsLocationsAccountConnectorsRequest =
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAccountConnectorsRequest>;
 
@@ -2589,7 +2592,7 @@ export const FetchUserRepositoriesProjectsLocationsAccountConnectorsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{accountConnector}:fetchUserRepositories",
+      path: "v1/{+accountConnector}:fetchUserRepositories",
     }),
     svc,
   ) as unknown as Schema.Schema<FetchUserRepositoriesProjectsLocationsAccountConnectorsRequest>;
@@ -2632,7 +2635,7 @@ export const FetchAccessTokenProjectsLocationsAccountConnectorsUsersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{accountConnector}/users:fetchAccessToken",
+      path: "v1/{+accountConnector}/users:fetchAccessToken",
       hasBody: true,
     }),
     svc,
@@ -2679,7 +2682,7 @@ export const ListProjectsLocationsAccountConnectorsUsersRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/users" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/users" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAccountConnectorsUsersRequest>;
 
@@ -2726,7 +2729,7 @@ export const DeleteProjectsLocationsAccountConnectorsUsersRequest =
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAccountConnectorsUsersRequest>;
 
@@ -2757,7 +2760,7 @@ export const FetchSelfProjectsLocationsAccountConnectorsUsersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/users:fetchSelf" }),
+    T.Http({ method: "GET", path: "v1/{+name}/users:fetchSelf" }),
     svc,
   ) as unknown as Schema.Schema<FetchSelfProjectsLocationsAccountConnectorsUsersRequest>;
 
@@ -2789,7 +2792,7 @@ export const DeleteSelfProjectsLocationsAccountConnectorsUsersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}/users:deleteSelf" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}/users:deleteSelf" }),
     svc,
   ) as unknown as Schema.Schema<DeleteSelfProjectsLocationsAccountConnectorsUsersRequest>;
 
@@ -2824,7 +2827,7 @@ export const StartOAuthFlowProjectsLocationsAccountConnectorsUsersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{accountConnector}/users:startOAuthFlow",
+      path: "v1/{+accountConnector}/users:startOAuthFlow",
     }),
     svc,
   ) as unknown as Schema.Schema<StartOAuthFlowProjectsLocationsAccountConnectorsUsersRequest>;
@@ -2885,7 +2888,7 @@ export const FinishOAuthFlowProjectsLocationsAccountConnectorsUsersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{accountConnector}/users:finishOAuthFlow",
+      path: "v1/{+accountConnector}/users:finishOAuthFlow",
     }),
     svc,
   ) as unknown as Schema.Schema<FinishOAuthFlowProjectsLocationsAccountConnectorsUsersRequest>;
@@ -2931,7 +2934,7 @@ export const ListProjectsLocationsInsightsConfigsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/insightsConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/insightsConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInsightsConfigsRequest>;
 
@@ -2982,7 +2985,7 @@ export const CreateProjectsLocationsInsightsConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/insightsConfigs",
+      path: "v1/{+parent}/insightsConfigs",
       hasBody: true,
     }),
     svc,
@@ -3015,7 +3018,7 @@ export const GetProjectsLocationsInsightsConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInsightsConfigsRequest>;
 
@@ -3062,7 +3065,7 @@ export const PatchProjectsLocationsInsightsConfigsRequest =
     ),
     body: Schema.optional(InsightsConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInsightsConfigsRequest>;
 
@@ -3104,7 +3107,7 @@ export const DeleteProjectsLocationsInsightsConfigsRequest =
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInsightsConfigsRequest>;
 
@@ -3135,7 +3138,7 @@ export const GetProjectsLocationsInsightsConfigsDeploymentEventsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInsightsConfigsDeploymentEventsRequest>;
 
@@ -3177,7 +3180,7 @@ export const ListProjectsLocationsInsightsConfigsDeploymentEventsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deploymentEvents" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deploymentEvents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInsightsConfigsDeploymentEventsRequest>;
 

--- a/packages/gcp/src/services/developerknowledge-v1alpha.ts
+++ b/packages/gcp/src/services/developerknowledge-v1alpha.ts
@@ -123,7 +123,7 @@ export interface GetDocumentsRequest {
 export const GetDocumentsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1alpha/{name}" }),
+  T.Http({ method: "GET", path: "v1alpha/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetDocumentsRequest>;
 

--- a/packages/gcp/src/services/dfareporting-v3.5.ts
+++ b/packages/gcp/src/services/dfareporting-v3.5.ts
@@ -373,7 +373,7 @@ export const UploadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "userprofiles/{profileId}/creativeAssets/{advertiserId}/creativeAssets",
+    path: "userprofiles/{+profileId}/creativeAssets/{+advertiserId}/creativeAssets",
     hasBody: true,
   }),
   svc,

--- a/packages/gcp/src/services/dfareporting-v4.ts
+++ b/packages/gcp/src/services/dfareporting-v4.ts
@@ -8013,7 +8013,7 @@ export interface ListRegionsRequest {
 export const ListRegionsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/regions" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/regions" }),
   svc,
 ) as unknown as Schema.Schema<ListRegionsRequest>;
 
@@ -8046,7 +8046,7 @@ export const GetMobileAppsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/mobileApps/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/mobileApps/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetMobileAppsRequest>;
 
@@ -8106,7 +8106,7 @@ export const ListMobileAppsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   ),
   ids: Schema.optional(Schema.Array(Schema.String)).pipe(T.HttpQuery("ids")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/mobileApps" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/mobileApps" }),
   svc,
 ) as unknown as Schema.Schema<ListMobileAppsRequest>;
 
@@ -8149,7 +8149,7 @@ export const PatchRemarketingListsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/remarketingLists",
+      path: "userprofiles/{+profileId}/remarketingLists",
       hasBody: true,
     }),
     svc,
@@ -8187,7 +8187,7 @@ export const InsertRemarketingListsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/remarketingLists",
+      path: "userprofiles/{+profileId}/remarketingLists",
       hasBody: true,
     }),
     svc,
@@ -8225,7 +8225,7 @@ export const GetRemarketingListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/remarketingLists/{id}",
+      path: "userprofiles/{+profileId}/remarketingLists/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetRemarketingListsRequest>;
@@ -8285,7 +8285,7 @@ export const ListRemarketingListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/remarketingLists",
+      path: "userprofiles/{+profileId}/remarketingLists",
     }),
     svc,
   ) as unknown as Schema.Schema<ListRemarketingListsRequest>;
@@ -8326,7 +8326,7 @@ export const UpdateRemarketingListsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/remarketingLists",
+      path: "userprofiles/{+profileId}/remarketingLists",
       hasBody: true,
     }),
     svc,
@@ -8358,7 +8358,7 @@ export interface ListBrowsersRequest {
 export const ListBrowsersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/browsers" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/browsers" }),
   svc,
 ) as unknown as Schema.Schema<ListBrowsersRequest>;
 
@@ -8394,7 +8394,7 @@ export const InsertCreativeGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/creativeGroups",
+      path: "userprofiles/{+profileId}/creativeGroups",
       hasBody: true,
     }),
     svc,
@@ -8435,7 +8435,7 @@ export const PatchCreativeGroupsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/creativeGroups",
+      path: "userprofiles/{+profileId}/creativeGroups",
       hasBody: true,
     }),
     svc,
@@ -8473,7 +8473,7 @@ export const GetCreativeGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/creativeGroups/{id}",
+      path: "userprofiles/{+profileId}/creativeGroups/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetCreativeGroupsRequest>;
@@ -8535,7 +8535,7 @@ export const ListCreativeGroupsRequest =
       T.HttpQuery("searchString"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "userprofiles/{profileId}/creativeGroups" }),
+    T.Http({ method: "GET", path: "userprofiles/{+profileId}/creativeGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListCreativeGroupsRequest>;
 
@@ -8575,7 +8575,7 @@ export const UpdateCreativeGroupsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/creativeGroups",
+      path: "userprofiles/{+profileId}/creativeGroups",
       hasBody: true,
     }),
     svc,
@@ -8610,7 +8610,7 @@ export const GetCreativesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   id: Schema.String.pipe(T.HttpPath("id")),
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/creatives/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/creatives/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetCreativesRequest>;
 
@@ -8729,7 +8729,7 @@ export const ListCreativesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   maxResults: Schema.optional(Schema.Number).pipe(T.HttpQuery("maxResults")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/creatives" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/creatives" }),
   svc,
 ) as unknown as Schema.Schema<ListCreativesRequest>;
 
@@ -8770,7 +8770,7 @@ export const UpdateCreativesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 ).pipe(
   T.Http({
     method: "PUT",
-    path: "userprofiles/{profileId}/creatives",
+    path: "userprofiles/{+profileId}/creatives",
     hasBody: true,
   }),
   svc,
@@ -8808,7 +8808,7 @@ export const InsertCreativesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 ).pipe(
   T.Http({
     method: "POST",
-    path: "userprofiles/{profileId}/creatives",
+    path: "userprofiles/{+profileId}/creatives",
     hasBody: true,
   }),
   svc,
@@ -8847,7 +8847,7 @@ export const PatchCreativesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "userprofiles/{profileId}/creatives",
+    path: "userprofiles/{+profileId}/creatives",
     hasBody: true,
   }),
   svc,
@@ -8884,7 +8884,7 @@ export const GetConnectionTypesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/connectionTypes/{id}",
+      path: "userprofiles/{+profileId}/connectionTypes/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetConnectionTypesRequest>;
@@ -8916,7 +8916,10 @@ export const ListConnectionTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     profileId: Schema.String.pipe(T.HttpPath("profileId")),
   }).pipe(
-    T.Http({ method: "GET", path: "userprofiles/{profileId}/connectionTypes" }),
+    T.Http({
+      method: "GET",
+      path: "userprofiles/{+profileId}/connectionTypes",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListConnectionTypesRequest>;
 
@@ -8956,7 +8959,7 @@ export const PatchPlacementsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 ).pipe(
   T.Http({
     method: "PATCH",
-    path: "userprofiles/{profileId}/placements",
+    path: "userprofiles/{+profileId}/placements",
     hasBody: true,
   }),
   svc,
@@ -8993,7 +8996,7 @@ export const InsertPlacementsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/placements",
+      path: "userprofiles/{+profileId}/placements",
       hasBody: true,
     }),
     svc,
@@ -9061,7 +9064,7 @@ export const GeneratetagsPlacementsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/placements/generatetags",
+      path: "userprofiles/{+profileId}/placements/generatetags",
       hasBody: true,
     }),
     svc,
@@ -9096,7 +9099,7 @@ export const GetPlacementsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/placements/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/placements/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetPlacementsRequest>;
 
@@ -9244,7 +9247,7 @@ export const ListPlacementsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("paymentSource"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/placements" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/placements" }),
   svc,
 ) as unknown as Schema.Schema<ListPlacementsRequest>;
 
@@ -9284,7 +9287,7 @@ export const UpdatePlacementsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/placements",
+      path: "userprofiles/{+profileId}/placements",
       hasBody: true,
     }),
     svc,
@@ -9321,7 +9324,7 @@ export const GetOperatingSystemVersionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/operatingSystemVersions/{id}",
+      path: "userprofiles/{+profileId}/operatingSystemVersions/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetOperatingSystemVersionsRequest>;
@@ -9355,7 +9358,7 @@ export const ListOperatingSystemVersionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/operatingSystemVersions",
+      path: "userprofiles/{+profileId}/operatingSystemVersions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListOperatingSystemVersionsRequest>;
@@ -9390,7 +9393,7 @@ export const GetProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   id: Schema.String.pipe(T.HttpPath("id")),
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/projects/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/projects/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetProjectsRequest>;
 
@@ -9444,7 +9447,7 @@ export const ListProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("searchString"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/projects" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/projects" }),
   svc,
 ) as unknown as Schema.Schema<ListProjectsRequest>;
 
@@ -9484,7 +9487,7 @@ export const InsertAdvertisersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/advertisers",
+      path: "userprofiles/{+profileId}/advertisers",
       hasBody: true,
     }),
     svc,
@@ -9524,7 +9527,7 @@ export const PatchAdvertisersRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/advertisers",
+      path: "userprofiles/{+profileId}/advertisers",
       hasBody: true,
     }),
     svc,
@@ -9558,7 +9561,10 @@ export const GetAdvertisersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   id: Schema.String.pipe(T.HttpPath("id")),
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/advertisers/{id}" }),
+  T.Http({
+    method: "GET",
+    path: "userprofiles/{+profileId}/advertisers/{+id}",
+  }),
   svc,
 ) as unknown as Schema.Schema<GetAdvertisersRequest>;
 
@@ -9635,7 +9641,7 @@ export const ListAdvertisersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     onlyParent: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("onlyParent")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/advertisers" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/advertisers" }),
   svc,
 ) as unknown as Schema.Schema<ListAdvertisersRequest>;
 
@@ -9675,7 +9681,7 @@ export const UpdateAdvertisersRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/advertisers",
+      path: "userprofiles/{+profileId}/advertisers",
       hasBody: true,
     }),
     svc,
@@ -9715,7 +9721,7 @@ export const InsertBillingAssignmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/billingProfiles/{billingProfileId}/billingAssignments",
+      path: "userprofiles/{+profileId}/billingProfiles/{+billingProfileId}/billingAssignments",
       hasBody: true,
     }),
     svc,
@@ -9753,7 +9759,7 @@ export const ListBillingAssignmentsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/billingProfiles/{billingProfileId}/billingAssignments",
+      path: "userprofiles/{+profileId}/billingProfiles/{+billingProfileId}/billingAssignments",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAssignmentsRequest>;
@@ -9789,7 +9795,7 @@ export const GetCountriesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "GET",
-    path: "userprofiles/{profileId}/countries/{dartId}",
+    path: "userprofiles/{+profileId}/countries/{+dartId}",
   }),
   svc,
 ) as unknown as Schema.Schema<GetCountriesRequest>;
@@ -9819,7 +9825,7 @@ export interface ListCountriesRequest {
 export const ListCountriesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/countries" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/countries" }),
   svc,
 ) as unknown as Schema.Schema<ListCountriesRequest>;
 
@@ -9857,7 +9863,7 @@ export const GeneratetagFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/floodlightActivities/generatetag",
+      path: "userprofiles/{+profileId}/floodlightActivities/generatetag",
       hasBody: true,
     }),
     svc,
@@ -9896,7 +9902,7 @@ export const GetFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/floodlightActivities/{id}",
+      path: "userprofiles/{+profileId}/floodlightActivities/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetFloodlightActivitiesRequest>;
@@ -9983,7 +9989,7 @@ export const ListFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/floodlightActivities",
+      path: "userprofiles/{+profileId}/floodlightActivities",
     }),
     svc,
   ) as unknown as Schema.Schema<ListFloodlightActivitiesRequest>;
@@ -10024,7 +10030,7 @@ export const UpdateFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/floodlightActivities",
+      path: "userprofiles/{+profileId}/floodlightActivities",
       hasBody: true,
     }),
     svc,
@@ -10062,7 +10068,7 @@ export const DeleteFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "userprofiles/{profileId}/floodlightActivities/{id}",
+      path: "userprofiles/{+profileId}/floodlightActivities/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteFloodlightActivitiesRequest>;
@@ -10101,7 +10107,7 @@ export const InsertFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/floodlightActivities",
+      path: "userprofiles/{+profileId}/floodlightActivities",
       hasBody: true,
     }),
     svc,
@@ -10142,7 +10148,7 @@ export const PatchFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/floodlightActivities",
+      path: "userprofiles/{+profileId}/floodlightActivities",
       hasBody: true,
     }),
     svc,
@@ -10180,7 +10186,7 @@ export const ListBillingRatesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/billingProfiles/{billingProfileId}/billingRates",
+      path: "userprofiles/{+profileId}/billingProfiles/{+billingProfileId}/billingRates",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBillingRatesRequest>;
@@ -10216,7 +10222,10 @@ export const GetVideoFormatsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     profileId: Schema.String.pipe(T.HttpPath("profileId")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/videoFormats/{id}" }),
+  T.Http({
+    method: "GET",
+    path: "userprofiles/{+profileId}/videoFormats/{+id}",
+  }),
   svc,
 ) as unknown as Schema.Schema<GetVideoFormatsRequest>;
 
@@ -10246,7 +10255,7 @@ export const ListVideoFormatsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     profileId: Schema.String.pipe(T.HttpPath("profileId")),
   }).pipe(
-    T.Http({ method: "GET", path: "userprofiles/{profileId}/videoFormats" }),
+    T.Http({ method: "GET", path: "userprofiles/{+profileId}/videoFormats" }),
     svc,
   ) as unknown as Schema.Schema<ListVideoFormatsRequest>;
 
@@ -10294,7 +10303,7 @@ export const ListCitiesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("dartIds"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/cities" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/cities" }),
   svc,
 ) as unknown as Schema.Schema<ListCitiesRequest>;
 
@@ -10331,7 +10340,7 @@ export const InsertEventTagsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 ).pipe(
   T.Http({
     method: "POST",
-    path: "userprofiles/{profileId}/eventTags",
+    path: "userprofiles/{+profileId}/eventTags",
     hasBody: true,
   }),
   svc,
@@ -10370,7 +10379,7 @@ export const PatchEventTagsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "userprofiles/{profileId}/eventTags",
+    path: "userprofiles/{+profileId}/eventTags",
     hasBody: true,
   }),
   svc,
@@ -10406,7 +10415,10 @@ export const DeleteEventTagsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     profileId: Schema.String.pipe(T.HttpPath("profileId")),
   },
 ).pipe(
-  T.Http({ method: "DELETE", path: "userprofiles/{profileId}/eventTags/{id}" }),
+  T.Http({
+    method: "DELETE",
+    path: "userprofiles/{+profileId}/eventTags/{+id}",
+  }),
   svc,
 ) as unknown as Schema.Schema<DeleteEventTagsRequest>;
 
@@ -10445,7 +10457,7 @@ export const UpdateEventTagsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 ).pipe(
   T.Http({
     method: "PUT",
-    path: "userprofiles/{profileId}/eventTags",
+    path: "userprofiles/{+profileId}/eventTags",
     hasBody: true,
   }),
   svc,
@@ -10479,7 +10491,7 @@ export const GetEventTagsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   id: Schema.String.pipe(T.HttpPath("id")),
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/eventTags/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/eventTags/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetEventTagsRequest>;
 
@@ -10550,7 +10562,7 @@ export const ListEventTagsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   sortField: Schema.optional(Schema.String).pipe(T.HttpQuery("sortField")),
   enabled: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("enabled")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/eventTags" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/eventTags" }),
   svc,
 ) as unknown as Schema.Schema<ListEventTagsRequest>;
 
@@ -10586,7 +10598,7 @@ export const DeletePlacementStrategiesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "userprofiles/{profileId}/placementStrategies/{id}",
+      path: "userprofiles/{+profileId}/placementStrategies/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeletePlacementStrategiesRequest>;
@@ -10628,7 +10640,7 @@ export const PatchPlacementStrategiesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/placementStrategies",
+      path: "userprofiles/{+profileId}/placementStrategies",
       hasBody: true,
     }),
     svc,
@@ -10666,7 +10678,7 @@ export const InsertPlacementStrategiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/placementStrategies",
+      path: "userprofiles/{+profileId}/placementStrategies",
       hasBody: true,
     }),
     svc,
@@ -10704,7 +10716,7 @@ export const GetPlacementStrategiesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/placementStrategies/{id}",
+      path: "userprofiles/{+profileId}/placementStrategies/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetPlacementStrategiesRequest>;
@@ -10758,7 +10770,7 @@ export const ListPlacementStrategiesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/placementStrategies",
+      path: "userprofiles/{+profileId}/placementStrategies",
     }),
     svc,
   ) as unknown as Schema.Schema<ListPlacementStrategiesRequest>;
@@ -10799,7 +10811,7 @@ export const UpdatePlacementStrategiesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/placementStrategies",
+      path: "userprofiles/{+profileId}/placementStrategies",
       hasBody: true,
     }),
     svc,
@@ -10837,7 +10849,7 @@ export const GetUserRolePermissionGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/userRolePermissionGroups/{id}",
+      path: "userprofiles/{+profileId}/userRolePermissionGroups/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetUserRolePermissionGroupsRequest>;
@@ -10871,7 +10883,7 @@ export const ListUserRolePermissionGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/userRolePermissionGroups",
+      path: "userprofiles/{+profileId}/userRolePermissionGroups",
     }),
     svc,
   ) as unknown as Schema.Schema<ListUserRolePermissionGroupsRequest>;
@@ -10909,7 +10921,7 @@ export const DeleteContentCategoriesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "userprofiles/{profileId}/contentCategories/{id}",
+      path: "userprofiles/{+profileId}/contentCategories/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteContentCategoriesRequest>;
@@ -10948,7 +10960,7 @@ export const InsertContentCategoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/contentCategories",
+      path: "userprofiles/{+profileId}/contentCategories",
       hasBody: true,
     }),
     svc,
@@ -10989,7 +11001,7 @@ export const PatchContentCategoriesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/contentCategories",
+      path: "userprofiles/{+profileId}/contentCategories",
       hasBody: true,
     }),
     svc,
@@ -11027,7 +11039,7 @@ export const GetContentCategoriesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/contentCategories/{id}",
+      path: "userprofiles/{+profileId}/contentCategories/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetContentCategoriesRequest>;
@@ -11081,7 +11093,7 @@ export const ListContentCategoriesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/contentCategories",
+      path: "userprofiles/{+profileId}/contentCategories",
     }),
     svc,
   ) as unknown as Schema.Schema<ListContentCategoriesRequest>;
@@ -11122,7 +11134,7 @@ export const UpdateContentCategoriesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/contentCategories",
+      path: "userprofiles/{+profileId}/contentCategories",
       hasBody: true,
     }),
     svc,
@@ -11159,7 +11171,7 @@ export const GetPostalCodesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "GET",
-    path: "userprofiles/{profileId}/postalCodes/{code}",
+    path: "userprofiles/{+profileId}/postalCodes/{+code}",
   }),
   svc,
 ) as unknown as Schema.Schema<GetPostalCodesRequest>;
@@ -11191,7 +11203,7 @@ export const ListPostalCodesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     profileId: Schema.String.pipe(T.HttpPath("profileId")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/postalCodes" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/postalCodes" }),
   svc,
 ) as unknown as Schema.Schema<ListPostalCodesRequest>;
 
@@ -11229,7 +11241,7 @@ export const PatchSitesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "userprofiles/{profileId}/sites",
+    path: "userprofiles/{+profileId}/sites",
     hasBody: true,
   }),
   svc,
@@ -11265,7 +11277,7 @@ export const InsertSitesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "userprofiles/{profileId}/sites",
+    path: "userprofiles/{+profileId}/sites",
     hasBody: true,
   }),
   svc,
@@ -11301,7 +11313,7 @@ export const UpdateSitesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PUT",
-    path: "userprofiles/{profileId}/sites",
+    path: "userprofiles/{+profileId}/sites",
     hasBody: true,
   }),
   svc,
@@ -11335,7 +11347,7 @@ export const GetSitesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/sites/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/sites/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetSitesRequest>;
 
@@ -11425,7 +11437,7 @@ export const ListSitesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("directorySiteIds"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/sites" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/sites" }),
   svc,
 ) as unknown as Schema.Schema<ListSitesRequest>;
 
@@ -11464,7 +11476,7 @@ export const GetPlatformTypesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/platformTypes/{id}",
+      path: "userprofiles/{+profileId}/platformTypes/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetPlatformTypesRequest>;
@@ -11496,7 +11508,7 @@ export const ListPlatformTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     profileId: Schema.String.pipe(T.HttpPath("profileId")),
   }).pipe(
-    T.Http({ method: "GET", path: "userprofiles/{profileId}/platformTypes" }),
+    T.Http({ method: "GET", path: "userprofiles/{+profileId}/platformTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListPlatformTypesRequest>;
 
@@ -11541,7 +11553,7 @@ export const ListAdvertiserInvoicesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/advertisers/{advertiserId}/invoices",
+      path: "userprofiles/{+profileId}/advertisers/{+advertiserId}/invoices",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertiserInvoicesRequest>;
@@ -11578,7 +11590,7 @@ export const GetDynamicFeedsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     dynamicFeedId: Schema.String.pipe(T.HttpPath("dynamicFeedId")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "studio/dynamicFeeds/{dynamicFeedId}" }),
+  T.Http({ method: "GET", path: "studio/dynamicFeeds/{+dynamicFeedId}" }),
   svc,
 ) as unknown as Schema.Schema<GetDynamicFeedsRequest>;
 
@@ -11672,7 +11684,7 @@ export const RetransformDynamicFeedsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "studio/dynamicFeeds/{dynamicFeedId}/retransform",
+      path: "studio/dynamicFeeds/{+dynamicFeedId}/retransform",
       hasBody: true,
     }),
     svc,
@@ -11738,7 +11750,7 @@ export const PublishStudioCreativesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "studio/creatives/{studioCreativeId}/publish",
+      path: "studio/creatives/{+studioCreativeId}/publish",
       hasBody: true,
     }),
     svc,
@@ -11773,7 +11785,7 @@ export const GetStudioCreativesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     studioCreativeId: Schema.String.pipe(T.HttpPath("studioCreativeId")),
   }).pipe(
-    T.Http({ method: "GET", path: "studio/creatives/{studioCreativeId}" }),
+    T.Http({ method: "GET", path: "studio/creatives/{+studioCreativeId}" }),
     svc,
   ) as unknown as Schema.Schema<GetStudioCreativesRequest>;
 
@@ -11810,7 +11822,7 @@ export const UpdateUserRolesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 ).pipe(
   T.Http({
     method: "PUT",
-    path: "userprofiles/{profileId}/userRoles",
+    path: "userprofiles/{+profileId}/userRoles",
     hasBody: true,
   }),
   svc,
@@ -11844,7 +11856,7 @@ export const GetUserRolesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/userRoles/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/userRoles/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetUserRolesRequest>;
 
@@ -11903,7 +11915,7 @@ export const ListUserRolesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   sortField: Schema.optional(Schema.String).pipe(T.HttpQuery("sortField")),
   maxResults: Schema.optional(Schema.Number).pipe(T.HttpQuery("maxResults")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/userRoles" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/userRoles" }),
   svc,
 ) as unknown as Schema.Schema<ListUserRolesRequest>;
 
@@ -11945,7 +11957,7 @@ export const PatchUserRolesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "userprofiles/{profileId}/userRoles",
+    path: "userprofiles/{+profileId}/userRoles",
     hasBody: true,
   }),
   svc,
@@ -11983,7 +11995,7 @@ export const InsertUserRolesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 ).pipe(
   T.Http({
     method: "POST",
-    path: "userprofiles/{profileId}/userRoles",
+    path: "userprofiles/{+profileId}/userRoles",
     hasBody: true,
   }),
   svc,
@@ -12019,7 +12031,10 @@ export const DeleteUserRolesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     profileId: Schema.String.pipe(T.HttpPath("profileId")),
   },
 ).pipe(
-  T.Http({ method: "DELETE", path: "userprofiles/{profileId}/userRoles/{id}" }),
+  T.Http({
+    method: "DELETE",
+    path: "userprofiles/{+profileId}/userRoles/{+id}",
+  }),
   svc,
 ) as unknown as Schema.Schema<DeleteUserRolesRequest>;
 
@@ -12068,7 +12083,7 @@ export const DeleteDynamicTargetingKeysRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "userprofiles/{profileId}/dynamicTargetingKeys/{objectId}",
+      path: "userprofiles/{+profileId}/dynamicTargetingKeys/{+objectId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteDynamicTargetingKeysRequest>;
@@ -12125,7 +12140,7 @@ export const ListDynamicTargetingKeysRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/dynamicTargetingKeys",
+      path: "userprofiles/{+profileId}/dynamicTargetingKeys",
     }),
     svc,
   ) as unknown as Schema.Schema<ListDynamicTargetingKeysRequest>;
@@ -12162,7 +12177,7 @@ export const InsertDynamicTargetingKeysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/dynamicTargetingKeys",
+      path: "userprofiles/{+profileId}/dynamicTargetingKeys",
       hasBody: true,
     }),
     svc,
@@ -12233,7 +12248,7 @@ export const GetAccountPermissionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/accountPermissions/{id}",
+      path: "userprofiles/{+profileId}/accountPermissions/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAccountPermissionsRequest>;
@@ -12267,7 +12282,7 @@ export const ListAccountPermissionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/accountPermissions",
+      path: "userprofiles/{+profileId}/accountPermissions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountPermissionsRequest>;
@@ -12306,7 +12321,7 @@ export const GetOrdersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "GET",
-    path: "userprofiles/{profileId}/projects/{projectId}/orders/{id}",
+    path: "userprofiles/{+profileId}/projects/{projectId}/orders/{+id}",
   }),
   svc,
 ) as unknown as Schema.Schema<GetOrdersRequest>;
@@ -12366,7 +12381,7 @@ export const ListOrdersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "GET",
-    path: "userprofiles/{profileId}/projects/{projectId}/orders",
+    path: "userprofiles/{+profileId}/projects/{projectId}/orders",
   }),
   svc,
 ) as unknown as Schema.Schema<ListOrdersRequest>;
@@ -12404,7 +12419,7 @@ export const GetAdsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/ads/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/ads/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetAdsRequest>;
 
@@ -12543,7 +12558,7 @@ export const ListAdsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("sslCompliant"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/ads" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/ads" }),
   svc,
 ) as unknown as Schema.Schema<ListAdsRequest>;
 
@@ -12581,7 +12596,7 @@ export const UpdateAdsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PUT",
-    path: "userprofiles/{profileId}/ads",
+    path: "userprofiles/{+profileId}/ads",
     hasBody: true,
   }),
   svc,
@@ -12617,7 +12632,7 @@ export const InsertAdsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "userprofiles/{profileId}/ads",
+    path: "userprofiles/{+profileId}/ads",
     hasBody: true,
   }),
   svc,
@@ -12656,7 +12671,7 @@ export const PatchAdsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "userprofiles/{profileId}/ads",
+    path: "userprofiles/{+profileId}/ads",
     hasBody: true,
   }),
   svc,
@@ -12777,7 +12792,7 @@ export const UpdateCreativeFieldValuesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/creativeFields/{creativeFieldId}/creativeFieldValues",
+      path: "userprofiles/{+profileId}/creativeFields/{+creativeFieldId}/creativeFieldValues",
       hasBody: true,
     }),
     svc,
@@ -12818,7 +12833,7 @@ export const GetCreativeFieldValuesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/creativeFields/{creativeFieldId}/creativeFieldValues/{id}",
+      path: "userprofiles/{+profileId}/creativeFields/{+creativeFieldId}/creativeFieldValues/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetCreativeFieldValuesRequest>;
@@ -12875,7 +12890,7 @@ export const ListCreativeFieldValuesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/creativeFields/{creativeFieldId}/creativeFieldValues",
+      path: "userprofiles/{+profileId}/creativeFields/{+creativeFieldId}/creativeFieldValues",
     }),
     svc,
   ) as unknown as Schema.Schema<ListCreativeFieldValuesRequest>;
@@ -12919,7 +12934,7 @@ export const InsertCreativeFieldValuesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/creativeFields/{creativeFieldId}/creativeFieldValues",
+      path: "userprofiles/{+profileId}/creativeFields/{+creativeFieldId}/creativeFieldValues",
       hasBody: true,
     }),
     svc,
@@ -12963,7 +12978,7 @@ export const PatchCreativeFieldValuesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/creativeFields/{creativeFieldId}/creativeFieldValues",
+      path: "userprofiles/{+profileId}/creativeFields/{+creativeFieldId}/creativeFieldValues",
       hasBody: true,
     }),
     svc,
@@ -13004,7 +13019,7 @@ export const DeleteCreativeFieldValuesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "userprofiles/{profileId}/creativeFields/{creativeFieldId}/creativeFieldValues/{id}",
+      path: "userprofiles/{+profileId}/creativeFields/{+creativeFieldId}/creativeFieldValues/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteCreativeFieldValuesRequest>;
@@ -13043,7 +13058,7 @@ export const GetTargetableRemarketingListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/targetableRemarketingLists/{id}",
+      path: "userprofiles/{+profileId}/targetableRemarketingLists/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetTargetableRemarketingListsRequest>;
@@ -13098,7 +13113,7 @@ export const ListTargetableRemarketingListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/targetableRemarketingLists",
+      path: "userprofiles/{+profileId}/targetableRemarketingLists",
     }),
     svc,
   ) as unknown as Schema.Schema<ListTargetableRemarketingListsRequest>;
@@ -13141,7 +13156,7 @@ export const InsertCampaignsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 ).pipe(
   T.Http({
     method: "POST",
-    path: "userprofiles/{profileId}/campaigns",
+    path: "userprofiles/{+profileId}/campaigns",
     hasBody: true,
   }),
   svc,
@@ -13180,7 +13195,7 @@ export const PatchCampaignsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "userprofiles/{profileId}/campaigns",
+    path: "userprofiles/{+profileId}/campaigns",
     hasBody: true,
   }),
   svc,
@@ -13214,7 +13229,7 @@ export const GetCampaignsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   id: Schema.String.pipe(T.HttpPath("id")),
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/campaigns/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/campaigns/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetCampaignsRequest>;
 
@@ -13296,7 +13311,7 @@ export const ListCampaignsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("advertiserGroupIds"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/campaigns" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/campaigns" }),
   svc,
 ) as unknown as Schema.Schema<ListCampaignsRequest>;
 
@@ -13337,7 +13352,7 @@ export const UpdateCampaignsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 ).pipe(
   T.Http({
     method: "PUT",
-    path: "userprofiles/{profileId}/campaigns",
+    path: "userprofiles/{+profileId}/campaigns",
     hasBody: true,
   }),
   svc,
@@ -13374,7 +13389,7 @@ export const GetMobileCarriersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/mobileCarriers/{id}",
+      path: "userprofiles/{+profileId}/mobileCarriers/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetMobileCarriersRequest>;
@@ -13406,7 +13421,7 @@ export const ListMobileCarriersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     profileId: Schema.String.pipe(T.HttpPath("profileId")),
   }).pipe(
-    T.Http({ method: "GET", path: "userprofiles/{profileId}/mobileCarriers" }),
+    T.Http({ method: "GET", path: "userprofiles/{+profileId}/mobileCarriers" }),
     svc,
   ) as unknown as Schema.Schema<ListMobileCarriersRequest>;
 
@@ -13442,7 +13457,7 @@ export const GetDirectorySitesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/directorySites/{id}",
+      path: "userprofiles/{+profileId}/directorySites/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetDirectorySitesRequest>;
@@ -13517,7 +13532,7 @@ export const ListDirectorySitesRequest =
       T.HttpQuery("acceptsInStreamVideoPlacements"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "userprofiles/{profileId}/directorySites" }),
+    T.Http({ method: "GET", path: "userprofiles/{+profileId}/directorySites" }),
     svc,
   ) as unknown as Schema.Schema<ListDirectorySitesRequest>;
 
@@ -13557,7 +13572,7 @@ export const InsertDirectorySitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/directorySites",
+      path: "userprofiles/{+profileId}/directorySites",
       hasBody: true,
     }),
     svc,
@@ -13595,7 +13610,7 @@ export const GetOperatingSystemsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/operatingSystems/{dartId}",
+      path: "userprofiles/{+profileId}/operatingSystems/{+dartId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetOperatingSystemsRequest>;
@@ -13629,7 +13644,7 @@ export const ListOperatingSystemsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/operatingSystems",
+      path: "userprofiles/{+profileId}/operatingSystems",
     }),
     svc,
   ) as unknown as Schema.Schema<ListOperatingSystemsRequest>;
@@ -13666,7 +13681,7 @@ export const UpdateFloodlightConfigurationsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/floodlightConfigurations",
+      path: "userprofiles/{+profileId}/floodlightConfigurations",
       hasBody: true,
     }),
     svc,
@@ -13707,7 +13722,7 @@ export const PatchFloodlightConfigurationsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/floodlightConfigurations",
+      path: "userprofiles/{+profileId}/floodlightConfigurations",
       hasBody: true,
     }),
     svc,
@@ -13745,7 +13760,7 @@ export const GetFloodlightConfigurationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/floodlightConfigurations/{id}",
+      path: "userprofiles/{+profileId}/floodlightConfigurations/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetFloodlightConfigurationsRequest>;
@@ -13782,7 +13797,7 @@ export const ListFloodlightConfigurationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/floodlightConfigurations",
+      path: "userprofiles/{+profileId}/floodlightConfigurations",
     }),
     svc,
   ) as unknown as Schema.Schema<ListFloodlightConfigurationsRequest>;
@@ -14220,7 +14235,7 @@ export interface ListMetrosRequest {
 export const ListMetrosRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/metros" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/metros" }),
   svc,
 ) as unknown as Schema.Schema<ListMetrosRequest>;
 
@@ -14253,7 +14268,7 @@ export const GetAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   id: Schema.String.pipe(T.HttpPath("id")),
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/accounts/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/accounts/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetAccountsRequest>;
 
@@ -14305,7 +14320,7 @@ export const ListAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   sortField: Schema.optional(Schema.String).pipe(T.HttpQuery("sortField")),
   maxResults: Schema.optional(Schema.Number).pipe(T.HttpQuery("maxResults")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/accounts" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/accounts" }),
   svc,
 ) as unknown as Schema.Schema<ListAccountsRequest>;
 
@@ -14344,7 +14359,7 @@ export const UpdateAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PUT",
-    path: "userprofiles/{profileId}/accounts",
+    path: "userprofiles/{+profileId}/accounts",
     hasBody: true,
   }),
   svc,
@@ -14383,7 +14398,7 @@ export const PatchAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "userprofiles/{profileId}/accounts",
+    path: "userprofiles/{+profileId}/accounts",
     hasBody: true,
   }),
   svc,
@@ -14423,7 +14438,7 @@ export const InsertCampaignCreativeAssociationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/campaigns/{campaignId}/campaignCreativeAssociations",
+      path: "userprofiles/{+profileId}/campaigns/{+campaignId}/campaignCreativeAssociations",
       hasBody: true,
     }),
     svc,
@@ -14471,7 +14486,7 @@ export const ListCampaignCreativeAssociationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/campaigns/{campaignId}/campaignCreativeAssociations",
+      path: "userprofiles/{+profileId}/campaigns/{+campaignId}/campaignCreativeAssociations",
     }),
     svc,
   ) as unknown as Schema.Schema<ListCampaignCreativeAssociationsRequest>;
@@ -14516,7 +14531,7 @@ export const GetInventoryItemsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/projects/{projectId}/inventoryItems/{id}",
+      path: "userprofiles/{+profileId}/projects/{projectId}/inventoryItems/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetInventoryItemsRequest>;
@@ -14587,7 +14602,7 @@ export const ListInventoryItemsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/projects/{projectId}/inventoryItems",
+      path: "userprofiles/{+profileId}/projects/{projectId}/inventoryItems",
     }),
     svc,
   ) as unknown as Schema.Schema<ListInventoryItemsRequest>;
@@ -14631,7 +14646,7 @@ export const PatchRemarketingListSharesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/remarketingListShares",
+      path: "userprofiles/{+profileId}/remarketingListShares",
       hasBody: true,
     }),
     svc,
@@ -14669,7 +14684,7 @@ export const UpdateRemarketingListSharesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/remarketingListShares",
+      path: "userprofiles/{+profileId}/remarketingListShares",
       hasBody: true,
     }),
     svc,
@@ -14707,7 +14722,7 @@ export const GetRemarketingListSharesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/remarketingListShares/{remarketingListId}",
+      path: "userprofiles/{+profileId}/remarketingListShares/{+remarketingListId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetRemarketingListSharesRequest>;
@@ -14744,7 +14759,7 @@ export const GetAccountUserProfilesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/accountUserProfiles/{id}",
+      path: "userprofiles/{profileId}/accountUserProfiles/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAccountUserProfilesRequest>;
@@ -14809,7 +14824,7 @@ export const ListAccountUserProfilesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/accountUserProfiles",
+      path: "userprofiles/{+profileId}/accountUserProfiles",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountUserProfilesRequest>;
@@ -14850,7 +14865,7 @@ export const UpdateAccountUserProfilesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/accountUserProfiles",
+      path: "userprofiles/{+profileId}/accountUserProfiles",
       hasBody: true,
     }),
     svc,
@@ -14888,7 +14903,7 @@ export const InsertAccountUserProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/accountUserProfiles",
+      path: "userprofiles/{+profileId}/accountUserProfiles",
       hasBody: true,
     }),
     svc,
@@ -14929,7 +14944,7 @@ export const PatchAccountUserProfilesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/accountUserProfiles",
+      path: "userprofiles/{+profileId}/accountUserProfiles",
       hasBody: true,
     }),
     svc,
@@ -14967,7 +14982,7 @@ export const UpdateBillingProfilesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/billingProfiles",
+      path: "userprofiles/{+profileId}/billingProfiles",
       hasBody: true,
     }),
     svc,
@@ -15005,7 +15020,7 @@ export const GetBillingProfilesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/billingProfiles/{id}",
+      path: "userprofiles/{+profileId}/billingProfiles/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetBillingProfilesRequest>;
@@ -15075,7 +15090,10 @@ export const ListBillingProfilesRequest =
     maxResults: Schema.optional(Schema.Number).pipe(T.HttpQuery("maxResults")),
     sortField: Schema.optional(Schema.String).pipe(T.HttpQuery("sortField")),
   }).pipe(
-    T.Http({ method: "GET", path: "userprofiles/{profileId}/billingProfiles" }),
+    T.Http({
+      method: "GET",
+      path: "userprofiles/{+profileId}/billingProfiles",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListBillingProfilesRequest>;
 
@@ -15115,7 +15133,7 @@ export const UpdateCreativeFieldsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/creativeFields",
+      path: "userprofiles/{+profileId}/creativeFields",
       hasBody: true,
     }),
     svc,
@@ -15153,7 +15171,7 @@ export const GetCreativeFieldsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/creativeFields/{id}",
+      path: "userprofiles/{+profileId}/creativeFields/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetCreativeFieldsRequest>;
@@ -15210,7 +15228,7 @@ export const ListCreativeFieldsRequest =
     sortField: Schema.optional(Schema.String).pipe(T.HttpQuery("sortField")),
     maxResults: Schema.optional(Schema.Number).pipe(T.HttpQuery("maxResults")),
   }).pipe(
-    T.Http({ method: "GET", path: "userprofiles/{profileId}/creativeFields" }),
+    T.Http({ method: "GET", path: "userprofiles/{+profileId}/creativeFields" }),
     svc,
   ) as unknown as Schema.Schema<ListCreativeFieldsRequest>;
 
@@ -15250,7 +15268,7 @@ export const InsertCreativeFieldsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/creativeFields",
+      path: "userprofiles/{+profileId}/creativeFields",
       hasBody: true,
     }),
     svc,
@@ -15291,7 +15309,7 @@ export const PatchCreativeFieldsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/creativeFields",
+      path: "userprofiles/{+profileId}/creativeFields",
       hasBody: true,
     }),
     svc,
@@ -15329,7 +15347,7 @@ export const DeleteCreativeFieldsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "userprofiles/{profileId}/creativeFields/{id}",
+      path: "userprofiles/{+profileId}/creativeFields/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteCreativeFieldsRequest>;
@@ -15368,7 +15386,7 @@ export const GetAccountPermissionGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/accountPermissionGroups/{id}",
+      path: "userprofiles/{+profileId}/accountPermissionGroups/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAccountPermissionGroupsRequest>;
@@ -15402,7 +15420,7 @@ export const ListAccountPermissionGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/accountPermissionGroups",
+      path: "userprofiles/{+profileId}/accountPermissionGroups",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountPermissionGroupsRequest>;
@@ -15443,7 +15461,7 @@ export const InsertCreativeAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/creativeAssets/{advertiserId}/creativeAssets",
+      path: "userprofiles/{+profileId}/creativeAssets/{+advertiserId}/creativeAssets",
       hasBody: true,
     }),
     svc,
@@ -15481,7 +15499,7 @@ export const InsertAdvertiserLandingPagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/advertiserLandingPages",
+      path: "userprofiles/{+profileId}/advertiserLandingPages",
       hasBody: true,
     }),
     svc,
@@ -15522,7 +15540,7 @@ export const PatchAdvertiserLandingPagesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/advertiserLandingPages",
+      path: "userprofiles/{+profileId}/advertiserLandingPages",
       hasBody: true,
     }),
     svc,
@@ -15560,7 +15578,7 @@ export const UpdateAdvertiserLandingPagesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/advertiserLandingPages",
+      path: "userprofiles/{+profileId}/advertiserLandingPages",
       hasBody: true,
     }),
     svc,
@@ -15598,7 +15616,7 @@ export const GetAdvertiserLandingPagesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/advertiserLandingPages/{id}",
+      path: "userprofiles/{+profileId}/advertiserLandingPages/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertiserLandingPagesRequest>;
@@ -15670,7 +15688,7 @@ export const ListAdvertiserLandingPagesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/advertiserLandingPages",
+      path: "userprofiles/{+profileId}/advertiserLandingPages",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertiserLandingPagesRequest>;
@@ -15715,7 +15733,7 @@ export const PatchSubaccountsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/subaccounts",
+      path: "userprofiles/{+profileId}/subaccounts",
       hasBody: true,
     }),
     svc,
@@ -15752,7 +15770,7 @@ export const InsertSubaccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/subaccounts",
+      path: "userprofiles/{+profileId}/subaccounts",
       hasBody: true,
     }),
     svc,
@@ -15786,7 +15804,10 @@ export const GetSubaccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   id: Schema.String.pipe(T.HttpPath("id")),
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/subaccounts/{id}" }),
+  T.Http({
+    method: "GET",
+    path: "userprofiles/{+profileId}/subaccounts/{+id}",
+  }),
   svc,
 ) as unknown as Schema.Schema<GetSubaccountsRequest>;
 
@@ -15837,7 +15858,7 @@ export const ListSubaccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     ),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/subaccounts" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/subaccounts" }),
   svc,
 ) as unknown as Schema.Schema<ListSubaccountsRequest>;
 
@@ -15877,7 +15898,7 @@ export const UpdateSubaccountsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/subaccounts",
+      path: "userprofiles/{+profileId}/subaccounts",
       hasBody: true,
     }),
     svc,
@@ -15914,7 +15935,7 @@ export const GetFloodlightActivityGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/floodlightActivityGroups/{id}",
+      path: "userprofiles/{+profileId}/floodlightActivityGroups/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetFloodlightActivityGroupsRequest>;
@@ -15981,7 +16002,7 @@ export const ListFloodlightActivityGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/floodlightActivityGroups",
+      path: "userprofiles/{+profileId}/floodlightActivityGroups",
     }),
     svc,
   ) as unknown as Schema.Schema<ListFloodlightActivityGroupsRequest>;
@@ -16023,7 +16044,7 @@ export const UpdateFloodlightActivityGroupsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/floodlightActivityGroups",
+      path: "userprofiles/{+profileId}/floodlightActivityGroups",
       hasBody: true,
     }),
     svc,
@@ -16061,7 +16082,7 @@ export const InsertFloodlightActivityGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/floodlightActivityGroups",
+      path: "userprofiles/{+profileId}/floodlightActivityGroups",
       hasBody: true,
     }),
     svc,
@@ -16102,7 +16123,7 @@ export const PatchFloodlightActivityGroupsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/floodlightActivityGroups",
+      path: "userprofiles/{+profileId}/floodlightActivityGroups",
       hasBody: true,
     }),
     svc,
@@ -16143,7 +16164,7 @@ export const PatchPlacementGroupsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/placementGroups",
+      path: "userprofiles/{+profileId}/placementGroups",
       hasBody: true,
     }),
     svc,
@@ -16181,7 +16202,7 @@ export const InsertPlacementGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/placementGroups",
+      path: "userprofiles/{+profileId}/placementGroups",
       hasBody: true,
     }),
     svc,
@@ -16219,7 +16240,7 @@ export const GetPlacementGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/placementGroups/{id}",
+      path: "userprofiles/{+profileId}/placementGroups/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetPlacementGroupsRequest>;
@@ -16348,7 +16369,10 @@ export const ListPlacementGroupsRequest =
     ),
     maxResults: Schema.optional(Schema.Number).pipe(T.HttpQuery("maxResults")),
   }).pipe(
-    T.Http({ method: "GET", path: "userprofiles/{profileId}/placementGroups" }),
+    T.Http({
+      method: "GET",
+      path: "userprofiles/{+profileId}/placementGroups",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListPlacementGroupsRequest>;
 
@@ -16388,7 +16412,7 @@ export const UpdatePlacementGroupsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/placementGroups",
+      path: "userprofiles/{+profileId}/placementGroups",
       hasBody: true,
     }),
     svc,
@@ -16429,7 +16453,7 @@ export const ListTvCampaignSummariesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/tvCampaignSummaries",
+      path: "userprofiles/{+profileId}/tvCampaignSummaries",
     }),
     svc,
   ) as unknown as Schema.Schema<ListTvCampaignSummariesRequest>;
@@ -16582,7 +16606,7 @@ export const PublishDynamicProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "studio/dynamicProfiles/{dynamicProfileId}/publish",
+      path: "studio/dynamicProfiles/{+dynamicProfileId}/publish",
       hasBody: true,
     }),
     svc,
@@ -16619,7 +16643,7 @@ export const GetDynamicProfilesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "studio/dynamicProfiles/{dynamicProfileId}",
+      path: "studio/dynamicProfiles/{+dynamicProfileId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetDynamicProfilesRequest>;
@@ -16653,7 +16677,7 @@ export const GenerateCodeDynamicProfilesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "studio/dynamicProfiles/{dynamicProfileId}/generateCode",
+      path: "studio/dynamicProfiles/{+dynamicProfileId}/generateCode",
     }),
     svc,
   ) as unknown as Schema.Schema<GenerateCodeDynamicProfilesRequest>;
@@ -16691,7 +16715,7 @@ export const UpdateAdvertiserGroupsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/advertiserGroups",
+      path: "userprofiles/{+profileId}/advertiserGroups",
       hasBody: true,
     }),
     svc,
@@ -16729,7 +16753,7 @@ export const GetAdvertiserGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/advertiserGroups/{id}",
+      path: "userprofiles/{+profileId}/advertiserGroups/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertiserGroupsRequest>;
@@ -16783,7 +16807,7 @@ export const ListAdvertiserGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/advertiserGroups",
+      path: "userprofiles/{+profileId}/advertiserGroups",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertiserGroupsRequest>;
@@ -16824,7 +16848,7 @@ export const InsertAdvertiserGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/advertiserGroups",
+      path: "userprofiles/{+profileId}/advertiserGroups",
       hasBody: true,
     }),
     svc,
@@ -16865,7 +16889,7 @@ export const PatchAdvertiserGroupsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/advertiserGroups",
+      path: "userprofiles/{+profileId}/advertiserGroups",
       hasBody: true,
     }),
     svc,
@@ -16903,7 +16927,7 @@ export const DeleteAdvertiserGroupsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "userprofiles/{profileId}/advertiserGroups/{id}",
+      path: "userprofiles/{+profileId}/advertiserGroups/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertiserGroupsRequest>;
@@ -16942,7 +16966,7 @@ export const GetUserRolePermissionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/userRolePermissions/{id}",
+      path: "userprofiles/{+profileId}/userRolePermissions/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetUserRolePermissionsRequest>;
@@ -16979,7 +17003,7 @@ export const ListUserRolePermissionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/userRolePermissions",
+      path: "userprofiles/{+profileId}/userRolePermissions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListUserRolePermissionsRequest>;
@@ -17010,7 +17034,7 @@ export interface ListLanguagesRequest {
 export const ListLanguagesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/languages" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/languages" }),
   svc,
 ) as unknown as Schema.Schema<ListLanguagesRequest>;
 
@@ -17046,7 +17070,7 @@ export const GetAccountActiveAdSummariesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/accountActiveAdSummaries/{summaryAccountId}",
+      path: "userprofiles/{+profileId}/accountActiveAdSummaries/{+summaryAccountId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAccountActiveAdSummariesRequest>;
@@ -17135,7 +17159,7 @@ export const GetTvCampaignDetailsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/tvCampaignDetails/{id}",
+      path: "userprofiles/{+profileId}/tvCampaignDetails/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetTvCampaignDetailsRequest>;
@@ -17169,7 +17193,7 @@ export const GetChangeLogsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   id: Schema.String.pipe(T.HttpPath("id")),
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/changeLogs/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/changeLogs/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetChangeLogsRequest>;
 
@@ -17300,7 +17324,7 @@ export const ListChangeLogsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   ids: Schema.optional(Schema.Array(Schema.String)).pipe(T.HttpQuery("ids")),
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/changeLogs" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/changeLogs" }),
   svc,
 ) as unknown as Schema.Schema<ListChangeLogsRequest>;
 
@@ -17419,7 +17443,7 @@ export const PatchTargetingTemplatesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/targetingTemplates",
+      path: "userprofiles/{+profileId}/targetingTemplates",
       hasBody: true,
     }),
     svc,
@@ -17457,7 +17481,7 @@ export const InsertTargetingTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/targetingTemplates",
+      path: "userprofiles/{+profileId}/targetingTemplates",
       hasBody: true,
     }),
     svc,
@@ -17495,7 +17519,7 @@ export const UpdateTargetingTemplatesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/targetingTemplates",
+      path: "userprofiles/{+profileId}/targetingTemplates",
       hasBody: true,
     }),
     svc,
@@ -17533,7 +17557,7 @@ export const GetTargetingTemplatesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/targetingTemplates/{id}",
+      path: "userprofiles/{+profileId}/targetingTemplates/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetTargetingTemplatesRequest>;
@@ -17592,7 +17616,7 @@ export const ListTargetingTemplatesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/targetingTemplates",
+      path: "userprofiles/{+profileId}/targetingTemplates",
     }),
     svc,
   ) as unknown as Schema.Schema<ListTargetingTemplatesRequest>;
@@ -17632,7 +17656,7 @@ export const InsertSizesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "userprofiles/{profileId}/sizes",
+    path: "userprofiles/{+profileId}/sizes",
     hasBody: true,
   }),
   svc,
@@ -17666,7 +17690,7 @@ export const GetSizesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/sizes/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/sizes/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetSizesRequest>;
 
@@ -17707,7 +17731,7 @@ export const ListSizesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   ids: Schema.optional(Schema.Array(Schema.String)).pipe(T.HttpQuery("ids")),
   height: Schema.optional(Schema.Number).pipe(T.HttpQuery("height")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/sizes" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/sizes" }),
   svc,
 ) as unknown as Schema.Schema<ListSizesRequest>;
 

--- a/packages/gcp/src/services/dfareporting-v5.ts
+++ b/packages/gcp/src/services/dfareporting-v5.ts
@@ -7613,7 +7613,7 @@ export interface ListRegionsRequest {
 export const ListRegionsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/regions" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/regions" }),
   svc,
 ) as unknown as Schema.Schema<ListRegionsRequest>;
 
@@ -7649,7 +7649,7 @@ export const UpdateAdvertisersRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/advertisers",
+      path: "userprofiles/{+profileId}/advertisers",
       hasBody: true,
     }),
     svc,
@@ -7683,7 +7683,10 @@ export const GetAdvertisersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/advertisers/{id}" }),
+  T.Http({
+    method: "GET",
+    path: "userprofiles/{+profileId}/advertisers/{+id}",
+  }),
   svc,
 ) as unknown as Schema.Schema<GetAdvertisersRequest>;
 
@@ -7718,7 +7721,7 @@ export const InsertAdvertisersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/advertisers",
+      path: "userprofiles/{+profileId}/advertisers",
       hasBody: true,
     }),
     svc,
@@ -7758,7 +7761,7 @@ export const PatchAdvertisersRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/advertisers",
+      path: "userprofiles/{+profileId}/advertisers",
       hasBody: true,
     }),
     svc,
@@ -7837,7 +7840,7 @@ export const ListAdvertisersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     ),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/advertisers" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/advertisers" }),
   svc,
 ) as unknown as Schema.Schema<ListAdvertisersRequest>;
 
@@ -7962,7 +7965,7 @@ export const GenerateCodeDynamicProfilesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "studio/dynamicProfiles/{dynamicProfileId}/generateCode",
+      path: "studio/dynamicProfiles/{+dynamicProfileId}/generateCode",
     }),
     svc,
   ) as unknown as Schema.Schema<GenerateCodeDynamicProfilesRequest>;
@@ -7997,7 +8000,7 @@ export const GetDynamicProfilesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "studio/dynamicProfiles/{dynamicProfileId}",
+      path: "studio/dynamicProfiles/{+dynamicProfileId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetDynamicProfilesRequest>;
@@ -8062,7 +8065,7 @@ export const PublishDynamicProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "studio/dynamicProfiles/{dynamicProfileId}/publish",
+      path: "studio/dynamicProfiles/{+dynamicProfileId}/publish",
       hasBody: true,
     }),
     svc,
@@ -8102,7 +8105,7 @@ export const GetPlatformTypesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/platformTypes/{id}",
+      path: "userprofiles/{+profileId}/platformTypes/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetPlatformTypesRequest>;
@@ -8134,7 +8137,7 @@ export const ListPlatformTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     profileId: Schema.String.pipe(T.HttpPath("profileId")),
   }).pipe(
-    T.Http({ method: "GET", path: "userprofiles/{profileId}/platformTypes" }),
+    T.Http({ method: "GET", path: "userprofiles/{+profileId}/platformTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListPlatformTypesRequest>;
 
@@ -8170,7 +8173,7 @@ export const GetTargetableRemarketingListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/targetableRemarketingLists/{id}",
+      path: "userprofiles/{+profileId}/targetableRemarketingLists/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetTargetableRemarketingListsRequest>;
@@ -8225,7 +8228,7 @@ export const ListTargetableRemarketingListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/targetableRemarketingLists",
+      path: "userprofiles/{+profileId}/targetableRemarketingLists",
     }),
     svc,
   ) as unknown as Schema.Schema<ListTargetableRemarketingListsRequest>;
@@ -8279,7 +8282,7 @@ export const ListCitiesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("regionDartIds"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/cities" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/cities" }),
   svc,
 ) as unknown as Schema.Schema<ListCitiesRequest>;
 
@@ -8315,7 +8318,7 @@ export const GetConnectionTypesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/connectionTypes/{id}",
+      path: "userprofiles/{+profileId}/connectionTypes/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetConnectionTypesRequest>;
@@ -8347,7 +8350,10 @@ export const ListConnectionTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     profileId: Schema.String.pipe(T.HttpPath("profileId")),
   }).pipe(
-    T.Http({ method: "GET", path: "userprofiles/{profileId}/connectionTypes" }),
+    T.Http({
+      method: "GET",
+      path: "userprofiles/{+profileId}/connectionTypes",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListConnectionTypesRequest>;
 
@@ -8386,7 +8392,7 @@ export const UpdateCreativeFieldValuesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/creativeFields/{creativeFieldId}/creativeFieldValues",
+      path: "userprofiles/{+profileId}/creativeFields/{+creativeFieldId}/creativeFieldValues",
       hasBody: true,
     }),
     svc,
@@ -8427,7 +8433,7 @@ export const DeleteCreativeFieldValuesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "userprofiles/{profileId}/creativeFields/{creativeFieldId}/creativeFieldValues/{id}",
+      path: "userprofiles/{+profileId}/creativeFields/{+creativeFieldId}/creativeFieldValues/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteCreativeFieldValuesRequest>;
@@ -8469,7 +8475,7 @@ export const GetCreativeFieldValuesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/creativeFields/{creativeFieldId}/creativeFieldValues/{id}",
+      path: "userprofiles/{+profileId}/creativeFields/{+creativeFieldId}/creativeFieldValues/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetCreativeFieldValuesRequest>;
@@ -8509,7 +8515,7 @@ export const InsertCreativeFieldValuesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/creativeFields/{creativeFieldId}/creativeFieldValues",
+      path: "userprofiles/{+profileId}/creativeFields/{+creativeFieldId}/creativeFieldValues",
       hasBody: true,
     }),
     svc,
@@ -8553,7 +8559,7 @@ export const PatchCreativeFieldValuesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/creativeFields/{creativeFieldId}/creativeFieldValues",
+      path: "userprofiles/{+profileId}/creativeFields/{+creativeFieldId}/creativeFieldValues",
       hasBody: true,
     }),
     svc,
@@ -8611,7 +8617,7 @@ export const ListCreativeFieldValuesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/creativeFields/{creativeFieldId}/creativeFieldValues",
+      path: "userprofiles/{+profileId}/creativeFields/{+creativeFieldId}/creativeFieldValues",
     }),
     svc,
   ) as unknown as Schema.Schema<ListCreativeFieldValuesRequest>;
@@ -8652,7 +8658,7 @@ export const InsertDynamicTargetingKeysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/dynamicTargetingKeys",
+      path: "userprofiles/{+profileId}/dynamicTargetingKeys",
       hasBody: true,
     }),
     svc,
@@ -8708,7 +8714,7 @@ export const ListDynamicTargetingKeysRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/dynamicTargetingKeys",
+      path: "userprofiles/{+profileId}/dynamicTargetingKeys",
     }),
     svc,
   ) as unknown as Schema.Schema<ListDynamicTargetingKeysRequest>;
@@ -8756,7 +8762,7 @@ export const DeleteDynamicTargetingKeysRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "userprofiles/{profileId}/dynamicTargetingKeys/{objectId}",
+      path: "userprofiles/{+profileId}/dynamicTargetingKeys/{+objectId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteDynamicTargetingKeysRequest>;
@@ -8819,7 +8825,7 @@ export const ListTvCampaignSummariesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/tvCampaignSummaries",
+      path: "userprofiles/{+profileId}/tvCampaignSummaries",
     }),
     svc,
   ) as unknown as Schema.Schema<ListTvCampaignSummariesRequest>;
@@ -8856,7 +8862,7 @@ export const GetAccountActiveAdSummariesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/accountActiveAdSummaries/{summaryAccountId}",
+      path: "userprofiles/{+profileId}/accountActiveAdSummaries/{+summaryAccountId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAccountActiveAdSummariesRequest>;
@@ -8896,7 +8902,7 @@ export const PatchRemarketingListSharesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/remarketingListShares",
+      path: "userprofiles/{+profileId}/remarketingListShares",
       hasBody: true,
     }),
     svc,
@@ -8934,7 +8940,7 @@ export const UpdateRemarketingListSharesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/remarketingListShares",
+      path: "userprofiles/{+profileId}/remarketingListShares",
       hasBody: true,
     }),
     svc,
@@ -8972,7 +8978,7 @@ export const GetRemarketingListSharesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/remarketingListShares/{remarketingListId}",
+      path: "userprofiles/{+profileId}/remarketingListShares/{+remarketingListId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetRemarketingListSharesRequest>;
@@ -9003,7 +9009,7 @@ export interface ListMetrosRequest {
 export const ListMetrosRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/metros" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/metros" }),
   svc,
 ) as unknown as Schema.Schema<ListMetrosRequest>;
 
@@ -9039,7 +9045,7 @@ export const DeletePlacementStrategiesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "userprofiles/{profileId}/placementStrategies/{id}",
+      path: "userprofiles/{+profileId}/placementStrategies/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeletePlacementStrategiesRequest>;
@@ -9078,7 +9084,7 @@ export const UpdatePlacementStrategiesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/placementStrategies",
+      path: "userprofiles/{+profileId}/placementStrategies",
       hasBody: true,
     }),
     svc,
@@ -9133,7 +9139,7 @@ export const ListPlacementStrategiesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/placementStrategies",
+      path: "userprofiles/{+profileId}/placementStrategies",
     }),
     svc,
   ) as unknown as Schema.Schema<ListPlacementStrategiesRequest>;
@@ -9174,7 +9180,7 @@ export const GetPlacementStrategiesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/placementStrategies/{id}",
+      path: "userprofiles/{+profileId}/placementStrategies/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetPlacementStrategiesRequest>;
@@ -9214,7 +9220,7 @@ export const PatchPlacementStrategiesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/placementStrategies",
+      path: "userprofiles/{+profileId}/placementStrategies",
       hasBody: true,
     }),
     svc,
@@ -9252,7 +9258,7 @@ export const InsertPlacementStrategiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/placementStrategies",
+      path: "userprofiles/{+profileId}/placementStrategies",
       hasBody: true,
     }),
     svc,
@@ -9287,7 +9293,7 @@ export const GetMobileAppsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/mobileApps/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/mobileApps/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetMobileAppsRequest>;
 
@@ -9347,7 +9353,7 @@ export const ListMobileAppsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   ids: Schema.optional(Schema.Array(Schema.String)).pipe(T.HttpQuery("ids")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/mobileApps" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/mobileApps" }),
   svc,
 ) as unknown as Schema.Schema<ListMobileAppsRequest>;
 
@@ -9387,7 +9393,7 @@ export const ListBillingAssignmentsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/billingProfiles/{billingProfileId}/billingAssignments",
+      path: "userprofiles/{+profileId}/billingProfiles/{+billingProfileId}/billingAssignments",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAssignmentsRequest>;
@@ -9427,7 +9433,7 @@ export const InsertBillingAssignmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/billingProfiles/{billingProfileId}/billingAssignments",
+      path: "userprofiles/{+profileId}/billingProfiles/{+billingProfileId}/billingAssignments",
       hasBody: true,
     }),
     svc,
@@ -9482,7 +9488,7 @@ export const ListContentCategoriesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/contentCategories",
+      path: "userprofiles/{+profileId}/contentCategories",
     }),
     svc,
   ) as unknown as Schema.Schema<ListContentCategoriesRequest>;
@@ -9523,7 +9529,7 @@ export const InsertContentCategoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/contentCategories",
+      path: "userprofiles/{+profileId}/contentCategories",
       hasBody: true,
     }),
     svc,
@@ -9564,7 +9570,7 @@ export const PatchContentCategoriesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/contentCategories",
+      path: "userprofiles/{+profileId}/contentCategories",
       hasBody: true,
     }),
     svc,
@@ -9602,7 +9608,7 @@ export const GetContentCategoriesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/contentCategories/{id}",
+      path: "userprofiles/{+profileId}/contentCategories/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetContentCategoriesRequest>;
@@ -9639,7 +9645,7 @@ export const DeleteContentCategoriesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "userprofiles/{profileId}/contentCategories/{id}",
+      path: "userprofiles/{+profileId}/contentCategories/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteContentCategoriesRequest>;
@@ -9678,7 +9684,7 @@ export const UpdateContentCategoriesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/contentCategories",
+      path: "userprofiles/{+profileId}/contentCategories",
       hasBody: true,
     }),
     svc,
@@ -9719,7 +9725,7 @@ export const PatchSubaccountsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/subaccounts",
+      path: "userprofiles/{+profileId}/subaccounts",
       hasBody: true,
     }),
     svc,
@@ -9756,7 +9762,7 @@ export const InsertSubaccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/subaccounts",
+      path: "userprofiles/{+profileId}/subaccounts",
       hasBody: true,
     }),
     svc,
@@ -9790,7 +9796,10 @@ export const GetSubaccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/subaccounts/{id}" }),
+  T.Http({
+    method: "GET",
+    path: "userprofiles/{+profileId}/subaccounts/{+id}",
+  }),
   svc,
 ) as unknown as Schema.Schema<GetSubaccountsRequest>;
 
@@ -9841,7 +9850,7 @@ export const ListSubaccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/subaccounts" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/subaccounts" }),
   svc,
 ) as unknown as Schema.Schema<ListSubaccountsRequest>;
 
@@ -9881,7 +9890,7 @@ export const UpdateSubaccountsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/subaccounts",
+      path: "userprofiles/{+profileId}/subaccounts",
       hasBody: true,
     }),
     svc,
@@ -9953,7 +9962,7 @@ export const ListAdvertiserLandingPagesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/advertiserLandingPages",
+      path: "userprofiles/{+profileId}/advertiserLandingPages",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertiserLandingPagesRequest>;
@@ -9995,7 +10004,7 @@ export const GetAdvertiserLandingPagesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/advertiserLandingPages/{id}",
+      path: "userprofiles/{+profileId}/advertiserLandingPages/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertiserLandingPagesRequest>;
@@ -10032,7 +10041,7 @@ export const InsertAdvertiserLandingPagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/advertiserLandingPages",
+      path: "userprofiles/{+profileId}/advertiserLandingPages",
       hasBody: true,
     }),
     svc,
@@ -10073,7 +10082,7 @@ export const PatchAdvertiserLandingPagesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/advertiserLandingPages",
+      path: "userprofiles/{+profileId}/advertiserLandingPages",
       hasBody: true,
     }),
     svc,
@@ -10111,7 +10120,7 @@ export const UpdateAdvertiserLandingPagesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/advertiserLandingPages",
+      path: "userprofiles/{+profileId}/advertiserLandingPages",
       hasBody: true,
     }),
     svc,
@@ -10149,7 +10158,7 @@ export const GetMobileCarriersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/mobileCarriers/{id}",
+      path: "userprofiles/{+profileId}/mobileCarriers/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetMobileCarriersRequest>;
@@ -10181,7 +10190,7 @@ export const ListMobileCarriersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     profileId: Schema.String.pipe(T.HttpPath("profileId")),
   }).pipe(
-    T.Http({ method: "GET", path: "userprofiles/{profileId}/mobileCarriers" }),
+    T.Http({ method: "GET", path: "userprofiles/{+profileId}/mobileCarriers" }),
     svc,
   ) as unknown as Schema.Schema<ListMobileCarriersRequest>;
 
@@ -10223,7 +10232,7 @@ export const ListSizesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   height: Schema.optional(Schema.Number).pipe(T.HttpQuery("height")),
   ids: Schema.optional(Schema.Array(Schema.String)).pipe(T.HttpQuery("ids")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/sizes" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/sizes" }),
   svc,
 ) as unknown as Schema.Schema<ListSizesRequest>;
 
@@ -10257,7 +10266,7 @@ export const InsertSizesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "userprofiles/{profileId}/sizes",
+    path: "userprofiles/{+profileId}/sizes",
     hasBody: true,
   }),
   svc,
@@ -10291,7 +10300,7 @@ export const GetSizesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/sizes/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/sizes/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetSizesRequest>;
 
@@ -10320,7 +10329,7 @@ export interface ListBrowsersRequest {
 export const ListBrowsersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/browsers" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/browsers" }),
   svc,
 ) as unknown as Schema.Schema<ListBrowsersRequest>;
 
@@ -10350,7 +10359,7 @@ export interface ListLanguagesRequest {
 export const ListLanguagesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/languages" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/languages" }),
   svc,
 ) as unknown as Schema.Schema<ListLanguagesRequest>;
 
@@ -10383,7 +10392,7 @@ export const GetChangeLogsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/changeLogs/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/changeLogs/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetChangeLogsRequest>;
 
@@ -10514,7 +10523,7 @@ export const ListChangeLogsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("maxChangeTime"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/changeLogs" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/changeLogs" }),
   svc,
 ) as unknown as Schema.Schema<ListChangeLogsRequest>;
 
@@ -10554,7 +10563,7 @@ export const GetPlacementGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/placementGroups/{id}",
+      path: "userprofiles/{+profileId}/placementGroups/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetPlacementGroupsRequest>;
@@ -10594,7 +10603,7 @@ export const PatchPlacementGroupsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/placementGroups",
+      path: "userprofiles/{+profileId}/placementGroups",
       hasBody: true,
     }),
     svc,
@@ -10632,7 +10641,7 @@ export const InsertPlacementGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/placementGroups",
+      path: "userprofiles/{+profileId}/placementGroups",
       hasBody: true,
     }),
     svc,
@@ -10762,7 +10771,10 @@ export const ListPlacementGroupsRequest =
       T.HttpQuery("placementGroupType"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "userprofiles/{profileId}/placementGroups" }),
+    T.Http({
+      method: "GET",
+      path: "userprofiles/{+profileId}/placementGroups",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListPlacementGroupsRequest>;
 
@@ -10802,7 +10814,7 @@ export const UpdatePlacementGroupsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/placementGroups",
+      path: "userprofiles/{+profileId}/placementGroups",
       hasBody: true,
     }),
     svc,
@@ -10840,7 +10852,7 @@ export const GetUserRolePermissionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/userRolePermissions/{id}",
+      path: "userprofiles/{+profileId}/userRolePermissions/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetUserRolePermissionsRequest>;
@@ -10877,7 +10889,7 @@ export const ListUserRolePermissionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/userRolePermissions",
+      path: "userprofiles/{+profileId}/userRolePermissions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListUserRolePermissionsRequest>;
@@ -10913,7 +10925,7 @@ export const UpdateAdsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PUT",
-    path: "userprofiles/{profileId}/ads",
+    path: "userprofiles/{+profileId}/ads",
     hasBody: true,
   }),
   svc,
@@ -10947,7 +10959,7 @@ export const GetAdsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/ads/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/ads/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetAdsRequest>;
 
@@ -10981,7 +10993,7 @@ export const InsertAdsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "userprofiles/{profileId}/ads",
+    path: "userprofiles/{+profileId}/ads",
     hasBody: true,
   }),
   svc,
@@ -11020,7 +11032,7 @@ export const PatchAdsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "userprofiles/{profileId}/ads",
+    path: "userprofiles/{+profileId}/ads",
     hasBody: true,
   }),
   svc,
@@ -11161,7 +11173,7 @@ export const ListAdsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("overriddenEventTagId"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/ads" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/ads" }),
   svc,
 ) as unknown as Schema.Schema<ListAdsRequest>;
 
@@ -11222,7 +11234,7 @@ export const ListTargetingTemplatesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/targetingTemplates",
+      path: "userprofiles/{+profileId}/targetingTemplates",
     }),
     svc,
   ) as unknown as Schema.Schema<ListTargetingTemplatesRequest>;
@@ -11266,7 +11278,7 @@ export const PatchTargetingTemplatesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/targetingTemplates",
+      path: "userprofiles/{+profileId}/targetingTemplates",
       hasBody: true,
     }),
     svc,
@@ -11304,7 +11316,7 @@ export const InsertTargetingTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/targetingTemplates",
+      path: "userprofiles/{+profileId}/targetingTemplates",
       hasBody: true,
     }),
     svc,
@@ -11342,7 +11354,7 @@ export const GetTargetingTemplatesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/targetingTemplates/{id}",
+      path: "userprofiles/{+profileId}/targetingTemplates/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetTargetingTemplatesRequest>;
@@ -11379,7 +11391,7 @@ export const UpdateTargetingTemplatesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/targetingTemplates",
+      path: "userprofiles/{+profileId}/targetingTemplates",
       hasBody: true,
     }),
     svc,
@@ -11420,7 +11432,7 @@ export const InsertCampaignCreativeAssociationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/campaigns/{campaignId}/campaignCreativeAssociations",
+      path: "userprofiles/{+profileId}/campaigns/{+campaignId}/campaignCreativeAssociations",
       hasBody: true,
     }),
     svc,
@@ -11468,7 +11480,7 @@ export const ListCampaignCreativeAssociationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/campaigns/{campaignId}/campaignCreativeAssociations",
+      path: "userprofiles/{+profileId}/campaigns/{+campaignId}/campaignCreativeAssociations",
     }),
     svc,
   ) as unknown as Schema.Schema<ListCampaignCreativeAssociationsRequest>;
@@ -11510,7 +11522,7 @@ export const GetAdvertiserGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/advertiserGroups/{id}",
+      path: "userprofiles/{+profileId}/advertiserGroups/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertiserGroupsRequest>;
@@ -11547,7 +11559,7 @@ export const InsertAdvertiserGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/advertiserGroups",
+      path: "userprofiles/{+profileId}/advertiserGroups",
       hasBody: true,
     }),
     svc,
@@ -11588,7 +11600,7 @@ export const PatchAdvertiserGroupsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/advertiserGroups",
+      path: "userprofiles/{+profileId}/advertiserGroups",
       hasBody: true,
     }),
     svc,
@@ -11643,7 +11655,7 @@ export const ListAdvertiserGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/advertiserGroups",
+      path: "userprofiles/{+profileId}/advertiserGroups",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertiserGroupsRequest>;
@@ -11684,7 +11696,7 @@ export const UpdateAdvertiserGroupsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/advertiserGroups",
+      path: "userprofiles/{+profileId}/advertiserGroups",
       hasBody: true,
     }),
     svc,
@@ -11722,7 +11734,7 @@ export const DeleteAdvertiserGroupsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "userprofiles/{profileId}/advertiserGroups/{id}",
+      path: "userprofiles/{+profileId}/advertiserGroups/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertiserGroupsRequest>;
@@ -12229,7 +12241,7 @@ export const ListCreativeGroupsRequest =
     profileId: Schema.String.pipe(T.HttpPath("profileId")),
     sortField: Schema.optional(Schema.String).pipe(T.HttpQuery("sortField")),
   }).pipe(
-    T.Http({ method: "GET", path: "userprofiles/{profileId}/creativeGroups" }),
+    T.Http({ method: "GET", path: "userprofiles/{+profileId}/creativeGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListCreativeGroupsRequest>;
 
@@ -12269,7 +12281,7 @@ export const InsertCreativeGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/creativeGroups",
+      path: "userprofiles/{+profileId}/creativeGroups",
       hasBody: true,
     }),
     svc,
@@ -12310,7 +12322,7 @@ export const PatchCreativeGroupsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/creativeGroups",
+      path: "userprofiles/{+profileId}/creativeGroups",
       hasBody: true,
     }),
     svc,
@@ -12348,7 +12360,7 @@ export const GetCreativeGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/creativeGroups/{id}",
+      path: "userprofiles/{+profileId}/creativeGroups/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetCreativeGroupsRequest>;
@@ -12385,7 +12397,7 @@ export const UpdateCreativeGroupsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/creativeGroups",
+      path: "userprofiles/{+profileId}/creativeGroups",
       hasBody: true,
     }),
     svc,
@@ -12423,7 +12435,7 @@ export const DeleteCreativeFieldsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "userprofiles/{profileId}/creativeFields/{id}",
+      path: "userprofiles/{+profileId}/creativeFields/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteCreativeFieldsRequest>;
@@ -12462,7 +12474,7 @@ export const UpdateCreativeFieldsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/creativeFields",
+      path: "userprofiles/{+profileId}/creativeFields",
       hasBody: true,
     }),
     svc,
@@ -12520,7 +12532,7 @@ export const ListCreativeFieldsRequest =
     maxResults: Schema.optional(Schema.Number).pipe(T.HttpQuery("maxResults")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "userprofiles/{profileId}/creativeFields" }),
+    T.Http({ method: "GET", path: "userprofiles/{+profileId}/creativeFields" }),
     svc,
   ) as unknown as Schema.Schema<ListCreativeFieldsRequest>;
 
@@ -12560,7 +12572,7 @@ export const GetCreativeFieldsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/creativeFields/{id}",
+      path: "userprofiles/{+profileId}/creativeFields/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetCreativeFieldsRequest>;
@@ -12597,7 +12609,7 @@ export const InsertCreativeFieldsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/creativeFields",
+      path: "userprofiles/{+profileId}/creativeFields",
       hasBody: true,
     }),
     svc,
@@ -12638,7 +12650,7 @@ export const PatchCreativeFieldsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/creativeFields",
+      path: "userprofiles/{+profileId}/creativeFields",
       hasBody: true,
     }),
     svc,
@@ -12676,7 +12688,7 @@ export const GetUserRolePermissionGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/userRolePermissionGroups/{id}",
+      path: "userprofiles/{+profileId}/userRolePermissionGroups/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetUserRolePermissionGroupsRequest>;
@@ -12710,7 +12722,7 @@ export const ListUserRolePermissionGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/userRolePermissionGroups",
+      path: "userprofiles/{+profileId}/userRolePermissionGroups",
     }),
     svc,
   ) as unknown as Schema.Schema<ListUserRolePermissionGroupsRequest>;
@@ -12748,7 +12760,7 @@ export const UpdateAccountUserProfilesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/accountUserProfiles",
+      path: "userprofiles/{+profileId}/accountUserProfiles",
       hasBody: true,
     }),
     svc,
@@ -12814,7 +12826,7 @@ export const ListAccountUserProfilesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/accountUserProfiles",
+      path: "userprofiles/{+profileId}/accountUserProfiles",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountUserProfilesRequest>;
@@ -12855,7 +12867,7 @@ export const GetAccountUserProfilesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/accountUserProfiles/{id}",
+      path: "userprofiles/{profileId}/accountUserProfiles/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAccountUserProfilesRequest>;
@@ -12892,7 +12904,7 @@ export const InsertAccountUserProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/accountUserProfiles",
+      path: "userprofiles/{+profileId}/accountUserProfiles",
       hasBody: true,
     }),
     svc,
@@ -12933,7 +12945,7 @@ export const PatchAccountUserProfilesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/accountUserProfiles",
+      path: "userprofiles/{+profileId}/accountUserProfiles",
       hasBody: true,
     }),
     svc,
@@ -12971,7 +12983,7 @@ export const UpdateRemarketingListsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/remarketingLists",
+      path: "userprofiles/{+profileId}/remarketingLists",
       hasBody: true,
     }),
     svc,
@@ -13032,7 +13044,7 @@ export const ListRemarketingListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/remarketingLists",
+      path: "userprofiles/{+profileId}/remarketingLists",
     }),
     svc,
   ) as unknown as Schema.Schema<ListRemarketingListsRequest>;
@@ -13076,7 +13088,7 @@ export const PatchRemarketingListsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/remarketingLists",
+      path: "userprofiles/{+profileId}/remarketingLists",
       hasBody: true,
     }),
     svc,
@@ -13114,7 +13126,7 @@ export const InsertRemarketingListsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/remarketingLists",
+      path: "userprofiles/{+profileId}/remarketingLists",
       hasBody: true,
     }),
     svc,
@@ -13152,7 +13164,7 @@ export const GetRemarketingListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/remarketingLists/{id}",
+      path: "userprofiles/{+profileId}/remarketingLists/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetRemarketingListsRequest>;
@@ -13273,7 +13285,7 @@ export const ListCreativesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("renderingIds"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/creatives" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/creatives" }),
   svc,
 ) as unknown as Schema.Schema<ListCreativesRequest>;
 
@@ -13310,7 +13322,7 @@ export const GetCreativesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/creatives/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/creatives/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetCreativesRequest>;
 
@@ -13346,7 +13358,7 @@ export const InsertCreativesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 ).pipe(
   T.Http({
     method: "POST",
-    path: "userprofiles/{profileId}/creatives",
+    path: "userprofiles/{+profileId}/creatives",
     hasBody: true,
   }),
   svc,
@@ -13385,7 +13397,7 @@ export const PatchCreativesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "userprofiles/{profileId}/creatives",
+    path: "userprofiles/{+profileId}/creatives",
     hasBody: true,
   }),
   svc,
@@ -13423,7 +13435,7 @@ export const UpdateCreativesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 ).pipe(
   T.Http({
     method: "PUT",
-    path: "userprofiles/{profileId}/creatives",
+    path: "userprofiles/{+profileId}/creatives",
     hasBody: true,
   }),
   svc,
@@ -13459,7 +13471,7 @@ export const GetPostalCodesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "GET",
-    path: "userprofiles/{profileId}/postalCodes/{code}",
+    path: "userprofiles/{+profileId}/postalCodes/{+code}",
   }),
   svc,
 ) as unknown as Schema.Schema<GetPostalCodesRequest>;
@@ -13491,7 +13503,7 @@ export const ListPostalCodesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     profileId: Schema.String.pipe(T.HttpPath("profileId")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/postalCodes" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/postalCodes" }),
   svc,
 ) as unknown as Schema.Schema<ListPostalCodesRequest>;
 
@@ -13577,7 +13589,7 @@ export const ListFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/floodlightActivities",
+      path: "userprofiles/{+profileId}/floodlightActivities",
     }),
     svc,
   ) as unknown as Schema.Schema<ListFloodlightActivitiesRequest>;
@@ -13618,7 +13630,7 @@ export const InsertFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/floodlightActivities",
+      path: "userprofiles/{+profileId}/floodlightActivities",
       hasBody: true,
     }),
     svc,
@@ -13659,7 +13671,7 @@ export const PatchFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/floodlightActivities",
+      path: "userprofiles/{+profileId}/floodlightActivities",
       hasBody: true,
     }),
     svc,
@@ -13697,7 +13709,7 @@ export const GetFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/floodlightActivities/{id}",
+      path: "userprofiles/{+profileId}/floodlightActivities/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetFloodlightActivitiesRequest>;
@@ -13734,7 +13746,7 @@ export const DeleteFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "userprofiles/{profileId}/floodlightActivities/{id}",
+      path: "userprofiles/{+profileId}/floodlightActivities/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteFloodlightActivitiesRequest>;
@@ -13773,7 +13785,7 @@ export const UpdateFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/floodlightActivities",
+      path: "userprofiles/{+profileId}/floodlightActivities",
       hasBody: true,
     }),
     svc,
@@ -13813,7 +13825,7 @@ export const GeneratetagFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/floodlightActivities/generatetag",
+      path: "userprofiles/{+profileId}/floodlightActivities/generatetag",
       hasBody: true,
     }),
     svc,
@@ -13852,7 +13864,7 @@ export const GetOperatingSystemVersionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/operatingSystemVersions/{id}",
+      path: "userprofiles/{+profileId}/operatingSystemVersions/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetOperatingSystemVersionsRequest>;
@@ -13886,7 +13898,7 @@ export const ListOperatingSystemVersionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/operatingSystemVersions",
+      path: "userprofiles/{+profileId}/operatingSystemVersions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListOperatingSystemVersionsRequest>;
@@ -13925,7 +13937,7 @@ export const InsertEventTagsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 ).pipe(
   T.Http({
     method: "POST",
-    path: "userprofiles/{profileId}/eventTags",
+    path: "userprofiles/{+profileId}/eventTags",
     hasBody: true,
   }),
   svc,
@@ -13964,7 +13976,7 @@ export const PatchEventTagsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "userprofiles/{profileId}/eventTags",
+    path: "userprofiles/{+profileId}/eventTags",
     hasBody: true,
   }),
   svc,
@@ -13998,7 +14010,7 @@ export const GetEventTagsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/eventTags/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/eventTags/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetEventTagsRequest>;
 
@@ -14069,7 +14081,7 @@ export const ListEventTagsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("eventTagTypes"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/eventTags" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/eventTags" }),
   svc,
 ) as unknown as Schema.Schema<ListEventTagsRequest>;
 
@@ -14106,7 +14118,7 @@ export const UpdateEventTagsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 ).pipe(
   T.Http({
     method: "PUT",
-    path: "userprofiles/{profileId}/eventTags",
+    path: "userprofiles/{+profileId}/eventTags",
     hasBody: true,
   }),
   svc,
@@ -14142,7 +14154,10 @@ export const DeleteEventTagsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     id: Schema.String.pipe(T.HttpPath("id")),
   },
 ).pipe(
-  T.Http({ method: "DELETE", path: "userprofiles/{profileId}/eventTags/{id}" }),
+  T.Http({
+    method: "DELETE",
+    path: "userprofiles/{+profileId}/eventTags/{+id}",
+  }),
   svc,
 ) as unknown as Schema.Schema<DeleteEventTagsRequest>;
 
@@ -14180,7 +14195,7 @@ export const GetAccountPermissionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/accountPermissions/{id}",
+      path: "userprofiles/{+profileId}/accountPermissions/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAccountPermissionsRequest>;
@@ -14214,7 +14229,7 @@ export const ListAccountPermissionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/accountPermissions",
+      path: "userprofiles/{+profileId}/accountPermissions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountPermissionsRequest>;
@@ -14250,7 +14265,7 @@ export const GetCountriesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "GET",
-    path: "userprofiles/{profileId}/countries/{dartId}",
+    path: "userprofiles/{+profileId}/countries/{+dartId}",
   }),
   svc,
 ) as unknown as Schema.Schema<GetCountriesRequest>;
@@ -14280,7 +14295,7 @@ export interface ListCountriesRequest {
 export const ListCountriesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/countries" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/countries" }),
   svc,
 ) as unknown as Schema.Schema<ListCountriesRequest>;
 
@@ -14371,7 +14386,7 @@ export const ListSitesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("directorySiteIds"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/sites" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/sites" }),
   svc,
 ) as unknown as Schema.Schema<ListSitesRequest>;
 
@@ -14412,7 +14427,7 @@ export const PatchSitesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "userprofiles/{profileId}/sites",
+    path: "userprofiles/{+profileId}/sites",
     hasBody: true,
   }),
   svc,
@@ -14448,7 +14463,7 @@ export const InsertSitesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "POST",
-    path: "userprofiles/{profileId}/sites",
+    path: "userprofiles/{+profileId}/sites",
     hasBody: true,
   }),
   svc,
@@ -14482,7 +14497,7 @@ export const GetSitesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/sites/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/sites/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetSitesRequest>;
 
@@ -14516,7 +14531,7 @@ export const UpdateSitesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PUT",
-    path: "userprofiles/{profileId}/sites",
+    path: "userprofiles/{+profileId}/sites",
     hasBody: true,
   }),
   svc,
@@ -14556,7 +14571,7 @@ export const InsertCreativeAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/creativeAssets/{advertiserId}/creativeAssets",
+      path: "userprofiles/{+profileId}/creativeAssets/{+advertiserId}/creativeAssets",
       hasBody: true,
     }),
     svc,
@@ -14594,7 +14609,7 @@ export const GetFloodlightConfigurationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/floodlightConfigurations/{id}",
+      path: "userprofiles/{+profileId}/floodlightConfigurations/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetFloodlightConfigurationsRequest>;
@@ -14631,7 +14646,7 @@ export const UpdateFloodlightConfigurationsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/floodlightConfigurations",
+      path: "userprofiles/{+profileId}/floodlightConfigurations",
       hasBody: true,
     }),
     svc,
@@ -14672,7 +14687,7 @@ export const PatchFloodlightConfigurationsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/floodlightConfigurations",
+      path: "userprofiles/{+profileId}/floodlightConfigurations",
       hasBody: true,
     }),
     svc,
@@ -14710,7 +14725,7 @@ export const ListFloodlightConfigurationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/floodlightConfigurations",
+      path: "userprofiles/{+profileId}/floodlightConfigurations",
     }),
     svc,
   ) as unknown as Schema.Schema<ListFloodlightConfigurationsRequest>;
@@ -14748,7 +14763,7 @@ export const UpdateFloodlightActivityGroupsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/floodlightActivityGroups",
+      path: "userprofiles/{+profileId}/floodlightActivityGroups",
       hasBody: true,
     }),
     svc,
@@ -14786,7 +14801,7 @@ export const InsertFloodlightActivityGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/floodlightActivityGroups",
+      path: "userprofiles/{+profileId}/floodlightActivityGroups",
       hasBody: true,
     }),
     svc,
@@ -14827,7 +14842,7 @@ export const PatchFloodlightActivityGroupsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "userprofiles/{profileId}/floodlightActivityGroups",
+      path: "userprofiles/{+profileId}/floodlightActivityGroups",
       hasBody: true,
     }),
     svc,
@@ -14865,7 +14880,7 @@ export const GetFloodlightActivityGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/floodlightActivityGroups/{id}",
+      path: "userprofiles/{+profileId}/floodlightActivityGroups/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetFloodlightActivityGroupsRequest>;
@@ -14932,7 +14947,7 @@ export const ListFloodlightActivityGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/floodlightActivityGroups",
+      path: "userprofiles/{+profileId}/floodlightActivityGroups",
     }),
     svc,
   ) as unknown as Schema.Schema<ListFloodlightActivityGroupsRequest>;
@@ -14974,7 +14989,7 @@ export const GetAccountPermissionGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/accountPermissionGroups/{id}",
+      path: "userprofiles/{+profileId}/accountPermissionGroups/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAccountPermissionGroupsRequest>;
@@ -15008,7 +15023,7 @@ export const ListAccountPermissionGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/accountPermissionGroups",
+      path: "userprofiles/{+profileId}/accountPermissionGroups",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountPermissionGroupsRequest>;
@@ -15045,7 +15060,10 @@ export const GetVideoFormatsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     id: Schema.Number.pipe(T.HttpPath("id")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/videoFormats/{id}" }),
+  T.Http({
+    method: "GET",
+    path: "userprofiles/{+profileId}/videoFormats/{+id}",
+  }),
   svc,
 ) as unknown as Schema.Schema<GetVideoFormatsRequest>;
 
@@ -15075,7 +15093,7 @@ export const ListVideoFormatsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     profileId: Schema.String.pipe(T.HttpPath("profileId")),
   }).pipe(
-    T.Http({ method: "GET", path: "userprofiles/{profileId}/videoFormats" }),
+    T.Http({ method: "GET", path: "userprofiles/{+profileId}/videoFormats" }),
     svc,
   ) as unknown as Schema.Schema<ListVideoFormatsRequest>;
 
@@ -15209,7 +15227,7 @@ export const ListAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("searchString"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/accounts" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/accounts" }),
   svc,
 ) as unknown as Schema.Schema<ListAccountsRequest>;
 
@@ -15248,7 +15266,7 @@ export const UpdateAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PUT",
-    path: "userprofiles/{profileId}/accounts",
+    path: "userprofiles/{+profileId}/accounts",
     hasBody: true,
   }),
   svc,
@@ -15287,7 +15305,7 @@ export const PatchAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "userprofiles/{profileId}/accounts",
+    path: "userprofiles/{+profileId}/accounts",
     hasBody: true,
   }),
   svc,
@@ -15321,7 +15339,7 @@ export const GetAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/accounts/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/accounts/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetAccountsRequest>;
 
@@ -15403,7 +15421,7 @@ export const ListCampaignsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   sortOrder: Schema.optional(Schema.String).pipe(T.HttpQuery("sortOrder")),
   archived: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("archived")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/campaigns" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/campaigns" }),
   svc,
 ) as unknown as Schema.Schema<ListCampaignsRequest>;
 
@@ -15440,7 +15458,7 @@ export const GetCampaignsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/campaigns/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/campaigns/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetCampaignsRequest>;
 
@@ -15476,7 +15494,7 @@ export const InsertCampaignsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 ).pipe(
   T.Http({
     method: "POST",
-    path: "userprofiles/{profileId}/campaigns",
+    path: "userprofiles/{+profileId}/campaigns",
     hasBody: true,
   }),
   svc,
@@ -15515,7 +15533,7 @@ export const PatchCampaignsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "userprofiles/{profileId}/campaigns",
+    path: "userprofiles/{+profileId}/campaigns",
     hasBody: true,
   }),
   svc,
@@ -15553,7 +15571,7 @@ export const UpdateCampaignsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 ).pipe(
   T.Http({
     method: "PUT",
-    path: "userprofiles/{profileId}/campaigns",
+    path: "userprofiles/{+profileId}/campaigns",
     hasBody: true,
   }),
   svc,
@@ -15587,7 +15605,7 @@ export const GetUserRolesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/userRoles/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/userRoles/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetUserRolesRequest>;
 
@@ -15624,7 +15642,7 @@ export const PatchUserRolesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 }).pipe(
   T.Http({
     method: "PATCH",
-    path: "userprofiles/{profileId}/userRoles",
+    path: "userprofiles/{+profileId}/userRoles",
     hasBody: true,
   }),
   svc,
@@ -15662,7 +15680,7 @@ export const InsertUserRolesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 ).pipe(
   T.Http({
     method: "POST",
-    path: "userprofiles/{profileId}/userRoles",
+    path: "userprofiles/{+profileId}/userRoles",
     hasBody: true,
   }),
   svc,
@@ -15723,7 +15741,7 @@ export const ListUserRolesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   ),
   maxResults: Schema.optional(Schema.Number).pipe(T.HttpQuery("maxResults")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/userRoles" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/userRoles" }),
   svc,
 ) as unknown as Schema.Schema<ListUserRolesRequest>;
 
@@ -15764,7 +15782,7 @@ export const UpdateUserRolesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 ).pipe(
   T.Http({
     method: "PUT",
-    path: "userprofiles/{profileId}/userRoles",
+    path: "userprofiles/{+profileId}/userRoles",
     hasBody: true,
   }),
   svc,
@@ -15800,7 +15818,10 @@ export const DeleteUserRolesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     id: Schema.String.pipe(T.HttpPath("id")),
   },
 ).pipe(
-  T.Http({ method: "DELETE", path: "userprofiles/{profileId}/userRoles/{id}" }),
+  T.Http({
+    method: "DELETE",
+    path: "userprofiles/{+profileId}/userRoles/{+id}",
+  }),
   svc,
 ) as unknown as Schema.Schema<DeleteUserRolesRequest>;
 
@@ -15887,7 +15908,7 @@ export const InsertDirectorySitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/directorySites",
+      path: "userprofiles/{+profileId}/directorySites",
       hasBody: true,
     }),
     svc,
@@ -15925,7 +15946,7 @@ export const GetDirectorySitesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/directorySites/{id}",
+      path: "userprofiles/{+profileId}/directorySites/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetDirectorySitesRequest>;
@@ -16000,7 +16021,7 @@ export const ListDirectorySitesRequest =
     ),
     maxResults: Schema.optional(Schema.Number).pipe(T.HttpQuery("maxResults")),
   }).pipe(
-    T.Http({ method: "GET", path: "userprofiles/{profileId}/directorySites" }),
+    T.Http({ method: "GET", path: "userprofiles/{+profileId}/directorySites" }),
     svc,
   ) as unknown as Schema.Schema<ListDirectorySitesRequest>;
 
@@ -16040,7 +16061,7 @@ export const GetOperatingSystemsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/operatingSystems/{dartId}",
+      path: "userprofiles/{+profileId}/operatingSystems/{+dartId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetOperatingSystemsRequest>;
@@ -16074,7 +16095,7 @@ export const ListOperatingSystemsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/operatingSystems",
+      path: "userprofiles/{+profileId}/operatingSystems",
     }),
     svc,
   ) as unknown as Schema.Schema<ListOperatingSystemsRequest>;
@@ -16144,7 +16165,7 @@ export const ListBillingRatesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/billingProfiles/{billingProfileId}/billingRates",
+      path: "userprofiles/{+profileId}/billingProfiles/{+billingProfileId}/billingRates",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBillingRatesRequest>;
@@ -16205,7 +16226,7 @@ export const GetTvCampaignDetailsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/tvCampaignDetails/{id}",
+      path: "userprofiles/{+profileId}/tvCampaignDetails/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetTvCampaignDetailsRequest>;
@@ -16251,7 +16272,7 @@ export const ListAdvertiserInvoicesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/advertisers/{advertiserId}/invoices",
+      path: "userprofiles/{+profileId}/advertisers/{+advertiserId}/invoices",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertiserInvoicesRequest>;
@@ -16325,7 +16346,10 @@ export const ListBillingProfilesRequest =
     name: Schema.optional(Schema.String).pipe(T.HttpQuery("name")),
     sortOrder: Schema.optional(Schema.String).pipe(T.HttpQuery("sortOrder")),
   }).pipe(
-    T.Http({ method: "GET", path: "userprofiles/{profileId}/billingProfiles" }),
+    T.Http({
+      method: "GET",
+      path: "userprofiles/{+profileId}/billingProfiles",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListBillingProfilesRequest>;
 
@@ -16365,7 +16389,7 @@ export const UpdateBillingProfilesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/billingProfiles",
+      path: "userprofiles/{+profileId}/billingProfiles",
       hasBody: true,
     }),
     svc,
@@ -16403,7 +16427,7 @@ export const GetBillingProfilesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "userprofiles/{profileId}/billingProfiles/{id}",
+      path: "userprofiles/{+profileId}/billingProfiles/{+id}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetBillingProfilesRequest>;
@@ -16437,7 +16461,7 @@ export const PublishStudioCreativesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "studio/creatives/{studioCreativeId}/publish",
+      path: "studio/creatives/{+studioCreativeId}/publish",
       hasBody: true,
     }),
     svc,
@@ -16472,7 +16496,7 @@ export const GetStudioCreativesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     studioCreativeId: Schema.String.pipe(T.HttpPath("studioCreativeId")),
   }).pipe(
-    T.Http({ method: "GET", path: "studio/creatives/{studioCreativeId}" }),
+    T.Http({ method: "GET", path: "studio/creatives/{+studioCreativeId}" }),
     svc,
   ) as unknown as Schema.Schema<GetStudioCreativesRequest>;
 
@@ -16536,7 +16560,7 @@ export const GetPlacementsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   profileId: Schema.String.pipe(T.HttpPath("profileId")),
   id: Schema.String.pipe(T.HttpPath("id")),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/placements/{id}" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/placements/{+id}" }),
   svc,
 ) as unknown as Schema.Schema<GetPlacementsRequest>;
 
@@ -16575,7 +16599,7 @@ export const PatchPlacementsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 ).pipe(
   T.Http({
     method: "PATCH",
-    path: "userprofiles/{profileId}/placements",
+    path: "userprofiles/{+profileId}/placements",
     hasBody: true,
   }),
   svc,
@@ -16612,7 +16636,7 @@ export const InsertPlacementsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/placements",
+      path: "userprofiles/{+profileId}/placements",
       hasBody: true,
     }),
     svc,
@@ -16762,7 +16786,7 @@ export const ListPlacementsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("sizeIds"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "userprofiles/{profileId}/placements" }),
+  T.Http({ method: "GET", path: "userprofiles/{+profileId}/placements" }),
   svc,
 ) as unknown as Schema.Schema<ListPlacementsRequest>;
 
@@ -16802,7 +16826,7 @@ export const UpdatePlacementsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "userprofiles/{profileId}/placements",
+      path: "userprofiles/{+profileId}/placements",
       hasBody: true,
     }),
     svc,
@@ -16885,7 +16909,7 @@ export const GeneratetagsPlacementsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "userprofiles/{profileId}/placements/generatetags",
+      path: "userprofiles/{+profileId}/placements/generatetags",
       hasBody: true,
     }),
     svc,
@@ -16981,7 +17005,7 @@ export const GetDynamicFeedsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     dynamicFeedId: Schema.String.pipe(T.HttpPath("dynamicFeedId")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "studio/dynamicFeeds/{dynamicFeedId}" }),
+  T.Http({ method: "GET", path: "studio/dynamicFeeds/{+dynamicFeedId}" }),
   svc,
 ) as unknown as Schema.Schema<GetDynamicFeedsRequest>;
 
@@ -17013,7 +17037,7 @@ export const RetransformDynamicFeedsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "studio/dynamicFeeds/{dynamicFeedId}/retransform",
+      path: "studio/dynamicFeeds/{+dynamicFeedId}/retransform",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/dialogflow-v2.ts
+++ b/packages/gcp/src/services/dialogflow-v2.ts
@@ -12179,7 +12179,7 @@ export const GetAgentProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/agent" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/agent" }),
     svc,
   ) as unknown as Schema.Schema<GetAgentProjectsRequest>;
 
@@ -12213,7 +12213,7 @@ export const SetAgentProjectsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2Agent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/agent", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/agent", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetAgentProjectsRequest>;
 
@@ -12242,7 +12242,7 @@ export const DeleteAgentProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{parent}/agent" }),
+    T.Http({ method: "DELETE", path: "v2/{+parent}/agent" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAgentProjectsRequest>;
 
@@ -12281,7 +12281,7 @@ export const ListProjectsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsOperationsRequest>;
 
@@ -12315,7 +12315,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 
@@ -12344,7 +12344,7 @@ export const CancelProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsOperationsRequest>;
 
@@ -12373,7 +12373,7 @@ export const GetAgentProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/agent" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/agent" }),
     svc,
   ) as unknown as Schema.Schema<GetAgentProjectsLocationsRequest>;
 
@@ -12407,7 +12407,7 @@ export const SetAgentProjectsLocationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2Agent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/agent", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/agent", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetAgentProjectsLocationsRequest>;
 
@@ -12436,7 +12436,7 @@ export const DeleteAgentProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{parent}/agent" }),
+    T.Http({ method: "DELETE", path: "v2/{+parent}/agent" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAgentProjectsLocationsRequest>;
 
@@ -12465,7 +12465,7 @@ export const GetEncryptionSpecProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEncryptionSpecProjectsLocationsRequest>;
 
@@ -12505,7 +12505,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -12539,7 +12539,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -12578,7 +12578,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -12612,7 +12612,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -12641,7 +12641,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -12674,7 +12674,7 @@ export const SearchProjectsLocationsAgentRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/agent:search" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/agent:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsLocationsAgentRequest>;
 
@@ -12713,7 +12713,7 @@ export const TrainProjectsLocationsAgentRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/agent:train", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/agent:train", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TrainProjectsLocationsAgentRequest>;
 
@@ -12747,7 +12747,11 @@ export const ExportProjectsLocationsAgentRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/agent:export", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+parent}/agent:export",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsAgentRequest>;
 
@@ -12781,7 +12785,11 @@ export const ImportProjectsLocationsAgentRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/agent:import", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+parent}/agent:import",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsLocationsAgentRequest>;
 
@@ -12817,7 +12825,7 @@ export const RestoreProjectsLocationsAgentRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/agent:restore",
+      path: "v2/{+parent}/agent:restore",
       hasBody: true,
     }),
     svc,
@@ -12852,7 +12860,7 @@ export const GetValidationResultProjectsLocationsAgentRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/agent/validationResult" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/agent/validationResult" }),
     svc,
   ) as unknown as Schema.Schema<GetValidationResultProjectsLocationsAgentRequest>;
 
@@ -12882,7 +12890,7 @@ export const GetFulfillmentProjectsLocationsAgentRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFulfillmentProjectsLocationsAgentRequest>;
 
@@ -12919,7 +12927,7 @@ export const UpdateFulfillmentProjectsLocationsAgentRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateFulfillmentProjectsLocationsAgentRequest>;
 
@@ -12949,7 +12957,7 @@ export const DeleteContextsProjectsLocationsAgentSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{parent}/contexts" }),
+    T.Http({ method: "DELETE", path: "v2/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<DeleteContextsProjectsLocationsAgentSessionsRequest>;
 
@@ -12986,7 +12994,7 @@ export const DetectIntentProjectsLocationsAgentSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{session}:detectIntent",
+      path: "v2/{+session}:detectIntent",
       hasBody: true,
     }),
     svc,
@@ -13022,7 +13030,7 @@ export const ListProjectsLocationsAgentSessionsContextsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/contexts" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentSessionsContextsRequest>;
 
@@ -13056,7 +13064,7 @@ export const GetProjectsLocationsAgentSessionsContextsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentSessionsContextsRequest>;
 
@@ -13089,7 +13097,7 @@ export const CreateProjectsLocationsAgentSessionsContextsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDialogflowV2Context).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/contexts", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/contexts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentSessionsContextsRequest>;
 
@@ -13124,7 +13132,7 @@ export const PatchProjectsLocationsAgentSessionsContextsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2Context).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentSessionsContextsRequest>;
 
@@ -13154,7 +13162,7 @@ export const DeleteProjectsLocationsAgentSessionsContextsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentSessionsContextsRequest>;
 
@@ -13188,7 +13196,7 @@ export const ListProjectsLocationsAgentSessionsEntityTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentSessionsEntityTypesRequest>;
 
@@ -13222,7 +13230,7 @@ export const GetProjectsLocationsAgentSessionsEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentSessionsEntityTypesRequest>;
 
@@ -13257,7 +13265,7 @@ export const CreateProjectsLocationsAgentSessionsEntityTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/entityTypes", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/entityTypes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentSessionsEntityTypesRequest>;
 
@@ -13295,7 +13303,7 @@ export const PatchProjectsLocationsAgentSessionsEntityTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentSessionsEntityTypesRequest>;
 
@@ -13325,7 +13333,7 @@ export const DeleteProjectsLocationsAgentSessionsEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentSessionsEntityTypesRequest>;
 
@@ -13366,7 +13374,7 @@ export const ListProjectsLocationsAgentIntentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/intents" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/intents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentIntentsRequest>;
 
@@ -13406,7 +13414,7 @@ export const GetProjectsLocationsAgentIntentsRequest =
     ),
     intentView: Schema.optional(Schema.String).pipe(T.HttpQuery("intentView")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentIntentsRequest>;
 
@@ -13445,7 +13453,7 @@ export const CreateProjectsLocationsAgentIntentsRequest =
     intentView: Schema.optional(Schema.String).pipe(T.HttpQuery("intentView")),
     body: Schema.optional(GoogleCloudDialogflowV2Intent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/intents", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/intents", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentIntentsRequest>;
 
@@ -13486,7 +13494,7 @@ export const PatchProjectsLocationsAgentIntentsRequest =
     intentView: Schema.optional(Schema.String).pipe(T.HttpQuery("intentView")),
     body: Schema.optional(GoogleCloudDialogflowV2Intent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentIntentsRequest>;
 
@@ -13516,7 +13524,7 @@ export const DeleteProjectsLocationsAgentIntentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentIntentsRequest>;
 
@@ -13552,7 +13560,7 @@ export const BatchUpdateProjectsLocationsAgentIntentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/intents:batchUpdate",
+      path: "v2/{+parent}/intents:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -13591,7 +13599,7 @@ export const BatchDeleteProjectsLocationsAgentIntentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/intents:batchDelete",
+      path: "v2/{+parent}/intents:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -13631,7 +13639,7 @@ export const ListProjectsLocationsAgentEntityTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentEntityTypesRequest>;
 
@@ -13669,7 +13677,7 @@ export const GetProjectsLocationsAgentEntityTypesRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentEntityTypesRequest>;
 
@@ -13706,7 +13714,7 @@ export const CreateProjectsLocationsAgentEntityTypesRequest =
     ),
     body: Schema.optional(GoogleCloudDialogflowV2EntityType).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/entityTypes", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/entityTypes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentEntityTypesRequest>;
 
@@ -13745,7 +13753,7 @@ export const PatchProjectsLocationsAgentEntityTypesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2EntityType).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentEntityTypesRequest>;
 
@@ -13775,7 +13783,7 @@ export const DeleteProjectsLocationsAgentEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentEntityTypesRequest>;
 
@@ -13812,7 +13820,7 @@ export const BatchUpdateProjectsLocationsAgentEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/entityTypes:batchUpdate",
+      path: "v2/{+parent}/entityTypes:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -13851,7 +13859,7 @@ export const BatchDeleteProjectsLocationsAgentEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/entityTypes:batchDelete",
+      path: "v2/{+parent}/entityTypes:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -13890,7 +13898,7 @@ export const BatchCreateProjectsLocationsAgentEntityTypesEntitiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/entities:batchCreate",
+      path: "v2/{+parent}/entities:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -13930,7 +13938,7 @@ export const BatchUpdateProjectsLocationsAgentEntityTypesEntitiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/entities:batchUpdate",
+      path: "v2/{+parent}/entities:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -13970,7 +13978,7 @@ export const BatchDeleteProjectsLocationsAgentEntityTypesEntitiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/entities:batchDelete",
+      path: "v2/{+parent}/entities:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -14007,7 +14015,7 @@ export const ListProjectsLocationsAgentEnvironmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/environments" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/environments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentEnvironmentsRequest>;
 
@@ -14041,7 +14049,7 @@ export const GetProjectsLocationsAgentEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentEnvironmentsRequest>;
 
@@ -14080,7 +14088,11 @@ export const CreateProjectsLocationsAgentEnvironmentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/environments", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+parent}/environments",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentEnvironmentsRequest>;
 
@@ -14121,7 +14133,7 @@ export const PatchProjectsLocationsAgentEnvironmentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentEnvironmentsRequest>;
 
@@ -14151,7 +14163,7 @@ export const DeleteProjectsLocationsAgentEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentEnvironmentsRequest>;
 
@@ -14185,7 +14197,7 @@ export const GetHistoryProjectsLocationsAgentEnvironmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/history" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/history" }),
     svc,
   ) as unknown as Schema.Schema<GetHistoryProjectsLocationsAgentEnvironmentsRequest>;
 
@@ -14219,7 +14231,7 @@ export const DeleteContextsProjectsLocationsAgentEnvironmentsUsersSessionsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{parent}/contexts" }),
+    T.Http({ method: "DELETE", path: "v2/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<DeleteContextsProjectsLocationsAgentEnvironmentsUsersSessionsRequest>;
 
@@ -14257,7 +14269,7 @@ export const DetectIntentProjectsLocationsAgentEnvironmentsUsersSessionsRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{session}:detectIntent",
+      path: "v2/{+session}:detectIntent",
       hasBody: true,
     }),
     svc,
@@ -14294,7 +14306,7 @@ export const ListProjectsLocationsAgentEnvironmentsUsersSessionsContextsRequest 
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/contexts" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentEnvironmentsUsersSessionsContextsRequest>;
 
@@ -14329,7 +14341,7 @@ export const GetProjectsLocationsAgentEnvironmentsUsersSessionsContextsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentEnvironmentsUsersSessionsContextsRequest>;
 
@@ -14363,7 +14375,7 @@ export const CreateProjectsLocationsAgentEnvironmentsUsersSessionsContextsReques
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDialogflowV2Context).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/contexts", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/contexts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentEnvironmentsUsersSessionsContextsRequest>;
 
@@ -14399,7 +14411,7 @@ export const PatchProjectsLocationsAgentEnvironmentsUsersSessionsContextsRequest
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2Context).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentEnvironmentsUsersSessionsContextsRequest>;
 
@@ -14430,7 +14442,7 @@ export const DeleteProjectsLocationsAgentEnvironmentsUsersSessionsContextsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentEnvironmentsUsersSessionsContextsRequest>;
 
@@ -14465,7 +14477,7 @@ export const ListProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesReque
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesRequest>;
 
@@ -14501,7 +14513,7 @@ export const GetProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesRequest>;
 
@@ -14537,7 +14549,7 @@ export const CreateProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesReq
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/entityTypes", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/entityTypes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesRequest>;
 
@@ -14577,7 +14589,7 @@ export const PatchProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesRequ
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesRequest>;
 
@@ -14609,7 +14621,7 @@ export const DeleteProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesReq
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesRequest>;
 
@@ -14652,7 +14664,7 @@ export const ListProjectsLocationsAgentEnvironmentsIntentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/intents" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/intents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentEnvironmentsIntentsRequest>;
 
@@ -14690,7 +14702,7 @@ export const ListProjectsLocationsAgentVersionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentVersionsRequest>;
 
@@ -14724,7 +14736,7 @@ export const GetProjectsLocationsAgentVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentVersionsRequest>;
 
@@ -14757,7 +14769,7 @@ export const CreateProjectsLocationsAgentVersionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDialogflowV2Version).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/versions", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/versions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentVersionsRequest>;
 
@@ -14792,7 +14804,7 @@ export const PatchProjectsLocationsAgentVersionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2Version).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentVersionsRequest>;
 
@@ -14822,7 +14834,7 @@ export const DeleteProjectsLocationsAgentVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentVersionsRequest>;
 
@@ -14856,7 +14868,7 @@ export const CreateProjectsLocationsToolsRequest =
     toolId: Schema.optional(Schema.String).pipe(T.HttpQuery("toolId")),
     body: Schema.optional(GoogleCloudDialogflowV2Tool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/tools", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/tools", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsToolsRequest>;
 
@@ -14885,7 +14897,7 @@ export const GetProjectsLocationsToolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsToolsRequest>;
 
@@ -14918,7 +14930,7 @@ export const ListProjectsLocationsToolsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/tools" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/tools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsToolsRequest>;
 
@@ -14952,7 +14964,7 @@ export const DeleteProjectsLocationsToolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsToolsRequest>;
 
@@ -14986,7 +14998,7 @@ export const PatchProjectsLocationsToolsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2Tool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsToolsRequest>;
 
@@ -15022,7 +15034,7 @@ export const CreateProjectsLocationsGeneratorsRequest =
     ),
     body: Schema.optional(GoogleCloudDialogflowV2Generator).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/generators", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/generators", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGeneratorsRequest>;
 
@@ -15052,7 +15064,7 @@ export const GetProjectsLocationsGeneratorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGeneratorsRequest>;
 
@@ -15086,7 +15098,7 @@ export const ListProjectsLocationsGeneratorsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/generators" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/generators" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGeneratorsRequest>;
 
@@ -15120,7 +15132,7 @@ export const DeleteProjectsLocationsGeneratorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGeneratorsRequest>;
 
@@ -15154,7 +15166,7 @@ export const PatchProjectsLocationsGeneratorsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2Generator).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGeneratorsRequest>;
 
@@ -15189,7 +15201,7 @@ export const CreateProjectsLocationsGeneratorsEvaluationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/evaluations", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/evaluations", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGeneratorsEvaluationsRequest>;
 
@@ -15219,7 +15231,7 @@ export const GetProjectsLocationsGeneratorsEvaluationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGeneratorsEvaluationsRequest>;
 
@@ -15253,7 +15265,7 @@ export const ListProjectsLocationsGeneratorsEvaluationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/evaluations" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/evaluations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGeneratorsEvaluationsRequest>;
 
@@ -15287,7 +15299,7 @@ export const DeleteProjectsLocationsGeneratorsEvaluationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGeneratorsEvaluationsRequest>;
 
@@ -15323,7 +15335,7 @@ export const ListProjectsLocationsAnswerRecordsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/answerRecords" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/answerRecords" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAnswerRecordsRequest>;
 
@@ -15364,7 +15376,7 @@ export const PatchProjectsLocationsAnswerRecordsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAnswerRecordsRequest>;
 
@@ -15401,7 +15413,7 @@ export const CreateProjectsLocationsConversationDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/conversationDatasets",
+      path: "v2/{+parent}/conversationDatasets",
       hasBody: true,
     }),
     svc,
@@ -15433,7 +15445,7 @@ export const GetProjectsLocationsConversationDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConversationDatasetsRequest>;
 
@@ -15467,7 +15479,7 @@ export const ListProjectsLocationsConversationDatasetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/conversationDatasets" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/conversationDatasets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConversationDatasetsRequest>;
 
@@ -15501,7 +15513,7 @@ export const DeleteProjectsLocationsConversationDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConversationDatasetsRequest>;
 
@@ -15538,7 +15550,7 @@ export const ImportConversationDataProjectsLocationsConversationDatasetsRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:importConversationData",
+      path: "v2/{+name}:importConversationData",
       hasBody: true,
     }),
     svc,
@@ -15578,7 +15590,7 @@ export const CreateProjectsLocationsConversationModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/conversationModels",
+      path: "v2/{+parent}/conversationModels",
       hasBody: true,
     }),
     svc,
@@ -15610,7 +15622,7 @@ export const GetProjectsLocationsConversationModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConversationModelsRequest>;
 
@@ -15644,7 +15656,7 @@ export const ListProjectsLocationsConversationModelsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/conversationModels" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/conversationModels" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConversationModelsRequest>;
 
@@ -15678,7 +15690,7 @@ export const DeleteProjectsLocationsConversationModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConversationModelsRequest>;
 
@@ -15713,7 +15725,7 @@ export const DeployProjectsLocationsConversationModelsRequest =
       GoogleCloudDialogflowV2DeployConversationModelRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:deploy", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:deploy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeployProjectsLocationsConversationModelsRequest>;
 
@@ -15748,7 +15760,7 @@ export const UndeployProjectsLocationsConversationModelsRequest =
       GoogleCloudDialogflowV2UndeployConversationModelRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:undeploy", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:undeploy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeployProjectsLocationsConversationModelsRequest>;
 
@@ -15778,7 +15790,7 @@ export const GetProjectsLocationsConversationModelsEvaluationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConversationModelsEvaluationsRequest>;
 
@@ -15813,7 +15825,7 @@ export const ListProjectsLocationsConversationModelsEvaluationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/evaluations" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/evaluations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConversationModelsEvaluationsRequest>;
 
@@ -15853,7 +15865,7 @@ export const CreateProjectsLocationsConversationModelsEvaluationsRequest =
       GoogleCloudDialogflowV2CreateConversationModelEvaluationRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/evaluations", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/evaluations", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsConversationModelsEvaluationsRequest>;
 
@@ -15888,7 +15900,7 @@ export const ListProjectsLocationsConversationProfilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/conversationProfiles" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/conversationProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConversationProfilesRequest>;
 
@@ -15922,7 +15934,7 @@ export const GetProjectsLocationsConversationProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConversationProfilesRequest>;
 
@@ -15959,7 +15971,7 @@ export const CreateProjectsLocationsConversationProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/conversationProfiles",
+      path: "v2/{+parent}/conversationProfiles",
       hasBody: true,
     }),
     svc,
@@ -15998,7 +16010,7 @@ export const PatchProjectsLocationsConversationProfilesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConversationProfilesRequest>;
 
@@ -16028,7 +16040,7 @@ export const DeleteProjectsLocationsConversationProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConversationProfilesRequest>;
 
@@ -16065,7 +16077,7 @@ export const SetSuggestionFeatureConfigProjectsLocationsConversationProfilesRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{conversationProfile}:setSuggestionFeatureConfig",
+      path: "v2/{+conversationProfile}:setSuggestionFeatureConfig",
       hasBody: true,
     }),
     svc,
@@ -16106,7 +16118,7 @@ export const ClearSuggestionFeatureConfigProjectsLocationsConversationProfilesRe
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{conversationProfile}:clearSuggestionFeatureConfig",
+      path: "v2/{+conversationProfile}:clearSuggestionFeatureConfig",
       hasBody: true,
     }),
     svc,
@@ -16152,7 +16164,7 @@ export const CreateProjectsLocationsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/conversations",
+      path: "v2/{+parent}/conversations",
       hasBody: true,
     }),
     svc,
@@ -16190,7 +16202,7 @@ export const ListProjectsLocationsConversationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConversationsRequest>;
 
@@ -16224,7 +16236,7 @@ export const GetProjectsLocationsConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConversationsRequest>;
 
@@ -16259,7 +16271,7 @@ export const CompleteProjectsLocationsConversationsRequest =
       GoogleCloudDialogflowV2CompleteConversationRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:complete", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:complete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CompleteProjectsLocationsConversationsRequest>;
 
@@ -16296,7 +16308,7 @@ export const IngestContextReferencesProjectsLocationsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{conversation}:ingestContextReferences",
+      path: "v2/{+conversation}:ingestContextReferences",
       hasBody: true,
     }),
     svc,
@@ -16334,7 +16346,11 @@ export const CreateProjectsLocationsConversationsParticipantsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/participants", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+parent}/participants",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsConversationsParticipantsRequest>;
 
@@ -16365,7 +16381,7 @@ export const GetProjectsLocationsConversationsParticipantsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConversationsParticipantsRequest>;
 
@@ -16399,7 +16415,7 @@ export const ListProjectsLocationsConversationsParticipantsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/participants" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/participants" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConversationsParticipantsRequest>;
 
@@ -16440,7 +16456,7 @@ export const PatchProjectsLocationsConversationsParticipantsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConversationsParticipantsRequest>;
 
@@ -16478,7 +16494,7 @@ export const AnalyzeContentProjectsLocationsConversationsParticipantsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{participant}:analyzeContent",
+      path: "v2/{+participant}:analyzeContent",
       hasBody: true,
     }),
     svc,
@@ -16518,7 +16534,7 @@ export const SuggestArticlesProjectsLocationsConversationsParticipantsSuggestion
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/suggestions:suggestArticles",
+      path: "v2/{+parent}/suggestions:suggestArticles",
       hasBody: true,
     }),
     svc,
@@ -16560,7 +16576,7 @@ export const SuggestFaqAnswersProjectsLocationsConversationsParticipantsSuggesti
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/suggestions:suggestFaqAnswers",
+      path: "v2/{+parent}/suggestions:suggestFaqAnswers",
       hasBody: true,
     }),
     svc,
@@ -16602,7 +16618,7 @@ export const SuggestSmartRepliesProjectsLocationsConversationsParticipantsSugges
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/suggestions:suggestSmartReplies",
+      path: "v2/{+parent}/suggestions:suggestSmartReplies",
       hasBody: true,
     }),
     svc,
@@ -16644,7 +16660,7 @@ export const SuggestKnowledgeAssistProjectsLocationsConversationsParticipantsSug
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/suggestions:suggestKnowledgeAssist",
+      path: "v2/{+parent}/suggestions:suggestKnowledgeAssist",
       hasBody: true,
     }),
     svc,
@@ -16685,7 +16701,7 @@ export const ListProjectsLocationsConversationsMessagesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/messages" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/messages" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConversationsMessagesRequest>;
 
@@ -16726,7 +16742,7 @@ export const SuggestConversationSummaryProjectsLocationsConversationsSuggestions
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{conversation}/suggestions:suggestConversationSummary",
+      path: "v2/{+conversation}/suggestions:suggestConversationSummary",
       hasBody: true,
     }),
     svc,
@@ -16768,7 +16784,7 @@ export const SearchKnowledgeProjectsLocationsConversationsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{conversation}/suggestions:searchKnowledge",
+      path: "v2/{+conversation}/suggestions:searchKnowledge",
       hasBody: true,
     }),
     svc,
@@ -16808,7 +16824,7 @@ export const GenerateProjectsLocationsConversationsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{conversation}/suggestions:generate",
+      path: "v2/{+conversation}/suggestions:generate",
       hasBody: true,
     }),
     svc,
@@ -16848,7 +16864,7 @@ export const GenerateStatelessSummaryProjectsLocationsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/suggestions:generateStatelessSummary",
+      path: "v2/{+parent}/suggestions:generateStatelessSummary",
       hasBody: true,
     }),
     svc,
@@ -16888,7 +16904,7 @@ export const SearchKnowledgeProjectsLocationsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/suggestions:searchKnowledge",
+      path: "v2/{+parent}/suggestions:searchKnowledge",
       hasBody: true,
     }),
     svc,
@@ -16927,7 +16943,7 @@ export const GenerateProjectsLocationsStatelessSuggestionRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/statelessSuggestion:generate",
+      path: "v2/{+parent}/statelessSuggestion:generate",
       hasBody: true,
     }),
     svc,
@@ -16964,7 +16980,7 @@ export const InitializeProjectsLocationsEncryptionSpecRequest =
       GoogleCloudDialogflowV2InitializeEncryptionSpecRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:initialize", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:initialize", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<InitializeProjectsLocationsEncryptionSpecRequest>;
 
@@ -17000,7 +17016,7 @@ export const ListProjectsLocationsKnowledgeBasesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/knowledgeBases" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/knowledgeBases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsKnowledgeBasesRequest>;
 
@@ -17034,7 +17050,7 @@ export const GetProjectsLocationsKnowledgeBasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsKnowledgeBasesRequest>;
 
@@ -17071,7 +17087,7 @@ export const CreateProjectsLocationsKnowledgeBasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/knowledgeBases",
+      path: "v2/{+parent}/knowledgeBases",
       hasBody: true,
     }),
     svc,
@@ -17105,7 +17121,7 @@ export const DeleteProjectsLocationsKnowledgeBasesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsKnowledgeBasesRequest>;
 
@@ -17141,7 +17157,7 @@ export const PatchProjectsLocationsKnowledgeBasesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsKnowledgeBasesRequest>;
 
@@ -17177,7 +17193,7 @@ export const ListProjectsLocationsKnowledgeBasesDocumentsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/documents" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/documents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsKnowledgeBasesDocumentsRequest>;
 
@@ -17211,7 +17227,7 @@ export const GetProjectsLocationsKnowledgeBasesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsKnowledgeBasesDocumentsRequest>;
 
@@ -17244,7 +17260,7 @@ export const CreateProjectsLocationsKnowledgeBasesDocumentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDialogflowV2Document).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/documents", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/documents", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsKnowledgeBasesDocumentsRequest>;
 
@@ -17281,7 +17297,7 @@ export const ImportProjectsLocationsKnowledgeBasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/documents:import",
+      path: "v2/{+parent}/documents:import",
       hasBody: true,
     }),
     svc,
@@ -17313,7 +17329,7 @@ export const DeleteProjectsLocationsKnowledgeBasesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsKnowledgeBasesDocumentsRequest>;
 
@@ -17348,7 +17364,7 @@ export const PatchProjectsLocationsKnowledgeBasesDocumentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2Document).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsKnowledgeBasesDocumentsRequest>;
 
@@ -17383,7 +17399,7 @@ export const ReloadProjectsLocationsKnowledgeBasesDocumentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:reload", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:reload", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReloadProjectsLocationsKnowledgeBasesDocumentsRequest>;
 
@@ -17418,7 +17434,7 @@ export const ExportProjectsLocationsKnowledgeBasesDocumentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsKnowledgeBasesDocumentsRequest>;
 
@@ -17451,7 +17467,7 @@ export const CreateProjectsLocationsSipTrunksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDialogflowV2SipTrunk).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/sipTrunks", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/sipTrunks", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSipTrunksRequest>;
 
@@ -17481,7 +17497,7 @@ export const DeleteProjectsLocationsSipTrunksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSipTrunksRequest>;
 
@@ -17514,7 +17530,7 @@ export const ListProjectsLocationsSipTrunksRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/sipTrunks" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/sipTrunks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSipTrunksRequest>;
 
@@ -17548,7 +17564,7 @@ export const GetProjectsLocationsSipTrunksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSipTrunksRequest>;
 
@@ -17583,7 +17599,7 @@ export const PatchProjectsLocationsSipTrunksRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2SipTrunk).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSipTrunksRequest>;
 
@@ -17617,7 +17633,7 @@ export const SearchProjectsAgentRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/agent:search" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/agent:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsAgentRequest>;
 
@@ -17656,7 +17672,7 @@ export const TrainProjectsAgentRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/agent:train", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/agent:train", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TrainProjectsAgentRequest>;
 
@@ -17690,7 +17706,11 @@ export const ExportProjectsAgentRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/agent:export", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+parent}/agent:export",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsAgentRequest>;
 
@@ -17724,7 +17744,11 @@ export const ImportProjectsAgentRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/agent:import", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+parent}/agent:import",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsAgentRequest>;
 
@@ -17760,7 +17784,7 @@ export const RestoreProjectsAgentRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/agent:restore",
+      path: "v2/{+parent}/agent:restore",
       hasBody: true,
     }),
     svc,
@@ -17795,7 +17819,7 @@ export const GetValidationResultProjectsAgentRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/agent/validationResult" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/agent/validationResult" }),
     svc,
   ) as unknown as Schema.Schema<GetValidationResultProjectsAgentRequest>;
 
@@ -17825,7 +17849,7 @@ export const GetFulfillmentProjectsAgentRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFulfillmentProjectsAgentRequest>;
 
@@ -17862,7 +17886,7 @@ export const UpdateFulfillmentProjectsAgentRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateFulfillmentProjectsAgentRequest>;
 
@@ -17892,7 +17916,7 @@ export const DeleteContextsProjectsAgentSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{parent}/contexts" }),
+    T.Http({ method: "DELETE", path: "v2/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<DeleteContextsProjectsAgentSessionsRequest>;
 
@@ -17928,7 +17952,7 @@ export const DetectIntentProjectsAgentSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{session}:detectIntent",
+      path: "v2/{+session}:detectIntent",
       hasBody: true,
     }),
     svc,
@@ -17964,7 +17988,7 @@ export const ListProjectsAgentSessionsContextsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/contexts" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentSessionsContextsRequest>;
 
@@ -17998,7 +18022,7 @@ export const GetProjectsAgentSessionsContextsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentSessionsContextsRequest>;
 
@@ -18031,7 +18055,7 @@ export const CreateProjectsAgentSessionsContextsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDialogflowV2Context).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/contexts", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/contexts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsAgentSessionsContextsRequest>;
 
@@ -18066,7 +18090,7 @@ export const PatchProjectsAgentSessionsContextsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2Context).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentSessionsContextsRequest>;
 
@@ -18096,7 +18120,7 @@ export const DeleteProjectsAgentSessionsContextsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentSessionsContextsRequest>;
 
@@ -18129,7 +18153,7 @@ export const ListProjectsAgentSessionsEntityTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentSessionsEntityTypesRequest>;
 
@@ -18163,7 +18187,7 @@ export const GetProjectsAgentSessionsEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentSessionsEntityTypesRequest>;
 
@@ -18198,7 +18222,7 @@ export const CreateProjectsAgentSessionsEntityTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/entityTypes", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/entityTypes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsAgentSessionsEntityTypesRequest>;
 
@@ -18235,7 +18259,7 @@ export const PatchProjectsAgentSessionsEntityTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentSessionsEntityTypesRequest>;
 
@@ -18265,7 +18289,7 @@ export const DeleteProjectsAgentSessionsEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentSessionsEntityTypesRequest>;
 
@@ -18305,7 +18329,7 @@ export const ListProjectsAgentIntentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/intents" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/intents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentIntentsRequest>;
 
@@ -18345,7 +18369,7 @@ export const GetProjectsAgentIntentsRequest =
     ),
     intentView: Schema.optional(Schema.String).pipe(T.HttpQuery("intentView")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentIntentsRequest>;
 
@@ -18383,7 +18407,7 @@ export const CreateProjectsAgentIntentsRequest =
     intentView: Schema.optional(Schema.String).pipe(T.HttpQuery("intentView")),
     body: Schema.optional(GoogleCloudDialogflowV2Intent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/intents", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/intents", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsAgentIntentsRequest>;
 
@@ -18423,7 +18447,7 @@ export const PatchProjectsAgentIntentsRequest =
     intentView: Schema.optional(Schema.String).pipe(T.HttpQuery("intentView")),
     body: Schema.optional(GoogleCloudDialogflowV2Intent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentIntentsRequest>;
 
@@ -18452,7 +18476,7 @@ export const DeleteProjectsAgentIntentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentIntentsRequest>;
 
@@ -18488,7 +18512,7 @@ export const BatchUpdateProjectsAgentIntentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/intents:batchUpdate",
+      path: "v2/{+parent}/intents:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -18527,7 +18551,7 @@ export const BatchDeleteProjectsAgentIntentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/intents:batchDelete",
+      path: "v2/{+parent}/intents:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -18567,7 +18591,7 @@ export const ListProjectsAgentEntityTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentEntityTypesRequest>;
 
@@ -18605,7 +18629,7 @@ export const GetProjectsAgentEntityTypesRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentEntityTypesRequest>;
 
@@ -18642,7 +18666,7 @@ export const CreateProjectsAgentEntityTypesRequest =
     ),
     body: Schema.optional(GoogleCloudDialogflowV2EntityType).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/entityTypes", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/entityTypes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsAgentEntityTypesRequest>;
 
@@ -18681,7 +18705,7 @@ export const PatchProjectsAgentEntityTypesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2EntityType).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentEntityTypesRequest>;
 
@@ -18711,7 +18735,7 @@ export const DeleteProjectsAgentEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentEntityTypesRequest>;
 
@@ -18747,7 +18771,7 @@ export const BatchUpdateProjectsAgentEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/entityTypes:batchUpdate",
+      path: "v2/{+parent}/entityTypes:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -18786,7 +18810,7 @@ export const BatchDeleteProjectsAgentEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/entityTypes:batchDelete",
+      path: "v2/{+parent}/entityTypes:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -18825,7 +18849,7 @@ export const BatchCreateProjectsAgentEntityTypesEntitiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/entities:batchCreate",
+      path: "v2/{+parent}/entities:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -18864,7 +18888,7 @@ export const BatchUpdateProjectsAgentEntityTypesEntitiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/entities:batchUpdate",
+      path: "v2/{+parent}/entities:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -18903,7 +18927,7 @@ export const BatchDeleteProjectsAgentEntityTypesEntitiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/entities:batchDelete",
+      path: "v2/{+parent}/entities:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -18939,7 +18963,7 @@ export const ListProjectsAgentEnvironmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/environments" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/environments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentEnvironmentsRequest>;
 
@@ -18973,7 +18997,7 @@ export const GetProjectsAgentEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentEnvironmentsRequest>;
 
@@ -19012,7 +19036,11 @@ export const CreateProjectsAgentEnvironmentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/environments", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+parent}/environments",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsAgentEnvironmentsRequest>;
 
@@ -19053,7 +19081,7 @@ export const PatchProjectsAgentEnvironmentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentEnvironmentsRequest>;
 
@@ -19083,7 +19111,7 @@ export const DeleteProjectsAgentEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentEnvironmentsRequest>;
 
@@ -19116,7 +19144,7 @@ export const GetHistoryProjectsAgentEnvironmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/history" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/history" }),
     svc,
   ) as unknown as Schema.Schema<GetHistoryProjectsAgentEnvironmentsRequest>;
 
@@ -19150,7 +19178,7 @@ export const DeleteContextsProjectsAgentEnvironmentsUsersSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{parent}/contexts" }),
+    T.Http({ method: "DELETE", path: "v2/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<DeleteContextsProjectsAgentEnvironmentsUsersSessionsRequest>;
 
@@ -19188,7 +19216,7 @@ export const DetectIntentProjectsAgentEnvironmentsUsersSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{session}:detectIntent",
+      path: "v2/{+session}:detectIntent",
       hasBody: true,
     }),
     svc,
@@ -19225,7 +19253,7 @@ export const ListProjectsAgentEnvironmentsUsersSessionsContextsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/contexts" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentEnvironmentsUsersSessionsContextsRequest>;
 
@@ -19260,7 +19288,7 @@ export const GetProjectsAgentEnvironmentsUsersSessionsContextsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentEnvironmentsUsersSessionsContextsRequest>;
 
@@ -19294,7 +19322,7 @@ export const CreateProjectsAgentEnvironmentsUsersSessionsContextsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDialogflowV2Context).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/contexts", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/contexts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsAgentEnvironmentsUsersSessionsContextsRequest>;
 
@@ -19330,7 +19358,7 @@ export const PatchProjectsAgentEnvironmentsUsersSessionsContextsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2Context).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentEnvironmentsUsersSessionsContextsRequest>;
 
@@ -19361,7 +19389,7 @@ export const DeleteProjectsAgentEnvironmentsUsersSessionsContextsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentEnvironmentsUsersSessionsContextsRequest>;
 
@@ -19396,7 +19424,7 @@ export const ListProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest>;
 
@@ -19431,7 +19459,7 @@ export const GetProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest>;
 
@@ -19467,7 +19495,7 @@ export const CreateProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/entityTypes", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/entityTypes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest>;
 
@@ -19505,7 +19533,7 @@ export const PatchProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest>;
 
@@ -19536,7 +19564,7 @@ export const DeleteProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest>;
 
@@ -19577,7 +19605,7 @@ export const ListProjectsAgentEnvironmentsIntentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/intents" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/intents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentEnvironmentsIntentsRequest>;
 
@@ -19617,7 +19645,7 @@ export const ListProjectsAgentKnowledgeBasesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/knowledgeBases" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/knowledgeBases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentKnowledgeBasesRequest>;
 
@@ -19651,7 +19679,7 @@ export const GetProjectsAgentKnowledgeBasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentKnowledgeBasesRequest>;
 
@@ -19688,7 +19716,7 @@ export const CreateProjectsAgentKnowledgeBasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/knowledgeBases",
+      path: "v2/{+parent}/knowledgeBases",
       hasBody: true,
     }),
     svc,
@@ -19722,7 +19750,7 @@ export const DeleteProjectsAgentKnowledgeBasesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentKnowledgeBasesRequest>;
 
@@ -19758,7 +19786,7 @@ export const PatchProjectsAgentKnowledgeBasesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentKnowledgeBasesRequest>;
 
@@ -19794,7 +19822,7 @@ export const ListProjectsAgentKnowledgeBasesDocumentsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/documents" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/documents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentKnowledgeBasesDocumentsRequest>;
 
@@ -19828,7 +19856,7 @@ export const GetProjectsAgentKnowledgeBasesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentKnowledgeBasesDocumentsRequest>;
 
@@ -19861,7 +19889,7 @@ export const CreateProjectsAgentKnowledgeBasesDocumentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDialogflowV2Document).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/documents", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/documents", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsAgentKnowledgeBasesDocumentsRequest>;
 
@@ -19891,7 +19919,7 @@ export const DeleteProjectsAgentKnowledgeBasesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentKnowledgeBasesDocumentsRequest>;
 
@@ -19926,7 +19954,7 @@ export const PatchProjectsAgentKnowledgeBasesDocumentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2Document).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentKnowledgeBasesDocumentsRequest>;
 
@@ -19961,7 +19989,7 @@ export const ReloadProjectsAgentKnowledgeBasesDocumentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:reload", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:reload", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReloadProjectsAgentKnowledgeBasesDocumentsRequest>;
 
@@ -19995,7 +20023,7 @@ export const ListProjectsAgentVersionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentVersionsRequest>;
 
@@ -20029,7 +20057,7 @@ export const GetProjectsAgentVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentVersionsRequest>;
 
@@ -20061,7 +20089,7 @@ export const CreateProjectsAgentVersionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDialogflowV2Version).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/versions", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/versions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsAgentVersionsRequest>;
 
@@ -20096,7 +20124,7 @@ export const PatchProjectsAgentVersionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2Version).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentVersionsRequest>;
 
@@ -20125,7 +20153,7 @@ export const DeleteProjectsAgentVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentVersionsRequest>;
 
@@ -20161,7 +20189,7 @@ export const CreateProjectsGeneratorsRequest =
     ),
     body: Schema.optional(GoogleCloudDialogflowV2Generator).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/generators", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/generators", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsGeneratorsRequest>;
 
@@ -20194,7 +20222,7 @@ export const ListProjectsGeneratorsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/generators" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/generators" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsGeneratorsRequest>;
 
@@ -20234,7 +20262,7 @@ export const ListProjectsAnswerRecordsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/answerRecords" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/answerRecords" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAnswerRecordsRequest>;
 
@@ -20275,7 +20303,7 @@ export const PatchProjectsAnswerRecordsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAnswerRecordsRequest>;
 
@@ -20305,7 +20333,7 @@ export const GetProjectsConversationDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsConversationDatasetsRequest>;
 
@@ -20339,7 +20367,7 @@ export const ListProjectsConversationDatasetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/conversationDatasets" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/conversationDatasets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsConversationDatasetsRequest>;
 
@@ -20380,7 +20408,7 @@ export const ImportConversationDataProjectsConversationDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:importConversationData",
+      path: "v2/{+name}:importConversationData",
       hasBody: true,
     }),
     svc,
@@ -20420,7 +20448,7 @@ export const CreateProjectsConversationModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/conversationModels",
+      path: "v2/{+parent}/conversationModels",
       hasBody: true,
     }),
     svc,
@@ -20452,7 +20480,7 @@ export const GetProjectsConversationModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsConversationModelsRequest>;
 
@@ -20486,7 +20514,7 @@ export const ListProjectsConversationModelsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/conversationModels" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/conversationModels" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsConversationModelsRequest>;
 
@@ -20520,7 +20548,7 @@ export const DeleteProjectsConversationModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsConversationModelsRequest>;
 
@@ -20555,7 +20583,7 @@ export const DeployProjectsConversationModelsRequest =
       GoogleCloudDialogflowV2DeployConversationModelRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:deploy", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:deploy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeployProjectsConversationModelsRequest>;
 
@@ -20590,7 +20618,7 @@ export const UndeployProjectsConversationModelsRequest =
       GoogleCloudDialogflowV2UndeployConversationModelRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:undeploy", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:undeploy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeployProjectsConversationModelsRequest>;
 
@@ -20620,7 +20648,7 @@ export const GetProjectsConversationModelsEvaluationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsConversationModelsEvaluationsRequest>;
 
@@ -20654,7 +20682,7 @@ export const ListProjectsConversationModelsEvaluationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/evaluations" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/evaluations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsConversationModelsEvaluationsRequest>;
 
@@ -20692,7 +20720,7 @@ export const ListProjectsConversationProfilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/conversationProfiles" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/conversationProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsConversationProfilesRequest>;
 
@@ -20726,7 +20754,7 @@ export const GetProjectsConversationProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsConversationProfilesRequest>;
 
@@ -20763,7 +20791,7 @@ export const CreateProjectsConversationProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/conversationProfiles",
+      path: "v2/{+parent}/conversationProfiles",
       hasBody: true,
     }),
     svc,
@@ -20802,7 +20830,7 @@ export const PatchProjectsConversationProfilesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsConversationProfilesRequest>;
 
@@ -20832,7 +20860,7 @@ export const DeleteProjectsConversationProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsConversationProfilesRequest>;
 
@@ -20868,7 +20896,7 @@ export const SetSuggestionFeatureConfigProjectsConversationProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{conversationProfile}:setSuggestionFeatureConfig",
+      path: "v2/{+conversationProfile}:setSuggestionFeatureConfig",
       hasBody: true,
     }),
     svc,
@@ -20908,7 +20936,7 @@ export const ClearSuggestionFeatureConfigProjectsConversationProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{conversationProfile}:clearSuggestionFeatureConfig",
+      path: "v2/{+conversationProfile}:clearSuggestionFeatureConfig",
       hasBody: true,
     }),
     svc,
@@ -20952,7 +20980,7 @@ export const CreateProjectsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/conversations",
+      path: "v2/{+parent}/conversations",
       hasBody: true,
     }),
     svc,
@@ -20990,7 +21018,7 @@ export const ListProjectsConversationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsConversationsRequest>;
 
@@ -21024,7 +21052,7 @@ export const GetProjectsConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsConversationsRequest>;
 
@@ -21059,7 +21087,7 @@ export const CompleteProjectsConversationsRequest =
       GoogleCloudDialogflowV2CompleteConversationRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:complete", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:complete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CompleteProjectsConversationsRequest>;
 
@@ -21094,7 +21122,11 @@ export const CreateProjectsConversationsParticipantsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/participants", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+parent}/participants",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsConversationsParticipantsRequest>;
 
@@ -21124,7 +21156,7 @@ export const GetProjectsConversationsParticipantsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsConversationsParticipantsRequest>;
 
@@ -21158,7 +21190,7 @@ export const ListProjectsConversationsParticipantsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/participants" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/participants" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsConversationsParticipantsRequest>;
 
@@ -21199,7 +21231,7 @@ export const PatchProjectsConversationsParticipantsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsConversationsParticipantsRequest>;
 
@@ -21236,7 +21268,7 @@ export const AnalyzeContentProjectsConversationsParticipantsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{participant}:analyzeContent",
+      path: "v2/{+participant}:analyzeContent",
       hasBody: true,
     }),
     svc,
@@ -21276,7 +21308,7 @@ export const SuggestArticlesProjectsConversationsParticipantsSuggestionsRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/suggestions:suggestArticles",
+      path: "v2/{+parent}/suggestions:suggestArticles",
       hasBody: true,
     }),
     svc,
@@ -21316,7 +21348,7 @@ export const SuggestFaqAnswersProjectsConversationsParticipantsSuggestionsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/suggestions:suggestFaqAnswers",
+      path: "v2/{+parent}/suggestions:suggestFaqAnswers",
       hasBody: true,
     }),
     svc,
@@ -21356,7 +21388,7 @@ export const SuggestSmartRepliesProjectsConversationsParticipantsSuggestionsRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/suggestions:suggestSmartReplies",
+      path: "v2/{+parent}/suggestions:suggestSmartReplies",
       hasBody: true,
     }),
     svc,
@@ -21397,7 +21429,7 @@ export const SuggestKnowledgeAssistProjectsConversationsParticipantsSuggestionsR
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/suggestions:suggestKnowledgeAssist",
+      path: "v2/{+parent}/suggestions:suggestKnowledgeAssist",
       hasBody: true,
     }),
     svc,
@@ -21438,7 +21470,7 @@ export const ListProjectsConversationsMessagesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/messages" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/messages" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsConversationsMessagesRequest>;
 
@@ -21479,7 +21511,7 @@ export const SuggestConversationSummaryProjectsConversationsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{conversation}/suggestions:suggestConversationSummary",
+      path: "v2/{+conversation}/suggestions:suggestConversationSummary",
       hasBody: true,
     }),
     svc,
@@ -21519,7 +21551,7 @@ export const SearchKnowledgeProjectsConversationsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{conversation}/suggestions:searchKnowledge",
+      path: "v2/{+conversation}/suggestions:searchKnowledge",
       hasBody: true,
     }),
     svc,
@@ -21559,7 +21591,7 @@ export const GenerateProjectsConversationsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{conversation}/suggestions:generate",
+      path: "v2/{+conversation}/suggestions:generate",
       hasBody: true,
     }),
     svc,
@@ -21598,7 +21630,7 @@ export const GenerateStatelessSummaryProjectsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/suggestions:generateStatelessSummary",
+      path: "v2/{+parent}/suggestions:generateStatelessSummary",
       hasBody: true,
     }),
     svc,
@@ -21637,7 +21669,7 @@ export const SearchKnowledgeProjectsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/suggestions:searchKnowledge",
+      path: "v2/{+parent}/suggestions:searchKnowledge",
       hasBody: true,
     }),
     svc,
@@ -21675,7 +21707,7 @@ export const ListProjectsKnowledgeBasesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/knowledgeBases" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/knowledgeBases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsKnowledgeBasesRequest>;
 
@@ -21709,7 +21741,7 @@ export const GetProjectsKnowledgeBasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsKnowledgeBasesRequest>;
 
@@ -21746,7 +21778,7 @@ export const CreateProjectsKnowledgeBasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/knowledgeBases",
+      path: "v2/{+parent}/knowledgeBases",
       hasBody: true,
     }),
     svc,
@@ -21780,7 +21812,7 @@ export const DeleteProjectsKnowledgeBasesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsKnowledgeBasesRequest>;
 
@@ -21816,7 +21848,7 @@ export const PatchProjectsKnowledgeBasesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsKnowledgeBasesRequest>;
 
@@ -21852,7 +21884,7 @@ export const ListProjectsKnowledgeBasesDocumentsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/documents" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/documents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsKnowledgeBasesDocumentsRequest>;
 
@@ -21886,7 +21918,7 @@ export const GetProjectsKnowledgeBasesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsKnowledgeBasesDocumentsRequest>;
 
@@ -21919,7 +21951,7 @@ export const CreateProjectsKnowledgeBasesDocumentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDialogflowV2Document).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/documents", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/documents", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsKnowledgeBasesDocumentsRequest>;
 
@@ -21956,7 +21988,7 @@ export const ImportProjectsKnowledgeBasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/documents:import",
+      path: "v2/{+parent}/documents:import",
       hasBody: true,
     }),
     svc,
@@ -21988,7 +22020,7 @@ export const DeleteProjectsKnowledgeBasesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsKnowledgeBasesDocumentsRequest>;
 
@@ -22023,7 +22055,7 @@ export const PatchProjectsKnowledgeBasesDocumentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2Document).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsKnowledgeBasesDocumentsRequest>;
 
@@ -22058,7 +22090,7 @@ export const ReloadProjectsKnowledgeBasesDocumentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:reload", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:reload", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReloadProjectsKnowledgeBasesDocumentsRequest>;
 
@@ -22093,7 +22125,7 @@ export const ExportProjectsKnowledgeBasesDocumentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsKnowledgeBasesDocumentsRequest>;
 

--- a/packages/gcp/src/services/dialogflow-v2beta1.ts
+++ b/packages/gcp/src/services/dialogflow-v2beta1.ts
@@ -12333,7 +12333,7 @@ export const GetAgentProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/agent" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/agent" }),
     svc,
   ) as unknown as Schema.Schema<GetAgentProjectsRequest>;
 
@@ -12367,7 +12367,7 @@ export const SetAgentProjectsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2beta1Agent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta1/{parent}/agent", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta1/{+parent}/agent", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetAgentProjectsRequest>;
 
@@ -12396,7 +12396,7 @@ export const DeleteAgentProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{parent}/agent" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+parent}/agent" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAgentProjectsRequest>;
 
@@ -12435,7 +12435,7 @@ export const ListProjectsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsOperationsRequest>;
 
@@ -12469,7 +12469,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 
@@ -12498,7 +12498,7 @@ export const CancelProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsOperationsRequest>;
 
@@ -12527,7 +12527,7 @@ export const GetFulfillmentProjectsAgentRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFulfillmentProjectsAgentRequest>;
 
@@ -12564,7 +12564,7 @@ export const UpdateFulfillmentProjectsAgentRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateFulfillmentProjectsAgentRequest>;
 
@@ -12598,7 +12598,7 @@ export const SearchProjectsAgentRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/agent:search" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/agent:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsAgentRequest>;
 
@@ -12639,7 +12639,7 @@ export const TrainProjectsAgentRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/agent:train",
+      path: "v2beta1/{+parent}/agent:train",
       hasBody: true,
     }),
     svc,
@@ -12677,7 +12677,7 @@ export const ExportProjectsAgentRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/agent:export",
+      path: "v2beta1/{+parent}/agent:export",
       hasBody: true,
     }),
     svc,
@@ -12715,7 +12715,7 @@ export const ImportProjectsAgentRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/agent:import",
+      path: "v2beta1/{+parent}/agent:import",
       hasBody: true,
     }),
     svc,
@@ -12753,7 +12753,7 @@ export const RestoreProjectsAgentRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/agent:restore",
+      path: "v2beta1/{+parent}/agent:restore",
       hasBody: true,
     }),
     svc,
@@ -12788,7 +12788,7 @@ export const GetValidationResultProjectsAgentRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/agent/validationResult" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/agent/validationResult" }),
     svc,
   ) as unknown as Schema.Schema<GetValidationResultProjectsAgentRequest>;
 
@@ -12822,7 +12822,7 @@ export const ListProjectsAgentEnvironmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/environments" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/environments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentEnvironmentsRequest>;
 
@@ -12856,7 +12856,7 @@ export const GetProjectsAgentEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentEnvironmentsRequest>;
 
@@ -12897,7 +12897,7 @@ export const CreateProjectsAgentEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/environments",
+      path: "v2beta1/{+parent}/environments",
       hasBody: true,
     }),
     svc,
@@ -12940,7 +12940,7 @@ export const PatchProjectsAgentEnvironmentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentEnvironmentsRequest>;
 
@@ -12970,7 +12970,7 @@ export const DeleteProjectsAgentEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentEnvironmentsRequest>;
 
@@ -13003,7 +13003,7 @@ export const GetHistoryProjectsAgentEnvironmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/history" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/history" }),
     svc,
   ) as unknown as Schema.Schema<GetHistoryProjectsAgentEnvironmentsRequest>;
 
@@ -13037,7 +13037,7 @@ export const DeleteContextsProjectsAgentEnvironmentsUsersSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{parent}/contexts" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<DeleteContextsProjectsAgentEnvironmentsUsersSessionsRequest>;
 
@@ -13075,7 +13075,7 @@ export const DetectIntentProjectsAgentEnvironmentsUsersSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{session}:detectIntent",
+      path: "v2beta1/{+session}:detectIntent",
       hasBody: true,
     }),
     svc,
@@ -13112,7 +13112,7 @@ export const ListProjectsAgentEnvironmentsUsersSessionsContextsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/contexts" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentEnvironmentsUsersSessionsContextsRequest>;
 
@@ -13147,7 +13147,7 @@ export const GetProjectsAgentEnvironmentsUsersSessionsContextsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentEnvironmentsUsersSessionsContextsRequest>;
 
@@ -13185,7 +13185,7 @@ export const CreateProjectsAgentEnvironmentsUsersSessionsContextsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/contexts",
+      path: "v2beta1/{+parent}/contexts",
       hasBody: true,
     }),
     svc,
@@ -13225,7 +13225,7 @@ export const PatchProjectsAgentEnvironmentsUsersSessionsContextsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentEnvironmentsUsersSessionsContextsRequest>;
 
@@ -13256,7 +13256,7 @@ export const DeleteProjectsAgentEnvironmentsUsersSessionsContextsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentEnvironmentsUsersSessionsContextsRequest>;
 
@@ -13291,7 +13291,7 @@ export const ListProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest>;
 
@@ -13326,7 +13326,7 @@ export const GetProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest>;
 
@@ -13364,7 +13364,7 @@ export const CreateProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/entityTypes",
+      path: "v2beta1/{+parent}/entityTypes",
       hasBody: true,
     }),
     svc,
@@ -13404,7 +13404,7 @@ export const PatchProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest>;
 
@@ -13435,7 +13435,7 @@ export const DeleteProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentEnvironmentsUsersSessionsEntityTypesRequest>;
 
@@ -13476,7 +13476,7 @@ export const ListProjectsAgentEnvironmentsIntentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/intents" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/intents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentEnvironmentsIntentsRequest>;
 
@@ -13510,7 +13510,7 @@ export const DeleteContextsProjectsAgentSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{parent}/contexts" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<DeleteContextsProjectsAgentSessionsRequest>;
 
@@ -13546,7 +13546,7 @@ export const DetectIntentProjectsAgentSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{session}:detectIntent",
+      path: "v2beta1/{+session}:detectIntent",
       hasBody: true,
     }),
     svc,
@@ -13582,7 +13582,7 @@ export const ListProjectsAgentSessionsContextsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/contexts" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentSessionsContextsRequest>;
 
@@ -13616,7 +13616,7 @@ export const GetProjectsAgentSessionsContextsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentSessionsContextsRequest>;
 
@@ -13653,7 +13653,7 @@ export const CreateProjectsAgentSessionsContextsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/contexts",
+      path: "v2beta1/{+parent}/contexts",
       hasBody: true,
     }),
     svc,
@@ -13692,7 +13692,7 @@ export const PatchProjectsAgentSessionsContextsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentSessionsContextsRequest>;
 
@@ -13722,7 +13722,7 @@ export const DeleteProjectsAgentSessionsContextsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentSessionsContextsRequest>;
 
@@ -13755,7 +13755,7 @@ export const ListProjectsAgentSessionsEntityTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentSessionsEntityTypesRequest>;
 
@@ -13789,7 +13789,7 @@ export const GetProjectsAgentSessionsEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentSessionsEntityTypesRequest>;
 
@@ -13826,7 +13826,7 @@ export const CreateProjectsAgentSessionsEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/entityTypes",
+      path: "v2beta1/{+parent}/entityTypes",
       hasBody: true,
     }),
     svc,
@@ -13865,7 +13865,7 @@ export const PatchProjectsAgentSessionsEntityTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentSessionsEntityTypesRequest>;
 
@@ -13895,7 +13895,7 @@ export const DeleteProjectsAgentSessionsEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentSessionsEntityTypesRequest>;
 
@@ -13935,7 +13935,7 @@ export const ListProjectsAgentIntentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/intents" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/intents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentIntentsRequest>;
 
@@ -13975,7 +13975,7 @@ export const GetProjectsAgentIntentsRequest =
     ),
     intentView: Schema.optional(Schema.String).pipe(T.HttpQuery("intentView")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentIntentsRequest>;
 
@@ -14016,7 +14016,11 @@ export const CreateProjectsAgentIntentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta1/{parent}/intents", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2beta1/{+parent}/intents",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsAgentIntentsRequest>;
 
@@ -14059,7 +14063,7 @@ export const PatchProjectsAgentIntentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentIntentsRequest>;
 
@@ -14089,7 +14093,7 @@ export const DeleteProjectsAgentIntentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentIntentsRequest>;
 
@@ -14125,7 +14129,7 @@ export const BatchUpdateProjectsAgentIntentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/intents:batchUpdate",
+      path: "v2beta1/{+parent}/intents:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -14164,7 +14168,7 @@ export const BatchDeleteProjectsAgentIntentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/intents:batchDelete",
+      path: "v2beta1/{+parent}/intents:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -14204,7 +14208,7 @@ export const ListProjectsAgentEntityTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentEntityTypesRequest>;
 
@@ -14242,7 +14246,7 @@ export const GetProjectsAgentEntityTypesRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentEntityTypesRequest>;
 
@@ -14283,7 +14287,7 @@ export const CreateProjectsAgentEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/entityTypes",
+      path: "v2beta1/{+parent}/entityTypes",
       hasBody: true,
     }),
     svc,
@@ -14326,7 +14330,7 @@ export const PatchProjectsAgentEntityTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentEntityTypesRequest>;
 
@@ -14356,7 +14360,7 @@ export const DeleteProjectsAgentEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentEntityTypesRequest>;
 
@@ -14392,7 +14396,7 @@ export const BatchUpdateProjectsAgentEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/entityTypes:batchUpdate",
+      path: "v2beta1/{+parent}/entityTypes:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -14431,7 +14435,7 @@ export const BatchDeleteProjectsAgentEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/entityTypes:batchDelete",
+      path: "v2beta1/{+parent}/entityTypes:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -14470,7 +14474,7 @@ export const BatchCreateProjectsAgentEntityTypesEntitiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/entities:batchCreate",
+      path: "v2beta1/{+parent}/entities:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -14509,7 +14513,7 @@ export const BatchUpdateProjectsAgentEntityTypesEntitiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/entities:batchUpdate",
+      path: "v2beta1/{+parent}/entities:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -14548,7 +14552,7 @@ export const BatchDeleteProjectsAgentEntityTypesEntitiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/entities:batchDelete",
+      path: "v2beta1/{+parent}/entities:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -14586,7 +14590,7 @@ export const ListProjectsAgentKnowledgeBasesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/knowledgeBases" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/knowledgeBases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentKnowledgeBasesRequest>;
 
@@ -14620,7 +14624,7 @@ export const GetProjectsAgentKnowledgeBasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentKnowledgeBasesRequest>;
 
@@ -14657,7 +14661,7 @@ export const CreateProjectsAgentKnowledgeBasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/knowledgeBases",
+      path: "v2beta1/{+parent}/knowledgeBases",
       hasBody: true,
     }),
     svc,
@@ -14691,7 +14695,7 @@ export const DeleteProjectsAgentKnowledgeBasesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentKnowledgeBasesRequest>;
 
@@ -14727,7 +14731,7 @@ export const PatchProjectsAgentKnowledgeBasesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentKnowledgeBasesRequest>;
 
@@ -14763,7 +14767,7 @@ export const ListProjectsAgentKnowledgeBasesDocumentsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/documents" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/documents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentKnowledgeBasesDocumentsRequest>;
 
@@ -14797,7 +14801,7 @@ export const GetProjectsAgentKnowledgeBasesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentKnowledgeBasesDocumentsRequest>;
 
@@ -14838,7 +14842,7 @@ export const CreateProjectsAgentKnowledgeBasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/documents",
+      path: "v2beta1/{+parent}/documents",
       hasBody: true,
     }),
     svc,
@@ -14870,7 +14874,7 @@ export const DeleteProjectsAgentKnowledgeBasesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentKnowledgeBasesDocumentsRequest>;
 
@@ -14907,7 +14911,7 @@ export const PatchProjectsAgentKnowledgeBasesDocumentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentKnowledgeBasesDocumentsRequest>;
 
@@ -14942,7 +14946,7 @@ export const ReloadProjectsAgentKnowledgeBasesDocumentsRequest =
       GoogleCloudDialogflowV2beta1ReloadDocumentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta1/{name}:reload", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta1/{+name}:reload", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReloadProjectsAgentKnowledgeBasesDocumentsRequest>;
 
@@ -14976,7 +14980,7 @@ export const ListProjectsAgentVersionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentVersionsRequest>;
 
@@ -15010,7 +15014,7 @@ export const GetProjectsAgentVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentVersionsRequest>;
 
@@ -15047,7 +15051,7 @@ export const CreateProjectsAgentVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/versions",
+      path: "v2beta1/{+parent}/versions",
       hasBody: true,
     }),
     svc,
@@ -15086,7 +15090,7 @@ export const PatchProjectsAgentVersionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentVersionsRequest>;
 
@@ -15116,7 +15120,7 @@ export const DeleteProjectsAgentVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentVersionsRequest>;
 
@@ -15145,7 +15149,7 @@ export const GetAgentProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/agent" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/agent" }),
     svc,
   ) as unknown as Schema.Schema<GetAgentProjectsLocationsRequest>;
 
@@ -15180,7 +15184,7 @@ export const SetAgentProjectsLocationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2beta1Agent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta1/{parent}/agent", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta1/{+parent}/agent", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetAgentProjectsLocationsRequest>;
 
@@ -15210,7 +15214,7 @@ export const DeleteAgentProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{parent}/agent" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+parent}/agent" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAgentProjectsLocationsRequest>;
 
@@ -15239,7 +15243,7 @@ export const GetEncryptionSpecProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEncryptionSpecProjectsLocationsRequest>;
 
@@ -15279,7 +15283,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -15313,7 +15317,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -15352,7 +15356,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -15386,7 +15390,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -15415,7 +15419,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -15444,7 +15448,7 @@ export const GetFulfillmentProjectsLocationsAgentRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFulfillmentProjectsLocationsAgentRequest>;
 
@@ -15481,7 +15485,7 @@ export const UpdateFulfillmentProjectsLocationsAgentRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateFulfillmentProjectsLocationsAgentRequest>;
 
@@ -15515,7 +15519,7 @@ export const SearchProjectsLocationsAgentRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/agent:search" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/agent:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsLocationsAgentRequest>;
 
@@ -15556,7 +15560,7 @@ export const TrainProjectsLocationsAgentRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/agent:train",
+      path: "v2beta1/{+parent}/agent:train",
       hasBody: true,
     }),
     svc,
@@ -15594,7 +15598,7 @@ export const ExportProjectsLocationsAgentRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/agent:export",
+      path: "v2beta1/{+parent}/agent:export",
       hasBody: true,
     }),
     svc,
@@ -15632,7 +15636,7 @@ export const ImportProjectsLocationsAgentRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/agent:import",
+      path: "v2beta1/{+parent}/agent:import",
       hasBody: true,
     }),
     svc,
@@ -15670,7 +15674,7 @@ export const RestoreProjectsLocationsAgentRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/agent:restore",
+      path: "v2beta1/{+parent}/agent:restore",
       hasBody: true,
     }),
     svc,
@@ -15705,7 +15709,7 @@ export const GetValidationResultProjectsLocationsAgentRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/agent/validationResult" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/agent/validationResult" }),
     svc,
   ) as unknown as Schema.Schema<GetValidationResultProjectsLocationsAgentRequest>;
 
@@ -15739,7 +15743,7 @@ export const ListProjectsLocationsAgentEnvironmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/environments" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/environments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentEnvironmentsRequest>;
 
@@ -15773,7 +15777,7 @@ export const GetProjectsLocationsAgentEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentEnvironmentsRequest>;
 
@@ -15814,7 +15818,7 @@ export const CreateProjectsLocationsAgentEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/environments",
+      path: "v2beta1/{+parent}/environments",
       hasBody: true,
     }),
     svc,
@@ -15857,7 +15861,7 @@ export const PatchProjectsLocationsAgentEnvironmentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentEnvironmentsRequest>;
 
@@ -15887,7 +15891,7 @@ export const DeleteProjectsLocationsAgentEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentEnvironmentsRequest>;
 
@@ -15921,7 +15925,7 @@ export const GetHistoryProjectsLocationsAgentEnvironmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/history" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/history" }),
     svc,
   ) as unknown as Schema.Schema<GetHistoryProjectsLocationsAgentEnvironmentsRequest>;
 
@@ -15955,7 +15959,7 @@ export const DeleteContextsProjectsLocationsAgentEnvironmentsUsersSessionsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{parent}/contexts" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<DeleteContextsProjectsLocationsAgentEnvironmentsUsersSessionsRequest>;
 
@@ -15993,7 +15997,7 @@ export const DetectIntentProjectsLocationsAgentEnvironmentsUsersSessionsRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{session}:detectIntent",
+      path: "v2beta1/{+session}:detectIntent",
       hasBody: true,
     }),
     svc,
@@ -16030,7 +16034,7 @@ export const ListProjectsLocationsAgentEnvironmentsUsersSessionsContextsRequest 
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/contexts" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentEnvironmentsUsersSessionsContextsRequest>;
 
@@ -16065,7 +16069,7 @@ export const GetProjectsLocationsAgentEnvironmentsUsersSessionsContextsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentEnvironmentsUsersSessionsContextsRequest>;
 
@@ -16103,7 +16107,7 @@ export const CreateProjectsLocationsAgentEnvironmentsUsersSessionsContextsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/contexts",
+      path: "v2beta1/{+parent}/contexts",
       hasBody: true,
     }),
     svc,
@@ -16143,7 +16147,7 @@ export const PatchProjectsLocationsAgentEnvironmentsUsersSessionsContextsRequest
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentEnvironmentsUsersSessionsContextsRequest>;
 
@@ -16174,7 +16178,7 @@ export const DeleteProjectsLocationsAgentEnvironmentsUsersSessionsContextsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentEnvironmentsUsersSessionsContextsRequest>;
 
@@ -16209,7 +16213,7 @@ export const ListProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesReque
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesRequest>;
 
@@ -16245,7 +16249,7 @@ export const GetProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesRequest>;
 
@@ -16283,7 +16287,7 @@ export const CreateProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/entityTypes",
+      path: "v2beta1/{+parent}/entityTypes",
       hasBody: true,
     }),
     svc,
@@ -16325,7 +16329,7 @@ export const PatchProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesRequ
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesRequest>;
 
@@ -16357,7 +16361,7 @@ export const DeleteProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesReq
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentEnvironmentsUsersSessionsEntityTypesRequest>;
 
@@ -16400,7 +16404,7 @@ export const ListProjectsLocationsAgentEnvironmentsIntentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/intents" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/intents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentEnvironmentsIntentsRequest>;
 
@@ -16434,7 +16438,7 @@ export const DeleteContextsProjectsLocationsAgentSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{parent}/contexts" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<DeleteContextsProjectsLocationsAgentSessionsRequest>;
 
@@ -16471,7 +16475,7 @@ export const DetectIntentProjectsLocationsAgentSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{session}:detectIntent",
+      path: "v2beta1/{+session}:detectIntent",
       hasBody: true,
     }),
     svc,
@@ -16507,7 +16511,7 @@ export const ListProjectsLocationsAgentSessionsContextsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/contexts" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentSessionsContextsRequest>;
 
@@ -16541,7 +16545,7 @@ export const GetProjectsLocationsAgentSessionsContextsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentSessionsContextsRequest>;
 
@@ -16578,7 +16582,7 @@ export const CreateProjectsLocationsAgentSessionsContextsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/contexts",
+      path: "v2beta1/{+parent}/contexts",
       hasBody: true,
     }),
     svc,
@@ -16617,7 +16621,7 @@ export const PatchProjectsLocationsAgentSessionsContextsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentSessionsContextsRequest>;
 
@@ -16647,7 +16651,7 @@ export const DeleteProjectsLocationsAgentSessionsContextsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentSessionsContextsRequest>;
 
@@ -16681,7 +16685,7 @@ export const ListProjectsLocationsAgentSessionsEntityTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentSessionsEntityTypesRequest>;
 
@@ -16715,7 +16719,7 @@ export const GetProjectsLocationsAgentSessionsEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentSessionsEntityTypesRequest>;
 
@@ -16752,7 +16756,7 @@ export const CreateProjectsLocationsAgentSessionsEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/entityTypes",
+      path: "v2beta1/{+parent}/entityTypes",
       hasBody: true,
     }),
     svc,
@@ -16792,7 +16796,7 @@ export const PatchProjectsLocationsAgentSessionsEntityTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentSessionsEntityTypesRequest>;
 
@@ -16822,7 +16826,7 @@ export const DeleteProjectsLocationsAgentSessionsEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentSessionsEntityTypesRequest>;
 
@@ -16863,7 +16867,7 @@ export const ListProjectsLocationsAgentIntentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/intents" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/intents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentIntentsRequest>;
 
@@ -16903,7 +16907,7 @@ export const GetProjectsLocationsAgentIntentsRequest =
     ),
     intentView: Schema.optional(Schema.String).pipe(T.HttpQuery("intentView")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentIntentsRequest>;
 
@@ -16944,7 +16948,11 @@ export const CreateProjectsLocationsAgentIntentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta1/{parent}/intents", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2beta1/{+parent}/intents",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentIntentsRequest>;
 
@@ -16987,7 +16995,7 @@ export const PatchProjectsLocationsAgentIntentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentIntentsRequest>;
 
@@ -17017,7 +17025,7 @@ export const DeleteProjectsLocationsAgentIntentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentIntentsRequest>;
 
@@ -17053,7 +17061,7 @@ export const BatchUpdateProjectsLocationsAgentIntentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/intents:batchUpdate",
+      path: "v2beta1/{+parent}/intents:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -17092,7 +17100,7 @@ export const BatchDeleteProjectsLocationsAgentIntentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/intents:batchDelete",
+      path: "v2beta1/{+parent}/intents:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -17132,7 +17140,7 @@ export const ListProjectsLocationsAgentEntityTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentEntityTypesRequest>;
 
@@ -17170,7 +17178,7 @@ export const GetProjectsLocationsAgentEntityTypesRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentEntityTypesRequest>;
 
@@ -17211,7 +17219,7 @@ export const CreateProjectsLocationsAgentEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/entityTypes",
+      path: "v2beta1/{+parent}/entityTypes",
       hasBody: true,
     }),
     svc,
@@ -17254,7 +17262,7 @@ export const PatchProjectsLocationsAgentEntityTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentEntityTypesRequest>;
 
@@ -17284,7 +17292,7 @@ export const DeleteProjectsLocationsAgentEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentEntityTypesRequest>;
 
@@ -17321,7 +17329,7 @@ export const BatchUpdateProjectsLocationsAgentEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/entityTypes:batchUpdate",
+      path: "v2beta1/{+parent}/entityTypes:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -17360,7 +17368,7 @@ export const BatchDeleteProjectsLocationsAgentEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/entityTypes:batchDelete",
+      path: "v2beta1/{+parent}/entityTypes:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -17399,7 +17407,7 @@ export const BatchCreateProjectsLocationsAgentEntityTypesEntitiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/entities:batchCreate",
+      path: "v2beta1/{+parent}/entities:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -17439,7 +17447,7 @@ export const BatchUpdateProjectsLocationsAgentEntityTypesEntitiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/entities:batchUpdate",
+      path: "v2beta1/{+parent}/entities:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -17479,7 +17487,7 @@ export const BatchDeleteProjectsLocationsAgentEntityTypesEntitiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/entities:batchDelete",
+      path: "v2beta1/{+parent}/entities:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -17516,7 +17524,7 @@ export const ListProjectsLocationsAgentVersionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentVersionsRequest>;
 
@@ -17550,7 +17558,7 @@ export const GetProjectsLocationsAgentVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentVersionsRequest>;
 
@@ -17587,7 +17595,7 @@ export const CreateProjectsLocationsAgentVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/versions",
+      path: "v2beta1/{+parent}/versions",
       hasBody: true,
     }),
     svc,
@@ -17626,7 +17634,7 @@ export const PatchProjectsLocationsAgentVersionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentVersionsRequest>;
 
@@ -17656,7 +17664,7 @@ export const DeleteProjectsLocationsAgentVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentVersionsRequest>;
 
@@ -17690,7 +17698,7 @@ export const CreateProjectsLocationsToolsRequest =
     toolId: Schema.optional(Schema.String).pipe(T.HttpQuery("toolId")),
     body: Schema.optional(GoogleCloudDialogflowV2beta1Tool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta1/{parent}/tools", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta1/{+parent}/tools", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsToolsRequest>;
 
@@ -17720,7 +17728,7 @@ export const GetProjectsLocationsToolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsToolsRequest>;
 
@@ -17754,7 +17762,7 @@ export const ListProjectsLocationsToolsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/tools" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/tools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsToolsRequest>;
 
@@ -17788,7 +17796,7 @@ export const DeleteProjectsLocationsToolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsToolsRequest>;
 
@@ -17822,7 +17830,7 @@ export const PatchProjectsLocationsToolsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowV2beta1Tool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsToolsRequest>;
 
@@ -17863,7 +17871,7 @@ export const CreateProjectsLocationsGeneratorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/generators",
+      path: "v2beta1/{+parent}/generators",
       hasBody: true,
     }),
     svc,
@@ -17895,7 +17903,7 @@ export const GetProjectsLocationsGeneratorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGeneratorsRequest>;
 
@@ -17929,7 +17937,7 @@ export const ListProjectsLocationsGeneratorsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/generators" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/generators" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGeneratorsRequest>;
 
@@ -17963,7 +17971,7 @@ export const DeleteProjectsLocationsGeneratorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGeneratorsRequest>;
 
@@ -17999,7 +18007,7 @@ export const PatchProjectsLocationsGeneratorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGeneratorsRequest>;
 
@@ -18036,7 +18044,7 @@ export const CreateProjectsLocationsGeneratorsEvaluationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/evaluations",
+      path: "v2beta1/{+parent}/evaluations",
       hasBody: true,
     }),
     svc,
@@ -18068,7 +18076,7 @@ export const GetProjectsLocationsGeneratorsEvaluationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGeneratorsEvaluationsRequest>;
 
@@ -18102,7 +18110,7 @@ export const ListProjectsLocationsGeneratorsEvaluationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/evaluations" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/evaluations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGeneratorsEvaluationsRequest>;
 
@@ -18136,7 +18144,7 @@ export const DeleteProjectsLocationsGeneratorsEvaluationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGeneratorsEvaluationsRequest>;
 
@@ -18166,7 +18174,7 @@ export const GetProjectsLocationsAnswerRecordsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAnswerRecordsRequest>;
 
@@ -18202,7 +18210,7 @@ export const ListProjectsLocationsAnswerRecordsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/answerRecords" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/answerRecords" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAnswerRecordsRequest>;
 
@@ -18243,7 +18251,7 @@ export const PatchProjectsLocationsAnswerRecordsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAnswerRecordsRequest>;
 
@@ -18277,7 +18285,7 @@ export const ListProjectsLocationsConversationProfilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/conversationProfiles" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/conversationProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConversationProfilesRequest>;
 
@@ -18311,7 +18319,7 @@ export const GetProjectsLocationsConversationProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConversationProfilesRequest>;
 
@@ -18348,7 +18356,7 @@ export const CreateProjectsLocationsConversationProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/conversationProfiles",
+      path: "v2beta1/{+parent}/conversationProfiles",
       hasBody: true,
     }),
     svc,
@@ -18387,7 +18395,7 @@ export const PatchProjectsLocationsConversationProfilesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConversationProfilesRequest>;
 
@@ -18417,7 +18425,7 @@ export const DeleteProjectsLocationsConversationProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConversationProfilesRequest>;
 
@@ -18454,7 +18462,7 @@ export const SetSuggestionFeatureConfigProjectsLocationsConversationProfilesRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{conversationProfile}:setSuggestionFeatureConfig",
+      path: "v2beta1/{+conversationProfile}:setSuggestionFeatureConfig",
       hasBody: true,
     }),
     svc,
@@ -18495,7 +18503,7 @@ export const ClearSuggestionFeatureConfigProjectsLocationsConversationProfilesRe
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{conversationProfile}:clearSuggestionFeatureConfig",
+      path: "v2beta1/{+conversationProfile}:clearSuggestionFeatureConfig",
       hasBody: true,
     }),
     svc,
@@ -18541,7 +18549,7 @@ export const CreateProjectsLocationsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/conversations",
+      path: "v2beta1/{+parent}/conversations",
       hasBody: true,
     }),
     svc,
@@ -18579,7 +18587,7 @@ export const ListProjectsLocationsConversationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConversationsRequest>;
 
@@ -18613,7 +18621,7 @@ export const GetProjectsLocationsConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConversationsRequest>;
 
@@ -18648,7 +18656,7 @@ export const CompleteProjectsLocationsConversationsRequest =
       GoogleCloudDialogflowV2beta1CompleteConversationRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta1/{name}:complete", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta1/{+name}:complete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CompleteProjectsLocationsConversationsRequest>;
 
@@ -18685,7 +18693,7 @@ export const IngestContextReferencesProjectsLocationsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{conversation}:ingestContextReferences",
+      path: "v2beta1/{+conversation}:ingestContextReferences",
       hasBody: true,
     }),
     svc,
@@ -18725,7 +18733,7 @@ export const CreateProjectsLocationsConversationsParticipantsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/participants",
+      path: "v2beta1/{+parent}/participants",
       hasBody: true,
     }),
     svc,
@@ -18758,7 +18766,7 @@ export const GetProjectsLocationsConversationsParticipantsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConversationsParticipantsRequest>;
 
@@ -18792,7 +18800,7 @@ export const ListProjectsLocationsConversationsParticipantsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/participants" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/participants" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConversationsParticipantsRequest>;
 
@@ -18833,7 +18841,7 @@ export const PatchProjectsLocationsConversationsParticipantsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConversationsParticipantsRequest>;
 
@@ -18871,7 +18879,7 @@ export const AnalyzeContentProjectsLocationsConversationsParticipantsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{participant}:analyzeContent",
+      path: "v2beta1/{+participant}:analyzeContent",
       hasBody: true,
     }),
     svc,
@@ -18911,7 +18919,7 @@ export const SuggestArticlesProjectsLocationsConversationsParticipantsSuggestion
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/suggestions:suggestArticles",
+      path: "v2beta1/{+parent}/suggestions:suggestArticles",
       hasBody: true,
     }),
     svc,
@@ -18953,7 +18961,7 @@ export const SuggestFaqAnswersProjectsLocationsConversationsParticipantsSuggesti
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/suggestions:suggestFaqAnswers",
+      path: "v2beta1/{+parent}/suggestions:suggestFaqAnswers",
       hasBody: true,
     }),
     svc,
@@ -18995,7 +19003,7 @@ export const SuggestSmartRepliesProjectsLocationsConversationsParticipantsSugges
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/suggestions:suggestSmartReplies",
+      path: "v2beta1/{+parent}/suggestions:suggestSmartReplies",
       hasBody: true,
     }),
     svc,
@@ -19037,7 +19045,7 @@ export const SuggestKnowledgeAssistProjectsLocationsConversationsParticipantsSug
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/suggestions:suggestKnowledgeAssist",
+      path: "v2beta1/{+parent}/suggestions:suggestKnowledgeAssist",
       hasBody: true,
     }),
     svc,
@@ -19079,7 +19087,7 @@ export const BatchCreateProjectsLocationsConversationsMessagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/messages:batchCreate",
+      path: "v2beta1/{+parent}/messages:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -19118,7 +19126,7 @@ export const ListProjectsLocationsConversationsMessagesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/messages" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/messages" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConversationsMessagesRequest>;
 
@@ -19159,7 +19167,7 @@ export const SuggestConversationSummaryProjectsLocationsConversationsSuggestions
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{conversation}/suggestions:suggestConversationSummary",
+      path: "v2beta1/{+conversation}/suggestions:suggestConversationSummary",
       hasBody: true,
     }),
     svc,
@@ -19201,7 +19209,7 @@ export const SearchKnowledgeProjectsLocationsConversationsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{conversation}/suggestions:searchKnowledge",
+      path: "v2beta1/{+conversation}/suggestions:searchKnowledge",
       hasBody: true,
     }),
     svc,
@@ -19241,7 +19249,7 @@ export const GenerateProjectsLocationsConversationsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{conversation}/suggestions:generate",
+      path: "v2beta1/{+conversation}/suggestions:generate",
       hasBody: true,
     }),
     svc,
@@ -19281,7 +19289,7 @@ export const GenerateStatelessSummaryProjectsLocationsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/suggestions:generateStatelessSummary",
+      path: "v2beta1/{+parent}/suggestions:generateStatelessSummary",
       hasBody: true,
     }),
     svc,
@@ -19321,7 +19329,7 @@ export const SearchKnowledgeProjectsLocationsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/suggestions:searchKnowledge",
+      path: "v2beta1/{+parent}/suggestions:searchKnowledge",
       hasBody: true,
     }),
     svc,
@@ -19360,7 +19368,7 @@ export const GenerateProjectsLocationsStatelessSuggestionRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/statelessSuggestion:generate",
+      path: "v2beta1/{+parent}/statelessSuggestion:generate",
       hasBody: true,
     }),
     svc,
@@ -19399,7 +19407,7 @@ export const InitializeProjectsLocationsEncryptionSpecRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{name}:initialize",
+      path: "v2beta1/{+name}:initialize",
       hasBody: true,
     }),
     svc,
@@ -19437,7 +19445,7 @@ export const ListProjectsLocationsKnowledgeBasesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/knowledgeBases" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/knowledgeBases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsKnowledgeBasesRequest>;
 
@@ -19471,7 +19479,7 @@ export const GetProjectsLocationsKnowledgeBasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsKnowledgeBasesRequest>;
 
@@ -19508,7 +19516,7 @@ export const CreateProjectsLocationsKnowledgeBasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/knowledgeBases",
+      path: "v2beta1/{+parent}/knowledgeBases",
       hasBody: true,
     }),
     svc,
@@ -19542,7 +19550,7 @@ export const DeleteProjectsLocationsKnowledgeBasesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsKnowledgeBasesRequest>;
 
@@ -19578,7 +19586,7 @@ export const PatchProjectsLocationsKnowledgeBasesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsKnowledgeBasesRequest>;
 
@@ -19614,7 +19622,7 @@ export const ListProjectsLocationsKnowledgeBasesDocumentsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/documents" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/documents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsKnowledgeBasesDocumentsRequest>;
 
@@ -19648,7 +19656,7 @@ export const GetProjectsLocationsKnowledgeBasesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsKnowledgeBasesDocumentsRequest>;
 
@@ -19689,7 +19697,7 @@ export const CreateProjectsLocationsKnowledgeBasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/documents",
+      path: "v2beta1/{+parent}/documents",
       hasBody: true,
     }),
     svc,
@@ -19728,7 +19736,7 @@ export const ImportProjectsLocationsKnowledgeBasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/documents:import",
+      path: "v2beta1/{+parent}/documents:import",
       hasBody: true,
     }),
     svc,
@@ -19760,7 +19768,7 @@ export const DeleteProjectsLocationsKnowledgeBasesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsKnowledgeBasesDocumentsRequest>;
 
@@ -19797,7 +19805,7 @@ export const PatchProjectsLocationsKnowledgeBasesDocumentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsKnowledgeBasesDocumentsRequest>;
 
@@ -19832,7 +19840,7 @@ export const ReloadProjectsLocationsKnowledgeBasesDocumentsRequest =
       GoogleCloudDialogflowV2beta1ReloadDocumentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta1/{name}:reload", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta1/{+name}:reload", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReloadProjectsLocationsKnowledgeBasesDocumentsRequest>;
 
@@ -19870,7 +19878,7 @@ export const ListProjectsLocationsPhoneNumbersRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/phoneNumbers" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/phoneNumbers" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPhoneNumbersRequest>;
 
@@ -19911,7 +19919,7 @@ export const PatchProjectsLocationsPhoneNumbersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPhoneNumbersRequest>;
 
@@ -19941,7 +19949,7 @@ export const DeleteProjectsLocationsPhoneNumbersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPhoneNumbersRequest>;
 
@@ -19976,7 +19984,7 @@ export const UndeleteProjectsLocationsPhoneNumbersRequest =
       GoogleCloudDialogflowV2beta1UndeletePhoneNumberRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsLocationsPhoneNumbersRequest>;
 
@@ -20013,7 +20021,7 @@ export const CreateProjectsLocationsSipTrunksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/sipTrunks",
+      path: "v2beta1/{+parent}/sipTrunks",
       hasBody: true,
     }),
     svc,
@@ -20045,7 +20053,7 @@ export const DeleteProjectsLocationsSipTrunksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSipTrunksRequest>;
 
@@ -20078,7 +20086,7 @@ export const ListProjectsLocationsSipTrunksRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/sipTrunks" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/sipTrunks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSipTrunksRequest>;
 
@@ -20112,7 +20120,7 @@ export const GetProjectsLocationsSipTrunksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSipTrunksRequest>;
 
@@ -20149,7 +20157,7 @@ export const PatchProjectsLocationsSipTrunksRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSipTrunksRequest>;
 
@@ -20190,7 +20198,7 @@ export const CreateProjectsGeneratorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/generators",
+      path: "v2beta1/{+parent}/generators",
       hasBody: true,
     }),
     svc,
@@ -20226,7 +20234,7 @@ export const ListProjectsGeneratorsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/generators" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/generators" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsGeneratorsRequest>;
 
@@ -20260,7 +20268,7 @@ export const GetProjectsAnswerRecordsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAnswerRecordsRequest>;
 
@@ -20296,7 +20304,7 @@ export const ListProjectsAnswerRecordsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/answerRecords" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/answerRecords" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAnswerRecordsRequest>;
 
@@ -20337,7 +20345,7 @@ export const PatchProjectsAnswerRecordsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAnswerRecordsRequest>;
 
@@ -20371,7 +20379,7 @@ export const ListProjectsConversationProfilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/conversationProfiles" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/conversationProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsConversationProfilesRequest>;
 
@@ -20405,7 +20413,7 @@ export const GetProjectsConversationProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsConversationProfilesRequest>;
 
@@ -20442,7 +20450,7 @@ export const CreateProjectsConversationProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/conversationProfiles",
+      path: "v2beta1/{+parent}/conversationProfiles",
       hasBody: true,
     }),
     svc,
@@ -20481,7 +20489,7 @@ export const PatchProjectsConversationProfilesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsConversationProfilesRequest>;
 
@@ -20511,7 +20519,7 @@ export const DeleteProjectsConversationProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsConversationProfilesRequest>;
 
@@ -20547,7 +20555,7 @@ export const SetSuggestionFeatureConfigProjectsConversationProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{conversationProfile}:setSuggestionFeatureConfig",
+      path: "v2beta1/{+conversationProfile}:setSuggestionFeatureConfig",
       hasBody: true,
     }),
     svc,
@@ -20587,7 +20595,7 @@ export const ClearSuggestionFeatureConfigProjectsConversationProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{conversationProfile}:clearSuggestionFeatureConfig",
+      path: "v2beta1/{+conversationProfile}:clearSuggestionFeatureConfig",
       hasBody: true,
     }),
     svc,
@@ -20631,7 +20639,7 @@ export const CreateProjectsConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/conversations",
+      path: "v2beta1/{+parent}/conversations",
       hasBody: true,
     }),
     svc,
@@ -20669,7 +20677,7 @@ export const ListProjectsConversationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsConversationsRequest>;
 
@@ -20703,7 +20711,7 @@ export const GetProjectsConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsConversationsRequest>;
 
@@ -20738,7 +20746,7 @@ export const CompleteProjectsConversationsRequest =
       GoogleCloudDialogflowV2beta1CompleteConversationRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta1/{name}:complete", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta1/{+name}:complete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CompleteProjectsConversationsRequest>;
 
@@ -20775,7 +20783,7 @@ export const CreateProjectsConversationsParticipantsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/participants",
+      path: "v2beta1/{+parent}/participants",
       hasBody: true,
     }),
     svc,
@@ -20807,7 +20815,7 @@ export const GetProjectsConversationsParticipantsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsConversationsParticipantsRequest>;
 
@@ -20841,7 +20849,7 @@ export const ListProjectsConversationsParticipantsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/participants" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/participants" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsConversationsParticipantsRequest>;
 
@@ -20882,7 +20890,7 @@ export const PatchProjectsConversationsParticipantsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsConversationsParticipantsRequest>;
 
@@ -20919,7 +20927,7 @@ export const AnalyzeContentProjectsConversationsParticipantsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{participant}:analyzeContent",
+      path: "v2beta1/{+participant}:analyzeContent",
       hasBody: true,
     }),
     svc,
@@ -20959,7 +20967,7 @@ export const SuggestArticlesProjectsConversationsParticipantsSuggestionsRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/suggestions:suggestArticles",
+      path: "v2beta1/{+parent}/suggestions:suggestArticles",
       hasBody: true,
     }),
     svc,
@@ -20999,7 +21007,7 @@ export const SuggestFaqAnswersProjectsConversationsParticipantsSuggestionsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/suggestions:suggestFaqAnswers",
+      path: "v2beta1/{+parent}/suggestions:suggestFaqAnswers",
       hasBody: true,
     }),
     svc,
@@ -21039,7 +21047,7 @@ export const SuggestSmartRepliesProjectsConversationsParticipantsSuggestionsRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/suggestions:suggestSmartReplies",
+      path: "v2beta1/{+parent}/suggestions:suggestSmartReplies",
       hasBody: true,
     }),
     svc,
@@ -21080,7 +21088,7 @@ export const SuggestKnowledgeAssistProjectsConversationsParticipantsSuggestionsR
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/suggestions:suggestKnowledgeAssist",
+      path: "v2beta1/{+parent}/suggestions:suggestKnowledgeAssist",
       hasBody: true,
     }),
     svc,
@@ -21121,7 +21129,7 @@ export const ListProjectsConversationsParticipantsSuggestionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/suggestions" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/suggestions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsConversationsParticipantsSuggestionsRequest>;
 
@@ -21163,7 +21171,7 @@ export const CompileProjectsConversationsParticipantsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/suggestions:compile",
+      path: "v2beta1/{+parent}/suggestions:compile",
       hasBody: true,
     }),
     svc,
@@ -21203,7 +21211,7 @@ export const BatchCreateProjectsConversationsMessagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/messages:batchCreate",
+      path: "v2beta1/{+parent}/messages:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -21241,7 +21249,7 @@ export const ListProjectsConversationsMessagesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/messages" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/messages" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsConversationsMessagesRequest>;
 
@@ -21282,7 +21290,7 @@ export const SuggestConversationSummaryProjectsConversationsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{conversation}/suggestions:suggestConversationSummary",
+      path: "v2beta1/{+conversation}/suggestions:suggestConversationSummary",
       hasBody: true,
     }),
     svc,
@@ -21322,7 +21330,7 @@ export const SearchKnowledgeProjectsConversationsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{conversation}/suggestions:searchKnowledge",
+      path: "v2beta1/{+conversation}/suggestions:searchKnowledge",
       hasBody: true,
     }),
     svc,
@@ -21362,7 +21370,7 @@ export const GenerateProjectsConversationsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{conversation}/suggestions:generate",
+      path: "v2beta1/{+conversation}/suggestions:generate",
       hasBody: true,
     }),
     svc,
@@ -21401,7 +21409,7 @@ export const GenerateStatelessSummaryProjectsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/suggestions:generateStatelessSummary",
+      path: "v2beta1/{+parent}/suggestions:generateStatelessSummary",
       hasBody: true,
     }),
     svc,
@@ -21440,7 +21448,7 @@ export const SearchKnowledgeProjectsSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/suggestions:searchKnowledge",
+      path: "v2beta1/{+parent}/suggestions:searchKnowledge",
       hasBody: true,
     }),
     svc,
@@ -21478,7 +21486,7 @@ export const ListProjectsKnowledgeBasesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/knowledgeBases" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/knowledgeBases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsKnowledgeBasesRequest>;
 
@@ -21512,7 +21520,7 @@ export const GetProjectsKnowledgeBasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsKnowledgeBasesRequest>;
 
@@ -21549,7 +21557,7 @@ export const CreateProjectsKnowledgeBasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/knowledgeBases",
+      path: "v2beta1/{+parent}/knowledgeBases",
       hasBody: true,
     }),
     svc,
@@ -21583,7 +21591,7 @@ export const DeleteProjectsKnowledgeBasesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsKnowledgeBasesRequest>;
 
@@ -21619,7 +21627,7 @@ export const PatchProjectsKnowledgeBasesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsKnowledgeBasesRequest>;
 
@@ -21655,7 +21663,7 @@ export const ListProjectsKnowledgeBasesDocumentsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/documents" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/documents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsKnowledgeBasesDocumentsRequest>;
 
@@ -21689,7 +21697,7 @@ export const GetProjectsKnowledgeBasesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{name}" }),
+    T.Http({ method: "GET", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsKnowledgeBasesDocumentsRequest>;
 
@@ -21730,7 +21738,7 @@ export const CreateProjectsKnowledgeBasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/documents",
+      path: "v2beta1/{+parent}/documents",
       hasBody: true,
     }),
     svc,
@@ -21769,7 +21777,7 @@ export const ImportProjectsKnowledgeBasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta1/{parent}/documents:import",
+      path: "v2beta1/{+parent}/documents:import",
       hasBody: true,
     }),
     svc,
@@ -21801,7 +21809,7 @@ export const DeleteProjectsKnowledgeBasesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsKnowledgeBasesDocumentsRequest>;
 
@@ -21838,7 +21846,7 @@ export const PatchProjectsKnowledgeBasesDocumentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsKnowledgeBasesDocumentsRequest>;
 
@@ -21873,7 +21881,7 @@ export const ReloadProjectsKnowledgeBasesDocumentsRequest =
       GoogleCloudDialogflowV2beta1ReloadDocumentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta1/{name}:reload", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta1/{+name}:reload", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReloadProjectsKnowledgeBasesDocumentsRequest>;
 
@@ -21911,7 +21919,7 @@ export const ListProjectsPhoneNumbersRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta1/{parent}/phoneNumbers" }),
+    T.Http({ method: "GET", path: "v2beta1/{+parent}/phoneNumbers" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsPhoneNumbersRequest>;
 
@@ -21952,7 +21960,7 @@ export const PatchProjectsPhoneNumbersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsPhoneNumbersRequest>;
 
@@ -21982,7 +21990,7 @@ export const DeleteProjectsPhoneNumbersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsPhoneNumbersRequest>;
 
@@ -22017,7 +22025,7 @@ export const UndeleteProjectsPhoneNumbersRequest =
       GoogleCloudDialogflowV2beta1UndeletePhoneNumberRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsPhoneNumbersRequest>;
 

--- a/packages/gcp/src/services/dialogflow-v3.ts
+++ b/packages/gcp/src/services/dialogflow-v3.ts
@@ -11649,7 +11649,7 @@ export const ListProjectsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}/operations" }),
+    T.Http({ method: "GET", path: "v3/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsOperationsRequest>;
 
@@ -11683,7 +11683,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 
@@ -11712,7 +11712,7 @@ export const CancelProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsOperationsRequest>;
 
@@ -11751,7 +11751,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}/locations" }),
+    T.Http({ method: "GET", path: "v3/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -11785,7 +11785,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -11824,7 +11824,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}/operations" }),
+    T.Http({ method: "GET", path: "v3/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -11858,7 +11858,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -11887,7 +11887,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -11923,7 +11923,7 @@ export const CreateProjectsLocationsSecuritySettingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}/securitySettings",
+      path: "v3/{+parent}/securitySettings",
       hasBody: true,
     }),
     svc,
@@ -11955,7 +11955,7 @@ export const GetProjectsLocationsSecuritySettingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSecuritySettingsRequest>;
 
@@ -11992,7 +11992,7 @@ export const PatchProjectsLocationsSecuritySettingsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSecuritySettingsRequest>;
 
@@ -12026,7 +12026,7 @@ export const ListProjectsLocationsSecuritySettingsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/securitySettings" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/securitySettings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSecuritySettingsRequest>;
 
@@ -12060,7 +12060,7 @@ export const DeleteProjectsLocationsSecuritySettingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSecuritySettingsRequest>;
 
@@ -12094,7 +12094,7 @@ export const ListProjectsLocationsAgentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/agents" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/agents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsRequest>;
 
@@ -12128,7 +12128,7 @@ export const GetProjectsLocationsAgentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsRequest>;
 
@@ -12160,7 +12160,7 @@ export const CreateProjectsLocationsAgentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDialogflowCxV3Agent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/agents", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/agents", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsRequest>;
 
@@ -12195,7 +12195,7 @@ export const PatchProjectsLocationsAgentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowCxV3Agent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsRequest>;
 
@@ -12225,7 +12225,7 @@ export const DeleteProjectsLocationsAgentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsRequest>;
 
@@ -12259,7 +12259,7 @@ export const ExportProjectsLocationsAgentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsAgentsRequest>;
 
@@ -12293,7 +12293,7 @@ export const RestoreProjectsLocationsAgentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsAgentsRequest>;
 
@@ -12327,7 +12327,7 @@ export const ValidateProjectsLocationsAgentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:validate", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:validate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ValidateProjectsLocationsAgentsRequest>;
 
@@ -12361,7 +12361,7 @@ export const GetValidationResultProjectsLocationsAgentsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetValidationResultProjectsLocationsAgentsRequest>;
 
@@ -12395,7 +12395,7 @@ export const GetGenerativeSettingsProjectsLocationsAgentsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetGenerativeSettingsProjectsLocationsAgentsRequest>;
 
@@ -12432,7 +12432,7 @@ export const UpdateGenerativeSettingsProjectsLocationsAgentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateGenerativeSettingsProjectsLocationsAgentsRequest>;
 
@@ -12470,7 +12470,7 @@ export const CreateProjectsLocationsAgentsFlowsRequest =
     ),
     body: Schema.optional(GoogleCloudDialogflowCxV3Flow).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/flows", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/flows", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsFlowsRequest>;
 
@@ -12502,7 +12502,7 @@ export const DeleteProjectsLocationsAgentsFlowsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsFlowsRequest>;
 
@@ -12539,7 +12539,7 @@ export const ListProjectsLocationsAgentsFlowsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/flows" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/flows" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsFlowsRequest>;
 
@@ -12577,7 +12577,7 @@ export const GetProjectsLocationsAgentsFlowsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsFlowsRequest>;
 
@@ -12616,7 +12616,7 @@ export const PatchProjectsLocationsAgentsFlowsRequest =
     ),
     body: Schema.optional(GoogleCloudDialogflowCxV3Flow).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsFlowsRequest>;
 
@@ -12651,7 +12651,7 @@ export const TrainProjectsLocationsAgentsFlowsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:train", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:train", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TrainProjectsLocationsAgentsFlowsRequest>;
 
@@ -12686,7 +12686,7 @@ export const ValidateProjectsLocationsAgentsFlowsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:validate", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:validate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ValidateProjectsLocationsAgentsFlowsRequest>;
 
@@ -12720,7 +12720,7 @@ export const GetValidationResultProjectsLocationsAgentsFlowsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetValidationResultProjectsLocationsAgentsFlowsRequest>;
 
@@ -12756,7 +12756,11 @@ export const ImportProjectsLocationsAgentsFlowsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/flows:import", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v3/{+parent}/flows:import",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsLocationsAgentsFlowsRequest>;
 
@@ -12791,7 +12795,7 @@ export const ExportProjectsLocationsAgentsFlowsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsAgentsFlowsRequest>;
 
@@ -12829,7 +12833,7 @@ export const ListProjectsLocationsAgentsFlowsPagesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/pages" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/pages" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsFlowsPagesRequest>;
 
@@ -12867,7 +12871,7 @@ export const GetProjectsLocationsAgentsFlowsPagesRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsFlowsPagesRequest>;
 
@@ -12904,7 +12908,7 @@ export const CreateProjectsLocationsAgentsFlowsPagesRequest =
     ),
     body: Schema.optional(GoogleCloudDialogflowCxV3Page).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/pages", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/pages", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsFlowsPagesRequest>;
 
@@ -12943,7 +12947,7 @@ export const PatchProjectsLocationsAgentsFlowsPagesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowCxV3Page).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsFlowsPagesRequest>;
 
@@ -12975,7 +12979,7 @@ export const DeleteProjectsLocationsAgentsFlowsPagesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsFlowsPagesRequest>;
 
@@ -13013,7 +13017,7 @@ export const ListProjectsLocationsAgentsFlowsTransitionRouteGroupsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/transitionRouteGroups" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/transitionRouteGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsFlowsTransitionRouteGroupsRequest>;
 
@@ -13052,7 +13056,7 @@ export const GetProjectsLocationsAgentsFlowsTransitionRouteGroupsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsFlowsTransitionRouteGroupsRequest>;
 
@@ -13094,7 +13098,7 @@ export const CreateProjectsLocationsAgentsFlowsTransitionRouteGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}/transitionRouteGroups",
+      path: "v3/{+parent}/transitionRouteGroups",
       hasBody: true,
     }),
     svc,
@@ -13138,7 +13142,7 @@ export const PatchProjectsLocationsAgentsFlowsTransitionRouteGroupsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsFlowsTransitionRouteGroupsRequest>;
 
@@ -13171,7 +13175,7 @@ export const DeleteProjectsLocationsAgentsFlowsTransitionRouteGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsFlowsTransitionRouteGroupsRequest>;
 
@@ -13206,7 +13210,7 @@ export const ListProjectsLocationsAgentsFlowsVersionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsFlowsVersionsRequest>;
 
@@ -13240,7 +13244,7 @@ export const GetProjectsLocationsAgentsFlowsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsFlowsVersionsRequest>;
 
@@ -13273,7 +13277,7 @@ export const CreateProjectsLocationsAgentsFlowsVersionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDialogflowCxV3Version).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/versions", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/versions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsFlowsVersionsRequest>;
 
@@ -13308,7 +13312,7 @@ export const PatchProjectsLocationsAgentsFlowsVersionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowCxV3Version).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsFlowsVersionsRequest>;
 
@@ -13338,7 +13342,7 @@ export const DeleteProjectsLocationsAgentsFlowsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsFlowsVersionsRequest>;
 
@@ -13373,7 +13377,7 @@ export const LoadProjectsLocationsAgentsFlowsVersionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:load", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:load", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<LoadProjectsLocationsAgentsFlowsVersionsRequest>;
 
@@ -13410,7 +13414,7 @@ export const CompareVersionsProjectsLocationsAgentsFlowsVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{baseVersion}:compareVersions",
+      path: "v3/{+baseVersion}:compareVersions",
       hasBody: true,
     }),
     svc,
@@ -13449,7 +13453,7 @@ export const ListProjectsLocationsAgentsChangelogsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/changelogs" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/changelogs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsChangelogsRequest>;
 
@@ -13483,7 +13487,7 @@ export const GetProjectsLocationsAgentsChangelogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsChangelogsRequest>;
 
@@ -13517,7 +13521,7 @@ export const GetProjectsLocationsAgentsEntityTypesRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsEntityTypesRequest>;
 
@@ -13556,7 +13560,7 @@ export const CreateProjectsLocationsAgentsEntityTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/entityTypes", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/entityTypes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsEntityTypesRequest>;
 
@@ -13597,7 +13601,7 @@ export const PatchProjectsLocationsAgentsEntityTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsEntityTypesRequest>;
 
@@ -13629,7 +13633,7 @@ export const DeleteProjectsLocationsAgentsEntityTypesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsEntityTypesRequest>;
 
@@ -13667,7 +13671,7 @@ export const ListProjectsLocationsAgentsEntityTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsEntityTypesRequest>;
 
@@ -13708,7 +13712,7 @@ export const ExportProjectsLocationsAgentsEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}/entityTypes:export",
+      path: "v3/{+parent}/entityTypes:export",
       hasBody: true,
     }),
     svc,
@@ -13747,7 +13751,7 @@ export const ImportProjectsLocationsAgentsEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}/entityTypes:import",
+      path: "v3/{+parent}/entityTypes:import",
       hasBody: true,
     }),
     svc,
@@ -13793,7 +13797,7 @@ export const ListProjectsLocationsAgentsIntentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/intents" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/intents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsIntentsRequest>;
 
@@ -13831,7 +13835,7 @@ export const GetProjectsLocationsAgentsIntentsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsIntentsRequest>;
 
@@ -13868,7 +13872,7 @@ export const CreateProjectsLocationsAgentsIntentsRequest =
     ),
     body: Schema.optional(GoogleCloudDialogflowCxV3Intent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/intents", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/intents", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsIntentsRequest>;
 
@@ -13907,7 +13911,7 @@ export const PatchProjectsLocationsAgentsIntentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowCxV3Intent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsIntentsRequest>;
 
@@ -13937,7 +13941,7 @@ export const DeleteProjectsLocationsAgentsIntentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsIntentsRequest>;
 
@@ -13973,7 +13977,7 @@ export const ImportProjectsLocationsAgentsIntentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}/intents:import",
+      path: "v3/{+parent}/intents:import",
       hasBody: true,
     }),
     svc,
@@ -14012,7 +14016,7 @@ export const ExportProjectsLocationsAgentsIntentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}/intents:export",
+      path: "v3/{+parent}/intents:export",
       hasBody: true,
     }),
     svc,
@@ -14051,7 +14055,7 @@ export const DetectIntentProjectsLocationsAgentsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{session}:detectIntent",
+      path: "v3/{+session}:detectIntent",
       hasBody: true,
     }),
     svc,
@@ -14090,7 +14094,7 @@ export const ServerStreamingDetectIntentProjectsLocationsAgentsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{session}:serverStreamingDetectIntent",
+      path: "v3/{+session}:serverStreamingDetectIntent",
       hasBody: true,
     }),
     svc,
@@ -14128,7 +14132,11 @@ export const MatchIntentProjectsLocationsAgentsSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{session}:matchIntent", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v3/{+session}:matchIntent",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<MatchIntentProjectsLocationsAgentsSessionsRequest>;
 
@@ -14165,7 +14173,7 @@ export const FulfillIntentProjectsLocationsAgentsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{session}:fulfillIntent",
+      path: "v3/{+session}:fulfillIntent",
       hasBody: true,
     }),
     svc,
@@ -14204,7 +14212,7 @@ export const SubmitAnswerFeedbackProjectsLocationsAgentsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{session}:submitAnswerFeedback",
+      path: "v3/{+session}:submitAnswerFeedback",
       hasBody: true,
     }),
     svc,
@@ -14241,7 +14249,7 @@ export const ListProjectsLocationsAgentsSessionsEntityTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsSessionsEntityTypesRequest>;
 
@@ -14275,7 +14283,7 @@ export const GetProjectsLocationsAgentsSessionsEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsSessionsEntityTypesRequest>;
 
@@ -14310,7 +14318,7 @@ export const CreateProjectsLocationsAgentsSessionsEntityTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/entityTypes", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/entityTypes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsSessionsEntityTypesRequest>;
 
@@ -14348,7 +14356,7 @@ export const PatchProjectsLocationsAgentsSessionsEntityTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsSessionsEntityTypesRequest>;
 
@@ -14379,7 +14387,7 @@ export const DeleteProjectsLocationsAgentsSessionsEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsSessionsEntityTypesRequest>;
 
@@ -14418,7 +14426,7 @@ export const ListProjectsLocationsAgentsTransitionRouteGroupsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/transitionRouteGroups" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/transitionRouteGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsTransitionRouteGroupsRequest>;
 
@@ -14457,7 +14465,7 @@ export const GetProjectsLocationsAgentsTransitionRouteGroupsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsTransitionRouteGroupsRequest>;
 
@@ -14499,7 +14507,7 @@ export const CreateProjectsLocationsAgentsTransitionRouteGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}/transitionRouteGroups",
+      path: "v3/{+parent}/transitionRouteGroups",
       hasBody: true,
     }),
     svc,
@@ -14543,7 +14551,7 @@ export const PatchProjectsLocationsAgentsTransitionRouteGroupsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsTransitionRouteGroupsRequest>;
 
@@ -14576,7 +14584,7 @@ export const DeleteProjectsLocationsAgentsTransitionRouteGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsTransitionRouteGroupsRequest>;
 
@@ -14613,7 +14621,7 @@ export const ListProjectsLocationsAgentsTestCasesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/testCases" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/testCases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsTestCasesRequest>;
 
@@ -14654,7 +14662,7 @@ export const BatchDeleteProjectsLocationsAgentsTestCasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}/testCases:batchDelete",
+      path: "v3/{+parent}/testCases:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -14686,7 +14694,7 @@ export const GetProjectsLocationsAgentsTestCasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsTestCasesRequest>;
 
@@ -14719,7 +14727,7 @@ export const CreateProjectsLocationsAgentsTestCasesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDialogflowCxV3TestCase).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/testCases", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/testCases", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsTestCasesRequest>;
 
@@ -14754,7 +14762,7 @@ export const PatchProjectsLocationsAgentsTestCasesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowCxV3TestCase).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsTestCasesRequest>;
 
@@ -14789,7 +14797,7 @@ export const RunProjectsLocationsAgentsTestCasesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsAgentsTestCasesRequest>;
 
@@ -14826,7 +14834,7 @@ export const BatchRunProjectsLocationsAgentsTestCasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}/testCases:batchRun",
+      path: "v3/{+parent}/testCases:batchRun",
       hasBody: true,
     }),
     svc,
@@ -14865,7 +14873,7 @@ export const CalculateCoverageProjectsLocationsAgentsTestCasesRequest =
     agent: Schema.String.pipe(T.HttpPath("agent")),
     type: Schema.optional(Schema.String).pipe(T.HttpQuery("type")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{agent}/testCases:calculateCoverage" }),
+    T.Http({ method: "GET", path: "v3/{+agent}/testCases:calculateCoverage" }),
     svc,
   ) as unknown as Schema.Schema<CalculateCoverageProjectsLocationsAgentsTestCasesRequest>;
 
@@ -14903,7 +14911,7 @@ export const ImportProjectsLocationsAgentsTestCasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}/testCases:import",
+      path: "v3/{+parent}/testCases:import",
       hasBody: true,
     }),
     svc,
@@ -14942,7 +14950,7 @@ export const ExportProjectsLocationsAgentsTestCasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}/testCases:export",
+      path: "v3/{+parent}/testCases:export",
       hasBody: true,
     }),
     svc,
@@ -14980,7 +14988,7 @@ export const ListProjectsLocationsAgentsTestCasesResultsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/results" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/results" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsTestCasesResultsRequest>;
 
@@ -15014,7 +15022,7 @@ export const GetProjectsLocationsAgentsTestCasesResultsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsTestCasesResultsRequest>;
 
@@ -15048,7 +15056,7 @@ export const ListProjectsLocationsAgentsWebhooksRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/webhooks" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/webhooks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsWebhooksRequest>;
 
@@ -15082,7 +15090,7 @@ export const GetProjectsLocationsAgentsWebhooksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsWebhooksRequest>;
 
@@ -15115,7 +15123,7 @@ export const CreateProjectsLocationsAgentsWebhooksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDialogflowCxV3Webhook).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/webhooks", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/webhooks", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsWebhooksRequest>;
 
@@ -15150,7 +15158,7 @@ export const PatchProjectsLocationsAgentsWebhooksRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowCxV3Webhook).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsWebhooksRequest>;
 
@@ -15182,7 +15190,7 @@ export const DeleteProjectsLocationsAgentsWebhooksRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsWebhooksRequest>;
 
@@ -15215,7 +15223,7 @@ export const ListProjectsLocationsAgentsEnvironmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/environments" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/environments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsEnvironmentsRequest>;
 
@@ -15249,7 +15257,7 @@ export const GetProjectsLocationsAgentsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsEnvironmentsRequest>;
 
@@ -15284,7 +15292,11 @@ export const CreateProjectsLocationsAgentsEnvironmentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/environments", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v3/{+parent}/environments",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsEnvironmentsRequest>;
 
@@ -15321,7 +15333,7 @@ export const PatchProjectsLocationsAgentsEnvironmentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsEnvironmentsRequest>;
 
@@ -15351,7 +15363,7 @@ export const DeleteProjectsLocationsAgentsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsEnvironmentsRequest>;
 
@@ -15385,7 +15397,7 @@ export const LookupEnvironmentHistoryProjectsLocationsAgentsEnvironmentsRequest 
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}:lookupEnvironmentHistory" }),
+    T.Http({ method: "GET", path: "v3/{+name}:lookupEnvironmentHistory" }),
     svc,
   ) as unknown as Schema.Schema<LookupEnvironmentHistoryProjectsLocationsAgentsEnvironmentsRequest>;
 
@@ -15427,7 +15439,7 @@ export const RunContinuousTestProjectsLocationsAgentsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{environment}:runContinuousTest",
+      path: "v3/{+environment}:runContinuousTest",
       hasBody: true,
     }),
     svc,
@@ -15467,7 +15479,7 @@ export const DeployFlowProjectsLocationsAgentsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{environment}:deployFlow",
+      path: "v3/{+environment}:deployFlow",
       hasBody: true,
     }),
     svc,
@@ -15503,7 +15515,7 @@ export const ListProjectsLocationsAgentsEnvironmentsDeploymentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsEnvironmentsDeploymentsRequest>;
 
@@ -15538,7 +15550,7 @@ export const GetProjectsLocationsAgentsEnvironmentsDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsEnvironmentsDeploymentsRequest>;
 
@@ -15576,7 +15588,7 @@ export const DetectIntentProjectsLocationsAgentsEnvironmentsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{session}:detectIntent",
+      path: "v3/{+session}:detectIntent",
       hasBody: true,
     }),
     svc,
@@ -15616,7 +15628,7 @@ export const ServerStreamingDetectIntentProjectsLocationsAgentsEnvironmentsSessi
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{session}:serverStreamingDetectIntent",
+      path: "v3/{+session}:serverStreamingDetectIntent",
       hasBody: true,
     }),
     svc,
@@ -15656,7 +15668,11 @@ export const MatchIntentProjectsLocationsAgentsEnvironmentsSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{session}:matchIntent", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v3/{+session}:matchIntent",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<MatchIntentProjectsLocationsAgentsEnvironmentsSessionsRequest>;
 
@@ -15694,7 +15710,7 @@ export const FulfillIntentProjectsLocationsAgentsEnvironmentsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{session}:fulfillIntent",
+      path: "v3/{+session}:fulfillIntent",
       hasBody: true,
     }),
     svc,
@@ -15731,7 +15747,7 @@ export const ListProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest>;
 
@@ -15766,7 +15782,7 @@ export const GetProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest>;
 
@@ -15802,7 +15818,7 @@ export const CreateProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/entityTypes", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/entityTypes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest>;
 
@@ -15840,7 +15856,7 @@ export const PatchProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest 
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest>;
 
@@ -15871,7 +15887,7 @@ export const DeleteProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest>;
 
@@ -15906,7 +15922,7 @@ export const ListProjectsLocationsAgentsEnvironmentsContinuousTestResultsRequest
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/continuousTestResults" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/continuousTestResults" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsEnvironmentsContinuousTestResultsRequest>;
 
@@ -15945,7 +15961,7 @@ export const ListProjectsLocationsAgentsEnvironmentsExperimentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/experiments" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/experiments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsEnvironmentsExperimentsRequest>;
 
@@ -15980,7 +15996,7 @@ export const GetProjectsLocationsAgentsEnvironmentsExperimentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsEnvironmentsExperimentsRequest>;
 
@@ -16016,7 +16032,7 @@ export const CreateProjectsLocationsAgentsEnvironmentsExperimentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/experiments", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/experiments", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsEnvironmentsExperimentsRequest>;
 
@@ -16054,7 +16070,7 @@ export const PatchProjectsLocationsAgentsEnvironmentsExperimentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsEnvironmentsExperimentsRequest>;
 
@@ -16085,7 +16101,7 @@ export const DeleteProjectsLocationsAgentsEnvironmentsExperimentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsEnvironmentsExperimentsRequest>;
 
@@ -16121,7 +16137,7 @@ export const StartProjectsLocationsAgentsEnvironmentsExperimentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsLocationsAgentsEnvironmentsExperimentsRequest>;
 
@@ -16157,7 +16173,7 @@ export const StopProjectsLocationsAgentsEnvironmentsExperimentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsAgentsEnvironmentsExperimentsRequest>;
 
@@ -16196,7 +16212,7 @@ export const ListProjectsLocationsAgentsGeneratorsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/generators" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/generators" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsGeneratorsRequest>;
 
@@ -16234,7 +16250,7 @@ export const GetProjectsLocationsAgentsGeneratorsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsGeneratorsRequest>;
 
@@ -16273,7 +16289,7 @@ export const CreateProjectsLocationsAgentsGeneratorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/generators", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/generators", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsGeneratorsRequest>;
 
@@ -16314,7 +16330,7 @@ export const PatchProjectsLocationsAgentsGeneratorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsGeneratorsRequest>;
 
@@ -16346,7 +16362,7 @@ export const DeleteProjectsLocationsAgentsGeneratorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsGeneratorsRequest>;
 
@@ -16379,7 +16395,7 @@ export const CreateProjectsLocationsAgentsPlaybooksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDialogflowCxV3Playbook).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/playbooks", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/playbooks", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsPlaybooksRequest>;
 
@@ -16409,7 +16425,7 @@ export const DeleteProjectsLocationsAgentsPlaybooksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsPlaybooksRequest>;
 
@@ -16443,7 +16459,7 @@ export const ListProjectsLocationsAgentsPlaybooksRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/playbooks" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/playbooks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsPlaybooksRequest>;
 
@@ -16477,7 +16493,7 @@ export const GetProjectsLocationsAgentsPlaybooksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsPlaybooksRequest>;
 
@@ -16512,7 +16528,7 @@ export const ExportProjectsLocationsAgentsPlaybooksRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsAgentsPlaybooksRequest>;
 
@@ -16549,7 +16565,7 @@ export const ImportProjectsLocationsAgentsPlaybooksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}/playbooks:import",
+      path: "v3/{+parent}/playbooks:import",
       hasBody: true,
     }),
     svc,
@@ -16586,7 +16602,7 @@ export const PatchProjectsLocationsAgentsPlaybooksRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowCxV3Playbook).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsPlaybooksRequest>;
 
@@ -16619,7 +16635,7 @@ export const CreateProjectsLocationsAgentsPlaybooksExamplesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDialogflowCxV3Example).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/examples", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/examples", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsPlaybooksExamplesRequest>;
 
@@ -16649,7 +16665,7 @@ export const DeleteProjectsLocationsAgentsPlaybooksExamplesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsPlaybooksExamplesRequest>;
 
@@ -16687,7 +16703,7 @@ export const ListProjectsLocationsAgentsPlaybooksExamplesRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/examples" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/examples" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsPlaybooksExamplesRequest>;
 
@@ -16721,7 +16737,7 @@ export const GetProjectsLocationsAgentsPlaybooksExamplesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsPlaybooksExamplesRequest>;
 
@@ -16756,7 +16772,7 @@ export const PatchProjectsLocationsAgentsPlaybooksExamplesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowCxV3Example).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsPlaybooksExamplesRequest>;
 
@@ -16791,7 +16807,7 @@ export const CreateProjectsLocationsAgentsPlaybooksVersionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/versions", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/versions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsPlaybooksVersionsRequest>;
 
@@ -16821,7 +16837,7 @@ export const GetProjectsLocationsAgentsPlaybooksVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsPlaybooksVersionsRequest>;
 
@@ -16856,7 +16872,7 @@ export const RestoreProjectsLocationsAgentsPlaybooksVersionsRequest =
       GoogleCloudDialogflowCxV3RestorePlaybookVersionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsAgentsPlaybooksVersionsRequest>;
 
@@ -16891,7 +16907,7 @@ export const ListProjectsLocationsAgentsPlaybooksVersionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsPlaybooksVersionsRequest>;
 
@@ -16925,7 +16941,7 @@ export const DeleteProjectsLocationsAgentsPlaybooksVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsPlaybooksVersionsRequest>;
 
@@ -16958,7 +16974,7 @@ export const CreateProjectsLocationsAgentsToolsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDialogflowCxV3Tool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/tools", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/tools", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsToolsRequest>;
 
@@ -16992,7 +17008,7 @@ export const ListProjectsLocationsAgentsToolsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/tools" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/tools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsToolsRequest>;
 
@@ -17026,7 +17042,7 @@ export const GetProjectsLocationsAgentsToolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsToolsRequest>;
 
@@ -17061,7 +17077,7 @@ export const PatchProjectsLocationsAgentsToolsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDialogflowCxV3Tool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsToolsRequest>;
 
@@ -17093,7 +17109,7 @@ export const DeleteProjectsLocationsAgentsToolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsToolsRequest>;
 
@@ -17126,7 +17142,7 @@ export const ListProjectsLocationsAgentsToolsVersionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsToolsVersionsRequest>;
 
@@ -17165,7 +17181,7 @@ export const CreateProjectsLocationsAgentsToolsVersionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/versions", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/versions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsToolsVersionsRequest>;
 
@@ -17195,7 +17211,7 @@ export const GetProjectsLocationsAgentsToolsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsToolsVersionsRequest>;
 
@@ -17227,7 +17243,7 @@ export const DeleteProjectsLocationsAgentsToolsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsToolsVersionsRequest>;
 
@@ -17262,7 +17278,7 @@ export const RestoreProjectsLocationsAgentsToolsVersionsRequest =
       GoogleCloudDialogflowCxV3RestoreToolVersionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsAgentsToolsVersionsRequest>;
 

--- a/packages/gcp/src/services/dialogflow-v3beta1.ts
+++ b/packages/gcp/src/services/dialogflow-v3beta1.ts
@@ -12583,7 +12583,7 @@ export const ListProjectsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsOperationsRequest>;
 
@@ -12617,7 +12617,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 
@@ -12646,7 +12646,7 @@ export const CancelProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsOperationsRequest>;
 
@@ -12685,7 +12685,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -12719,7 +12719,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -12758,7 +12758,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -12792,7 +12792,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -12821,7 +12821,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -12857,7 +12857,7 @@ export const CreateProjectsLocationsSecuritySettingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/securitySettings",
+      path: "v3beta1/{+parent}/securitySettings",
       hasBody: true,
     }),
     svc,
@@ -12889,7 +12889,7 @@ export const GetProjectsLocationsSecuritySettingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSecuritySettingsRequest>;
 
@@ -12926,7 +12926,7 @@ export const PatchProjectsLocationsSecuritySettingsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSecuritySettingsRequest>;
 
@@ -12960,7 +12960,7 @@ export const ListProjectsLocationsSecuritySettingsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/securitySettings" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/securitySettings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSecuritySettingsRequest>;
 
@@ -12994,7 +12994,7 @@ export const DeleteProjectsLocationsSecuritySettingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSecuritySettingsRequest>;
 
@@ -13028,7 +13028,7 @@ export const ListProjectsLocationsAgentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/agents" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/agents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsRequest>;
 
@@ -13062,7 +13062,7 @@ export const GetProjectsLocationsAgentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsRequest>;
 
@@ -13097,7 +13097,7 @@ export const CreateProjectsLocationsAgentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{parent}/agents", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+parent}/agents", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsRequest>;
 
@@ -13134,7 +13134,7 @@ export const PatchProjectsLocationsAgentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsRequest>;
 
@@ -13164,7 +13164,7 @@ export const DeleteProjectsLocationsAgentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsRequest>;
 
@@ -13198,7 +13198,7 @@ export const ExportProjectsLocationsAgentsRequest =
       GoogleCloudDialogflowCxV3beta1ExportAgentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsAgentsRequest>;
 
@@ -13232,7 +13232,7 @@ export const RestoreProjectsLocationsAgentsRequest =
       GoogleCloudDialogflowCxV3beta1RestoreAgentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsAgentsRequest>;
 
@@ -13266,7 +13266,7 @@ export const ValidateProjectsLocationsAgentsRequest =
       GoogleCloudDialogflowCxV3beta1ValidateAgentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{name}:validate", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+name}:validate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ValidateProjectsLocationsAgentsRequest>;
 
@@ -13300,7 +13300,7 @@ export const GetValidationResultProjectsLocationsAgentsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetValidationResultProjectsLocationsAgentsRequest>;
 
@@ -13334,7 +13334,7 @@ export const GetGenerativeSettingsProjectsLocationsAgentsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetGenerativeSettingsProjectsLocationsAgentsRequest>;
 
@@ -13371,7 +13371,7 @@ export const UpdateGenerativeSettingsProjectsLocationsAgentsRequest =
       GoogleCloudDialogflowCxV3beta1GenerativeSettings,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateGenerativeSettingsProjectsLocationsAgentsRequest>;
 
@@ -13411,7 +13411,7 @@ export const CreateProjectsLocationsAgentsFlowsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{parent}/flows", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+parent}/flows", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsFlowsRequest>;
 
@@ -13443,7 +13443,7 @@ export const DeleteProjectsLocationsAgentsFlowsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsFlowsRequest>;
 
@@ -13480,7 +13480,7 @@ export const ListProjectsLocationsAgentsFlowsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/flows" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/flows" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsFlowsRequest>;
 
@@ -13518,7 +13518,7 @@ export const GetProjectsLocationsAgentsFlowsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsFlowsRequest>;
 
@@ -13559,7 +13559,7 @@ export const PatchProjectsLocationsAgentsFlowsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsFlowsRequest>;
 
@@ -13594,7 +13594,7 @@ export const TrainProjectsLocationsAgentsFlowsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{name}:train", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+name}:train", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TrainProjectsLocationsAgentsFlowsRequest>;
 
@@ -13629,7 +13629,7 @@ export const ValidateProjectsLocationsAgentsFlowsRequest =
       GoogleCloudDialogflowCxV3beta1ValidateFlowRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{name}:validate", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+name}:validate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ValidateProjectsLocationsAgentsFlowsRequest>;
 
@@ -13663,7 +13663,7 @@ export const GetValidationResultProjectsLocationsAgentsFlowsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetValidationResultProjectsLocationsAgentsFlowsRequest>;
 
@@ -13701,7 +13701,7 @@ export const ImportProjectsLocationsAgentsFlowsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/flows:import",
+      path: "v3beta1/{+parent}/flows:import",
       hasBody: true,
     }),
     svc,
@@ -13738,7 +13738,7 @@ export const ExportProjectsLocationsAgentsFlowsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsAgentsFlowsRequest>;
 
@@ -13776,7 +13776,7 @@ export const ListProjectsLocationsAgentsFlowsPagesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/pages" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/pages" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsFlowsPagesRequest>;
 
@@ -13814,7 +13814,7 @@ export const GetProjectsLocationsAgentsFlowsPagesRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsFlowsPagesRequest>;
 
@@ -13853,7 +13853,7 @@ export const CreateProjectsLocationsAgentsFlowsPagesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{parent}/pages", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+parent}/pages", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsFlowsPagesRequest>;
 
@@ -13894,7 +13894,7 @@ export const PatchProjectsLocationsAgentsFlowsPagesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsFlowsPagesRequest>;
 
@@ -13926,7 +13926,7 @@ export const DeleteProjectsLocationsAgentsFlowsPagesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsFlowsPagesRequest>;
 
@@ -13964,7 +13964,7 @@ export const ListProjectsLocationsAgentsFlowsTransitionRouteGroupsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/transitionRouteGroups" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/transitionRouteGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsFlowsTransitionRouteGroupsRequest>;
 
@@ -14003,7 +14003,7 @@ export const GetProjectsLocationsAgentsFlowsTransitionRouteGroupsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsFlowsTransitionRouteGroupsRequest>;
 
@@ -14045,7 +14045,7 @@ export const CreateProjectsLocationsAgentsFlowsTransitionRouteGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/transitionRouteGroups",
+      path: "v3beta1/{+parent}/transitionRouteGroups",
       hasBody: true,
     }),
     svc,
@@ -14089,7 +14089,7 @@ export const PatchProjectsLocationsAgentsFlowsTransitionRouteGroupsRequest =
       GoogleCloudDialogflowCxV3beta1TransitionRouteGroup,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsFlowsTransitionRouteGroupsRequest>;
 
@@ -14122,7 +14122,7 @@ export const DeleteProjectsLocationsAgentsFlowsTransitionRouteGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsFlowsTransitionRouteGroupsRequest>;
 
@@ -14157,7 +14157,7 @@ export const ListProjectsLocationsAgentsFlowsVersionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsFlowsVersionsRequest>;
 
@@ -14191,7 +14191,7 @@ export const GetProjectsLocationsAgentsFlowsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsFlowsVersionsRequest>;
 
@@ -14228,7 +14228,7 @@ export const CreateProjectsLocationsAgentsFlowsVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/versions",
+      path: "v3beta1/{+parent}/versions",
       hasBody: true,
     }),
     svc,
@@ -14267,7 +14267,7 @@ export const PatchProjectsLocationsAgentsFlowsVersionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsFlowsVersionsRequest>;
 
@@ -14297,7 +14297,7 @@ export const DeleteProjectsLocationsAgentsFlowsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsFlowsVersionsRequest>;
 
@@ -14332,7 +14332,7 @@ export const LoadProjectsLocationsAgentsFlowsVersionsRequest =
       GoogleCloudDialogflowCxV3beta1LoadVersionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{name}:load", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+name}:load", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<LoadProjectsLocationsAgentsFlowsVersionsRequest>;
 
@@ -14369,7 +14369,7 @@ export const CompareVersionsProjectsLocationsAgentsFlowsVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{baseVersion}:compareVersions",
+      path: "v3beta1/{+baseVersion}:compareVersions",
       hasBody: true,
     }),
     svc,
@@ -14408,7 +14408,7 @@ export const ListProjectsLocationsAgentsChangelogsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/changelogs" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/changelogs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsChangelogsRequest>;
 
@@ -14442,7 +14442,7 @@ export const GetProjectsLocationsAgentsChangelogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsChangelogsRequest>;
 
@@ -14486,7 +14486,7 @@ export const ListProjectsLocationsAgentsIntentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/intents" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/intents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsIntentsRequest>;
 
@@ -14524,7 +14524,7 @@ export const GetProjectsLocationsAgentsIntentsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsIntentsRequest>;
 
@@ -14563,7 +14563,11 @@ export const CreateProjectsLocationsAgentsIntentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{parent}/intents", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v3beta1/{+parent}/intents",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsIntentsRequest>;
 
@@ -14604,7 +14608,7 @@ export const PatchProjectsLocationsAgentsIntentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsIntentsRequest>;
 
@@ -14634,7 +14638,7 @@ export const DeleteProjectsLocationsAgentsIntentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsIntentsRequest>;
 
@@ -14670,7 +14674,7 @@ export const ImportProjectsLocationsAgentsIntentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/intents:import",
+      path: "v3beta1/{+parent}/intents:import",
       hasBody: true,
     }),
     svc,
@@ -14709,7 +14713,7 @@ export const ExportProjectsLocationsAgentsIntentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/intents:export",
+      path: "v3beta1/{+parent}/intents:export",
       hasBody: true,
     }),
     svc,
@@ -14745,7 +14749,7 @@ export const GetProjectsLocationsAgentsEntityTypesRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsEntityTypesRequest>;
 
@@ -14786,7 +14790,7 @@ export const CreateProjectsLocationsAgentsEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/entityTypes",
+      path: "v3beta1/{+parent}/entityTypes",
       hasBody: true,
     }),
     svc,
@@ -14829,7 +14833,7 @@ export const PatchProjectsLocationsAgentsEntityTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsEntityTypesRequest>;
 
@@ -14861,7 +14865,7 @@ export const DeleteProjectsLocationsAgentsEntityTypesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsEntityTypesRequest>;
 
@@ -14899,7 +14903,7 @@ export const ListProjectsLocationsAgentsEntityTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsEntityTypesRequest>;
 
@@ -14940,7 +14944,7 @@ export const ExportProjectsLocationsAgentsEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/entityTypes:export",
+      path: "v3beta1/{+parent}/entityTypes:export",
       hasBody: true,
     }),
     svc,
@@ -14979,7 +14983,7 @@ export const ImportProjectsLocationsAgentsEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/entityTypes:import",
+      path: "v3beta1/{+parent}/entityTypes:import",
       hasBody: true,
     }),
     svc,
@@ -15018,7 +15022,7 @@ export const DetectIntentProjectsLocationsAgentsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{session}:detectIntent",
+      path: "v3beta1/{+session}:detectIntent",
       hasBody: true,
     }),
     svc,
@@ -15057,7 +15061,7 @@ export const ServerStreamingDetectIntentProjectsLocationsAgentsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{session}:serverStreamingDetectIntent",
+      path: "v3beta1/{+session}:serverStreamingDetectIntent",
       hasBody: true,
     }),
     svc,
@@ -15097,7 +15101,7 @@ export const MatchIntentProjectsLocationsAgentsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{session}:matchIntent",
+      path: "v3beta1/{+session}:matchIntent",
       hasBody: true,
     }),
     svc,
@@ -15136,7 +15140,7 @@ export const FulfillIntentProjectsLocationsAgentsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{session}:fulfillIntent",
+      path: "v3beta1/{+session}:fulfillIntent",
       hasBody: true,
     }),
     svc,
@@ -15175,7 +15179,7 @@ export const SubmitAnswerFeedbackProjectsLocationsAgentsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{session}:submitAnswerFeedback",
+      path: "v3beta1/{+session}:submitAnswerFeedback",
       hasBody: true,
     }),
     svc,
@@ -15212,7 +15216,7 @@ export const ListProjectsLocationsAgentsSessionsEntityTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsSessionsEntityTypesRequest>;
 
@@ -15246,7 +15250,7 @@ export const GetProjectsLocationsAgentsSessionsEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsSessionsEntityTypesRequest>;
 
@@ -15283,7 +15287,7 @@ export const CreateProjectsLocationsAgentsSessionsEntityTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/entityTypes",
+      path: "v3beta1/{+parent}/entityTypes",
       hasBody: true,
     }),
     svc,
@@ -15323,7 +15327,7 @@ export const PatchProjectsLocationsAgentsSessionsEntityTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsSessionsEntityTypesRequest>;
 
@@ -15354,7 +15358,7 @@ export const DeleteProjectsLocationsAgentsSessionsEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsSessionsEntityTypesRequest>;
 
@@ -15393,7 +15397,7 @@ export const ListProjectsLocationsAgentsTransitionRouteGroupsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/transitionRouteGroups" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/transitionRouteGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsTransitionRouteGroupsRequest>;
 
@@ -15432,7 +15436,7 @@ export const GetProjectsLocationsAgentsTransitionRouteGroupsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsTransitionRouteGroupsRequest>;
 
@@ -15474,7 +15478,7 @@ export const CreateProjectsLocationsAgentsTransitionRouteGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/transitionRouteGroups",
+      path: "v3beta1/{+parent}/transitionRouteGroups",
       hasBody: true,
     }),
     svc,
@@ -15518,7 +15522,7 @@ export const PatchProjectsLocationsAgentsTransitionRouteGroupsRequest =
       GoogleCloudDialogflowCxV3beta1TransitionRouteGroup,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsTransitionRouteGroupsRequest>;
 
@@ -15551,7 +15555,7 @@ export const DeleteProjectsLocationsAgentsTransitionRouteGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsTransitionRouteGroupsRequest>;
 
@@ -15588,7 +15592,7 @@ export const ListProjectsLocationsAgentsTestCasesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/testCases" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/testCases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsTestCasesRequest>;
 
@@ -15629,7 +15633,7 @@ export const BatchDeleteProjectsLocationsAgentsTestCasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/testCases:batchDelete",
+      path: "v3beta1/{+parent}/testCases:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -15661,7 +15665,7 @@ export const GetProjectsLocationsAgentsTestCasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsTestCasesRequest>;
 
@@ -15698,7 +15702,7 @@ export const CreateProjectsLocationsAgentsTestCasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/testCases",
+      path: "v3beta1/{+parent}/testCases",
       hasBody: true,
     }),
     svc,
@@ -15737,7 +15741,7 @@ export const PatchProjectsLocationsAgentsTestCasesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsTestCasesRequest>;
 
@@ -15772,7 +15776,7 @@ export const RunProjectsLocationsAgentsTestCasesRequest =
       GoogleCloudDialogflowCxV3beta1RunTestCaseRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsAgentsTestCasesRequest>;
 
@@ -15809,7 +15813,7 @@ export const BatchRunProjectsLocationsAgentsTestCasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/testCases:batchRun",
+      path: "v3beta1/{+parent}/testCases:batchRun",
       hasBody: true,
     }),
     svc,
@@ -15850,7 +15854,7 @@ export const CalculateCoverageProjectsLocationsAgentsTestCasesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3beta1/{agent}/testCases:calculateCoverage",
+      path: "v3beta1/{+agent}/testCases:calculateCoverage",
     }),
     svc,
   ) as unknown as Schema.Schema<CalculateCoverageProjectsLocationsAgentsTestCasesRequest>;
@@ -15889,7 +15893,7 @@ export const ImportProjectsLocationsAgentsTestCasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/testCases:import",
+      path: "v3beta1/{+parent}/testCases:import",
       hasBody: true,
     }),
     svc,
@@ -15928,7 +15932,7 @@ export const ExportProjectsLocationsAgentsTestCasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/testCases:export",
+      path: "v3beta1/{+parent}/testCases:export",
       hasBody: true,
     }),
     svc,
@@ -15966,7 +15970,7 @@ export const ListProjectsLocationsAgentsTestCasesResultsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/results" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/results" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsTestCasesResultsRequest>;
 
@@ -16000,7 +16004,7 @@ export const GetProjectsLocationsAgentsTestCasesResultsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsTestCasesResultsRequest>;
 
@@ -16034,7 +16038,7 @@ export const ListProjectsLocationsAgentsWebhooksRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/webhooks" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/webhooks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsWebhooksRequest>;
 
@@ -16068,7 +16072,7 @@ export const GetProjectsLocationsAgentsWebhooksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsWebhooksRequest>;
 
@@ -16105,7 +16109,7 @@ export const CreateProjectsLocationsAgentsWebhooksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/webhooks",
+      path: "v3beta1/{+parent}/webhooks",
       hasBody: true,
     }),
     svc,
@@ -16144,7 +16148,7 @@ export const PatchProjectsLocationsAgentsWebhooksRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsWebhooksRequest>;
 
@@ -16176,7 +16180,7 @@ export const DeleteProjectsLocationsAgentsWebhooksRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsWebhooksRequest>;
 
@@ -16209,7 +16213,7 @@ export const ListProjectsLocationsAgentsEnvironmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/environments" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/environments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsEnvironmentsRequest>;
 
@@ -16243,7 +16247,7 @@ export const GetProjectsLocationsAgentsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsEnvironmentsRequest>;
 
@@ -16280,7 +16284,7 @@ export const CreateProjectsLocationsAgentsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/environments",
+      path: "v3beta1/{+parent}/environments",
       hasBody: true,
     }),
     svc,
@@ -16319,7 +16323,7 @@ export const PatchProjectsLocationsAgentsEnvironmentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsEnvironmentsRequest>;
 
@@ -16349,7 +16353,7 @@ export const DeleteProjectsLocationsAgentsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsEnvironmentsRequest>;
 
@@ -16383,7 +16387,7 @@ export const LookupEnvironmentHistoryProjectsLocationsAgentsEnvironmentsRequest 
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}:lookupEnvironmentHistory" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}:lookupEnvironmentHistory" }),
     svc,
   ) as unknown as Schema.Schema<LookupEnvironmentHistoryProjectsLocationsAgentsEnvironmentsRequest>;
 
@@ -16425,7 +16429,7 @@ export const RunContinuousTestProjectsLocationsAgentsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{environment}:runContinuousTest",
+      path: "v3beta1/{+environment}:runContinuousTest",
       hasBody: true,
     }),
     svc,
@@ -16465,7 +16469,7 @@ export const DeployFlowProjectsLocationsAgentsEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{environment}:deployFlow",
+      path: "v3beta1/{+environment}:deployFlow",
       hasBody: true,
     }),
     svc,
@@ -16504,7 +16508,7 @@ export const DetectIntentProjectsLocationsAgentsEnvironmentsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{session}:detectIntent",
+      path: "v3beta1/{+session}:detectIntent",
       hasBody: true,
     }),
     svc,
@@ -16544,7 +16548,7 @@ export const ServerStreamingDetectIntentProjectsLocationsAgentsEnvironmentsSessi
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{session}:serverStreamingDetectIntent",
+      path: "v3beta1/{+session}:serverStreamingDetectIntent",
       hasBody: true,
     }),
     svc,
@@ -16586,7 +16590,7 @@ export const MatchIntentProjectsLocationsAgentsEnvironmentsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{session}:matchIntent",
+      path: "v3beta1/{+session}:matchIntent",
       hasBody: true,
     }),
     svc,
@@ -16626,7 +16630,7 @@ export const FulfillIntentProjectsLocationsAgentsEnvironmentsSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{session}:fulfillIntent",
+      path: "v3beta1/{+session}:fulfillIntent",
       hasBody: true,
     }),
     svc,
@@ -16663,7 +16667,7 @@ export const ListProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/entityTypes" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/entityTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest>;
 
@@ -16698,7 +16702,7 @@ export const GetProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest>;
 
@@ -16736,7 +16740,7 @@ export const CreateProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/entityTypes",
+      path: "v3beta1/{+parent}/entityTypes",
       hasBody: true,
     }),
     svc,
@@ -16776,7 +16780,7 @@ export const PatchProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest 
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest>;
 
@@ -16807,7 +16811,7 @@ export const DeleteProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsEnvironmentsSessionsEntityTypesRequest>;
 
@@ -16842,7 +16846,7 @@ export const ListProjectsLocationsAgentsEnvironmentsContinuousTestResultsRequest
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/continuousTestResults" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/continuousTestResults" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsEnvironmentsContinuousTestResultsRequest>;
 
@@ -16881,7 +16885,7 @@ export const ListProjectsLocationsAgentsEnvironmentsDeploymentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsEnvironmentsDeploymentsRequest>;
 
@@ -16916,7 +16920,7 @@ export const GetProjectsLocationsAgentsEnvironmentsDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsEnvironmentsDeploymentsRequest>;
 
@@ -16951,7 +16955,7 @@ export const ListProjectsLocationsAgentsEnvironmentsExperimentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/experiments" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/experiments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsEnvironmentsExperimentsRequest>;
 
@@ -16986,7 +16990,7 @@ export const GetProjectsLocationsAgentsEnvironmentsExperimentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsEnvironmentsExperimentsRequest>;
 
@@ -17024,7 +17028,7 @@ export const CreateProjectsLocationsAgentsEnvironmentsExperimentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/experiments",
+      path: "v3beta1/{+parent}/experiments",
       hasBody: true,
     }),
     svc,
@@ -17064,7 +17068,7 @@ export const PatchProjectsLocationsAgentsEnvironmentsExperimentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsEnvironmentsExperimentsRequest>;
 
@@ -17095,7 +17099,7 @@ export const DeleteProjectsLocationsAgentsEnvironmentsExperimentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsEnvironmentsExperimentsRequest>;
 
@@ -17131,7 +17135,7 @@ export const StartProjectsLocationsAgentsEnvironmentsExperimentsRequest =
       GoogleCloudDialogflowCxV3beta1StartExperimentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsLocationsAgentsEnvironmentsExperimentsRequest>;
 
@@ -17167,7 +17171,7 @@ export const StopProjectsLocationsAgentsEnvironmentsExperimentsRequest =
       GoogleCloudDialogflowCxV3beta1StopExperimentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsAgentsEnvironmentsExperimentsRequest>;
 
@@ -17204,7 +17208,7 @@ export const ListProjectsLocationsAgentsConversationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsConversationsRequest>;
 
@@ -17238,7 +17242,7 @@ export const GetProjectsLocationsAgentsConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsConversationsRequest>;
 
@@ -17268,7 +17272,7 @@ export const DeleteProjectsLocationsAgentsConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsConversationsRequest>;
 
@@ -17306,7 +17310,7 @@ export const ListProjectsLocationsAgentsGeneratorsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/generators" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/generators" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsGeneratorsRequest>;
 
@@ -17344,7 +17348,7 @@ export const GetProjectsLocationsAgentsGeneratorsRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsGeneratorsRequest>;
 
@@ -17385,7 +17389,7 @@ export const CreateProjectsLocationsAgentsGeneratorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/generators",
+      path: "v3beta1/{+parent}/generators",
       hasBody: true,
     }),
     svc,
@@ -17428,7 +17432,7 @@ export const PatchProjectsLocationsAgentsGeneratorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsGeneratorsRequest>;
 
@@ -17460,7 +17464,7 @@ export const DeleteProjectsLocationsAgentsGeneratorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsGeneratorsRequest>;
 
@@ -17497,7 +17501,7 @@ export const CreateProjectsLocationsAgentsPlaybooksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/playbooks",
+      path: "v3beta1/{+parent}/playbooks",
       hasBody: true,
     }),
     svc,
@@ -17529,7 +17533,7 @@ export const DeleteProjectsLocationsAgentsPlaybooksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsPlaybooksRequest>;
 
@@ -17563,7 +17567,7 @@ export const ListProjectsLocationsAgentsPlaybooksRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/playbooks" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/playbooks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsPlaybooksRequest>;
 
@@ -17597,7 +17601,7 @@ export const GetProjectsLocationsAgentsPlaybooksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsPlaybooksRequest>;
 
@@ -17632,7 +17636,7 @@ export const ExportProjectsLocationsAgentsPlaybooksRequest =
       GoogleCloudDialogflowCxV3beta1ExportPlaybookRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsAgentsPlaybooksRequest>;
 
@@ -17669,7 +17673,7 @@ export const ImportProjectsLocationsAgentsPlaybooksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/playbooks:import",
+      path: "v3beta1/{+parent}/playbooks:import",
       hasBody: true,
     }),
     svc,
@@ -17708,7 +17712,7 @@ export const PatchProjectsLocationsAgentsPlaybooksRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsPlaybooksRequest>;
 
@@ -17745,7 +17749,7 @@ export const CreateProjectsLocationsAgentsPlaybooksExamplesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/examples",
+      path: "v3beta1/{+parent}/examples",
       hasBody: true,
     }),
     svc,
@@ -17777,7 +17781,7 @@ export const DeleteProjectsLocationsAgentsPlaybooksExamplesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsPlaybooksExamplesRequest>;
 
@@ -17815,7 +17819,7 @@ export const ListProjectsLocationsAgentsPlaybooksExamplesRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/examples" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/examples" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsPlaybooksExamplesRequest>;
 
@@ -17849,7 +17853,7 @@ export const GetProjectsLocationsAgentsPlaybooksExamplesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsPlaybooksExamplesRequest>;
 
@@ -17886,7 +17890,7 @@ export const PatchProjectsLocationsAgentsPlaybooksExamplesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsPlaybooksExamplesRequest>;
 
@@ -17923,7 +17927,7 @@ export const CreateProjectsLocationsAgentsPlaybooksVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/versions",
+      path: "v3beta1/{+parent}/versions",
       hasBody: true,
     }),
     svc,
@@ -17955,7 +17959,7 @@ export const GetProjectsLocationsAgentsPlaybooksVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsPlaybooksVersionsRequest>;
 
@@ -17990,7 +17994,7 @@ export const RestoreProjectsLocationsAgentsPlaybooksVersionsRequest =
       GoogleCloudDialogflowCxV3beta1RestorePlaybookVersionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsAgentsPlaybooksVersionsRequest>;
 
@@ -18025,7 +18029,7 @@ export const ListProjectsLocationsAgentsPlaybooksVersionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsPlaybooksVersionsRequest>;
 
@@ -18059,7 +18063,7 @@ export const DeleteProjectsLocationsAgentsPlaybooksVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsPlaybooksVersionsRequest>;
 
@@ -18094,7 +18098,7 @@ export const CreateProjectsLocationsAgentsToolsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{parent}/tools", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+parent}/tools", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAgentsToolsRequest>;
 
@@ -18128,7 +18132,7 @@ export const ListProjectsLocationsAgentsToolsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/tools" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/tools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsToolsRequest>;
 
@@ -18169,7 +18173,7 @@ export const ExportProjectsLocationsAgentsToolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/tools:export",
+      path: "v3beta1/{+parent}/tools:export",
       hasBody: true,
     }),
     svc,
@@ -18201,7 +18205,7 @@ export const GetProjectsLocationsAgentsToolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsToolsRequest>;
 
@@ -18238,7 +18242,7 @@ export const PatchProjectsLocationsAgentsToolsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentsToolsRequest>;
 
@@ -18270,7 +18274,7 @@ export const DeleteProjectsLocationsAgentsToolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsToolsRequest>;
 
@@ -18303,7 +18307,7 @@ export const ListProjectsLocationsAgentsToolsVersionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentsToolsVersionsRequest>;
 
@@ -18344,7 +18348,7 @@ export const CreateProjectsLocationsAgentsToolsVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/versions",
+      path: "v3beta1/{+parent}/versions",
       hasBody: true,
     }),
     svc,
@@ -18376,7 +18380,7 @@ export const GetProjectsLocationsAgentsToolsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentsToolsVersionsRequest>;
 
@@ -18408,7 +18412,7 @@ export const DeleteProjectsLocationsAgentsToolsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentsToolsVersionsRequest>;
 
@@ -18443,7 +18447,7 @@ export const RestoreProjectsLocationsAgentsToolsVersionsRequest =
       GoogleCloudDialogflowCxV3beta1RestoreToolVersionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsAgentsToolsVersionsRequest>;
 

--- a/packages/gcp/src/services/discoveryengine-v1.ts
+++ b/packages/gcp/src/services/discoveryengine-v1.ts
@@ -20586,7 +20586,7 @@ export const DistributeLicenseConfigBillingAccountsBillingAccountLicenseConfigsR
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{billingAccountLicenseConfig}:distributeLicenseConfig",
+      path: "v1/{+billingAccountLicenseConfig}:distributeLicenseConfig",
       hasBody: true,
     }),
     svc,
@@ -20632,7 +20632,7 @@ export const RetractLicenseConfigBillingAccountsBillingAccountLicenseConfigsRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{billingAccountLicenseConfig}:retractLicenseConfig",
+      path: "v1/{+billingAccountLicenseConfig}:retractLicenseConfig",
       hasBody: true,
     }),
     svc,
@@ -20673,7 +20673,7 @@ export const ProvisionProjectsRequest =
       GoogleCloudDiscoveryengineV1ProvisionProjectRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:provision", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:provision", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ProvisionProjectsRequest>;
 
@@ -20721,7 +20721,7 @@ export const SetUpDataConnectorV2ProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:setUpDataConnectorV2",
+      path: "v1/{+parent}:setUpDataConnectorV2",
       hasBody: true,
     }),
     svc,
@@ -20755,7 +20755,7 @@ export const GetAclConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAclConfigProjectsLocationsRequest>;
 
@@ -20795,7 +20795,7 @@ export const UpdateCmekConfigProjectsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateCmekConfigProjectsLocationsRequest>;
 
@@ -20832,7 +20832,7 @@ export const UpdateAclConfigProjectsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAclConfigProjectsLocationsRequest>;
 
@@ -20864,7 +20864,7 @@ export const GetCmekConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCmekConfigProjectsLocationsRequest>;
 
@@ -20903,7 +20903,7 @@ export const SetUpDataConnectorProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:setUpDataConnector",
+      path: "v1/{+parent}:setUpDataConnector",
       hasBody: true,
     }),
     svc,
@@ -20944,7 +20944,7 @@ export const ImportProjectsLocationsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/userEvents:import",
+      path: "v1/{+parent}/userEvents:import",
       hasBody: true,
     }),
     svc,
@@ -20988,7 +20988,7 @@ export const WriteProjectsLocationsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/userEvents:write",
+      path: "v1/{+parent}/userEvents:write",
       hasBody: true,
     }),
     svc,
@@ -21031,7 +21031,7 @@ export const CollectProjectsLocationsUserEventsRequest =
     userEvent: Schema.optional(Schema.String).pipe(T.HttpQuery("userEvent")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/userEvents:collect" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/userEvents:collect" }),
     svc,
   ) as unknown as Schema.Schema<CollectProjectsLocationsUserEventsRequest>;
 
@@ -21062,7 +21062,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -21107,7 +21107,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -21150,7 +21150,7 @@ export const CheckProjectsLocationsGroundingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{groundingConfig}:check",
+      path: "v1/{+groundingConfig}:check",
       hasBody: true,
     }),
     svc,
@@ -21184,7 +21184,7 @@ export const ListProjectsLocationsCmekConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/cmekConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/cmekConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCmekConfigsRequest>;
 
@@ -21216,7 +21216,7 @@ export const DeleteProjectsLocationsCmekConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCmekConfigsRequest>;
 
@@ -21248,7 +21248,7 @@ export const GetProjectsLocationsCmekConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCmekConfigsRequest>;
 
@@ -21288,7 +21288,7 @@ export const PatchProjectsLocationsCmekConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCmekConfigsRequest>;
 
@@ -21320,7 +21320,7 @@ export const GetProjectsLocationsPodcastsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPodcastsOperationsRequest>;
 
@@ -21357,7 +21357,7 @@ export const RankProjectsLocationsRankingConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{rankingConfig}:rank", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+rankingConfig}:rank", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RankProjectsLocationsRankingConfigsRequest>;
 
@@ -21398,7 +21398,7 @@ export const ListProjectsLocationsDataStoresRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dataStores" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dataStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresRequest>;
 
@@ -21464,7 +21464,7 @@ export const CreateProjectsLocationsDataStoresRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/dataStores", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/dataStores", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataStoresRequest>;
 
@@ -21496,7 +21496,7 @@ export const DeleteProjectsLocationsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresRequest>;
 
@@ -21544,7 +21544,7 @@ export const CompleteQueryProjectsLocationsDataStoresRequest =
     ),
     dataStore: Schema.String.pipe(T.HttpPath("dataStore")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{dataStore}:completeQuery" }),
+    T.Http({ method: "GET", path: "v1/{+dataStore}:completeQuery" }),
     svc,
   ) as unknown as Schema.Schema<CompleteQueryProjectsLocationsDataStoresRequest>;
 
@@ -21576,7 +21576,7 @@ export const GetProjectsLocationsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresRequest>;
 
@@ -21608,7 +21608,7 @@ export const GetSiteSearchEngineProjectsLocationsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSiteSearchEngineProjectsLocationsDataStoresRequest>;
 
@@ -21648,7 +21648,7 @@ export const PatchProjectsLocationsDataStoresRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresRequest>;
 
@@ -21686,7 +21686,7 @@ export const ListProjectsLocationsDataStoresSchemasRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/schemas" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/schemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresSchemasRequest>;
 
@@ -21730,7 +21730,7 @@ export const CreateProjectsLocationsDataStoresSchemasRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/schemas", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/schemas", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataStoresSchemasRequest>;
 
@@ -21762,7 +21762,7 @@ export const GetProjectsLocationsDataStoresSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresSchemasRequest>;
 
@@ -21794,7 +21794,7 @@ export const DeleteProjectsLocationsDataStoresSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresSchemasRequest>;
 
@@ -21836,7 +21836,7 @@ export const PatchProjectsLocationsDataStoresSchemasRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresSchemasRequest>;
 
@@ -21875,7 +21875,7 @@ export const CompleteQueryProjectsLocationsDataStoresCompletionConfigRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{completionConfig}:completeQuery",
+      path: "v1/{+completionConfig}:completeQuery",
       hasBody: true,
     }),
     svc,
@@ -21919,7 +21919,7 @@ export const CollectProjectsLocationsDataStoresUserEventsRequest =
     ets: Schema.optional(Schema.String).pipe(T.HttpQuery("ets")),
     userEvent: Schema.optional(Schema.String).pipe(T.HttpQuery("userEvent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/userEvents:collect" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/userEvents:collect" }),
     svc,
   ) as unknown as Schema.Schema<CollectProjectsLocationsDataStoresUserEventsRequest>;
 
@@ -21961,7 +21961,7 @@ export const WriteProjectsLocationsDataStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/userEvents:write",
+      path: "v1/{+parent}/userEvents:write",
       hasBody: true,
     }),
     svc,
@@ -22002,7 +22002,7 @@ export const ImportProjectsLocationsDataStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/userEvents:import",
+      path: "v1/{+parent}/userEvents:import",
       hasBody: true,
     }),
     svc,
@@ -22043,7 +22043,7 @@ export const PurgeProjectsLocationsDataStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/userEvents:purge",
+      path: "v1/{+parent}/userEvents:purge",
       hasBody: true,
     }),
     svc,
@@ -22091,7 +22091,7 @@ export const ListProjectsLocationsDataStoresModelsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresModelsOperationsRequest>;
 
@@ -22128,7 +22128,7 @@ export const GetProjectsLocationsDataStoresModelsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresModelsOperationsRequest>;
 
@@ -22160,7 +22160,7 @@ export const DeleteProjectsLocationsDataStoresControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresControlsRequest>;
 
@@ -22192,7 +22192,7 @@ export const GetProjectsLocationsDataStoresControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresControlsRequest>;
 
@@ -22233,7 +22233,7 @@ export const ListProjectsLocationsDataStoresControlsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/controls" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/controls" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresControlsRequest>;
 
@@ -22277,7 +22277,7 @@ export const PatchProjectsLocationsDataStoresControlsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresControlsRequest>;
 
@@ -22317,7 +22317,7 @@ export const CreateProjectsLocationsDataStoresControlsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/controls", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/controls", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataStoresControlsRequest>;
 
@@ -22361,7 +22361,7 @@ export const GetProjectsLocationsDataStoresWidgetConfigsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresWidgetConfigsRequest>;
 
@@ -22401,7 +22401,7 @@ export const PatchProjectsLocationsDataStoresWidgetConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresWidgetConfigsRequest>;
 
@@ -22440,7 +22440,7 @@ export const SearchProjectsLocationsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{servingConfig}:search",
+      path: "v1/{+servingConfig}:search",
       hasBody: true,
     }),
     svc,
@@ -22475,7 +22475,7 @@ export const GetProjectsLocationsDataStoresServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresServingConfigsRequest>;
 
@@ -22514,7 +22514,7 @@ export const AnswerProjectsLocationsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{servingConfig}:answer",
+      path: "v1/{+servingConfig}:answer",
       hasBody: true,
     }),
     svc,
@@ -22556,7 +22556,7 @@ export const StreamAnswerProjectsLocationsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{servingConfig}:streamAnswer",
+      path: "v1/{+servingConfig}:streamAnswer",
       hasBody: true,
     }),
     svc,
@@ -22599,7 +22599,7 @@ export const PatchProjectsLocationsDataStoresServingConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresServingConfigsRequest>;
 
@@ -22638,7 +22638,7 @@ export const RecommendProjectsLocationsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{servingConfig}:recommend",
+      path: "v1/{+servingConfig}:recommend",
       hasBody: true,
     }),
     svc,
@@ -22679,7 +22679,7 @@ export const ListProjectsLocationsDataStoresServingConfigsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/servingConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/servingConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresServingConfigsRequest>;
 
@@ -22715,7 +22715,7 @@ export const DeleteProjectsLocationsDataStoresServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresServingConfigsRequest>;
 
@@ -22760,7 +22760,7 @@ export const CreateProjectsLocationsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/servingConfigs",
+      path: "v1/{+parent}/servingConfigs",
       hasBody: true,
     }),
     svc,
@@ -22802,7 +22802,7 @@ export const SearchLiteProjectsLocationsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{servingConfig}:searchLite",
+      path: "v1/{+servingConfig}:searchLite",
       hasBody: true,
     }),
     svc,
@@ -22845,7 +22845,7 @@ export const PatchProjectsLocationsDataStoresConversationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresConversationsRequest>;
 
@@ -22877,7 +22877,7 @@ export const DeleteProjectsLocationsDataStoresConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresConversationsRequest>;
 
@@ -22916,7 +22916,7 @@ export const CreateProjectsLocationsDataStoresConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/conversations",
+      path: "v1/{+parent}/conversations",
       hasBody: true,
     }),
     svc,
@@ -22955,7 +22955,7 @@ export const ConverseProjectsLocationsDataStoresConversationsRequest =
       GoogleCloudDiscoveryengineV1ConverseConversationRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:converse", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:converse", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ConverseProjectsLocationsDataStoresConversationsRequest>;
 
@@ -23000,7 +23000,7 @@ export const ListProjectsLocationsDataStoresConversationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresConversationsRequest>;
 
@@ -23036,7 +23036,7 @@ export const GetProjectsLocationsDataStoresConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresConversationsRequest>;
 
@@ -23068,7 +23068,7 @@ export const GetProjectsLocationsDataStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresOperationsRequest>;
 
@@ -23114,7 +23114,7 @@ export const ListProjectsLocationsDataStoresOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresOperationsRequest>;
 
@@ -23158,7 +23158,7 @@ export const PatchProjectsLocationsDataStoresSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresSessionsRequest>;
 
@@ -23198,7 +23198,7 @@ export const CreateProjectsLocationsDataStoresSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/sessions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/sessions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataStoresSessionsRequest>;
 
@@ -23242,7 +23242,7 @@ export const ListProjectsLocationsDataStoresSessionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sessions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sessions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresSessionsRequest>;
 
@@ -23283,7 +23283,7 @@ export const GetProjectsLocationsDataStoresSessionsRequest =
       T.HttpQuery("includeAnswerDetails"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresSessionsRequest>;
 
@@ -23315,7 +23315,7 @@ export const DeleteProjectsLocationsDataStoresSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresSessionsRequest>;
 
@@ -23347,7 +23347,7 @@ export const GetProjectsLocationsDataStoresSessionsAnswersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresSessionsAnswersRequest>;
 
@@ -23386,7 +23386,7 @@ export const PurgeProjectsLocationsDataStoresSuggestionDenyListEntriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/suggestionDenyListEntries:purge",
+      path: "v1/{+parent}/suggestionDenyListEntries:purge",
       hasBody: true,
     }),
     svc,
@@ -23428,7 +23428,7 @@ export const ImportProjectsLocationsDataStoresSuggestionDenyListEntriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/suggestionDenyListEntries:import",
+      path: "v1/{+parent}/suggestionDenyListEntries:import",
       hasBody: true,
     }),
     svc,
@@ -23470,7 +23470,7 @@ export const RecrawlUrisProjectsLocationsDataStoresSiteSearchEngineRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{siteSearchEngine}:recrawlUris",
+      path: "v1/{+siteSearchEngine}:recrawlUris",
       hasBody: true,
     }),
     svc,
@@ -23512,7 +23512,7 @@ export const DisableAdvancedSiteSearchProjectsLocationsDataStoresSiteSearchEngin
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{siteSearchEngine}:disableAdvancedSiteSearch",
+      path: "v1/{+siteSearchEngine}:disableAdvancedSiteSearch",
       hasBody: true,
     }),
     svc,
@@ -23556,7 +23556,7 @@ export const EnableAdvancedSiteSearchProjectsLocationsDataStoresSiteSearchEngine
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{siteSearchEngine}:enableAdvancedSiteSearch",
+      path: "v1/{+siteSearchEngine}:enableAdvancedSiteSearch",
       hasBody: true,
     }),
     svc,
@@ -23598,7 +23598,7 @@ export const CreateProjectsLocationsDataStoresSiteSearchEngineSitemapsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/sitemaps", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/sitemaps", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataStoresSiteSearchEngineSitemapsRequest>;
 
@@ -23631,7 +23631,7 @@ export const DeleteProjectsLocationsDataStoresSiteSearchEngineSitemapsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresSiteSearchEngineSitemapsRequest>;
 
@@ -23669,7 +23669,7 @@ export const FetchProjectsLocationsDataStoresSiteSearchEngineSitemapsRequest =
       Schema.Array(Schema.String),
     ).pipe(T.HttpQuery("matcher.urisMatcher.uris")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sitemaps:fetch" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sitemaps:fetch" }),
     svc,
   ) as unknown as Schema.Schema<FetchProjectsLocationsDataStoresSiteSearchEngineSitemapsRequest>;
 
@@ -23707,7 +23707,7 @@ export const CreateProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/targetSites", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/targetSites", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -23745,7 +23745,7 @@ export const PatchProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest 
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -23778,7 +23778,7 @@ export const GetProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -23811,7 +23811,7 @@ export const DeleteProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -23850,7 +23850,7 @@ export const ListProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/targetSites" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/targetSites" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -23894,7 +23894,7 @@ export const BatchCreateProjectsLocationsDataStoresSiteSearchEngineTargetSitesRe
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/targetSites:batchCreate",
+      path: "v1/{+parent}/targetSites:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -23941,7 +23941,7 @@ export const BatchGetDocumentsMetadataProjectsLocationsDataStoresBranchesRequest
     ).pipe(T.HttpQuery("matcher.fhirMatcher.fhirResources")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/batchGetDocumentsMetadata" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/batchGetDocumentsMetadata" }),
     svc,
   ) as unknown as Schema.Schema<BatchGetDocumentsMetadataProjectsLocationsDataStoresBranchesRequest>;
 
@@ -23987,7 +23987,7 @@ export const PatchProjectsLocationsDataStoresBranchesDocumentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresBranchesDocumentsRequest>;
 
@@ -24028,7 +24028,7 @@ export const CreateProjectsLocationsDataStoresBranchesDocumentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/documents", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/documents", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataStoresBranchesDocumentsRequest>;
 
@@ -24068,7 +24068,7 @@ export const PurgeProjectsLocationsDataStoresBranchesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/documents:purge",
+      path: "v1/{+parent}/documents:purge",
       hasBody: true,
     }),
     svc,
@@ -24109,7 +24109,7 @@ export const ListProjectsLocationsDataStoresBranchesDocumentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/documents" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/documents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresBranchesDocumentsRequest>;
 
@@ -24146,7 +24146,7 @@ export const GetProjectsLocationsDataStoresBranchesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresBranchesDocumentsRequest>;
 
@@ -24179,7 +24179,7 @@ export const DeleteProjectsLocationsDataStoresBranchesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresBranchesDocumentsRequest>;
 
@@ -24219,7 +24219,7 @@ export const ImportProjectsLocationsDataStoresBranchesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/documents:import",
+      path: "v1/{+parent}/documents:import",
       hasBody: true,
     }),
     svc,
@@ -24259,7 +24259,7 @@ export const CancelProjectsLocationsDataStoresBranchesOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDataStoresBranchesOperationsRequest>;
 
@@ -24292,7 +24292,7 @@ export const GetProjectsLocationsDataStoresBranchesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresBranchesOperationsRequest>;
 
@@ -24339,7 +24339,7 @@ export const ListProjectsLocationsDataStoresBranchesOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresBranchesOperationsRequest>;
 
@@ -24383,7 +24383,7 @@ export const ImportProjectsLocationsDataStoresCompletionSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/completionSuggestions:import",
+      path: "v1/{+parent}/completionSuggestions:import",
       hasBody: true,
     }),
     svc,
@@ -24425,7 +24425,7 @@ export const PurgeProjectsLocationsDataStoresCompletionSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/completionSuggestions:purge",
+      path: "v1/{+parent}/completionSuggestions:purge",
       hasBody: true,
     }),
     svc,
@@ -24467,7 +24467,7 @@ export const BatchUpdateUserLicensesProjectsLocationsUserStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:batchUpdateUserLicenses",
+      path: "v1/{+parent}:batchUpdateUserLicenses",
       hasBody: true,
     }),
     svc,
@@ -24510,7 +24510,7 @@ export const PatchProjectsLocationsUserStoresRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsUserStoresRequest>;
 
@@ -24542,7 +24542,7 @@ export const GetProjectsLocationsUserStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsUserStoresRequest>;
 
@@ -24586,7 +24586,7 @@ export const ListProjectsLocationsUserStoresUserLicensesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/userLicenses" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/userLicenses" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsUserStoresUserLicensesRequest>;
 
@@ -24622,7 +24622,7 @@ export const ListProjectsLocationsUserStoresLicenseConfigsUsageStatsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/licenseConfigsUsageStats" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/licenseConfigsUsageStats" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsUserStoresLicenseConfigsUsageStatsRequest>;
 
@@ -24664,7 +24664,7 @@ export const PurgeIdentityMappingsProjectsLocationsIdentityMappingStoresRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{identityMappingStore}:purgeIdentityMappings",
+      path: "v1/{+identityMappingStore}:purgeIdentityMappings",
       hasBody: true,
     }),
     svc,
@@ -24709,7 +24709,7 @@ export const ListIdentityMappingsProjectsLocationsIdentityMappingStoresRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{identityMappingStore}:listIdentityMappings",
+      path: "v1/{+identityMappingStore}:listIdentityMappings",
     }),
     svc,
   ) as unknown as Schema.Schema<ListIdentityMappingsProjectsLocationsIdentityMappingStoresRequest>;
@@ -24747,7 +24747,7 @@ export const GetProjectsLocationsIdentityMappingStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIdentityMappingStoresRequest>;
 
@@ -24801,7 +24801,7 @@ export const CreateProjectsLocationsIdentityMappingStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/identityMappingStores",
+      path: "v1/{+parent}/identityMappingStores",
       hasBody: true,
     }),
     svc,
@@ -24841,7 +24841,7 @@ export const ListProjectsLocationsIdentityMappingStoresRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/identityMappingStores" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/identityMappingStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIdentityMappingStoresRequest>;
 
@@ -24886,7 +24886,7 @@ export const ImportIdentityMappingsProjectsLocationsIdentityMappingStoresRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{identityMappingStore}:importIdentityMappings",
+      path: "v1/{+identityMappingStore}:importIdentityMappings",
       hasBody: true,
     }),
     svc,
@@ -24921,7 +24921,7 @@ export const DeleteProjectsLocationsIdentityMappingStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsIdentityMappingStoresRequest>;
 
@@ -24953,7 +24953,7 @@ export const GetProjectsLocationsIdentityMappingStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIdentityMappingStoresOperationsRequest>;
 
@@ -25000,7 +25000,7 @@ export const ListProjectsLocationsIdentityMappingStoresOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIdentityMappingStoresOperationsRequest>;
 
@@ -25037,7 +25037,7 @@ export const DeleteProjectsLocationsCollectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsRequest>;
 
@@ -25077,7 +25077,7 @@ export const UpdateDataConnectorProjectsLocationsCollectionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateDataConnectorProjectsLocationsCollectionsRequest>;
 
@@ -25110,7 +25110,7 @@ export const GetDataConnectorProjectsLocationsCollectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDataConnectorProjectsLocationsCollectionsRequest>;
 
@@ -25142,7 +25142,7 @@ export const GetProjectsLocationsCollectionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsOperationsRequest>;
 
@@ -25188,7 +25188,7 @@ export const ListProjectsLocationsCollectionsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsOperationsRequest>;
 
@@ -25275,7 +25275,7 @@ export const GetProjectsLocationsCollectionsDataConnectorOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataConnectorOperationsRequest>;
 
@@ -25322,7 +25322,7 @@ export const ListProjectsLocationsCollectionsDataConnectorOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataConnectorOperationsRequest>;
 
@@ -25367,7 +25367,7 @@ export const PatchProjectsLocationsCollectionsDataStoresRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -25415,7 +25415,7 @@ export const CompleteQueryProjectsLocationsCollectionsDataStoresRequest =
     query: Schema.optional(Schema.String).pipe(T.HttpQuery("query")),
     dataStore: Schema.String.pipe(T.HttpPath("dataStore")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{dataStore}:completeQuery" }),
+    T.Http({ method: "GET", path: "v1/{+dataStore}:completeQuery" }),
     svc,
   ) as unknown as Schema.Schema<CompleteQueryProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -25457,7 +25457,7 @@ export const ListProjectsLocationsCollectionsDataStoresRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dataStores" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dataStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -25500,7 +25500,7 @@ export const TrainCustomModelProjectsLocationsCollectionsDataStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{dataStore}:trainCustomModel",
+      path: "v1/{+dataStore}:trainCustomModel",
       hasBody: true,
     }),
     svc,
@@ -25535,7 +25535,7 @@ export const GetSiteSearchEngineProjectsLocationsCollectionsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSiteSearchEngineProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -25568,7 +25568,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -25630,7 +25630,7 @@ export const CreateProjectsLocationsCollectionsDataStoresRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/dataStores", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/dataStores", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -25662,7 +25662,7 @@ export const GetProjectsLocationsCollectionsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -25701,7 +25701,7 @@ export const SearchProjectsLocationsCollectionsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{servingConfig}:search",
+      path: "v1/{+servingConfig}:search",
       hasBody: true,
     }),
     svc,
@@ -25736,7 +25736,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresServingConfigsRequest>;
 
@@ -25781,7 +25781,7 @@ export const CreateProjectsLocationsCollectionsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/servingConfigs",
+      path: "v1/{+parent}/servingConfigs",
       hasBody: true,
     }),
     svc,
@@ -25824,7 +25824,7 @@ export const PatchProjectsLocationsCollectionsDataStoresServingConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresServingConfigsRequest>;
 
@@ -25864,7 +25864,7 @@ export const StreamAnswerProjectsLocationsCollectionsDataStoresServingConfigsReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{servingConfig}:streamAnswer",
+      path: "v1/{+servingConfig}:streamAnswer",
       hasBody: true,
     }),
     svc,
@@ -25908,7 +25908,7 @@ export const SearchLiteProjectsLocationsCollectionsDataStoresServingConfigsReque
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{servingConfig}:searchLite",
+      path: "v1/{+servingConfig}:searchLite",
       hasBody: true,
     }),
     svc,
@@ -25950,7 +25950,7 @@ export const ListProjectsLocationsCollectionsDataStoresServingConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/servingConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/servingConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresServingConfigsRequest>;
 
@@ -25994,7 +25994,7 @@ export const RecommendProjectsLocationsCollectionsDataStoresServingConfigsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{servingConfig}:recommend",
+      path: "v1/{+servingConfig}:recommend",
       hasBody: true,
     }),
     svc,
@@ -26029,7 +26029,7 @@ export const GetProjectsLocationsCollectionsDataStoresServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresServingConfigsRequest>;
 
@@ -26069,7 +26069,7 @@ export const AnswerProjectsLocationsCollectionsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{servingConfig}:answer",
+      path: "v1/{+servingConfig}:answer",
       hasBody: true,
     }),
     svc,
@@ -26104,7 +26104,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresSessionsRequest>;
 
@@ -26142,7 +26142,7 @@ export const GetProjectsLocationsCollectionsDataStoresSessionsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSessionsRequest>;
 
@@ -26183,7 +26183,7 @@ export const CreateProjectsLocationsCollectionsDataStoresSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/sessions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/sessions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsDataStoresSessionsRequest>;
 
@@ -26224,7 +26224,7 @@ export const PatchProjectsLocationsCollectionsDataStoresSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresSessionsRequest>;
 
@@ -26269,7 +26269,7 @@ export const ListProjectsLocationsCollectionsDataStoresSessionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sessions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sessions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresSessionsRequest>;
 
@@ -26306,7 +26306,7 @@ export const GetProjectsLocationsCollectionsDataStoresSessionsAnswersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSessionsAnswersRequest>;
 
@@ -26353,7 +26353,7 @@ export const ListProjectsLocationsCollectionsDataStoresOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresOperationsRequest>;
 
@@ -26390,7 +26390,7 @@ export const GetProjectsLocationsCollectionsDataStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresOperationsRequest>;
 
@@ -26437,7 +26437,7 @@ export const ListProjectsLocationsCollectionsDataStoresModelsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresModelsOperationsRequest>;
 
@@ -26474,7 +26474,7 @@ export const GetProjectsLocationsCollectionsDataStoresModelsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresModelsOperationsRequest>;
 
@@ -26507,7 +26507,7 @@ export const GetProjectsLocationsCollectionsDataStoresConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresConversationsRequest>;
 
@@ -26547,7 +26547,7 @@ export const CreateProjectsLocationsCollectionsDataStoresConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/conversations",
+      path: "v1/{+parent}/conversations",
       hasBody: true,
     }),
     svc,
@@ -26587,7 +26587,7 @@ export const ConverseProjectsLocationsCollectionsDataStoresConversationsRequest 
       GoogleCloudDiscoveryengineV1ConverseConversationRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:converse", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:converse", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ConverseProjectsLocationsCollectionsDataStoresConversationsRequest>;
 
@@ -26620,7 +26620,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresConversationsRequest>;
 
@@ -26665,7 +26665,7 @@ export const ListProjectsLocationsCollectionsDataStoresConversationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresConversationsRequest>;
 
@@ -26710,7 +26710,7 @@ export const PatchProjectsLocationsCollectionsDataStoresConversationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresConversationsRequest>;
 
@@ -26751,7 +26751,7 @@ export const CreateProjectsLocationsCollectionsDataStoresSchemasRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/schemas", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/schemas", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsDataStoresSchemasRequest>;
 
@@ -26790,7 +26790,7 @@ export const ListProjectsLocationsCollectionsDataStoresSchemasRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/schemas" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/schemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresSchemasRequest>;
 
@@ -26827,7 +26827,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresSchemasRequest>;
 
@@ -26870,7 +26870,7 @@ export const PatchProjectsLocationsCollectionsDataStoresSchemasRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresSchemasRequest>;
 
@@ -26903,7 +26903,7 @@ export const GetProjectsLocationsCollectionsDataStoresSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSchemasRequest>;
 
@@ -26950,7 +26950,7 @@ export const ListProjectsLocationsCollectionsDataStoresSchemasOperationsRequest 
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresSchemasOperationsRequest>;
 
@@ -26987,7 +26987,7 @@ export const GetProjectsLocationsCollectionsDataStoresSchemasOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSchemasOperationsRequest>;
 
@@ -27027,7 +27027,7 @@ export const PurgeProjectsLocationsCollectionsDataStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/userEvents:purge",
+      path: "v1/{+parent}/userEvents:purge",
       hasBody: true,
     }),
     svc,
@@ -27069,7 +27069,7 @@ export const ImportProjectsLocationsCollectionsDataStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/userEvents:import",
+      path: "v1/{+parent}/userEvents:import",
       hasBody: true,
     }),
     svc,
@@ -27114,7 +27114,7 @@ export const WriteProjectsLocationsCollectionsDataStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/userEvents:write",
+      path: "v1/{+parent}/userEvents:write",
       hasBody: true,
     }),
     svc,
@@ -27158,7 +27158,7 @@ export const CollectProjectsLocationsCollectionsDataStoresUserEventsRequest =
     uri: Schema.optional(Schema.String).pipe(T.HttpQuery("uri")),
     ets: Schema.optional(Schema.String).pipe(T.HttpQuery("ets")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/userEvents:collect" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/userEvents:collect" }),
     svc,
   ) as unknown as Schema.Schema<CollectProjectsLocationsCollectionsDataStoresUserEventsRequest>;
 
@@ -27198,7 +27198,7 @@ export const PurgeProjectsLocationsCollectionsDataStoresCompletionSuggestionsReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/completionSuggestions:purge",
+      path: "v1/{+parent}/completionSuggestions:purge",
       hasBody: true,
     }),
     svc,
@@ -27242,7 +27242,7 @@ export const ImportProjectsLocationsCollectionsDataStoresCompletionSuggestionsRe
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/completionSuggestions:import",
+      path: "v1/{+parent}/completionSuggestions:import",
       hasBody: true,
     }),
     svc,
@@ -27279,7 +27279,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresControlsRequest>;
 
@@ -27321,7 +27321,7 @@ export const ListProjectsLocationsCollectionsDataStoresControlsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/controls" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/controls" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresControlsRequest>;
 
@@ -27366,7 +27366,7 @@ export const PatchProjectsLocationsCollectionsDataStoresControlsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresControlsRequest>;
 
@@ -27407,7 +27407,7 @@ export const CreateProjectsLocationsCollectionsDataStoresControlsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/controls", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/controls", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsDataStoresControlsRequest>;
 
@@ -27440,7 +27440,7 @@ export const GetProjectsLocationsCollectionsDataStoresControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresControlsRequest>;
 
@@ -27480,7 +27480,7 @@ export const ImportProjectsLocationsCollectionsDataStoresSuggestionDenyListEntri
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/suggestionDenyListEntries:import",
+      path: "v1/{+parent}/suggestionDenyListEntries:import",
       hasBody: true,
     }),
     svc,
@@ -27524,7 +27524,7 @@ export const PurgeProjectsLocationsCollectionsDataStoresSuggestionDenyListEntrie
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/suggestionDenyListEntries:purge",
+      path: "v1/{+parent}/suggestionDenyListEntries:purge",
       hasBody: true,
     }),
     svc,
@@ -27568,7 +27568,7 @@ export const DisableAdvancedSiteSearchProjectsLocationsCollectionsDataStoresSite
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{siteSearchEngine}:disableAdvancedSiteSearch",
+      path: "v1/{+siteSearchEngine}:disableAdvancedSiteSearch",
       hasBody: true,
     }),
     svc,
@@ -27612,7 +27612,7 @@ export const EnableAdvancedSiteSearchProjectsLocationsCollectionsDataStoresSiteS
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{siteSearchEngine}:enableAdvancedSiteSearch",
+      path: "v1/{+siteSearchEngine}:enableAdvancedSiteSearch",
       hasBody: true,
     }),
     svc,
@@ -27656,7 +27656,7 @@ export const RecrawlUrisProjectsLocationsCollectionsDataStoresSiteSearchEngineRe
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{siteSearchEngine}:recrawlUris",
+      path: "v1/{+siteSearchEngine}:recrawlUris",
       hasBody: true,
     }),
     svc,
@@ -27700,7 +27700,7 @@ export const BatchVerifyTargetSitesProjectsLocationsCollectionsDataStoresSiteSea
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:batchVerifyTargetSites",
+      path: "v1/{+parent}:batchVerifyTargetSites",
       hasBody: true,
     }),
     svc,
@@ -27745,7 +27745,7 @@ export const FetchDomainVerificationStatusProjectsLocationsCollectionsDataStores
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{siteSearchEngine}:fetchDomainVerificationStatus",
+      path: "v1/{+siteSearchEngine}:fetchDomainVerificationStatus",
     }),
     svc,
   ) as unknown as Schema.Schema<FetchDomainVerificationStatusProjectsLocationsCollectionsDataStoresSiteSearchEngineRequest>;
@@ -27791,7 +27791,7 @@ export const ListProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSit
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/targetSites" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/targetSites" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -27835,7 +27835,7 @@ export const PatchProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSi
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -27875,7 +27875,7 @@ export const CreateProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetS
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/targetSites", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/targetSites", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -27910,7 +27910,7 @@ export const GetProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSite
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -27952,7 +27952,7 @@ export const BatchCreateProjectsLocationsCollectionsDataStoresSiteSearchEngineTa
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/targetSites:batchCreate",
+      path: "v1/{+parent}/targetSites:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -27989,7 +27989,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetS
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -28038,7 +28038,7 @@ export const ListProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSit
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesOperationsRequest>;
 
@@ -28077,7 +28077,7 @@ export const GetProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSite
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesOperationsRequest>;
 
@@ -28117,7 +28117,7 @@ export const CreateProjectsLocationsCollectionsDataStoresSiteSearchEngineSitemap
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/sitemaps", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/sitemaps", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsDataStoresSiteSearchEngineSitemapsRequest>;
 
@@ -28157,7 +28157,7 @@ export const FetchProjectsLocationsCollectionsDataStoresSiteSearchEngineSitemaps
       Schema.Array(Schema.String),
     ).pipe(T.HttpQuery("matcher.urisMatcher.uris")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sitemaps:fetch" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sitemaps:fetch" }),
     svc,
   ) as unknown as Schema.Schema<FetchProjectsLocationsCollectionsDataStoresSiteSearchEngineSitemapsRequest>;
 
@@ -28192,7 +28192,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresSiteSearchEngineSitemap
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresSiteSearchEngineSitemapsRequest>;
 
@@ -28241,7 +28241,7 @@ export const ListProjectsLocationsCollectionsDataStoresSiteSearchEngineOperation
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresSiteSearchEngineOperationsRequest>;
 
@@ -28280,7 +28280,7 @@ export const GetProjectsLocationsCollectionsDataStoresSiteSearchEngineOperations
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSiteSearchEngineOperationsRequest>;
 
@@ -28325,7 +28325,7 @@ export const BatchGetDocumentsMetadataProjectsLocationsCollectionsDataStoresBran
     ).pipe(T.HttpQuery("matcher.urisMatcher.uris")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/batchGetDocumentsMetadata" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/batchGetDocumentsMetadata" }),
     svc,
   ) as unknown as Schema.Schema<BatchGetDocumentsMetadataProjectsLocationsCollectionsDataStoresBranchesRequest>;
 
@@ -28360,7 +28360,7 @@ export const GetProjectsLocationsCollectionsDataStoresBranchesOperationsRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresBranchesOperationsRequest>;
 
@@ -28407,7 +28407,7 @@ export const ListProjectsLocationsCollectionsDataStoresBranchesOperationsRequest
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresBranchesOperationsRequest>;
 
@@ -28449,7 +28449,7 @@ export const CancelProjectsLocationsCollectionsDataStoresBranchesOperationsReque
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsCollectionsDataStoresBranchesOperationsRequest>;
 
@@ -28491,7 +28491,7 @@ export const CreateProjectsLocationsCollectionsDataStoresBranchesDocumentsReques
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/documents", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/documents", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest>;
 
@@ -28530,7 +28530,7 @@ export const ListProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest 
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/documents" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/documents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest>;
 
@@ -28567,7 +28567,7 @@ export const GetProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest>;
 
@@ -28607,7 +28607,7 @@ export const ImportProjectsLocationsCollectionsDataStoresBranchesDocumentsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/documents:import",
+      path: "v1/{+parent}/documents:import",
       hasBody: true,
     }),
     svc,
@@ -28642,7 +28642,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresBranchesDocumentsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest>;
 
@@ -28688,7 +28688,7 @@ export const PatchProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest>;
 
@@ -28728,7 +28728,7 @@ export const PurgeProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/documents:purge",
+      path: "v1/{+parent}/documents:purge",
       hasBody: true,
     }),
     svc,
@@ -28770,7 +28770,7 @@ export const CompleteQueryProjectsLocationsCollectionsDataStoresCompletionConfig
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{completionConfig}:completeQuery",
+      path: "v1/{+completionConfig}:completeQuery",
       hasBody: true,
     }),
     svc,
@@ -28807,7 +28807,7 @@ export const ListProjectsLocationsCollectionsDataStoresCustomModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     dataStore: Schema.String.pipe(T.HttpPath("dataStore")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{dataStore}/customModels" }),
+    T.Http({ method: "GET", path: "v1/{+dataStore}/customModels" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresCustomModelsRequest>;
 
@@ -28848,7 +28848,7 @@ export const PatchProjectsLocationsCollectionsDataStoresWidgetConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresWidgetConfigsRequest>;
 
@@ -28893,7 +28893,7 @@ export const GetProjectsLocationsCollectionsDataStoresWidgetConfigsRequest =
       T.HttpQuery("getWidgetConfigRequestOption.turnOffCollectionComponents"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresWidgetConfigsRequest>;
 
@@ -28926,7 +28926,7 @@ export const DeleteProjectsLocationsCollectionsEnginesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesRequest>;
 
@@ -28958,7 +28958,7 @@ export const GetProjectsLocationsCollectionsEnginesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesRequest>;
 
@@ -28998,7 +28998,7 @@ export const CreateProjectsLocationsCollectionsEnginesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/engines", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/engines", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsEnginesRequest>;
 
@@ -29039,7 +29039,7 @@ export const ListProjectsLocationsCollectionsEnginesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/engines" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/engines" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesRequest>;
 
@@ -29083,7 +29083,7 @@ export const PatchProjectsLocationsCollectionsEnginesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesRequest>;
 
@@ -29120,7 +29120,7 @@ export const GetIamPolicyProjectsLocationsCollectionsEnginesRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsCollectionsEnginesRequest>;
 
@@ -29158,7 +29158,7 @@ export const SetIamPolicyProjectsLocationsCollectionsEnginesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -29199,7 +29199,7 @@ export const ListProjectsLocationsCollectionsEnginesServingConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/servingConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/servingConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesServingConfigsRequest>;
 
@@ -29243,7 +29243,7 @@ export const SearchProjectsLocationsCollectionsEnginesServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{servingConfig}:search",
+      path: "v1/{+servingConfig}:search",
       hasBody: true,
     }),
     svc,
@@ -29278,7 +29278,7 @@ export const DeleteProjectsLocationsCollectionsEnginesServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesServingConfigsRequest>;
 
@@ -29318,7 +29318,7 @@ export const RecommendProjectsLocationsCollectionsEnginesServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{servingConfig}:recommend",
+      path: "v1/{+servingConfig}:recommend",
       hasBody: true,
     }),
     svc,
@@ -29361,7 +29361,7 @@ export const PatchProjectsLocationsCollectionsEnginesServingConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesServingConfigsRequest>;
 
@@ -29406,7 +29406,7 @@ export const CreateProjectsLocationsCollectionsEnginesServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/servingConfigs",
+      path: "v1/{+parent}/servingConfigs",
       hasBody: true,
     }),
     svc,
@@ -29448,7 +29448,7 @@ export const StreamAnswerProjectsLocationsCollectionsEnginesServingConfigsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{servingConfig}:streamAnswer",
+      path: "v1/{+servingConfig}:streamAnswer",
       hasBody: true,
     }),
     svc,
@@ -29483,7 +29483,7 @@ export const GetProjectsLocationsCollectionsEnginesServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesServingConfigsRequest>;
 
@@ -29523,7 +29523,7 @@ export const SearchLiteProjectsLocationsCollectionsEnginesServingConfigsRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{servingConfig}:searchLite",
+      path: "v1/{+servingConfig}:searchLite",
       hasBody: true,
     }),
     svc,
@@ -29565,7 +29565,7 @@ export const AnswerProjectsLocationsCollectionsEnginesServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{servingConfig}:answer",
+      path: "v1/{+servingConfig}:answer",
       hasBody: true,
     }),
     svc,
@@ -29600,7 +29600,7 @@ export const GetProjectsLocationsCollectionsEnginesConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesConversationsRequest>;
 
@@ -29640,7 +29640,7 @@ export const CreateProjectsLocationsCollectionsEnginesConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/conversations",
+      path: "v1/{+parent}/conversations",
       hasBody: true,
     }),
     svc,
@@ -29687,7 +29687,7 @@ export const ListProjectsLocationsCollectionsEnginesConversationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesConversationsRequest>;
 
@@ -29729,7 +29729,7 @@ export const ConverseProjectsLocationsCollectionsEnginesConversationsRequest =
       GoogleCloudDiscoveryengineV1ConverseConversationRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:converse", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:converse", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ConverseProjectsLocationsCollectionsEnginesConversationsRequest>;
 
@@ -29762,7 +29762,7 @@ export const DeleteProjectsLocationsCollectionsEnginesConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesConversationsRequest>;
 
@@ -29803,7 +29803,7 @@ export const PatchProjectsLocationsCollectionsEnginesConversationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesConversationsRequest>;
 
@@ -29844,7 +29844,7 @@ export const PatchProjectsLocationsCollectionsEnginesWidgetConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesWidgetConfigsRequest>;
 
@@ -29889,7 +29889,7 @@ export const GetProjectsLocationsCollectionsEnginesWidgetConfigsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesWidgetConfigsRequest>;
 
@@ -29930,7 +29930,7 @@ export const PatchProjectsLocationsCollectionsEnginesControlsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesControlsRequest>;
 
@@ -29972,7 +29972,7 @@ export const ListProjectsLocationsCollectionsEnginesControlsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/controls" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/controls" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesControlsRequest>;
 
@@ -30009,7 +30009,7 @@ export const GetProjectsLocationsCollectionsEnginesControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesControlsRequest>;
 
@@ -30049,7 +30049,7 @@ export const CreateProjectsLocationsCollectionsEnginesControlsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/controls", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/controls", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsEnginesControlsRequest>;
 
@@ -30082,7 +30082,7 @@ export const DeleteProjectsLocationsCollectionsEnginesControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesControlsRequest>;
 
@@ -30120,7 +30120,7 @@ export const CancelProjectsLocationsCollectionsEnginesOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsCollectionsEnginesOperationsRequest>;
 
@@ -30153,7 +30153,7 @@ export const GetProjectsLocationsCollectionsEnginesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesOperationsRequest>;
 
@@ -30200,7 +30200,7 @@ export const ListProjectsLocationsCollectionsEnginesOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesOperationsRequest>;
 
@@ -30237,7 +30237,7 @@ export const GetProjectsLocationsCollectionsEnginesAssistantsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesAssistantsRequest>;
 
@@ -30278,7 +30278,7 @@ export const PatchProjectsLocationsCollectionsEnginesAssistantsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesAssistantsRequest>;
 
@@ -30321,7 +30321,7 @@ export const CreateProjectsLocationsCollectionsEnginesAssistantsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/assistants", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/assistants", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsEnginesAssistantsRequest>;
 
@@ -30354,7 +30354,7 @@ export const DeleteProjectsLocationsCollectionsEnginesAssistantsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesAssistantsRequest>;
 
@@ -30392,7 +30392,7 @@ export const StreamAssistProjectsLocationsCollectionsEnginesAssistantsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:streamAssist", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:streamAssist", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StreamAssistProjectsLocationsCollectionsEnginesAssistantsRequest>;
 
@@ -30431,7 +30431,7 @@ export const ListProjectsLocationsCollectionsEnginesAssistantsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/assistants" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/assistants" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesAssistantsRequest>;
 
@@ -30468,7 +30468,7 @@ export const GetProjectsLocationsCollectionsEnginesAssistantsAgentsOperationsReq
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesAssistantsAgentsOperationsRequest>;
 
@@ -30503,7 +30503,7 @@ export const GetCardProjectsLocationsCollectionsEnginesAssistantsAgentsA2aV1Requ
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     tenant: Schema.String.pipe(T.HttpPath("tenant")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{tenant}/a2a/v1/card" }),
+    T.Http({ method: "GET", path: "v1/{+tenant}/a2a/v1/card" }),
     svc,
   ) as unknown as Schema.Schema<GetCardProjectsLocationsCollectionsEnginesAssistantsAgentsA2aV1Request>;
 
@@ -30540,7 +30540,7 @@ export const SubscribeProjectsLocationsCollectionsEnginesAssistantsAgentsA2aV1Ta
     tenant: Schema.String.pipe(T.HttpPath("tenant")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{tenant}/a2a/v1/{name}:subscribe" }),
+    T.Http({ method: "GET", path: "v1/{+tenant}/a2a/v1/{+name}:subscribe" }),
     svc,
   ) as unknown as Schema.Schema<SubscribeProjectsLocationsCollectionsEnginesAssistantsAgentsA2aV1TasksRequest>;
 
@@ -30583,7 +30583,7 @@ export const CancelProjectsLocationsCollectionsEnginesAssistantsAgentsA2aV1Tasks
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{tenant}/a2a/v1/{name}:cancel",
+      path: "v1/{+tenant}/a2a/v1/{+name}:cancel",
       hasBody: true,
     }),
     svc,
@@ -30628,7 +30628,7 @@ export const GetProjectsLocationsCollectionsEnginesAssistantsAgentsA2aV1TasksReq
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{tenant}/a2a/v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+tenant}/a2a/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesAssistantsAgentsA2aV1TasksRequest>;
 
@@ -30666,7 +30666,7 @@ export const DeleteProjectsLocationsCollectionsEnginesAssistantsAgentsA2aV1Tasks
     name: Schema.String.pipe(T.HttpPath("name")),
     tenant: Schema.String.pipe(T.HttpPath("tenant")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{tenant}/a2a/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+tenant}/a2a/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesAssistantsAgentsA2aV1TasksPushNotificationConfigsRequest>;
 
@@ -30712,7 +30712,7 @@ export const ListProjectsLocationsCollectionsEnginesAssistantsAgentsA2aV1TasksPu
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{tenant}/a2a/v1/{parent}/pushNotificationConfigs",
+      path: "v1/{+tenant}/a2a/v1/{+parent}/pushNotificationConfigs",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesAssistantsAgentsA2aV1TasksPushNotificationConfigsRequest>;
@@ -30755,7 +30755,7 @@ export const GetProjectsLocationsCollectionsEnginesAssistantsAgentsA2aV1TasksPus
     name: Schema.String.pipe(T.HttpPath("name")),
     tenant: Schema.String.pipe(T.HttpPath("tenant")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{tenant}/a2a/v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+tenant}/a2a/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesAssistantsAgentsA2aV1TasksPushNotificationConfigsRequest>;
 
@@ -30801,7 +30801,7 @@ export const CreateProjectsLocationsCollectionsEnginesAssistantsAgentsA2aV1Tasks
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{tenant}/a2a/v1/{parent}",
+      path: "v1/{+tenant}/a2a/v1/{+parent}",
       hasBody: true,
     }),
     svc,
@@ -30843,7 +30843,7 @@ export const StreamProjectsLocationsCollectionsEnginesAssistantsAgentsA2aV1Messa
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{tenant}/a2a/v1/message:stream",
+      path: "v1/{+tenant}/a2a/v1/message:stream",
       hasBody: true,
     }),
     svc,
@@ -30885,7 +30885,7 @@ export const SendProjectsLocationsCollectionsEnginesAssistantsAgentsA2aV1Message
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{tenant}/a2a/v1/message:send",
+      path: "v1/{+tenant}/a2a/v1/message:send",
       hasBody: true,
     }),
     svc,
@@ -30929,7 +30929,7 @@ export const CompleteQueryProjectsLocationsCollectionsEnginesCompletionConfigReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{completionConfig}:completeQuery",
+      path: "v1/{+completionConfig}:completeQuery",
       hasBody: true,
     }),
     svc,
@@ -30978,7 +30978,7 @@ export const ListProjectsLocationsCollectionsEnginesSessionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sessions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sessions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesSessionsRequest>;
 
@@ -31015,7 +31015,7 @@ export const DeleteProjectsLocationsCollectionsEnginesSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesSessionsRequest>;
 
@@ -31056,7 +31056,7 @@ export const CreateProjectsLocationsCollectionsEnginesSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/sessions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/sessions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsEnginesSessionsRequest>;
 
@@ -31097,7 +31097,7 @@ export const PatchProjectsLocationsCollectionsEnginesSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesSessionsRequest>;
 
@@ -31135,7 +31135,7 @@ export const GetProjectsLocationsCollectionsEnginesSessionsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesSessionsRequest>;
 
@@ -31167,7 +31167,7 @@ export const GetProjectsLocationsCollectionsEnginesSessionsAnswersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesSessionsAnswersRequest>;
 
@@ -31212,7 +31212,7 @@ export const CreateProjectsLocationsLicenseConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/licenseConfigs",
+      path: "v1/{+parent}/licenseConfigs",
       hasBody: true,
     }),
     svc,
@@ -31246,7 +31246,7 @@ export const GetProjectsLocationsLicenseConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsLicenseConfigsRequest>;
 
@@ -31286,7 +31286,7 @@ export const PatchProjectsLocationsLicenseConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsLicenseConfigsRequest>;
 
@@ -31318,7 +31318,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 
@@ -31354,7 +31354,7 @@ export const CancelProjectsOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsOperationsRequest>;
 
@@ -31399,7 +31399,7 @@ export const ListProjectsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsOperationsRequest>;
 

--- a/packages/gcp/src/services/discoveryengine-v1alpha.ts
+++ b/packages/gcp/src/services/discoveryengine-v1alpha.ts
@@ -21788,7 +21788,7 @@ export const ListBillingAccountsBillingAccountLicenseConfigsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}/billingAccountLicenseConfigs",
+      path: "v1alpha/{+parent}/billingAccountLicenseConfigs",
     }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsBillingAccountLicenseConfigsRequest>;
@@ -21835,7 +21835,7 @@ export const DistributeLicenseConfigBillingAccountsBillingAccountLicenseConfigsR
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{billingAccountLicenseConfig}:distributeLicenseConfig",
+      path: "v1alpha/{+billingAccountLicenseConfig}:distributeLicenseConfig",
       hasBody: true,
     }),
     svc,
@@ -21872,7 +21872,7 @@ export const GetBillingAccountsBillingAccountLicenseConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsBillingAccountLicenseConfigsRequest>;
 
@@ -21913,7 +21913,7 @@ export const RetractLicenseConfigBillingAccountsBillingAccountLicenseConfigsRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{billingAccountLicenseConfig}:retractLicenseConfig",
+      path: "v1alpha/{+billingAccountLicenseConfig}:retractLicenseConfig",
       hasBody: true,
     }),
     svc,
@@ -21956,7 +21956,7 @@ export const PatchProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpBody(),
   ),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchProjectsRequest>;
 
@@ -21986,7 +21986,7 @@ export interface GetProjectsRequest {
 export const GetProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1alpha/{name}" }),
+  T.Http({ method: "GET", path: "v1alpha/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetProjectsRequest>;
 
@@ -22024,7 +22024,7 @@ export const ReportConsentChangeProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{project}:reportConsentChange",
+      path: "v1alpha/{+project}:reportConsentChange",
       hasBody: true,
     }),
     svc,
@@ -22063,7 +22063,11 @@ export const ProvisionProjectsRequest =
       GoogleCloudDiscoveryengineV1alphaProvisionProjectRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:provision", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1alpha/{+name}:provision",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<ProvisionProjectsRequest>;
 
@@ -22094,7 +22098,7 @@ export const GetAclConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAclConfigProjectsLocationsRequest>;
 
@@ -22131,7 +22135,7 @@ export const UpdateAclConfigProjectsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAclConfigProjectsLocationsRequest>;
 
@@ -22189,7 +22193,7 @@ export const CompleteExternalIdentitiesProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}:completeExternalIdentities",
+      path: "v1alpha/{+parent}:completeExternalIdentities",
     }),
     svc,
   ) as unknown as Schema.Schema<CompleteExternalIdentitiesProjectsLocationsRequest>;
@@ -22269,7 +22273,7 @@ export const QueryConfigurablePricingUsageStatsProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{project}/locations/{location}:queryConfigurablePricingUsageStats",
+      path: "v1alpha/{+project}/locations/{location}:queryConfigurablePricingUsageStats",
     }),
     svc,
   ) as unknown as Schema.Schema<QueryConfigurablePricingUsageStatsProjectsLocationsRequest>;
@@ -22310,7 +22314,7 @@ export const SetUpDataConnectorProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}:setUpDataConnector",
+      path: "v1alpha/{+parent}:setUpDataConnector",
       hasBody: true,
     }),
     svc,
@@ -22351,7 +22355,7 @@ export const RemoveDedicatedCrawlRateProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{location}:removeDedicatedCrawlRate",
+      path: "v1alpha/{+location}:removeDedicatedCrawlRate",
       hasBody: true,
     }),
     svc,
@@ -22393,7 +22397,7 @@ export const UpdateCmekConfigProjectsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateCmekConfigProjectsLocationsRequest>;
 
@@ -22442,7 +22446,7 @@ export const SetUpDataConnectorV2ProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}:setUpDataConnectorV2",
+      path: "v1alpha/{+parent}:setUpDataConnectorV2",
       hasBody: true,
     }),
     svc,
@@ -22483,7 +22487,7 @@ export const EstimateDataSizeProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{location}:estimateDataSize",
+      path: "v1alpha/{+location}:estimateDataSize",
       hasBody: true,
     }),
     svc,
@@ -22524,7 +22528,7 @@ export const SetDedicatedCrawlRateProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{location}:setDedicatedCrawlRate",
+      path: "v1alpha/{+location}:setDedicatedCrawlRate",
       hasBody: true,
     }),
     svc,
@@ -22565,7 +22569,7 @@ export const ObtainCrawlRateProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{location}:obtainCrawlRate",
+      path: "v1alpha/{+location}:obtainCrawlRate",
       hasBody: true,
     }),
     svc,
@@ -22599,7 +22603,7 @@ export const GetCmekConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCmekConfigProjectsLocationsRequest>;
 
@@ -22643,7 +22647,7 @@ export const CreateProjectsLocationsSampleQuerySetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/sampleQuerySets",
+      path: "v1alpha/{+parent}/sampleQuerySets",
       hasBody: true,
     }),
     svc,
@@ -22677,7 +22681,7 @@ export const GetProjectsLocationsSampleQuerySetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSampleQuerySetsRequest>;
 
@@ -22709,7 +22713,7 @@ export const DeleteProjectsLocationsSampleQuerySetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSampleQuerySetsRequest>;
 
@@ -22747,7 +22751,7 @@ export const ListProjectsLocationsSampleQuerySetsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/sampleQuerySets" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/sampleQuerySets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSampleQuerySetsRequest>;
 
@@ -22791,7 +22795,7 @@ export const PatchProjectsLocationsSampleQuerySetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSampleQuerySetsRequest>;
 
@@ -22835,7 +22839,7 @@ export const CreateProjectsLocationsSampleQuerySetsSampleQueriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/sampleQueries",
+      path: "v1alpha/{+parent}/sampleQueries",
       hasBody: true,
     }),
     svc,
@@ -22877,7 +22881,7 @@ export const ImportProjectsLocationsSampleQuerySetsSampleQueriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/sampleQueries:import",
+      path: "v1alpha/{+parent}/sampleQueries:import",
       hasBody: true,
     }),
     svc,
@@ -22920,7 +22924,7 @@ export const PatchProjectsLocationsSampleQuerySetsSampleQueriesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSampleQuerySetsSampleQueriesRequest>;
 
@@ -22953,7 +22957,7 @@ export const DeleteProjectsLocationsSampleQuerySetsSampleQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSampleQuerySetsSampleQueriesRequest>;
 
@@ -22986,7 +22990,7 @@ export const GetProjectsLocationsSampleQuerySetsSampleQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSampleQuerySetsSampleQueriesRequest>;
 
@@ -23025,7 +23029,7 @@ export const ListProjectsLocationsSampleQuerySetsSampleQueriesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/sampleQueries" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/sampleQueries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSampleQuerySetsSampleQueriesRequest>;
 
@@ -23062,7 +23066,7 @@ export const GetProjectsLocationsSampleQuerySetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSampleQuerySetsOperationsRequest>;
 
@@ -23101,7 +23105,7 @@ export const CheckProjectsLocationsGroundingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{groundingConfig}:check",
+      path: "v1alpha/{+groundingConfig}:check",
       hasBody: true,
     }),
     svc,
@@ -23143,7 +23147,7 @@ export const PatchProjectsLocationsLicenseConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsLicenseConfigsRequest>;
 
@@ -23175,7 +23179,7 @@ export const GetProjectsLocationsLicenseConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsLicenseConfigsRequest>;
 
@@ -23219,7 +23223,7 @@ export const CreateProjectsLocationsLicenseConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/licenseConfigs",
+      path: "v1alpha/{+parent}/licenseConfigs",
       hasBody: true,
     }),
     svc,
@@ -23253,7 +23257,7 @@ export const GetProjectsLocationsUserStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsUserStoresRequest>;
 
@@ -23293,7 +23297,7 @@ export const PatchProjectsLocationsUserStoresRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsUserStoresRequest>;
 
@@ -23332,7 +23336,7 @@ export const BatchUpdateUserLicensesProjectsLocationsUserStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}:batchUpdateUserLicenses",
+      path: "v1alpha/{+parent}:batchUpdateUserLicenses",
       hasBody: true,
     }),
     svc,
@@ -23369,7 +23373,7 @@ export const ListProjectsLocationsUserStoresLicenseConfigsUsageStatsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}/licenseConfigsUsageStats",
+      path: "v1alpha/{+parent}/licenseConfigsUsageStats",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsUserStoresLicenseConfigsUsageStatsRequest>;
@@ -23403,7 +23407,7 @@ export const GetProjectsLocationsUserStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsUserStoresOperationsRequest>;
 
@@ -23449,7 +23453,7 @@ export const ListProjectsLocationsUserStoresOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsUserStoresOperationsRequest>;
 
@@ -23497,7 +23501,7 @@ export const ListProjectsLocationsUserStoresUserLicensesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/userLicenses" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/userLicenses" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsUserStoresUserLicensesRequest>;
 
@@ -23545,7 +23549,7 @@ export const CreateProjectsLocationsAuthorizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/authorizations",
+      path: "v1alpha/{+parent}/authorizations",
       hasBody: true,
     }),
     svc,
@@ -23585,7 +23589,7 @@ export const ListProjectsLocationsAuthorizationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/authorizations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/authorizations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAuthorizationsRequest>;
 
@@ -23621,7 +23625,7 @@ export const DeleteProjectsLocationsAuthorizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAuthorizationsRequest>;
 
@@ -23652,7 +23656,7 @@ export const GetProjectsLocationsAuthorizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAuthorizationsRequest>;
 
@@ -23692,7 +23696,7 @@ export const PatchProjectsLocationsAuthorizationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAuthorizationsRequest>;
 
@@ -23724,7 +23728,7 @@ export const GetProjectsLocationsCollectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsRequest>;
 
@@ -23756,7 +23760,7 @@ export const GetDataConnectorProjectsLocationsCollectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDataConnectorProjectsLocationsCollectionsRequest>;
 
@@ -23796,7 +23800,7 @@ export const PatchProjectsLocationsCollectionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsRequest>;
 
@@ -23837,7 +23841,7 @@ export const ListProjectsLocationsCollectionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/collections" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/collections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsRequest>;
 
@@ -23873,7 +23877,7 @@ export const DeleteProjectsLocationsCollectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsRequest>;
 
@@ -23913,7 +23917,7 @@ export const UpdateDataConnectorProjectsLocationsCollectionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateDataConnectorProjectsLocationsCollectionsRequest>;
 
@@ -23951,7 +23955,7 @@ export const TuneProjectsLocationsCollectionsEnginesRequest =
       GoogleCloudDiscoveryengineV1alphaTuneEngineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:tune", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:tune", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TuneProjectsLocationsCollectionsEnginesRequest>;
 
@@ -23988,7 +23992,7 @@ export const SetIamPolicyProjectsLocationsCollectionsEnginesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -24028,7 +24032,7 @@ export const GetIamPolicyProjectsLocationsCollectionsEnginesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsCollectionsEnginesRequest>;
 
@@ -24070,7 +24074,7 @@ export const ListProjectsLocationsCollectionsEnginesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/engines" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/engines" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesRequest>;
 
@@ -24114,7 +24118,11 @@ export const CreateProjectsLocationsCollectionsEnginesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{parent}/engines", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1alpha/{+parent}/engines",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsEnginesRequest>;
 
@@ -24146,7 +24154,7 @@ export const DeleteProjectsLocationsCollectionsEnginesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesRequest>;
 
@@ -24178,7 +24186,7 @@ export const GetWorkspaceSettingsProjectsLocationsCollectionsEnginesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}:getWorkspaceSettings" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}:getWorkspaceSettings" }),
     svc,
   ) as unknown as Schema.Schema<GetWorkspaceSettingsProjectsLocationsCollectionsEnginesRequest>;
 
@@ -24216,7 +24224,7 @@ export const ResumeProjectsLocationsCollectionsEnginesRequest =
       GoogleCloudDiscoveryengineV1alphaResumeEngineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsCollectionsEnginesRequest>;
 
@@ -24248,7 +24256,7 @@ export const GetProjectsLocationsCollectionsEnginesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesRequest>;
 
@@ -24288,7 +24296,7 @@ export const PatchProjectsLocationsCollectionsEnginesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesRequest>;
 
@@ -24325,7 +24333,7 @@ export const PauseProjectsLocationsCollectionsEnginesRequest =
       GoogleCloudDiscoveryengineV1alphaPauseEngineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsLocationsCollectionsEnginesRequest>;
 
@@ -24357,7 +24365,7 @@ export const GetProjectsLocationsCollectionsEnginesControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesControlsRequest>;
 
@@ -24399,7 +24407,7 @@ export const CreateProjectsLocationsCollectionsEnginesControlsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/controls",
+      path: "v1alpha/{+parent}/controls",
       hasBody: true,
     }),
     svc,
@@ -24442,7 +24450,7 @@ export const PatchProjectsLocationsCollectionsEnginesControlsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesControlsRequest>;
 
@@ -24484,7 +24492,7 @@ export const ListProjectsLocationsCollectionsEnginesControlsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/controls" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/controls" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesControlsRequest>;
 
@@ -24521,7 +24529,7 @@ export const DeleteProjectsLocationsCollectionsEnginesControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesControlsRequest>;
 
@@ -24561,7 +24569,7 @@ export const CompleteQueryProjectsLocationsCollectionsEnginesCompletionConfigReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{completionConfig}:completeQuery",
+      path: "v1alpha/{+completionConfig}:completeQuery",
       hasBody: true,
     }),
     svc,
@@ -24605,7 +24613,7 @@ export const RemoveSuggestionProjectsLocationsCollectionsEnginesCompletionConfig
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{completionConfig}:removeSuggestion",
+      path: "v1alpha/{+completionConfig}:removeSuggestion",
       hasBody: true,
     }),
     svc,
@@ -24647,7 +24655,7 @@ export const ConverseProjectsLocationsCollectionsEnginesConversationsRequest =
       GoogleCloudDiscoveryengineV1alphaConverseConversationRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:converse", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:converse", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ConverseProjectsLocationsCollectionsEnginesConversationsRequest>;
 
@@ -24688,7 +24696,7 @@ export const PatchProjectsLocationsCollectionsEnginesConversationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesConversationsRequest>;
 
@@ -24733,7 +24741,7 @@ export const ListProjectsLocationsCollectionsEnginesConversationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesConversationsRequest>;
 
@@ -24770,7 +24778,7 @@ export const DeleteProjectsLocationsCollectionsEnginesConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesConversationsRequest>;
 
@@ -24803,7 +24811,7 @@ export const GetProjectsLocationsCollectionsEnginesConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesConversationsRequest>;
 
@@ -24843,7 +24851,7 @@ export const CreateProjectsLocationsCollectionsEnginesConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/conversations",
+      path: "v1alpha/{+parent}/conversations",
       hasBody: true,
     }),
     svc,
@@ -24878,7 +24886,7 @@ export const GetConfigProjectsLocationsCollectionsEnginesAnalyticsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigProjectsLocationsCollectionsEnginesAnalyticsRequest>;
 
@@ -24919,7 +24927,7 @@ export const UpdateConfigProjectsLocationsCollectionsEnginesAnalyticsRequest =
       GoogleCloudDiscoveryengineV1alphaAnalyticsConfig,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigProjectsLocationsCollectionsEnginesAnalyticsRequest>;
 
@@ -24959,7 +24967,7 @@ export const ExportMetricsProjectsLocationsCollectionsEnginesAnalyticsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{analytics}:exportMetrics",
+      path: "v1alpha/{+analytics}:exportMetrics",
       hasBody: true,
     }),
     svc,
@@ -24994,7 +25002,7 @@ export const GetProjectsLocationsCollectionsEnginesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesOperationsRequest>;
 
@@ -25041,7 +25049,7 @@ export const ListProjectsLocationsCollectionsEnginesOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesOperationsRequest>;
 
@@ -25086,7 +25094,7 @@ export const PatchProjectsLocationsCollectionsEnginesWidgetConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesWidgetConfigsRequest>;
 
@@ -25131,7 +25139,7 @@ export const GetProjectsLocationsCollectionsEnginesWidgetConfigsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesWidgetConfigsRequest>;
 
@@ -25171,7 +25179,7 @@ export const AnswerProjectsLocationsCollectionsEnginesServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{servingConfig}:answer",
+      path: "v1alpha/{+servingConfig}:answer",
       hasBody: true,
     }),
     svc,
@@ -25212,7 +25220,7 @@ export const ListProjectsLocationsCollectionsEnginesServingConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/servingConfigs" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/servingConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesServingConfigsRequest>;
 
@@ -25256,7 +25264,7 @@ export const SearchLiteProjectsLocationsCollectionsEnginesServingConfigsRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{servingConfig}:searchLite",
+      path: "v1alpha/{+servingConfig}:searchLite",
       hasBody: true,
     }),
     svc,
@@ -25298,7 +25306,7 @@ export const SearchProjectsLocationsCollectionsEnginesServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{servingConfig}:search",
+      path: "v1alpha/{+servingConfig}:search",
       hasBody: true,
     }),
     svc,
@@ -25333,7 +25341,7 @@ export const DeleteProjectsLocationsCollectionsEnginesServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesServingConfigsRequest>;
 
@@ -25378,7 +25386,7 @@ export const CreateProjectsLocationsCollectionsEnginesServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/servingConfigs",
+      path: "v1alpha/{+parent}/servingConfigs",
       hasBody: true,
     }),
     svc,
@@ -25420,7 +25428,7 @@ export const RecommendProjectsLocationsCollectionsEnginesServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{servingConfig}:recommend",
+      path: "v1alpha/{+servingConfig}:recommend",
       hasBody: true,
     }),
     svc,
@@ -25463,7 +25471,7 @@ export const PatchProjectsLocationsCollectionsEnginesServingConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesServingConfigsRequest>;
 
@@ -25503,7 +25511,7 @@ export const StreamAnswerProjectsLocationsCollectionsEnginesServingConfigsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{servingConfig}:streamAnswer",
+      path: "v1alpha/{+servingConfig}:streamAnswer",
       hasBody: true,
     }),
     svc,
@@ -25538,7 +25546,7 @@ export const GetProjectsLocationsCollectionsEnginesServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesServingConfigsRequest>;
 
@@ -25579,7 +25587,7 @@ export const PatchProjectsLocationsCollectionsEnginesSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesSessionsRequest>;
 
@@ -25624,7 +25632,7 @@ export const ListProjectsLocationsCollectionsEnginesSessionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/sessions" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/sessions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesSessionsRequest>;
 
@@ -25666,7 +25674,7 @@ export const GetProjectsLocationsCollectionsEnginesSessionsRequest =
       T.HttpQuery("includeAnswerDetails"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesSessionsRequest>;
 
@@ -25698,7 +25706,7 @@ export const DeleteProjectsLocationsCollectionsEnginesSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesSessionsRequest>;
 
@@ -25741,7 +25749,7 @@ export const CreateProjectsLocationsCollectionsEnginesSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/sessions",
+      path: "v1alpha/{+parent}/sessions",
       hasBody: true,
     }),
     svc,
@@ -25788,7 +25796,7 @@ export const ListProjectsLocationsCollectionsEnginesSessionsFilesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/files" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/files" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesSessionsFilesRequest>;
 
@@ -25825,7 +25833,7 @@ export const GetProjectsLocationsCollectionsEnginesSessionsAnswersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesSessionsAnswersRequest>;
 
@@ -25858,7 +25866,7 @@ export const GetProjectsLocationsCollectionsEnginesSessionsAlphaEvolveExperiment
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesSessionsAlphaEvolveExperimentsOperationsRequest>;
 
@@ -25893,7 +25901,7 @@ export const GetProjectsLocationsCollectionsEnginesSessionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesSessionsOperationsRequest>;
 
@@ -25926,7 +25934,7 @@ export const GetProjectsLocationsCollectionsEnginesAssistantsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesAssistantsRequest>;
 
@@ -25959,7 +25967,7 @@ export const DeleteProjectsLocationsCollectionsEnginesAssistantsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesAssistantsRequest>;
 
@@ -26000,7 +26008,7 @@ export const PatchProjectsLocationsCollectionsEnginesAssistantsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesAssistantsRequest>;
 
@@ -26045,7 +26053,7 @@ export const CreateProjectsLocationsCollectionsEnginesAssistantsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/assistants",
+      path: "v1alpha/{+parent}/assistants",
       hasBody: true,
     }),
     svc,
@@ -26086,7 +26094,7 @@ export const ListProjectsLocationsCollectionsEnginesAssistantsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/assistants" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/assistants" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesAssistantsRequest>;
 
@@ -26130,7 +26138,7 @@ export const StreamAssistProjectsLocationsCollectionsEnginesAssistantsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{name}:streamAssist",
+      path: "v1alpha/{+name}:streamAssist",
       hasBody: true,
     }),
     svc,
@@ -26170,7 +26178,7 @@ export const CreateProjectsLocationsCollectionsEnginesAssistantsAgentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{parent}/agents", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+parent}/agents", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsEnginesAssistantsAgentsRequest>;
 
@@ -26215,7 +26223,7 @@ export const ListProjectsLocationsCollectionsEnginesAssistantsAgentsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/agents" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/agents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesAssistantsAgentsRequest>;
 
@@ -26252,7 +26260,7 @@ export const GetProjectsLocationsCollectionsEnginesAssistantsAgentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesAssistantsAgentsRequest>;
 
@@ -26285,7 +26293,7 @@ export const DeleteProjectsLocationsCollectionsEnginesAssistantsAgentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesAssistantsAgentsRequest>;
 
@@ -26326,7 +26334,7 @@ export const PatchProjectsLocationsCollectionsEnginesAssistantsAgentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesAssistantsAgentsRequest>;
 
@@ -26366,7 +26374,7 @@ export const ImportProjectsLocationsCollectionsEnginesAssistantsAgentsFilesReque
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/files:import",
+      path: "v1alpha/{+parent}/files:import",
       hasBody: true,
     }),
     svc,
@@ -26402,7 +26410,7 @@ export const GetProjectsLocationsCollectionsEnginesAssistantsAgentsOperationsReq
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesAssistantsAgentsOperationsRequest>;
 
@@ -26445,7 +26453,7 @@ export const PatchProjectsLocationsCollectionsEnginesAssistantsCannedQueriesRequ
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesAssistantsCannedQueriesRequest>;
 
@@ -26488,7 +26496,7 @@ export const ListProjectsLocationsCollectionsEnginesAssistantsCannedQueriesReque
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/cannedQueries" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/cannedQueries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesAssistantsCannedQueriesRequest>;
 
@@ -26538,7 +26546,7 @@ export const CreateProjectsLocationsCollectionsEnginesAssistantsCannedQueriesReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/cannedQueries",
+      path: "v1alpha/{+parent}/cannedQueries",
       hasBody: true,
     }),
     svc,
@@ -26575,7 +26583,7 @@ export const DeleteProjectsLocationsCollectionsEnginesAssistantsCannedQueriesReq
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesAssistantsCannedQueriesRequest>;
 
@@ -26610,7 +26618,7 @@ export const GetProjectsLocationsCollectionsEnginesAssistantsCannedQueriesReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesAssistantsCannedQueriesRequest>;
 
@@ -26650,7 +26658,7 @@ export const TrainCustomModelProjectsLocationsCollectionsDataStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{dataStore}:trainCustomModel",
+      path: "v1alpha/{+dataStore}:trainCustomModel",
       hasBody: true,
     }),
     svc,
@@ -26694,7 +26702,7 @@ export const ListProjectsLocationsCollectionsDataStoresRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/dataStores" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/dataStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -26730,7 +26738,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -26778,7 +26786,7 @@ export const CompleteQueryProjectsLocationsCollectionsDataStoresRequest =
       T.HttpQuery("userPseudoId"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{dataStore}:completeQuery" }),
+    T.Http({ method: "GET", path: "v1alpha/{+dataStore}:completeQuery" }),
     svc,
   ) as unknown as Schema.Schema<CompleteQueryProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -26819,7 +26827,7 @@ export const UpdateDocumentProcessingConfigProjectsLocationsCollectionsDataStore
       GoogleCloudDiscoveryengineV1alphaDocumentProcessingConfig,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateDocumentProcessingConfigProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -26861,7 +26869,7 @@ export const DeletePatientFilterProjectsLocationsCollectionsDataStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{dataStore}:deletePatientFilter",
+      path: "v1alpha/{+dataStore}:deletePatientFilter",
       hasBody: true,
     }),
     svc,
@@ -26904,7 +26912,7 @@ export const PatchProjectsLocationsCollectionsDataStoresRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -26936,7 +26944,7 @@ export const GetSiteSearchEngineProjectsLocationsCollectionsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSiteSearchEngineProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -27001,7 +27009,7 @@ export const CreateProjectsLocationsCollectionsDataStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/dataStores",
+      path: "v1alpha/{+parent}/dataStores",
       hasBody: true,
     }),
     svc,
@@ -27042,7 +27050,7 @@ export const ReplacePatientFilterProjectsLocationsCollectionsDataStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{dataStore}:replacePatientFilter",
+      path: "v1alpha/{+dataStore}:replacePatientFilter",
       hasBody: true,
     }),
     svc,
@@ -27084,7 +27092,7 @@ export const RemovePatientFilterProjectsLocationsCollectionsDataStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{dataStore}:removePatientFilter",
+      path: "v1alpha/{+dataStore}:removePatientFilter",
       hasBody: true,
     }),
     svc,
@@ -27119,7 +27127,7 @@ export const GetDocumentProcessingConfigProjectsLocationsCollectionsDataStoresRe
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDocumentProcessingConfigProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -27161,7 +27169,7 @@ export const AddPatientFilterProjectsLocationsCollectionsDataStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{dataStore}:addPatientFilter",
+      path: "v1alpha/{+dataStore}:addPatientFilter",
       hasBody: true,
     }),
     svc,
@@ -27196,7 +27204,7 @@ export const GetProjectsLocationsCollectionsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -27235,7 +27243,7 @@ export const CompleteQueryProjectsLocationsCollectionsDataStoresCompletionConfig
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{completionConfig}:completeQuery",
+      path: "v1alpha/{+completionConfig}:completeQuery",
       hasBody: true,
     }),
     svc,
@@ -27272,7 +27280,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresServingConfigsRequest>;
 
@@ -27311,7 +27319,7 @@ export const ListProjectsLocationsCollectionsDataStoresServingConfigsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/servingConfigs" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/servingConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresServingConfigsRequest>;
 
@@ -27355,7 +27363,7 @@ export const AnswerProjectsLocationsCollectionsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{servingConfig}:answer",
+      path: "v1alpha/{+servingConfig}:answer",
       hasBody: true,
     }),
     svc,
@@ -27397,7 +27405,7 @@ export const StreamAnswerProjectsLocationsCollectionsDataStoresServingConfigsReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{servingConfig}:streamAnswer",
+      path: "v1alpha/{+servingConfig}:streamAnswer",
       hasBody: true,
     }),
     svc,
@@ -27442,7 +27450,7 @@ export const PatchProjectsLocationsCollectionsDataStoresServingConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresServingConfigsRequest>;
 
@@ -27482,7 +27490,7 @@ export const RecommendProjectsLocationsCollectionsDataStoresServingConfigsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{servingConfig}:recommend",
+      path: "v1alpha/{+servingConfig}:recommend",
       hasBody: true,
     }),
     svc,
@@ -27524,7 +27532,7 @@ export const SearchProjectsLocationsCollectionsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{servingConfig}:search",
+      path: "v1alpha/{+servingConfig}:search",
       hasBody: true,
     }),
     svc,
@@ -27566,7 +27574,7 @@ export const SearchLiteProjectsLocationsCollectionsDataStoresServingConfigsReque
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{servingConfig}:searchLite",
+      path: "v1alpha/{+servingConfig}:searchLite",
       hasBody: true,
     }),
     svc,
@@ -27602,7 +27610,7 @@ export const GetProjectsLocationsCollectionsDataStoresServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresServingConfigsRequest>;
 
@@ -27647,7 +27655,7 @@ export const CreateProjectsLocationsCollectionsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/servingConfigs",
+      path: "v1alpha/{+parent}/servingConfigs",
       hasBody: true,
     }),
     svc,
@@ -27690,7 +27698,7 @@ export const PatchProjectsLocationsCollectionsDataStoresWidgetConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresWidgetConfigsRequest>;
 
@@ -27735,7 +27743,7 @@ export const GetProjectsLocationsCollectionsDataStoresWidgetConfigsRequest =
       T.HttpQuery("getWidgetConfigRequestOption.turnOffCollectionComponents"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresWidgetConfigsRequest>;
 
@@ -27780,7 +27788,7 @@ export const BatchGetDocumentsMetadataProjectsLocationsCollectionsDataStoresBran
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}/batchGetDocumentsMetadata",
+      path: "v1alpha/{+parent}/batchGetDocumentsMetadata",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetDocumentsMetadataProjectsLocationsCollectionsDataStoresBranchesRequest>;
@@ -27823,7 +27831,7 @@ export const ListProjectsLocationsCollectionsDataStoresBranchesRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/branches" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/branches" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresBranchesRequest>;
 
@@ -27863,7 +27871,7 @@ export const GetProjectsLocationsCollectionsDataStoresBranchesRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresBranchesRequest>;
 
@@ -27910,7 +27918,7 @@ export const ListProjectsLocationsCollectionsDataStoresBranchesOperationsRequest
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresBranchesOperationsRequest>;
 
@@ -27947,7 +27955,7 @@ export const GetProjectsLocationsCollectionsDataStoresBranchesOperationsRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresBranchesOperationsRequest>;
 
@@ -27985,7 +27993,7 @@ export const CancelProjectsLocationsCollectionsDataStoresBranchesOperationsReque
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsCollectionsDataStoresBranchesOperationsRequest>;
 
@@ -28025,7 +28033,7 @@ export const ListProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest 
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/documents" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/documents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest>;
 
@@ -28069,7 +28077,7 @@ export const PurgeProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/documents:purge",
+      path: "v1alpha/{+parent}/documents:purge",
       hasBody: true,
     }),
     svc,
@@ -28114,7 +28122,7 @@ export const CreateProjectsLocationsCollectionsDataStoresBranchesDocumentsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/documents",
+      path: "v1alpha/{+parent}/documents",
       hasBody: true,
     }),
     svc,
@@ -28149,7 +28157,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresBranchesDocumentsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest>;
 
@@ -28189,7 +28197,7 @@ export const ImportProjectsLocationsCollectionsDataStoresBranchesDocumentsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/documents:import",
+      path: "v1alpha/{+parent}/documents:import",
       hasBody: true,
     }),
     svc,
@@ -28237,7 +28245,7 @@ export const PatchProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest>;
 
@@ -28270,7 +28278,7 @@ export const GetProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest>;
 
@@ -28325,7 +28333,7 @@ export const GetProcessedDocumentProjectsLocationsCollectionsDataStoresBranchesD
     ),
     imageId: Schema.optional(Schema.String).pipe(T.HttpQuery("imageId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}:getProcessedDocument" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}:getProcessedDocument" }),
     svc,
   ) as unknown as Schema.Schema<GetProcessedDocumentProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest>;
 
@@ -28360,7 +28368,7 @@ export const GetProjectsLocationsCollectionsDataStoresBranchesDocumentsChunksReq
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresBranchesDocumentsChunksRequest>;
 
@@ -28401,7 +28409,7 @@ export const ListProjectsLocationsCollectionsDataStoresBranchesDocumentsChunksRe
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/chunks" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/chunks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresBranchesDocumentsChunksRequest>;
 
@@ -28447,7 +28455,7 @@ export const ImportProjectsLocationsCollectionsDataStoresCompletionSuggestionsRe
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/completionSuggestions:import",
+      path: "v1alpha/{+parent}/completionSuggestions:import",
       hasBody: true,
     }),
     svc,
@@ -28491,7 +28499,7 @@ export const PurgeProjectsLocationsCollectionsDataStoresCompletionSuggestionsReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/completionSuggestions:purge",
+      path: "v1alpha/{+parent}/completionSuggestions:purge",
       hasBody: true,
     }),
     svc,
@@ -28534,7 +28542,7 @@ export const ListProjectsLocationsCollectionsDataStoresSchemasRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/schemas" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/schemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresSchemasRequest>;
 
@@ -28579,7 +28587,11 @@ export const CreateProjectsLocationsCollectionsDataStoresSchemasRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{parent}/schemas", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1alpha/{+parent}/schemas",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsDataStoresSchemasRequest>;
 
@@ -28612,7 +28624,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresSchemasRequest>;
 
@@ -28645,7 +28657,7 @@ export const GetProjectsLocationsCollectionsDataStoresSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSchemasRequest>;
 
@@ -28688,7 +28700,7 @@ export const PatchProjectsLocationsCollectionsDataStoresSchemasRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresSchemasRequest>;
 
@@ -28721,7 +28733,7 @@ export const GetProjectsLocationsCollectionsDataStoresSchemasOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSchemasOperationsRequest>;
 
@@ -28768,7 +28780,7 @@ export const ListProjectsLocationsCollectionsDataStoresSchemasOperationsRequest 
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresSchemasOperationsRequest>;
 
@@ -28805,7 +28817,7 @@ export const ListProjectsLocationsCollectionsDataStoresCustomModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     dataStore: Schema.String.pipe(T.HttpPath("dataStore")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{dataStore}/customModels" }),
+    T.Http({ method: "GET", path: "v1alpha/{+dataStore}/customModels" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresCustomModelsRequest>;
 
@@ -28838,7 +28850,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresSessionsRequest>;
 
@@ -28876,7 +28888,7 @@ export const GetProjectsLocationsCollectionsDataStoresSessionsRequest =
       T.HttpQuery("includeAnswerDetails"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSessionsRequest>;
 
@@ -28917,7 +28929,7 @@ export const PatchProjectsLocationsCollectionsDataStoresSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresSessionsRequest>;
 
@@ -28962,7 +28974,7 @@ export const ListProjectsLocationsCollectionsDataStoresSessionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/sessions" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/sessions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresSessionsRequest>;
 
@@ -29009,7 +29021,7 @@ export const CreateProjectsLocationsCollectionsDataStoresSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/sessions",
+      path: "v1alpha/{+parent}/sessions",
       hasBody: true,
     }),
     svc,
@@ -29044,7 +29056,7 @@ export const GetProjectsLocationsCollectionsDataStoresSessionsAnswersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSessionsAnswersRequest>;
 
@@ -29087,7 +29099,7 @@ export const WriteProjectsLocationsCollectionsDataStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/userEvents:write",
+      path: "v1alpha/{+parent}/userEvents:write",
       hasBody: true,
     }),
     svc,
@@ -29131,7 +29143,7 @@ export const CollectProjectsLocationsCollectionsDataStoresUserEventsRequest =
     ets: Schema.optional(Schema.String).pipe(T.HttpQuery("ets")),
     userEvent: Schema.optional(Schema.String).pipe(T.HttpQuery("userEvent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/userEvents:collect" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/userEvents:collect" }),
     svc,
   ) as unknown as Schema.Schema<CollectProjectsLocationsCollectionsDataStoresUserEventsRequest>;
 
@@ -29171,7 +29183,7 @@ export const PurgeProjectsLocationsCollectionsDataStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/userEvents:purge",
+      path: "v1alpha/{+parent}/userEvents:purge",
       hasBody: true,
     }),
     svc,
@@ -29213,7 +29225,7 @@ export const ImportProjectsLocationsCollectionsDataStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/userEvents:import",
+      path: "v1alpha/{+parent}/userEvents:import",
       hasBody: true,
     }),
     svc,
@@ -29248,7 +29260,7 @@ export const GetProjectsLocationsCollectionsDataStoresModelsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresModelsOperationsRequest>;
 
@@ -29295,7 +29307,7 @@ export const ListProjectsLocationsCollectionsDataStoresModelsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresModelsOperationsRequest>;
 
@@ -29337,7 +29349,7 @@ export const ConverseProjectsLocationsCollectionsDataStoresConversationsRequest 
       GoogleCloudDiscoveryengineV1alphaConverseConversationRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:converse", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:converse", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ConverseProjectsLocationsCollectionsDataStoresConversationsRequest>;
 
@@ -29382,7 +29394,7 @@ export const ListProjectsLocationsCollectionsDataStoresConversationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresConversationsRequest>;
 
@@ -29419,7 +29431,7 @@ export const GetProjectsLocationsCollectionsDataStoresConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresConversationsRequest>;
 
@@ -29459,7 +29471,7 @@ export const CreateProjectsLocationsCollectionsDataStoresConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/conversations",
+      path: "v1alpha/{+parent}/conversations",
       hasBody: true,
     }),
     svc,
@@ -29494,7 +29506,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresConversationsRequest>;
 
@@ -29535,7 +29547,7 @@ export const PatchProjectsLocationsCollectionsDataStoresConversationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresConversationsRequest>;
 
@@ -29568,7 +29580,7 @@ export const GetProjectsLocationsCollectionsDataStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresOperationsRequest>;
 
@@ -29615,7 +29627,7 @@ export const ListProjectsLocationsCollectionsDataStoresOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresOperationsRequest>;
 
@@ -29659,7 +29671,7 @@ export const PurgeProjectsLocationsCollectionsDataStoresSuggestionDenyListEntrie
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/suggestionDenyListEntries:purge",
+      path: "v1alpha/{+parent}/suggestionDenyListEntries:purge",
       hasBody: true,
     }),
     svc,
@@ -29703,7 +29715,7 @@ export const ImportProjectsLocationsCollectionsDataStoresSuggestionDenyListEntri
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/suggestionDenyListEntries:import",
+      path: "v1alpha/{+parent}/suggestionDenyListEntries:import",
       hasBody: true,
     }),
     svc,
@@ -29740,7 +29752,7 @@ export const GetProjectsLocationsCollectionsDataStoresControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresControlsRequest>;
 
@@ -29782,7 +29794,7 @@ export const ListProjectsLocationsCollectionsDataStoresControlsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/controls" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/controls" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresControlsRequest>;
 
@@ -29829,7 +29841,7 @@ export const CreateProjectsLocationsCollectionsDataStoresControlsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/controls",
+      path: "v1alpha/{+parent}/controls",
       hasBody: true,
     }),
     svc,
@@ -29864,7 +29876,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresControlsRequest>;
 
@@ -29905,7 +29917,7 @@ export const PatchProjectsLocationsCollectionsDataStoresControlsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresControlsRequest>;
 
@@ -29940,7 +29952,7 @@ export const GetUriPatternDocumentDataProjectsLocationsCollectionsDataStoresSite
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{siteSearchEngine}:getUriPatternDocumentData",
+      path: "v1alpha/{+siteSearchEngine}:getUriPatternDocumentData",
     }),
     svc,
   ) as unknown as Schema.Schema<GetUriPatternDocumentDataProjectsLocationsCollectionsDataStoresSiteSearchEngineRequest>;
@@ -29983,7 +29995,7 @@ export const DisableAdvancedSiteSearchProjectsLocationsCollectionsDataStoresSite
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{siteSearchEngine}:disableAdvancedSiteSearch",
+      path: "v1alpha/{+siteSearchEngine}:disableAdvancedSiteSearch",
       hasBody: true,
     }),
     svc,
@@ -30027,7 +30039,7 @@ export const EnableAdvancedSiteSearchProjectsLocationsCollectionsDataStoresSiteS
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{siteSearchEngine}:enableAdvancedSiteSearch",
+      path: "v1alpha/{+siteSearchEngine}:enableAdvancedSiteSearch",
       hasBody: true,
     }),
     svc,
@@ -30072,7 +30084,7 @@ export const FetchDomainVerificationStatusProjectsLocationsCollectionsDataStores
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{siteSearchEngine}:fetchDomainVerificationStatus",
+      path: "v1alpha/{+siteSearchEngine}:fetchDomainVerificationStatus",
     }),
     svc,
   ) as unknown as Schema.Schema<FetchDomainVerificationStatusProjectsLocationsCollectionsDataStoresSiteSearchEngineRequest>;
@@ -30119,7 +30131,7 @@ export const BatchVerifyTargetSitesProjectsLocationsCollectionsDataStoresSiteSea
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}:batchVerifyTargetSites",
+      path: "v1alpha/{+parent}:batchVerifyTargetSites",
       hasBody: true,
     }),
     svc,
@@ -30163,7 +30175,7 @@ export const RecrawlUrisProjectsLocationsCollectionsDataStoresSiteSearchEngineRe
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{siteSearchEngine}:recrawlUris",
+      path: "v1alpha/{+siteSearchEngine}:recrawlUris",
       hasBody: true,
     }),
     svc,
@@ -30207,7 +30219,7 @@ export const SetUriPatternDocumentDataProjectsLocationsCollectionsDataStoresSite
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{siteSearchEngine}:setUriPatternDocumentData",
+      path: "v1alpha/{+siteSearchEngine}:setUriPatternDocumentData",
       hasBody: true,
     }),
     svc,
@@ -30251,7 +30263,7 @@ export const CreateProjectsLocationsCollectionsDataStoresSiteSearchEngineSitemap
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/sitemaps",
+      path: "v1alpha/{+parent}/sitemaps",
       hasBody: true,
     }),
     svc,
@@ -30293,7 +30305,7 @@ export const FetchProjectsLocationsCollectionsDataStoresSiteSearchEngineSitemaps
     ).pipe(T.HttpQuery("matcher.urisMatcher.uris")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/sitemaps:fetch" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/sitemaps:fetch" }),
     svc,
   ) as unknown as Schema.Schema<FetchProjectsLocationsCollectionsDataStoresSiteSearchEngineSitemapsRequest>;
 
@@ -30328,7 +30340,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresSiteSearchEngineSitemap
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresSiteSearchEngineSitemapsRequest>;
 
@@ -30363,7 +30375,7 @@ export const GetProjectsLocationsCollectionsDataStoresSiteSearchEngineOperations
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSiteSearchEngineOperationsRequest>;
 
@@ -30412,7 +30424,7 @@ export const ListProjectsLocationsCollectionsDataStoresSiteSearchEngineOperation
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresSiteSearchEngineOperationsRequest>;
 
@@ -30458,7 +30470,7 @@ export const BatchCreateProjectsLocationsCollectionsDataStoresSiteSearchEngineTa
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/targetSites:batchCreate",
+      path: "v1alpha/{+parent}/targetSites:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -30495,7 +30507,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetS
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -30537,7 +30549,7 @@ export const CreateProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetS
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/targetSites",
+      path: "v1alpha/{+parent}/targetSites",
       hasBody: true,
     }),
     svc,
@@ -30580,7 +30592,7 @@ export const ListProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSit
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/targetSites" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/targetSites" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -30619,7 +30631,7 @@ export const GetProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSite
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -30659,7 +30671,7 @@ export const PatchProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSi
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -30694,7 +30706,7 @@ export const GetProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSite
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesOperationsRequest>;
 
@@ -30743,7 +30755,7 @@ export const ListProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSit
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesOperationsRequest>;
 
@@ -30796,7 +30808,7 @@ export const ListProjectsLocationsCollectionsOperationsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsOperationsRequest>;
 
@@ -30832,7 +30844,7 @@ export const GetProjectsLocationsCollectionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsOperationsRequest>;
 
@@ -30864,7 +30876,7 @@ export const GetConnectorSecretProjectsLocationsCollectionsDataConnectorRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}:getConnectorSecret" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}:getConnectorSecret" }),
     svc,
   ) as unknown as Schema.Schema<GetConnectorSecretProjectsLocationsCollectionsDataConnectorRequest>;
 
@@ -30904,7 +30916,7 @@ export const AcquireAccessTokenProjectsLocationsCollectionsDataConnectorRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{name}:acquireAccessToken",
+      path: "v1alpha/{+name}:acquireAccessToken",
       hasBody: true,
     }),
     svc,
@@ -30946,7 +30958,7 @@ export const StartConnectorRunProjectsLocationsCollectionsDataConnectorRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}:startConnectorRun",
+      path: "v1alpha/{+parent}:startConnectorRun",
       hasBody: true,
     }),
     svc,
@@ -31032,7 +31044,7 @@ export const CheckRefreshTokenProjectsLocationsCollectionsDataConnectorRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}:checkRefreshToken" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}:checkRefreshToken" }),
     svc,
   ) as unknown as Schema.Schema<CheckRefreshTokenProjectsLocationsCollectionsDataConnectorRequest>;
 
@@ -31079,7 +31091,7 @@ export const ListProjectsLocationsCollectionsDataConnectorOperationsRequest =
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataConnectorOperationsRequest>;
 
@@ -31116,7 +31128,7 @@ export const GetProjectsLocationsCollectionsDataConnectorOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataConnectorOperationsRequest>;
 
@@ -31155,7 +31167,7 @@ export const ListProjectsLocationsCollectionsDataConnectorConnectorRunsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/connectorRuns" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/connectorRuns" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataConnectorConnectorRunsRequest>;
 
@@ -31192,7 +31204,7 @@ export const ListProjectsLocationsCmekConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/cmekConfigs" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/cmekConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCmekConfigsRequest>;
 
@@ -31224,7 +31236,7 @@ export const GetProjectsLocationsCmekConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCmekConfigsRequest>;
 
@@ -31256,7 +31268,7 @@ export const DeleteProjectsLocationsCmekConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCmekConfigsRequest>;
 
@@ -31296,7 +31308,7 @@ export const PatchProjectsLocationsCmekConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCmekConfigsRequest>;
 
@@ -31328,7 +31340,7 @@ export const GetProjectsLocationsIdentityMappingStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIdentityMappingStoresRequest>;
 
@@ -31369,7 +31381,7 @@ export const ImportIdentityMappingsProjectsLocationsIdentityMappingStoresRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{identityMappingStore}:importIdentityMappings",
+      path: "v1alpha/{+identityMappingStore}:importIdentityMappings",
       hasBody: true,
     }),
     svc,
@@ -31404,7 +31416,7 @@ export const DeleteProjectsLocationsIdentityMappingStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsIdentityMappingStoresRequest>;
 
@@ -31442,7 +31454,7 @@ export const ListProjectsLocationsIdentityMappingStoresRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/identityMappingStores" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/identityMappingStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIdentityMappingStoresRequest>;
 
@@ -31500,7 +31512,7 @@ export const CreateProjectsLocationsIdentityMappingStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/identityMappingStores",
+      path: "v1alpha/{+parent}/identityMappingStores",
       hasBody: true,
     }),
     svc,
@@ -31543,7 +31555,7 @@ export const PurgeIdentityMappingsProjectsLocationsIdentityMappingStoresRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{identityMappingStore}:purgeIdentityMappings",
+      path: "v1alpha/{+identityMappingStore}:purgeIdentityMappings",
       hasBody: true,
     }),
     svc,
@@ -31588,7 +31600,7 @@ export const ListIdentityMappingsProjectsLocationsIdentityMappingStoresRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{identityMappingStore}:listIdentityMappings",
+      path: "v1alpha/{+identityMappingStore}:listIdentityMappings",
     }),
     svc,
   ) as unknown as Schema.Schema<ListIdentityMappingsProjectsLocationsIdentityMappingStoresRequest>;
@@ -31640,7 +31652,7 @@ export const ListProjectsLocationsIdentityMappingStoresOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIdentityMappingStoresOperationsRequest>;
 
@@ -31677,7 +31689,7 @@ export const GetProjectsLocationsIdentityMappingStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIdentityMappingStoresOperationsRequest>;
 
@@ -31717,7 +31729,7 @@ export const RankProjectsLocationsRankingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{rankingConfig}:rank",
+      path: "v1alpha/{+rankingConfig}:rank",
       hasBody: true,
     }),
     svc,
@@ -31758,7 +31770,7 @@ export const BatchDeleteProjectsLocationsNotebooksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/notebooks:batchDelete",
+      path: "v1alpha/{+parent}/notebooks:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -31791,7 +31803,7 @@ export const GetProjectsLocationsNotebooksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNotebooksRequest>;
 
@@ -31830,7 +31842,7 @@ export const CreateProjectsLocationsNotebooksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/notebooks",
+      path: "v1alpha/{+parent}/notebooks",
       hasBody: true,
     }),
     svc,
@@ -31872,7 +31884,7 @@ export const ListRecentlyViewedProjectsLocationsNotebooksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}/notebooks:listRecentlyViewed",
+      path: "v1alpha/{+parent}/notebooks:listRecentlyViewed",
     }),
     svc,
   ) as unknown as Schema.Schema<ListRecentlyViewedProjectsLocationsNotebooksRequest>;
@@ -31914,7 +31926,7 @@ export const ShareProjectsLocationsNotebooksRequest =
       GoogleCloudNotebooklmV1alphaShareNotebookRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:share", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:share", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ShareProjectsLocationsNotebooksRequest>;
 
@@ -31953,7 +31965,7 @@ export const CreateProjectsLocationsNotebooksAudioOverviewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/audioOverviews",
+      path: "v1alpha/{+parent}/audioOverviews",
       hasBody: true,
     }),
     svc,
@@ -31987,7 +31999,7 @@ export const DeleteProjectsLocationsNotebooksAudioOverviewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNotebooksAudioOverviewsRequest>;
 
@@ -32026,7 +32038,7 @@ export const BatchDeleteProjectsLocationsNotebooksSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/sources:batchDelete",
+      path: "v1alpha/{+parent}/sources:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -32060,7 +32072,7 @@ export const GetProjectsLocationsNotebooksSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNotebooksSourcesRequest>;
 
@@ -32099,7 +32111,7 @@ export const BatchCreateProjectsLocationsNotebooksSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/sources:batchCreate",
+      path: "v1alpha/{+parent}/sources:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -32133,7 +32145,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -32178,7 +32190,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -32224,7 +32236,7 @@ export const WriteProjectsLocationsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/userEvents:write",
+      path: "v1alpha/{+parent}/userEvents:write",
       hasBody: true,
     }),
     svc,
@@ -32265,7 +32277,7 @@ export const ImportProjectsLocationsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/userEvents:import",
+      path: "v1alpha/{+parent}/userEvents:import",
       hasBody: true,
     }),
     svc,
@@ -32308,7 +32320,7 @@ export const CollectProjectsLocationsUserEventsRequest =
     userEvent: Schema.optional(Schema.String).pipe(T.HttpQuery("userEvent")),
     uri: Schema.optional(Schema.String).pipe(T.HttpQuery("uri")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/userEvents:collect" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/userEvents:collect" }),
     svc,
   ) as unknown as Schema.Schema<CollectProjectsLocationsUserEventsRequest>;
 
@@ -32339,7 +32351,7 @@ export const GetProjectsLocationsPodcastsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPodcastsOperationsRequest>;
 
@@ -32378,7 +32390,7 @@ export const CheckRequirementProjectsLocationsRequirementsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{location}/requirements:checkRequirement",
+      path: "v1alpha/{+location}/requirements:checkRequirement",
       hasBody: true,
     }),
     svc,
@@ -32419,7 +32431,7 @@ export const RemovePatientFilterProjectsLocationsDataStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{dataStore}:removePatientFilter",
+      path: "v1alpha/{+dataStore}:removePatientFilter",
       hasBody: true,
     }),
     svc,
@@ -32460,7 +32472,7 @@ export const DeletePatientFilterProjectsLocationsDataStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{dataStore}:deletePatientFilter",
+      path: "v1alpha/{+dataStore}:deletePatientFilter",
       hasBody: true,
     }),
     svc,
@@ -32494,7 +32506,7 @@ export const GetDocumentProcessingConfigProjectsLocationsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDocumentProcessingConfigProjectsLocationsDataStoresRequest>;
 
@@ -32535,7 +32547,7 @@ export const UpdateDocumentProcessingConfigProjectsLocationsDataStoresRequest =
       GoogleCloudDiscoveryengineV1alphaDocumentProcessingConfig,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateDocumentProcessingConfigProjectsLocationsDataStoresRequest>;
 
@@ -32575,7 +32587,7 @@ export const ReplacePatientFilterProjectsLocationsDataStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{dataStore}:replacePatientFilter",
+      path: "v1alpha/{+dataStore}:replacePatientFilter",
       hasBody: true,
     }),
     svc,
@@ -32610,7 +32622,7 @@ export const GetProjectsLocationsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresRequest>;
 
@@ -32674,7 +32686,7 @@ export const CreateProjectsLocationsDataStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/dataStores",
+      path: "v1alpha/{+parent}/dataStores",
       hasBody: true,
     }),
     svc,
@@ -32708,7 +32720,7 @@ export const GetSiteSearchEngineProjectsLocationsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSiteSearchEngineProjectsLocationsDataStoresRequest>;
 
@@ -32756,7 +32768,7 @@ export const CompleteQueryProjectsLocationsDataStoresRequest =
     query: Schema.optional(Schema.String).pipe(T.HttpQuery("query")),
     dataStore: Schema.String.pipe(T.HttpPath("dataStore")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{dataStore}:completeQuery" }),
+    T.Http({ method: "GET", path: "v1alpha/{+dataStore}:completeQuery" }),
     svc,
   ) as unknown as Schema.Schema<CompleteQueryProjectsLocationsDataStoresRequest>;
 
@@ -32795,7 +32807,7 @@ export const AddPatientFilterProjectsLocationsDataStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{dataStore}:addPatientFilter",
+      path: "v1alpha/{+dataStore}:addPatientFilter",
       hasBody: true,
     }),
     svc,
@@ -32837,7 +32849,7 @@ export const PatchProjectsLocationsDataStoresRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresRequest>;
 
@@ -32869,7 +32881,7 @@ export const DeleteProjectsLocationsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresRequest>;
 
@@ -32910,7 +32922,7 @@ export const ListProjectsLocationsDataStoresRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/dataStores" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/dataStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresRequest>;
 
@@ -32958,7 +32970,7 @@ export const GetProjectsLocationsDataStoresWidgetConfigsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresWidgetConfigsRequest>;
 
@@ -32998,7 +33010,7 @@ export const PatchProjectsLocationsDataStoresWidgetConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresWidgetConfigsRequest>;
 
@@ -33030,7 +33042,7 @@ export const GetProjectsLocationsDataStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresOperationsRequest>;
 
@@ -33076,7 +33088,7 @@ export const ListProjectsLocationsDataStoresOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresOperationsRequest>;
 
@@ -33119,7 +33131,7 @@ export const PurgeProjectsLocationsDataStoresSuggestionDenyListEntriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/suggestionDenyListEntries:purge",
+      path: "v1alpha/{+parent}/suggestionDenyListEntries:purge",
       hasBody: true,
     }),
     svc,
@@ -33161,7 +33173,7 @@ export const ImportProjectsLocationsDataStoresSuggestionDenyListEntriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/suggestionDenyListEntries:import",
+      path: "v1alpha/{+parent}/suggestionDenyListEntries:import",
       hasBody: true,
     }),
     svc,
@@ -33204,7 +33216,11 @@ export const CreateProjectsLocationsDataStoresSchemasRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{parent}/schemas", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1alpha/{+parent}/schemas",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataStoresSchemasRequest>;
 
@@ -33236,7 +33252,7 @@ export const GetProjectsLocationsDataStoresSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresSchemasRequest>;
 
@@ -33268,7 +33284,7 @@ export const DeleteProjectsLocationsDataStoresSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresSchemasRequest>;
 
@@ -33306,7 +33322,7 @@ export const ListProjectsLocationsDataStoresSchemasRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/schemas" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/schemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresSchemasRequest>;
 
@@ -33352,7 +33368,7 @@ export const PatchProjectsLocationsDataStoresSchemasRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresSchemasRequest>;
 
@@ -33391,7 +33407,7 @@ export const StreamAnswerProjectsLocationsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{servingConfig}:streamAnswer",
+      path: "v1alpha/{+servingConfig}:streamAnswer",
       hasBody: true,
     }),
     svc,
@@ -33432,7 +33448,7 @@ export const ListProjectsLocationsDataStoresServingConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/servingConfigs" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/servingConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresServingConfigsRequest>;
 
@@ -33475,7 +33491,7 @@ export const SearchProjectsLocationsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{servingConfig}:search",
+      path: "v1alpha/{+servingConfig}:search",
       hasBody: true,
     }),
     svc,
@@ -33517,7 +33533,7 @@ export const SearchLiteProjectsLocationsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{servingConfig}:searchLite",
+      path: "v1alpha/{+servingConfig}:searchLite",
       hasBody: true,
     }),
     svc,
@@ -33552,7 +33568,7 @@ export const GetProjectsLocationsDataStoresServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresServingConfigsRequest>;
 
@@ -33592,7 +33608,7 @@ export const PatchProjectsLocationsDataStoresServingConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresServingConfigsRequest>;
 
@@ -33624,7 +33640,7 @@ export const DeleteProjectsLocationsDataStoresServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresServingConfigsRequest>;
 
@@ -33664,7 +33680,7 @@ export const AnswerProjectsLocationsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{servingConfig}:answer",
+      path: "v1alpha/{+servingConfig}:answer",
       hasBody: true,
     }),
     svc,
@@ -33706,7 +33722,7 @@ export const RecommendProjectsLocationsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{servingConfig}:recommend",
+      path: "v1alpha/{+servingConfig}:recommend",
       hasBody: true,
     }),
     svc,
@@ -33753,7 +33769,7 @@ export const CreateProjectsLocationsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/servingConfigs",
+      path: "v1alpha/{+parent}/servingConfigs",
       hasBody: true,
     }),
     svc,
@@ -33788,7 +33804,7 @@ export const GetProjectsLocationsDataStoresControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresControlsRequest>;
 
@@ -33830,7 +33846,7 @@ export const CreateProjectsLocationsDataStoresControlsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/controls",
+      path: "v1alpha/{+parent}/controls",
       hasBody: true,
     }),
     svc,
@@ -33864,7 +33880,7 @@ export const DeleteProjectsLocationsDataStoresControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresControlsRequest>;
 
@@ -33905,7 +33921,7 @@ export const ListProjectsLocationsDataStoresControlsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/controls" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/controls" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresControlsRequest>;
 
@@ -33949,7 +33965,7 @@ export const PatchProjectsLocationsDataStoresControlsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresControlsRequest>;
 
@@ -33989,7 +34005,7 @@ export const PatchProjectsLocationsDataStoresSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresSessionsRequest>;
 
@@ -34033,7 +34049,7 @@ export const ListProjectsLocationsDataStoresSessionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/sessions" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/sessions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresSessionsRequest>;
 
@@ -34074,7 +34090,7 @@ export const GetProjectsLocationsDataStoresSessionsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresSessionsRequest>;
 
@@ -34106,7 +34122,7 @@ export const DeleteProjectsLocationsDataStoresSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresSessionsRequest>;
 
@@ -34148,7 +34164,7 @@ export const CreateProjectsLocationsDataStoresSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/sessions",
+      path: "v1alpha/{+parent}/sessions",
       hasBody: true,
     }),
     svc,
@@ -34182,7 +34198,7 @@ export const GetProjectsLocationsDataStoresSessionsAnswersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresSessionsAnswersRequest>;
 
@@ -34226,7 +34242,7 @@ export const BatchGetDocumentsMetadataProjectsLocationsDataStoresBranchesRequest
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}/batchGetDocumentsMetadata",
+      path: "v1alpha/{+parent}/batchGetDocumentsMetadata",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetDocumentsMetadataProjectsLocationsDataStoresBranchesRequest>;
@@ -34267,7 +34283,7 @@ export const ListProjectsLocationsDataStoresBranchesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/branches" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/branches" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresBranchesRequest>;
 
@@ -34306,7 +34322,7 @@ export const GetProjectsLocationsDataStoresBranchesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresBranchesRequest>;
 
@@ -34352,7 +34368,7 @@ export const ListProjectsLocationsDataStoresBranchesOperationsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresBranchesOperationsRequest>;
 
@@ -34389,7 +34405,7 @@ export const GetProjectsLocationsDataStoresBranchesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresBranchesOperationsRequest>;
 
@@ -34427,7 +34443,7 @@ export const CancelProjectsLocationsDataStoresBranchesOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDataStoresBranchesOperationsRequest>;
 
@@ -34473,7 +34489,7 @@ export const PatchProjectsLocationsDataStoresBranchesDocumentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresBranchesDocumentsRequest>;
 
@@ -34506,7 +34522,7 @@ export const DeleteProjectsLocationsDataStoresBranchesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresBranchesDocumentsRequest>;
 
@@ -34545,7 +34561,7 @@ export const ListProjectsLocationsDataStoresBranchesDocumentsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/documents" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/documents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresBranchesDocumentsRequest>;
 
@@ -34592,7 +34608,7 @@ export const CreateProjectsLocationsDataStoresBranchesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/documents",
+      path: "v1alpha/{+parent}/documents",
       hasBody: true,
     }),
     svc,
@@ -34634,7 +34650,7 @@ export const PurgeProjectsLocationsDataStoresBranchesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/documents:purge",
+      path: "v1alpha/{+parent}/documents:purge",
       hasBody: true,
     }),
     svc,
@@ -34669,7 +34685,7 @@ export const GetProjectsLocationsDataStoresBranchesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresBranchesDocumentsRequest>;
 
@@ -34709,7 +34725,7 @@ export const ImportProjectsLocationsDataStoresBranchesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/documents:import",
+      path: "v1alpha/{+parent}/documents:import",
       hasBody: true,
     }),
     svc,
@@ -34766,7 +34782,7 @@ export const GetProcessedDocumentProjectsLocationsDataStoresBranchesDocumentsReq
       T.HttpQuery("processedDocumentType"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}:getProcessedDocument" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}:getProcessedDocument" }),
     svc,
   ) as unknown as Schema.Schema<GetProcessedDocumentProjectsLocationsDataStoresBranchesDocumentsRequest>;
 
@@ -34801,7 +34817,7 @@ export const GetProjectsLocationsDataStoresBranchesDocumentsChunksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresBranchesDocumentsChunksRequest>;
 
@@ -34840,7 +34856,7 @@ export const ListProjectsLocationsDataStoresBranchesDocumentsChunksRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/chunks" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/chunks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresBranchesDocumentsChunksRequest>;
 
@@ -34884,7 +34900,7 @@ export const ImportProjectsLocationsDataStoresCompletionSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/completionSuggestions:import",
+      path: "v1alpha/{+parent}/completionSuggestions:import",
       hasBody: true,
     }),
     svc,
@@ -34926,7 +34942,7 @@ export const PurgeProjectsLocationsDataStoresCompletionSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/completionSuggestions:purge",
+      path: "v1alpha/{+parent}/completionSuggestions:purge",
       hasBody: true,
     }),
     svc,
@@ -34968,7 +34984,7 @@ export const DisableAdvancedSiteSearchProjectsLocationsDataStoresSiteSearchEngin
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{siteSearchEngine}:disableAdvancedSiteSearch",
+      path: "v1alpha/{+siteSearchEngine}:disableAdvancedSiteSearch",
       hasBody: true,
     }),
     svc,
@@ -35012,7 +35028,7 @@ export const RecrawlUrisProjectsLocationsDataStoresSiteSearchEngineRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{siteSearchEngine}:recrawlUris",
+      path: "v1alpha/{+siteSearchEngine}:recrawlUris",
       hasBody: true,
     }),
     svc,
@@ -35054,7 +35070,7 @@ export const EnableAdvancedSiteSearchProjectsLocationsDataStoresSiteSearchEngine
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{siteSearchEngine}:enableAdvancedSiteSearch",
+      path: "v1alpha/{+siteSearchEngine}:enableAdvancedSiteSearch",
       hasBody: true,
     }),
     svc,
@@ -35098,7 +35114,7 @@ export const CreateProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/targetSites",
+      path: "v1alpha/{+parent}/targetSites",
       hasBody: true,
     }),
     svc,
@@ -35139,7 +35155,7 @@ export const ListProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/targetSites" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/targetSites" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -35183,7 +35199,7 @@ export const BatchCreateProjectsLocationsDataStoresSiteSearchEngineTargetSitesRe
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/targetSites:batchCreate",
+      path: "v1alpha/{+parent}/targetSites:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -35220,7 +35236,7 @@ export const DeleteProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -35258,7 +35274,7 @@ export const PatchProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest 
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -35291,7 +35307,7 @@ export const GetProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -35329,7 +35345,7 @@ export const FetchProjectsLocationsDataStoresSiteSearchEngineSitemapsRequest =
       Schema.Array(Schema.String),
     ).pipe(T.HttpQuery("matcher.urisMatcher.uris")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/sitemaps:fetch" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/sitemaps:fetch" }),
     svc,
   ) as unknown as Schema.Schema<FetchProjectsLocationsDataStoresSiteSearchEngineSitemapsRequest>;
 
@@ -35362,7 +35378,7 @@ export const DeleteProjectsLocationsDataStoresSiteSearchEngineSitemapsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresSiteSearchEngineSitemapsRequest>;
 
@@ -35402,7 +35418,7 @@ export const CreateProjectsLocationsDataStoresSiteSearchEngineSitemapsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/sitemaps",
+      path: "v1alpha/{+parent}/sitemaps",
       hasBody: true,
     }),
     svc,
@@ -35444,7 +35460,7 @@ export const CompleteQueryProjectsLocationsDataStoresCompletionConfigRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{completionConfig}:completeQuery",
+      path: "v1alpha/{+completionConfig}:completeQuery",
       hasBody: true,
     }),
     svc,
@@ -35486,7 +35502,7 @@ export const ImportProjectsLocationsDataStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/userEvents:import",
+      path: "v1alpha/{+parent}/userEvents:import",
       hasBody: true,
     }),
     svc,
@@ -35527,7 +35543,7 @@ export const PurgeProjectsLocationsDataStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/userEvents:purge",
+      path: "v1alpha/{+parent}/userEvents:purge",
       hasBody: true,
     }),
     svc,
@@ -35571,7 +35587,7 @@ export const WriteProjectsLocationsDataStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/userEvents:write",
+      path: "v1alpha/{+parent}/userEvents:write",
       hasBody: true,
     }),
     svc,
@@ -35614,7 +35630,7 @@ export const CollectProjectsLocationsDataStoresUserEventsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     uri: Schema.optional(Schema.String).pipe(T.HttpQuery("uri")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/userEvents:collect" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/userEvents:collect" }),
     svc,
   ) as unknown as Schema.Schema<CollectProjectsLocationsDataStoresUserEventsRequest>;
 
@@ -35658,7 +35674,7 @@ export const ListProjectsLocationsDataStoresConversationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresConversationsRequest>;
 
@@ -35701,7 +35717,7 @@ export const CreateProjectsLocationsDataStoresConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/conversations",
+      path: "v1alpha/{+parent}/conversations",
       hasBody: true,
     }),
     svc,
@@ -35735,7 +35751,7 @@ export const DeleteProjectsLocationsDataStoresConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresConversationsRequest>;
 
@@ -35772,7 +35788,7 @@ export const ConverseProjectsLocationsDataStoresConversationsRequest =
       GoogleCloudDiscoveryengineV1alphaConverseConversationRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:converse", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:converse", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ConverseProjectsLocationsDataStoresConversationsRequest>;
 
@@ -35813,7 +35829,7 @@ export const PatchProjectsLocationsDataStoresConversationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresConversationsRequest>;
 
@@ -35845,7 +35861,7 @@ export const GetProjectsLocationsDataStoresConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresConversationsRequest>;
 
@@ -35891,7 +35907,7 @@ export const ListProjectsLocationsDataStoresModelsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresModelsOperationsRequest>;
 
@@ -35928,7 +35944,7 @@ export const GetProjectsLocationsDataStoresModelsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresModelsOperationsRequest>;
 
@@ -35966,7 +35982,7 @@ export const ListProjectsLocationsEvaluationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/evaluations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/evaluations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEvaluationsRequest>;
 
@@ -36009,7 +36025,7 @@ export const CreateProjectsLocationsEvaluationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/evaluations",
+      path: "v1alpha/{+parent}/evaluations",
       hasBody: true,
     }),
     svc,
@@ -36049,7 +36065,7 @@ export const ListResultsProjectsLocationsEvaluationsRequest =
     evaluation: Schema.String.pipe(T.HttpPath("evaluation")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{evaluation}:listResults" }),
+    T.Http({ method: "GET", path: "v1alpha/{+evaluation}:listResults" }),
     svc,
   ) as unknown as Schema.Schema<ListResultsProjectsLocationsEvaluationsRequest>;
 
@@ -36085,7 +36101,7 @@ export const GetProjectsLocationsEvaluationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEvaluationsRequest>;
 
@@ -36117,7 +36133,7 @@ export const GetProjectsLocationsEvaluationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEvaluationsOperationsRequest>;
 
@@ -36163,7 +36179,7 @@ export const ListProjectsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsOperationsRequest>;
 
@@ -36199,7 +36215,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 

--- a/packages/gcp/src/services/discoveryengine-v1beta.ts
+++ b/packages/gcp/src/services/discoveryengine-v1beta.ts
@@ -19824,7 +19824,7 @@ export const RetractLicenseConfigBillingAccountsBillingAccountLicenseConfigsRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{billingAccountLicenseConfig}:retractLicenseConfig",
+      path: "v1beta/{+billingAccountLicenseConfig}:retractLicenseConfig",
       hasBody: true,
     }),
     svc,
@@ -19869,7 +19869,7 @@ export const DistributeLicenseConfigBillingAccountsBillingAccountLicenseConfigsR
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{billingAccountLicenseConfig}:distributeLicenseConfig",
+      path: "v1beta/{+billingAccountLicenseConfig}:distributeLicenseConfig",
       hasBody: true,
     }),
     svc,
@@ -19911,7 +19911,7 @@ export const ProvisionProjectsRequest =
       GoogleCloudDiscoveryengineV1betaProvisionProjectRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:provision", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:provision", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ProvisionProjectsRequest>;
 
@@ -19956,7 +19956,7 @@ export const ListProjectsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsOperationsRequest>;
 
@@ -19992,7 +19992,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 
@@ -20028,7 +20028,7 @@ export const UpdateAclConfigProjectsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAclConfigProjectsLocationsRequest>;
 
@@ -20060,7 +20060,7 @@ export const GetCmekConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCmekConfigProjectsLocationsRequest>;
 
@@ -20099,7 +20099,7 @@ export const ObtainCrawlRateProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{location}:obtainCrawlRate",
+      path: "v1beta/{+location}:obtainCrawlRate",
       hasBody: true,
     }),
     svc,
@@ -20140,7 +20140,7 @@ export const SetDedicatedCrawlRateProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{location}:setDedicatedCrawlRate",
+      path: "v1beta/{+location}:setDedicatedCrawlRate",
       hasBody: true,
     }),
     svc,
@@ -20182,7 +20182,7 @@ export const UpdateCmekConfigProjectsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateCmekConfigProjectsLocationsRequest>;
 
@@ -20214,7 +20214,7 @@ export const GetAclConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAclConfigProjectsLocationsRequest>;
 
@@ -20253,7 +20253,7 @@ export const RemoveDedicatedCrawlRateProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{location}:removeDedicatedCrawlRate",
+      path: "v1beta/{+location}:removeDedicatedCrawlRate",
       hasBody: true,
     }),
     svc,
@@ -20294,7 +20294,7 @@ export const CheckProjectsLocationsGroundingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{groundingConfig}:check",
+      path: "v1beta/{+groundingConfig}:check",
       hasBody: true,
     }),
     svc,
@@ -20342,7 +20342,7 @@ export const ListProjectsLocationsCollectionsDataConnectorOperationsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataConnectorOperationsRequest>;
 
@@ -20379,7 +20379,7 @@ export const GetProjectsLocationsCollectionsDataConnectorOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataConnectorOperationsRequest>;
 
@@ -20420,7 +20420,7 @@ export const PatchProjectsLocationsCollectionsDataStoresRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -20452,7 +20452,7 @@ export const GetSiteSearchEngineProjectsLocationsCollectionsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSiteSearchEngineProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -20485,7 +20485,7 @@ export const GetProjectsLocationsCollectionsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -20526,7 +20526,7 @@ export const ListProjectsLocationsCollectionsDataStoresRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/dataStores" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/dataStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -20569,7 +20569,7 @@ export const TrainCustomModelProjectsLocationsCollectionsDataStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{dataStore}:trainCustomModel",
+      path: "v1beta/{+dataStore}:trainCustomModel",
       hasBody: true,
     }),
     svc,
@@ -20620,7 +20620,7 @@ export const CompleteQueryProjectsLocationsCollectionsDataStoresRequest =
       T.HttpQuery("userPseudoId"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{dataStore}:completeQuery" }),
+    T.Http({ method: "GET", path: "v1beta/{+dataStore}:completeQuery" }),
     svc,
   ) as unknown as Schema.Schema<CompleteQueryProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -20685,7 +20685,7 @@ export const CreateProjectsLocationsCollectionsDataStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/dataStores",
+      path: "v1beta/{+parent}/dataStores",
       hasBody: true,
     }),
     svc,
@@ -20719,7 +20719,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresRequest>;
 
@@ -20759,7 +20759,7 @@ export const PatchProjectsLocationsCollectionsDataStoresConversationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresConversationsRequest>;
 
@@ -20792,7 +20792,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresConversationsRequest>;
 
@@ -20825,7 +20825,7 @@ export const GetProjectsLocationsCollectionsDataStoresConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresConversationsRequest>;
 
@@ -20863,7 +20863,7 @@ export const ConverseProjectsLocationsCollectionsDataStoresConversationsRequest 
       GoogleCloudDiscoveryengineV1betaConverseConversationRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:converse", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:converse", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ConverseProjectsLocationsCollectionsDataStoresConversationsRequest>;
 
@@ -20903,7 +20903,7 @@ export const CreateProjectsLocationsCollectionsDataStoresConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/conversations",
+      path: "v1beta/{+parent}/conversations",
       hasBody: true,
     }),
     svc,
@@ -20950,7 +20950,7 @@ export const ListProjectsLocationsCollectionsDataStoresConversationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresConversationsRequest>;
 
@@ -20994,7 +20994,7 @@ export const CompleteQueryProjectsLocationsCollectionsDataStoresCompletionConfig
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{completionConfig}:completeQuery",
+      path: "v1beta/{+completionConfig}:completeQuery",
       hasBody: true,
     }),
     svc,
@@ -21038,7 +21038,7 @@ export const ImportProjectsLocationsCollectionsDataStoresCompletionSuggestionsRe
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/completionSuggestions:import",
+      path: "v1beta/{+parent}/completionSuggestions:import",
       hasBody: true,
     }),
     svc,
@@ -21082,7 +21082,7 @@ export const PurgeProjectsLocationsCollectionsDataStoresCompletionSuggestionsReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/completionSuggestions:purge",
+      path: "v1beta/{+parent}/completionSuggestions:purge",
       hasBody: true,
     }),
     svc,
@@ -21126,7 +21126,7 @@ export const PurgeProjectsLocationsCollectionsDataStoresSuggestionDenyListEntrie
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/suggestionDenyListEntries:purge",
+      path: "v1beta/{+parent}/suggestionDenyListEntries:purge",
       hasBody: true,
     }),
     svc,
@@ -21170,7 +21170,7 @@ export const ImportProjectsLocationsCollectionsDataStoresSuggestionDenyListEntri
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/suggestionDenyListEntries:import",
+      path: "v1beta/{+parent}/suggestionDenyListEntries:import",
       hasBody: true,
     }),
     svc,
@@ -21215,7 +21215,7 @@ export const FetchDomainVerificationStatusProjectsLocationsCollectionsDataStores
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta/{siteSearchEngine}:fetchDomainVerificationStatus",
+      path: "v1beta/{+siteSearchEngine}:fetchDomainVerificationStatus",
     }),
     svc,
   ) as unknown as Schema.Schema<FetchDomainVerificationStatusProjectsLocationsCollectionsDataStoresSiteSearchEngineRequest>;
@@ -21262,7 +21262,7 @@ export const DisableAdvancedSiteSearchProjectsLocationsCollectionsDataStoresSite
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{siteSearchEngine}:disableAdvancedSiteSearch",
+      path: "v1beta/{+siteSearchEngine}:disableAdvancedSiteSearch",
       hasBody: true,
     }),
     svc,
@@ -21306,7 +21306,7 @@ export const BatchVerifyTargetSitesProjectsLocationsCollectionsDataStoresSiteSea
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}:batchVerifyTargetSites",
+      path: "v1beta/{+parent}:batchVerifyTargetSites",
       hasBody: true,
     }),
     svc,
@@ -21350,7 +21350,7 @@ export const EnableAdvancedSiteSearchProjectsLocationsCollectionsDataStoresSiteS
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{siteSearchEngine}:enableAdvancedSiteSearch",
+      path: "v1beta/{+siteSearchEngine}:enableAdvancedSiteSearch",
       hasBody: true,
     }),
     svc,
@@ -21394,7 +21394,7 @@ export const RecrawlUrisProjectsLocationsCollectionsDataStoresSiteSearchEngineRe
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{siteSearchEngine}:recrawlUris",
+      path: "v1beta/{+siteSearchEngine}:recrawlUris",
       hasBody: true,
     }),
     svc,
@@ -21431,7 +21431,7 @@ export const GetProjectsLocationsCollectionsDataStoresSiteSearchEngineOperations
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSiteSearchEngineOperationsRequest>;
 
@@ -21480,7 +21480,7 @@ export const ListProjectsLocationsCollectionsDataStoresSiteSearchEngineOperation
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresSiteSearchEngineOperationsRequest>;
 
@@ -21524,7 +21524,7 @@ export const PatchProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSi
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -21559,7 +21559,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetS
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -21601,7 +21601,7 @@ export const CreateProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetS
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/targetSites",
+      path: "v1beta/{+parent}/targetSites",
       hasBody: true,
     }),
     svc,
@@ -21638,7 +21638,7 @@ export const GetProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSite
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -21679,7 +21679,7 @@ export const ListProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSit
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/targetSites" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/targetSites" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -21725,7 +21725,7 @@ export const BatchCreateProjectsLocationsCollectionsDataStoresSiteSearchEngineTa
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/targetSites:batchCreate",
+      path: "v1beta/{+parent}/targetSites:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -21776,7 +21776,7 @@ export const ListProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSit
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesOperationsRequest>;
 
@@ -21815,7 +21815,7 @@ export const GetProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSite
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSiteSearchEngineTargetSitesOperationsRequest>;
 
@@ -21855,7 +21855,11 @@ export const CreateProjectsLocationsCollectionsDataStoresSiteSearchEngineSitemap
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/sitemaps", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/sitemaps",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsDataStoresSiteSearchEngineSitemapsRequest>;
 
@@ -21895,7 +21899,7 @@ export const FetchProjectsLocationsCollectionsDataStoresSiteSearchEngineSitemaps
     ).pipe(T.HttpQuery("matcher.urisMatcher.uris")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/sitemaps:fetch" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/sitemaps:fetch" }),
     svc,
   ) as unknown as Schema.Schema<FetchProjectsLocationsCollectionsDataStoresSiteSearchEngineSitemapsRequest>;
 
@@ -21930,7 +21934,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresSiteSearchEngineSitemap
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresSiteSearchEngineSitemapsRequest>;
 
@@ -21965,7 +21969,7 @@ export const GetProjectsLocationsCollectionsDataStoresServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresServingConfigsRequest>;
 
@@ -22006,7 +22010,7 @@ export const PatchProjectsLocationsCollectionsDataStoresServingConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresServingConfigsRequest>;
 
@@ -22046,7 +22050,7 @@ export const SearchLiteProjectsLocationsCollectionsDataStoresServingConfigsReque
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{servingConfig}:searchLite",
+      path: "v1beta/{+servingConfig}:searchLite",
       hasBody: true,
     }),
     svc,
@@ -22089,7 +22093,7 @@ export const AnswerProjectsLocationsCollectionsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{servingConfig}:answer",
+      path: "v1beta/{+servingConfig}:answer",
       hasBody: true,
     }),
     svc,
@@ -22131,7 +22135,7 @@ export const StreamAnswerProjectsLocationsCollectionsDataStoresServingConfigsReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{servingConfig}:streamAnswer",
+      path: "v1beta/{+servingConfig}:streamAnswer",
       hasBody: true,
     }),
     svc,
@@ -22174,7 +22178,7 @@ export const ListProjectsLocationsCollectionsDataStoresServingConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/servingConfigs" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/servingConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresServingConfigsRequest>;
 
@@ -22223,7 +22227,7 @@ export const CreateProjectsLocationsCollectionsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/servingConfigs",
+      path: "v1beta/{+parent}/servingConfigs",
       hasBody: true,
     }),
     svc,
@@ -22265,7 +22269,7 @@ export const RecommendProjectsLocationsCollectionsDataStoresServingConfigsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{servingConfig}:recommend",
+      path: "v1beta/{+servingConfig}:recommend",
       hasBody: true,
     }),
     svc,
@@ -22307,7 +22311,7 @@ export const SearchProjectsLocationsCollectionsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{servingConfig}:search",
+      path: "v1beta/{+servingConfig}:search",
       hasBody: true,
     }),
     svc,
@@ -22342,7 +22346,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresServingConfigsRequest>;
 
@@ -22381,7 +22385,7 @@ export const ListProjectsLocationsCollectionsDataStoresSchemasRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/schemas" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/schemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresSchemasRequest>;
 
@@ -22428,7 +22432,7 @@ export const PatchProjectsLocationsCollectionsDataStoresSchemasRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresSchemasRequest>;
 
@@ -22461,7 +22465,7 @@ export const GetProjectsLocationsCollectionsDataStoresSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSchemasRequest>;
 
@@ -22494,7 +22498,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresSchemasRequest>;
 
@@ -22535,7 +22539,7 @@ export const CreateProjectsLocationsCollectionsDataStoresSchemasRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/schemas", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/schemas", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsDataStoresSchemasRequest>;
 
@@ -22582,7 +22586,7 @@ export const ListProjectsLocationsCollectionsDataStoresSchemasOperationsRequest 
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresSchemasOperationsRequest>;
 
@@ -22619,7 +22623,7 @@ export const GetProjectsLocationsCollectionsDataStoresSchemasOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSchemasOperationsRequest>;
 
@@ -22657,7 +22661,7 @@ export const GetProjectsLocationsCollectionsDataStoresSessionsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSessionsRequest>;
 
@@ -22698,7 +22702,11 @@ export const CreateProjectsLocationsCollectionsDataStoresSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/sessions", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/sessions",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsDataStoresSessionsRequest>;
 
@@ -22743,7 +22751,7 @@ export const ListProjectsLocationsCollectionsDataStoresSessionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/sessions" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/sessions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresSessionsRequest>;
 
@@ -22788,7 +22796,7 @@ export const PatchProjectsLocationsCollectionsDataStoresSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresSessionsRequest>;
 
@@ -22821,7 +22829,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresSessionsRequest>;
 
@@ -22854,7 +22862,7 @@ export const GetProjectsLocationsCollectionsDataStoresSessionsAnswersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresSessionsAnswersRequest>;
 
@@ -22896,7 +22904,7 @@ export const CollectProjectsLocationsCollectionsDataStoresUserEventsRequest =
     uri: Schema.optional(Schema.String).pipe(T.HttpQuery("uri")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/userEvents:collect" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/userEvents:collect" }),
     svc,
   ) as unknown as Schema.Schema<CollectProjectsLocationsCollectionsDataStoresUserEventsRequest>;
 
@@ -22939,7 +22947,7 @@ export const WriteProjectsLocationsCollectionsDataStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/userEvents:write",
+      path: "v1beta/{+parent}/userEvents:write",
       hasBody: true,
     }),
     svc,
@@ -22981,7 +22989,7 @@ export const ImportProjectsLocationsCollectionsDataStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/userEvents:import",
+      path: "v1beta/{+parent}/userEvents:import",
       hasBody: true,
     }),
     svc,
@@ -23023,7 +23031,7 @@ export const PurgeProjectsLocationsCollectionsDataStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/userEvents:purge",
+      path: "v1beta/{+parent}/userEvents:purge",
       hasBody: true,
     }),
     svc,
@@ -23070,7 +23078,7 @@ export const BatchGetDocumentsMetadataProjectsLocationsCollectionsDataStoresBran
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta/{parent}/batchGetDocumentsMetadata",
+      path: "v1beta/{+parent}/batchGetDocumentsMetadata",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetDocumentsMetadataProjectsLocationsCollectionsDataStoresBranchesRequest>;
@@ -23106,7 +23114,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresBranchesDocumentsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest>;
 
@@ -23145,7 +23153,7 @@ export const ListProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest 
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/documents" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/documents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest>;
 
@@ -23189,7 +23197,7 @@ export const PurgeProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/documents:purge",
+      path: "v1beta/{+parent}/documents:purge",
       hasBody: true,
     }),
     svc,
@@ -23237,7 +23245,7 @@ export const PatchProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest>;
 
@@ -23280,7 +23288,7 @@ export const CreateProjectsLocationsCollectionsDataStoresBranchesDocumentsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/documents",
+      path: "v1beta/{+parent}/documents",
       hasBody: true,
     }),
     svc,
@@ -23315,7 +23323,7 @@ export const GetProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresBranchesDocumentsRequest>;
 
@@ -23355,7 +23363,7 @@ export const ImportProjectsLocationsCollectionsDataStoresBranchesDocumentsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/documents:import",
+      path: "v1beta/{+parent}/documents:import",
       hasBody: true,
     }),
     svc,
@@ -23395,7 +23403,7 @@ export const CancelProjectsLocationsCollectionsDataStoresBranchesOperationsReque
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsCollectionsDataStoresBranchesOperationsRequest>;
 
@@ -23443,7 +23451,7 @@ export const ListProjectsLocationsCollectionsDataStoresBranchesOperationsRequest
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresBranchesOperationsRequest>;
 
@@ -23480,7 +23488,7 @@ export const GetProjectsLocationsCollectionsDataStoresBranchesOperationsRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresBranchesOperationsRequest>;
 
@@ -23527,7 +23535,7 @@ export const ListProjectsLocationsCollectionsDataStoresModelsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresModelsOperationsRequest>;
 
@@ -23564,7 +23572,7 @@ export const GetProjectsLocationsCollectionsDataStoresModelsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresModelsOperationsRequest>;
 
@@ -23611,7 +23619,7 @@ export const ListProjectsLocationsCollectionsDataStoresOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresOperationsRequest>;
 
@@ -23648,7 +23656,7 @@ export const GetProjectsLocationsCollectionsDataStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresOperationsRequest>;
 
@@ -23689,7 +23697,7 @@ export const PatchProjectsLocationsCollectionsDataStoresControlsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsDataStoresControlsRequest>;
 
@@ -23722,7 +23730,7 @@ export const DeleteProjectsLocationsCollectionsDataStoresControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsDataStoresControlsRequest>;
 
@@ -23764,7 +23772,7 @@ export const ListProjectsLocationsCollectionsDataStoresControlsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/controls" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/controls" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresControlsRequest>;
 
@@ -23809,7 +23817,11 @@ export const CreateProjectsLocationsCollectionsDataStoresControlsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/controls", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/controls",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsDataStoresControlsRequest>;
 
@@ -23842,7 +23854,7 @@ export const GetProjectsLocationsCollectionsDataStoresControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsDataStoresControlsRequest>;
 
@@ -23875,7 +23887,7 @@ export const ListProjectsLocationsCollectionsDataStoresCustomModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     dataStore: Schema.String.pipe(T.HttpPath("dataStore")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{dataStore}/customModels" }),
+    T.Http({ method: "GET", path: "v1beta/{+dataStore}/customModels" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsDataStoresCustomModelsRequest>;
 
@@ -23916,7 +23928,7 @@ export const CreateProjectsLocationsCollectionsEnginesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/engines", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/engines", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsEnginesRequest>;
 
@@ -23953,7 +23965,7 @@ export const TuneProjectsLocationsCollectionsEnginesRequest =
       GoogleCloudDiscoveryengineV1betaTuneEngineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:tune", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:tune", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TuneProjectsLocationsCollectionsEnginesRequest>;
 
@@ -23990,7 +24002,7 @@ export const GetIamPolicyProjectsLocationsCollectionsEnginesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsCollectionsEnginesRequest>;
 
@@ -24028,7 +24040,7 @@ export const ResumeProjectsLocationsCollectionsEnginesRequest =
       GoogleCloudDiscoveryengineV1betaResumeEngineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsCollectionsEnginesRequest>;
 
@@ -24069,7 +24081,7 @@ export const ListProjectsLocationsCollectionsEnginesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/engines" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/engines" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesRequest>;
 
@@ -24105,7 +24117,7 @@ export const DeleteProjectsLocationsCollectionsEnginesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesRequest>;
 
@@ -24145,7 +24157,7 @@ export const PatchProjectsLocationsCollectionsEnginesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesRequest>;
 
@@ -24177,7 +24189,7 @@ export const GetProjectsLocationsCollectionsEnginesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesRequest>;
 
@@ -24214,7 +24226,7 @@ export const PauseProjectsLocationsCollectionsEnginesRequest =
       GoogleCloudDiscoveryengineV1betaPauseEngineRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsLocationsCollectionsEnginesRequest>;
 
@@ -24251,7 +24263,7 @@ export const SetIamPolicyProjectsLocationsCollectionsEnginesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:setIamPolicy",
+      path: "v1beta/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -24298,7 +24310,7 @@ export const ListProjectsLocationsCollectionsEnginesConversationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesConversationsRequest>;
 
@@ -24343,7 +24355,7 @@ export const PatchProjectsLocationsCollectionsEnginesConversationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesConversationsRequest>;
 
@@ -24376,7 +24388,7 @@ export const GetProjectsLocationsCollectionsEnginesConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesConversationsRequest>;
 
@@ -24416,7 +24428,7 @@ export const CreateProjectsLocationsCollectionsEnginesConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/conversations",
+      path: "v1beta/{+parent}/conversations",
       hasBody: true,
     }),
     svc,
@@ -24456,7 +24468,7 @@ export const ConverseProjectsLocationsCollectionsEnginesConversationsRequest =
       GoogleCloudDiscoveryengineV1betaConverseConversationRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:converse", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:converse", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ConverseProjectsLocationsCollectionsEnginesConversationsRequest>;
 
@@ -24489,7 +24501,7 @@ export const DeleteProjectsLocationsCollectionsEnginesConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesConversationsRequest>;
 
@@ -24522,7 +24534,7 @@ export const GetProjectsLocationsCollectionsEnginesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesOperationsRequest>;
 
@@ -24569,7 +24581,7 @@ export const ListProjectsLocationsCollectionsEnginesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesOperationsRequest>;
 
@@ -24613,7 +24625,7 @@ export const CompleteQueryProjectsLocationsCollectionsEnginesCompletionConfigReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{completionConfig}:completeQuery",
+      path: "v1beta/{+completionConfig}:completeQuery",
       hasBody: true,
     }),
     svc,
@@ -24657,7 +24669,7 @@ export const RemoveSuggestionProjectsLocationsCollectionsEnginesCompletionConfig
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{completionConfig}:removeSuggestion",
+      path: "v1beta/{+completionConfig}:removeSuggestion",
       hasBody: true,
     }),
     svc,
@@ -24703,7 +24715,7 @@ export const ListProjectsLocationsCollectionsEnginesControlsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/controls" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/controls" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesControlsRequest>;
 
@@ -24748,7 +24760,11 @@ export const CreateProjectsLocationsCollectionsEnginesControlsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/controls", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/controls",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsEnginesControlsRequest>;
 
@@ -24781,7 +24797,7 @@ export const DeleteProjectsLocationsCollectionsEnginesControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesControlsRequest>;
 
@@ -24822,7 +24838,7 @@ export const PatchProjectsLocationsCollectionsEnginesControlsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesControlsRequest>;
 
@@ -24855,7 +24871,7 @@ export const GetProjectsLocationsCollectionsEnginesControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesControlsRequest>;
 
@@ -24887,7 +24903,7 @@ export const GetProjectsLocationsCollectionsEnginesAssistantsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesAssistantsRequest>;
 
@@ -24932,7 +24948,7 @@ export const CreateProjectsLocationsCollectionsEnginesAssistantsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/assistants",
+      path: "v1beta/{+parent}/assistants",
       hasBody: true,
     }),
     svc,
@@ -24974,7 +24990,7 @@ export const StreamAssistProjectsLocationsCollectionsEnginesAssistantsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{name}:streamAssist",
+      path: "v1beta/{+name}:streamAssist",
       hasBody: true,
     }),
     svc,
@@ -25017,7 +25033,7 @@ export const PatchProjectsLocationsCollectionsEnginesAssistantsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesAssistantsRequest>;
 
@@ -25056,7 +25072,7 @@ export const ListProjectsLocationsCollectionsEnginesAssistantsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/assistants" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/assistants" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesAssistantsRequest>;
 
@@ -25093,7 +25109,7 @@ export const DeleteProjectsLocationsCollectionsEnginesAssistantsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesAssistantsRequest>;
 
@@ -25126,7 +25142,7 @@ export const GetProjectsLocationsCollectionsEnginesAssistantsAgentsOperationsReq
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesAssistantsAgentsOperationsRequest>;
 
@@ -25169,7 +25185,7 @@ export const PatchProjectsLocationsCollectionsEnginesServingConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesServingConfigsRequest>;
 
@@ -25202,7 +25218,7 @@ export const DeleteProjectsLocationsCollectionsEnginesServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesServingConfigsRequest>;
 
@@ -25242,7 +25258,7 @@ export const SearchLiteProjectsLocationsCollectionsEnginesServingConfigsRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{servingConfig}:searchLite",
+      path: "v1beta/{+servingConfig}:searchLite",
       hasBody: true,
     }),
     svc,
@@ -25283,7 +25299,7 @@ export const ListProjectsLocationsCollectionsEnginesServingConfigsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/servingConfigs" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/servingConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesServingConfigsRequest>;
 
@@ -25332,7 +25348,7 @@ export const CreateProjectsLocationsCollectionsEnginesServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/servingConfigs",
+      path: "v1beta/{+parent}/servingConfigs",
       hasBody: true,
     }),
     svc,
@@ -25374,7 +25390,7 @@ export const StreamAnswerProjectsLocationsCollectionsEnginesServingConfigsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{servingConfig}:streamAnswer",
+      path: "v1beta/{+servingConfig}:streamAnswer",
       hasBody: true,
     }),
     svc,
@@ -25416,7 +25432,7 @@ export const AnswerProjectsLocationsCollectionsEnginesServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{servingConfig}:answer",
+      path: "v1beta/{+servingConfig}:answer",
       hasBody: true,
     }),
     svc,
@@ -25451,7 +25467,7 @@ export const GetProjectsLocationsCollectionsEnginesServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesServingConfigsRequest>;
 
@@ -25491,7 +25507,7 @@ export const SearchProjectsLocationsCollectionsEnginesServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{servingConfig}:search",
+      path: "v1beta/{+servingConfig}:search",
       hasBody: true,
     }),
     svc,
@@ -25533,7 +25549,7 @@ export const RecommendProjectsLocationsCollectionsEnginesServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{servingConfig}:recommend",
+      path: "v1beta/{+servingConfig}:recommend",
       hasBody: true,
     }),
     svc,
@@ -25573,7 +25589,7 @@ export const GetProjectsLocationsCollectionsEnginesSessionsRequest =
       T.HttpQuery("includeAnswerDetails"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesSessionsRequest>;
 
@@ -25613,7 +25629,7 @@ export const PatchProjectsLocationsCollectionsEnginesSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectionsEnginesSessionsRequest>;
 
@@ -25654,7 +25670,11 @@ export const CreateProjectsLocationsCollectionsEnginesSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/sessions", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/sessions",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectionsEnginesSessionsRequest>;
 
@@ -25687,7 +25707,7 @@ export const DeleteProjectsLocationsCollectionsEnginesSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectionsEnginesSessionsRequest>;
 
@@ -25732,7 +25752,7 @@ export const ListProjectsLocationsCollectionsEnginesSessionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/sessions" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/sessions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsEnginesSessionsRequest>;
 
@@ -25769,7 +25789,7 @@ export const GetProjectsLocationsCollectionsEnginesSessionsAnswersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsEnginesSessionsAnswersRequest>;
 
@@ -25816,7 +25836,7 @@ export const ListProjectsLocationsCollectionsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectionsOperationsRequest>;
 
@@ -25852,7 +25872,7 @@ export const GetProjectsLocationsCollectionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectionsOperationsRequest>;
 
@@ -25884,7 +25904,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -25929,7 +25949,7 @@ export const ListProjectsLocationsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -25972,7 +25992,7 @@ export const RankProjectsLocationsRankingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{rankingConfig}:rank",
+      path: "v1beta/{+rankingConfig}:rank",
       hasBody: true,
     }),
     svc,
@@ -26014,7 +26034,7 @@ export const PatchProjectsLocationsLicenseConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsLicenseConfigsRequest>;
 
@@ -26046,7 +26066,7 @@ export const GetProjectsLocationsLicenseConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsLicenseConfigsRequest>;
 
@@ -26090,7 +26110,7 @@ export const CreateProjectsLocationsLicenseConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/licenseConfigs",
+      path: "v1beta/{+parent}/licenseConfigs",
       hasBody: true,
     }),
     svc,
@@ -26134,7 +26154,7 @@ export const WriteProjectsLocationsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/userEvents:write",
+      path: "v1beta/{+parent}/userEvents:write",
       hasBody: true,
     }),
     svc,
@@ -26175,7 +26195,7 @@ export const ImportProjectsLocationsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/userEvents:import",
+      path: "v1beta/{+parent}/userEvents:import",
       hasBody: true,
     }),
     svc,
@@ -26218,7 +26238,7 @@ export const CollectProjectsLocationsUserEventsRequest =
     ets: Schema.optional(Schema.String).pipe(T.HttpQuery("ets")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/userEvents:collect" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/userEvents:collect" }),
     svc,
   ) as unknown as Schema.Schema<CollectProjectsLocationsUserEventsRequest>;
 
@@ -26257,7 +26277,7 @@ export const PatchProjectsLocationsDataStoresRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresRequest>;
 
@@ -26289,7 +26309,7 @@ export const GetSiteSearchEngineProjectsLocationsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSiteSearchEngineProjectsLocationsDataStoresRequest>;
 
@@ -26321,7 +26341,7 @@ export const DeleteProjectsLocationsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresRequest>;
 
@@ -26369,7 +26389,7 @@ export const CompleteQueryProjectsLocationsDataStoresRequest =
     dataStore: Schema.String.pipe(T.HttpPath("dataStore")),
     queryModel: Schema.optional(Schema.String).pipe(T.HttpQuery("queryModel")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{dataStore}:completeQuery" }),
+    T.Http({ method: "GET", path: "v1beta/{+dataStore}:completeQuery" }),
     svc,
   ) as unknown as Schema.Schema<CompleteQueryProjectsLocationsDataStoresRequest>;
 
@@ -26433,7 +26453,7 @@ export const CreateProjectsLocationsDataStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/dataStores",
+      path: "v1beta/{+parent}/dataStores",
       hasBody: true,
     }),
     svc,
@@ -26476,7 +26496,7 @@ export const ListProjectsLocationsDataStoresRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/dataStores" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/dataStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresRequest>;
 
@@ -26512,7 +26532,7 @@ export const GetProjectsLocationsDataStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresRequest>;
 
@@ -26556,7 +26576,7 @@ export const BatchGetDocumentsMetadataProjectsLocationsDataStoresBranchesRequest
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta/{parent}/batchGetDocumentsMetadata",
+      path: "v1beta/{+parent}/batchGetDocumentsMetadata",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetDocumentsMetadataProjectsLocationsDataStoresBranchesRequest>;
@@ -26604,7 +26624,7 @@ export const ListProjectsLocationsDataStoresBranchesOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresBranchesOperationsRequest>;
 
@@ -26646,7 +26666,7 @@ export const CancelProjectsLocationsDataStoresBranchesOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDataStoresBranchesOperationsRequest>;
 
@@ -26679,7 +26699,7 @@ export const GetProjectsLocationsDataStoresBranchesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresBranchesOperationsRequest>;
 
@@ -26712,7 +26732,7 @@ export const DeleteProjectsLocationsDataStoresBranchesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresBranchesDocumentsRequest>;
 
@@ -26758,7 +26778,7 @@ export const PatchProjectsLocationsDataStoresBranchesDocumentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresBranchesDocumentsRequest>;
 
@@ -26791,7 +26811,7 @@ export const GetProjectsLocationsDataStoresBranchesDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresBranchesDocumentsRequest>;
 
@@ -26830,7 +26850,7 @@ export const ListProjectsLocationsDataStoresBranchesDocumentsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/documents" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/documents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresBranchesDocumentsRequest>;
 
@@ -26874,7 +26894,7 @@ export const PurgeProjectsLocationsDataStoresBranchesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/documents:purge",
+      path: "v1beta/{+parent}/documents:purge",
       hasBody: true,
     }),
     svc,
@@ -26916,7 +26936,7 @@ export const ImportProjectsLocationsDataStoresBranchesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/documents:import",
+      path: "v1beta/{+parent}/documents:import",
       hasBody: true,
     }),
     svc,
@@ -26961,7 +26981,7 @@ export const CreateProjectsLocationsDataStoresBranchesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/documents",
+      path: "v1beta/{+parent}/documents",
       hasBody: true,
     }),
     svc,
@@ -27003,7 +27023,7 @@ export const CompleteQueryProjectsLocationsDataStoresCompletionConfigRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{completionConfig}:completeQuery",
+      path: "v1beta/{+completionConfig}:completeQuery",
       hasBody: true,
     }),
     svc,
@@ -27046,7 +27066,7 @@ export const PatchProjectsLocationsDataStoresConversationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresConversationsRequest>;
 
@@ -27083,7 +27103,7 @@ export const ConverseProjectsLocationsDataStoresConversationsRequest =
       GoogleCloudDiscoveryengineV1betaConverseConversationRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:converse", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:converse", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ConverseProjectsLocationsDataStoresConversationsRequest>;
 
@@ -27116,7 +27136,7 @@ export const GetProjectsLocationsDataStoresConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresConversationsRequest>;
 
@@ -27148,7 +27168,7 @@ export const DeleteProjectsLocationsDataStoresConversationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresConversationsRequest>;
 
@@ -27187,7 +27207,7 @@ export const CreateProjectsLocationsDataStoresConversationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/conversations",
+      path: "v1beta/{+parent}/conversations",
       hasBody: true,
     }),
     svc,
@@ -27233,7 +27253,7 @@ export const ListProjectsLocationsDataStoresConversationsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/conversations" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/conversations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresConversationsRequest>;
 
@@ -27276,7 +27296,7 @@ export const ImportProjectsLocationsDataStoresSuggestionDenyListEntriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/suggestionDenyListEntries:import",
+      path: "v1beta/{+parent}/suggestionDenyListEntries:import",
       hasBody: true,
     }),
     svc,
@@ -27318,7 +27338,7 @@ export const PurgeProjectsLocationsDataStoresSuggestionDenyListEntriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/suggestionDenyListEntries:purge",
+      path: "v1beta/{+parent}/suggestionDenyListEntries:purge",
       hasBody: true,
     }),
     svc,
@@ -27367,7 +27387,7 @@ export const ListProjectsLocationsDataStoresModelsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresModelsOperationsRequest>;
 
@@ -27404,7 +27424,7 @@ export const GetProjectsLocationsDataStoresModelsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresModelsOperationsRequest>;
 
@@ -27443,7 +27463,7 @@ export const EnableAdvancedSiteSearchProjectsLocationsDataStoresSiteSearchEngine
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{siteSearchEngine}:enableAdvancedSiteSearch",
+      path: "v1beta/{+siteSearchEngine}:enableAdvancedSiteSearch",
       hasBody: true,
     }),
     svc,
@@ -27487,7 +27507,7 @@ export const DisableAdvancedSiteSearchProjectsLocationsDataStoresSiteSearchEngin
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{siteSearchEngine}:disableAdvancedSiteSearch",
+      path: "v1beta/{+siteSearchEngine}:disableAdvancedSiteSearch",
       hasBody: true,
     }),
     svc,
@@ -27531,7 +27551,7 @@ export const RecrawlUrisProjectsLocationsDataStoresSiteSearchEngineRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{siteSearchEngine}:recrawlUris",
+      path: "v1beta/{+siteSearchEngine}:recrawlUris",
       hasBody: true,
     }),
     svc,
@@ -27571,7 +27591,7 @@ export const FetchProjectsLocationsDataStoresSiteSearchEngineSitemapsRequest =
       Schema.Array(Schema.String),
     ).pipe(T.HttpQuery("matcher.urisMatcher.uris")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/sitemaps:fetch" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/sitemaps:fetch" }),
     svc,
   ) as unknown as Schema.Schema<FetchProjectsLocationsDataStoresSiteSearchEngineSitemapsRequest>;
 
@@ -27609,7 +27629,11 @@ export const CreateProjectsLocationsDataStoresSiteSearchEngineSitemapsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/sitemaps", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/sitemaps",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataStoresSiteSearchEngineSitemapsRequest>;
 
@@ -27642,7 +27666,7 @@ export const DeleteProjectsLocationsDataStoresSiteSearchEngineSitemapsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresSiteSearchEngineSitemapsRequest>;
 
@@ -27682,7 +27706,7 @@ export const BatchCreateProjectsLocationsDataStoresSiteSearchEngineTargetSitesRe
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/targetSites:batchCreate",
+      path: "v1beta/{+parent}/targetSites:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -27726,7 +27750,7 @@ export const CreateProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/targetSites",
+      path: "v1beta/{+parent}/targetSites",
       hasBody: true,
     }),
     svc,
@@ -27767,7 +27791,7 @@ export const ListProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/targetSites" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/targetSites" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -27804,7 +27828,7 @@ export const GetProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -27837,7 +27861,7 @@ export const DeleteProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -27875,7 +27899,7 @@ export const PatchProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest 
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresSiteSearchEngineTargetSitesRequest>;
 
@@ -27908,7 +27932,7 @@ export const GetProjectsLocationsDataStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresOperationsRequest>;
 
@@ -27954,7 +27978,7 @@ export const ListProjectsLocationsDataStoresOperationsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresOperationsRequest>;
 
@@ -27996,7 +28020,7 @@ export const ListProjectsLocationsDataStoresServingConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/servingConfigs" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/servingConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresServingConfigsRequest>;
 
@@ -28044,7 +28068,7 @@ export const CreateProjectsLocationsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/servingConfigs",
+      path: "v1beta/{+parent}/servingConfigs",
       hasBody: true,
     }),
     svc,
@@ -28079,7 +28103,7 @@ export const DeleteProjectsLocationsDataStoresServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresServingConfigsRequest>;
 
@@ -28119,7 +28143,7 @@ export const AnswerProjectsLocationsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{servingConfig}:answer",
+      path: "v1beta/{+servingConfig}:answer",
       hasBody: true,
     }),
     svc,
@@ -28161,7 +28185,7 @@ export const SearchProjectsLocationsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{servingConfig}:search",
+      path: "v1beta/{+servingConfig}:search",
       hasBody: true,
     }),
     svc,
@@ -28196,7 +28220,7 @@ export const GetProjectsLocationsDataStoresServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresServingConfigsRequest>;
 
@@ -28236,7 +28260,7 @@ export const PatchProjectsLocationsDataStoresServingConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresServingConfigsRequest>;
 
@@ -28275,7 +28299,7 @@ export const RecommendProjectsLocationsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{servingConfig}:recommend",
+      path: "v1beta/{+servingConfig}:recommend",
       hasBody: true,
     }),
     svc,
@@ -28317,7 +28341,7 @@ export const SearchLiteProjectsLocationsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{servingConfig}:searchLite",
+      path: "v1beta/{+servingConfig}:searchLite",
       hasBody: true,
     }),
     svc,
@@ -28359,7 +28383,7 @@ export const StreamAnswerProjectsLocationsDataStoresServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{servingConfig}:streamAnswer",
+      path: "v1beta/{+servingConfig}:streamAnswer",
       hasBody: true,
     }),
     svc,
@@ -28402,7 +28426,7 @@ export const CreateProjectsLocationsDataStoresSchemasRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/schemas", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/schemas", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataStoresSchemasRequest>;
 
@@ -28434,7 +28458,7 @@ export const GetProjectsLocationsDataStoresSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresSchemasRequest>;
 
@@ -28476,7 +28500,7 @@ export const PatchProjectsLocationsDataStoresSchemasRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresSchemasRequest>;
 
@@ -28508,7 +28532,7 @@ export const DeleteProjectsLocationsDataStoresSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresSchemasRequest>;
 
@@ -28546,7 +28570,7 @@ export const ListProjectsLocationsDataStoresSchemasRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/schemas" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/schemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresSchemasRequest>;
 
@@ -28589,7 +28613,7 @@ export const ImportProjectsLocationsDataStoresCompletionSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/completionSuggestions:import",
+      path: "v1beta/{+parent}/completionSuggestions:import",
       hasBody: true,
     }),
     svc,
@@ -28631,7 +28655,7 @@ export const PurgeProjectsLocationsDataStoresCompletionSuggestionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/completionSuggestions:purge",
+      path: "v1beta/{+parent}/completionSuggestions:purge",
       hasBody: true,
     }),
     svc,
@@ -28673,7 +28697,7 @@ export const ImportProjectsLocationsDataStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/userEvents:import",
+      path: "v1beta/{+parent}/userEvents:import",
       hasBody: true,
     }),
     svc,
@@ -28714,7 +28738,7 @@ export const PurgeProjectsLocationsDataStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/userEvents:purge",
+      path: "v1beta/{+parent}/userEvents:purge",
       hasBody: true,
     }),
     svc,
@@ -28758,7 +28782,7 @@ export const WriteProjectsLocationsDataStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/userEvents:write",
+      path: "v1beta/{+parent}/userEvents:write",
       hasBody: true,
     }),
     svc,
@@ -28801,7 +28825,7 @@ export const CollectProjectsLocationsDataStoresUserEventsRequest =
     ets: Schema.optional(Schema.String).pipe(T.HttpQuery("ets")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/userEvents:collect" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/userEvents:collect" }),
     svc,
   ) as unknown as Schema.Schema<CollectProjectsLocationsDataStoresUserEventsRequest>;
 
@@ -28838,7 +28862,7 @@ export const GetProjectsLocationsDataStoresSessionsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresSessionsRequest>;
 
@@ -28878,7 +28902,11 @@ export const CreateProjectsLocationsDataStoresSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/sessions", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/sessions",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataStoresSessionsRequest>;
 
@@ -28910,7 +28938,7 @@ export const DeleteProjectsLocationsDataStoresSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresSessionsRequest>;
 
@@ -28950,7 +28978,7 @@ export const PatchProjectsLocationsDataStoresSessionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresSessionsRequest>;
 
@@ -28994,7 +29022,7 @@ export const ListProjectsLocationsDataStoresSessionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/sessions" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/sessions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresSessionsRequest>;
 
@@ -29030,7 +29058,7 @@ export const GetProjectsLocationsDataStoresSessionsAnswersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresSessionsAnswersRequest>;
 
@@ -29070,7 +29098,11 @@ export const CreateProjectsLocationsDataStoresControlsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/controls", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/controls",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDataStoresControlsRequest>;
 
@@ -29102,7 +29134,7 @@ export const DeleteProjectsLocationsDataStoresControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDataStoresControlsRequest>;
 
@@ -29134,7 +29166,7 @@ export const GetProjectsLocationsDataStoresControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDataStoresControlsRequest>;
 
@@ -29174,7 +29206,7 @@ export const PatchProjectsLocationsDataStoresControlsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDataStoresControlsRequest>;
 
@@ -29215,7 +29247,7 @@ export const ListProjectsLocationsDataStoresControlsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/controls" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/controls" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDataStoresControlsRequest>;
 
@@ -29263,7 +29295,7 @@ export const CreateProjectsLocationsSampleQuerySetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/sampleQuerySets",
+      path: "v1beta/{+parent}/sampleQuerySets",
       hasBody: true,
     }),
     svc,
@@ -29303,7 +29335,7 @@ export const ListProjectsLocationsSampleQuerySetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/sampleQuerySets" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/sampleQuerySets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSampleQuerySetsRequest>;
 
@@ -29339,7 +29371,7 @@ export const GetProjectsLocationsSampleQuerySetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSampleQuerySetsRequest>;
 
@@ -29371,7 +29403,7 @@ export const DeleteProjectsLocationsSampleQuerySetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSampleQuerySetsRequest>;
 
@@ -29411,7 +29443,7 @@ export const PatchProjectsLocationsSampleQuerySetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSampleQuerySetsRequest>;
 
@@ -29451,7 +29483,7 @@ export const PatchProjectsLocationsSampleQuerySetsSampleQueriesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSampleQuerySetsSampleQueriesRequest>;
 
@@ -29484,7 +29516,7 @@ export const DeleteProjectsLocationsSampleQuerySetsSampleQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSampleQuerySetsSampleQueriesRequest>;
 
@@ -29529,7 +29561,7 @@ export const CreateProjectsLocationsSampleQuerySetsSampleQueriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/sampleQueries",
+      path: "v1beta/{+parent}/sampleQueries",
       hasBody: true,
     }),
     svc,
@@ -29564,7 +29596,7 @@ export const GetProjectsLocationsSampleQuerySetsSampleQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSampleQuerySetsSampleQueriesRequest>;
 
@@ -29603,7 +29635,7 @@ export const ListProjectsLocationsSampleQuerySetsSampleQueriesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/sampleQueries" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/sampleQueries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSampleQuerySetsSampleQueriesRequest>;
 
@@ -29647,7 +29679,7 @@ export const ImportProjectsLocationsSampleQuerySetsSampleQueriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/sampleQueries:import",
+      path: "v1beta/{+parent}/sampleQueries:import",
       hasBody: true,
     }),
     svc,
@@ -29682,7 +29714,7 @@ export const GetProjectsLocationsSampleQuerySetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSampleQuerySetsOperationsRequest>;
 
@@ -29714,7 +29746,7 @@ export const GetProjectsLocationsCmekConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCmekConfigsRequest>;
 
@@ -29746,7 +29778,7 @@ export const ListProjectsLocationsCmekConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/cmekConfigs" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/cmekConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCmekConfigsRequest>;
 
@@ -29778,7 +29810,7 @@ export const DeleteProjectsLocationsCmekConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCmekConfigsRequest>;
 
@@ -29818,7 +29850,7 @@ export const PatchProjectsLocationsCmekConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCmekConfigsRequest>;
 
@@ -29858,7 +29890,7 @@ export const PatchProjectsLocationsUserStoresRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsUserStoresRequest>;
 
@@ -29897,7 +29929,7 @@ export const BatchUpdateUserLicensesProjectsLocationsUserStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}:batchUpdateUserLicenses",
+      path: "v1beta/{+parent}:batchUpdateUserLicenses",
       hasBody: true,
     }),
     svc,
@@ -29932,7 +29964,7 @@ export const GetProjectsLocationsUserStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsUserStoresRequest>;
 
@@ -29976,7 +30008,7 @@ export const ListProjectsLocationsUserStoresUserLicensesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/userLicenses" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/userLicenses" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsUserStoresUserLicensesRequest>;
 
@@ -30012,7 +30044,10 @@ export const ListProjectsLocationsUserStoresLicenseConfigsUsageStatsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/licenseConfigsUsageStats" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta/{+parent}/licenseConfigsUsageStats",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsUserStoresLicenseConfigsUsageStatsRequest>;
 
@@ -30052,7 +30087,7 @@ export const CreateProjectsLocationsEvaluationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/evaluations",
+      path: "v1beta/{+parent}/evaluations",
       hasBody: true,
     }),
     svc,
@@ -30086,7 +30121,7 @@ export const GetProjectsLocationsEvaluationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEvaluationsRequest>;
 
@@ -30124,7 +30159,7 @@ export const ListResultsProjectsLocationsEvaluationsRequest =
     evaluation: Schema.String.pipe(T.HttpPath("evaluation")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{evaluation}:listResults" }),
+    T.Http({ method: "GET", path: "v1beta/{+evaluation}:listResults" }),
     svc,
   ) as unknown as Schema.Schema<ListResultsProjectsLocationsEvaluationsRequest>;
 
@@ -30166,7 +30201,7 @@ export const ListProjectsLocationsEvaluationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/evaluations" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/evaluations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEvaluationsRequest>;
 
@@ -30202,7 +30237,7 @@ export const GetProjectsLocationsEvaluationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEvaluationsOperationsRequest>;
 
@@ -30244,7 +30279,7 @@ export const ListIdentityMappingsProjectsLocationsIdentityMappingStoresRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta/{identityMappingStore}:listIdentityMappings",
+      path: "v1beta/{+identityMappingStore}:listIdentityMappings",
     }),
     svc,
   ) as unknown as Schema.Schema<ListIdentityMappingsProjectsLocationsIdentityMappingStoresRequest>;
@@ -30291,7 +30326,7 @@ export const ImportIdentityMappingsProjectsLocationsIdentityMappingStoresRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{identityMappingStore}:importIdentityMappings",
+      path: "v1beta/{+identityMappingStore}:importIdentityMappings",
       hasBody: true,
     }),
     svc,
@@ -30332,7 +30367,7 @@ export const ListProjectsLocationsIdentityMappingStoresRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/identityMappingStores" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/identityMappingStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIdentityMappingStoresRequest>;
 
@@ -30390,7 +30425,7 @@ export const CreateProjectsLocationsIdentityMappingStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/identityMappingStores",
+      path: "v1beta/{+parent}/identityMappingStores",
       hasBody: true,
     }),
     svc,
@@ -30424,7 +30459,7 @@ export const GetProjectsLocationsIdentityMappingStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIdentityMappingStoresRequest>;
 
@@ -30456,7 +30491,7 @@ export const DeleteProjectsLocationsIdentityMappingStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsIdentityMappingStoresRequest>;
 
@@ -30497,7 +30532,7 @@ export const PurgeIdentityMappingsProjectsLocationsIdentityMappingStoresRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{identityMappingStore}:purgeIdentityMappings",
+      path: "v1beta/{+identityMappingStore}:purgeIdentityMappings",
       hasBody: true,
     }),
     svc,
@@ -30546,7 +30581,7 @@ export const ListProjectsLocationsIdentityMappingStoresOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIdentityMappingStoresOperationsRequest>;
 
@@ -30583,7 +30618,7 @@ export const GetProjectsLocationsIdentityMappingStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIdentityMappingStoresOperationsRequest>;
 
@@ -30616,7 +30651,7 @@ export const GetProjectsLocationsPodcastsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPodcastsOperationsRequest>;
 

--- a/packages/gcp/src/services/displayvideo-v2.ts
+++ b/packages/gcp/src/services/displayvideo-v2.ts
@@ -7744,7 +7744,7 @@ export const PatchAdvertisersRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2/advertisers/{advertiserId}",
+      path: "v2/advertisers/{+advertiserId}",
       hasBody: true,
     }),
     svc,
@@ -7790,7 +7790,7 @@ export const ListAssignedTargetingOptionsAdvertisersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}:listAssignedTargetingOptions",
+      path: "v2/advertisers/{+advertiserId}:listAssignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAssignedTargetingOptionsAdvertisersRequest>;
@@ -7826,7 +7826,7 @@ export interface GetAdvertisersRequest {
 export const GetAdvertisersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   advertiserId: Schema.String.pipe(T.HttpPath("advertiserId")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/advertisers/{advertiserId}" }),
+  T.Http({ method: "GET", path: "v2/advertisers/{+advertiserId}" }),
   svc,
 ) as unknown as Schema.Schema<GetAdvertisersRequest>;
 
@@ -7863,7 +7863,7 @@ export const EditAssignedTargetingOptionsAdvertisersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}:editAssignedTargetingOptions",
+      path: "v2/advertisers/{+advertiserId}:editAssignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -7897,7 +7897,7 @@ export const DeleteAdvertisersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     advertiserId: Schema.String.pipe(T.HttpPath("advertiserId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/advertisers/{advertiserId}" }),
+    T.Http({ method: "DELETE", path: "v2/advertisers/{+advertiserId}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersRequest>;
 
@@ -7978,7 +7978,7 @@ export const AuditAdvertisersRequest =
     advertiserId: Schema.String.pipe(T.HttpPath("advertiserId")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/advertisers/{advertiserId}:audit" }),
+    T.Http({ method: "GET", path: "v2/advertisers/{+advertiserId}:audit" }),
     svc,
   ) as unknown as Schema.Schema<AuditAdvertisersRequest>;
 
@@ -8044,7 +8044,7 @@ export const CreateAdvertisersNegativeKeywordListsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/negativeKeywordLists",
+      path: "v2/advertisers/{+advertiserId}/negativeKeywordLists",
       hasBody: true,
     }),
     svc,
@@ -8085,7 +8085,7 @@ export const ListAdvertisersNegativeKeywordListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/negativeKeywordLists",
+      path: "v2/advertisers/{+advertiserId}/negativeKeywordLists",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersNegativeKeywordListsRequest>;
@@ -8129,7 +8129,7 @@ export const DeleteAdvertisersNegativeKeywordListsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v2/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}",
+      path: "v2/advertisers/{+advertiserId}/negativeKeywordLists/{+negativeKeywordListId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersNegativeKeywordListsRequest>;
@@ -8168,7 +8168,7 @@ export const GetAdvertisersNegativeKeywordListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}",
+      path: "v2/advertisers/{+advertiserId}/negativeKeywordLists/{+negativeKeywordListId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersNegativeKeywordListsRequest>;
@@ -8213,7 +8213,7 @@ export const PatchAdvertisersNegativeKeywordListsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}",
+      path: "v2/advertisers/{+advertiserId}/negativeKeywordLists/{negativeKeywordListId}",
       hasBody: true,
     }),
     svc,
@@ -8256,7 +8256,7 @@ export const BulkEditAdvertisersNegativeKeywordListsNegativeKeywordsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}/negativeKeywords:bulkEdit",
+      path: "v2/advertisers/{advertiserId}/negativeKeywordLists/{+negativeKeywordListId}/negativeKeywords:bulkEdit",
       hasBody: true,
     }),
     svc,
@@ -8301,7 +8301,7 @@ export const CreateAdvertisersNegativeKeywordListsNegativeKeywordsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}/negativeKeywords",
+      path: "v2/advertisers/{advertiserId}/negativeKeywordLists/{+negativeKeywordListId}/negativeKeywords",
       hasBody: true,
     }),
     svc,
@@ -8355,7 +8355,7 @@ export const ListAdvertisersNegativeKeywordListsNegativeKeywordsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}/negativeKeywords",
+      path: "v2/advertisers/{+advertiserId}/negativeKeywordLists/{+negativeKeywordListId}/negativeKeywords",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersNegativeKeywordListsNegativeKeywordsRequest>;
@@ -8403,7 +8403,7 @@ export const ReplaceAdvertisersNegativeKeywordListsNegativeKeywordsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}/negativeKeywords:replace",
+      path: "v2/advertisers/{advertiserId}/negativeKeywordLists/{+negativeKeywordListId}/negativeKeywords:replace",
       hasBody: true,
     }),
     svc,
@@ -8448,7 +8448,7 @@ export const DeleteAdvertisersNegativeKeywordListsNegativeKeywordsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v2/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}/negativeKeywords/{keywordValue}",
+      path: "v2/advertisers/{advertiserId}/negativeKeywordLists/{+negativeKeywordListId}/negativeKeywords/{+keywordValue}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersNegativeKeywordListsNegativeKeywordsRequest>;
@@ -8493,7 +8493,7 @@ export const PatchAdvertisersLocationListsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2/advertisers/{advertiserId}/locationLists/{locationListId}",
+      path: "v2/advertisers/{+advertiserId}/locationLists/{locationListId}",
       hasBody: true,
     }),
     svc,
@@ -8531,7 +8531,7 @@ export const CreateAdvertisersLocationListsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/locationLists",
+      path: "v2/advertisers/{+advertiserId}/locationLists",
       hasBody: true,
     }),
     svc,
@@ -8569,7 +8569,7 @@ export const GetAdvertisersLocationListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/locationLists/{locationListId}",
+      path: "v2/advertisers/{+advertiserId}/locationLists/{+locationListId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersLocationListsRequest>;
@@ -8615,7 +8615,7 @@ export const ListAdvertisersLocationListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/locationLists",
+      path: "v2/advertisers/{+advertiserId}/locationLists",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersLocationListsRequest>;
@@ -8659,7 +8659,7 @@ export const DeleteAdvertisersLocationListsAssignedLocationsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v2/advertisers/{advertiserId}/locationLists/{locationListId}/assignedLocations/{assignedLocationId}",
+      path: "v2/advertisers/{advertiserId}/locationLists/{locationListId}/assignedLocations/{+assignedLocationId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersLocationListsAssignedLocationsRequest>;
@@ -8754,7 +8754,7 @@ export const BulkEditAdvertisersLocationListsAssignedLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/locationLists/{locationListId}/assignedLocations:bulkEdit",
+      path: "v2/advertisers/{advertiserId}/locationLists/{+locationListId}/assignedLocations:bulkEdit",
       hasBody: true,
     }),
     svc,
@@ -8837,7 +8837,7 @@ export const GetAdvertisersCreativesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/creatives/{creativeId}",
+      path: "v2/advertisers/{+advertiserId}/creatives/{+creativeId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersCreativesRequest>;
@@ -8880,7 +8880,7 @@ export const PatchAdvertisersCreativesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2/advertisers/{advertiserId}/creatives/{creativeId}",
+      path: "v2/advertisers/{+advertiserId}/creatives/{+creativeId}",
       hasBody: true,
     }),
     svc,
@@ -8918,7 +8918,7 @@ export const CreateAdvertisersCreativesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/creatives",
+      path: "v2/advertisers/{+advertiserId}/creatives",
       hasBody: true,
     }),
     svc,
@@ -8963,7 +8963,7 @@ export const ListAdvertisersCreativesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/advertisers/{advertiserId}/creatives" }),
+    T.Http({ method: "GET", path: "v2/advertisers/{+advertiserId}/creatives" }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersCreativesRequest>;
 
@@ -9003,7 +9003,7 @@ export const DeleteAdvertisersCreativesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v2/advertisers/{advertiserId}/creatives/{creativeId}",
+      path: "v2/advertisers/{+advertiserId}/creatives/{+creativeId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersCreativesRequest>;
@@ -9040,7 +9040,7 @@ export const GetAdvertisersInsertionOrdersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/insertionOrders/{insertionOrderId}",
+      path: "v2/advertisers/{+advertiserId}/insertionOrders/{+insertionOrderId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersInsertionOrdersRequest>;
@@ -9083,7 +9083,7 @@ export const PatchAdvertisersInsertionOrdersRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2/advertisers/{advertiserId}/insertionOrders/{insertionOrderId}",
+      path: "v2/advertisers/{+advertiserId}/insertionOrders/{+insertionOrderId}",
       hasBody: true,
     }),
     svc,
@@ -9130,7 +9130,7 @@ export const ListAdvertisersInsertionOrdersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/insertionOrders",
+      path: "v2/advertisers/{+advertiserId}/insertionOrders",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersInsertionOrdersRequest>;
@@ -9172,7 +9172,7 @@ export const CreateAdvertisersInsertionOrdersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/insertionOrders",
+      path: "v2/advertisers/{+advertiserId}/insertionOrders",
       hasBody: true,
     }),
     svc,
@@ -9210,7 +9210,7 @@ export const DeleteAdvertisersInsertionOrdersRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v2/advertisers/{advertiserId}/insertionOrders/{insertionOrderId}",
+      path: "v2/advertisers/{+advertiserId}/insertionOrders/{+insertionOrderId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersInsertionOrdersRequest>;
@@ -9256,7 +9256,7 @@ export const PatchAdvertisersChannelsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2/advertisers/{advertiserId}/channels/{channelId}",
+      path: "v2/advertisers/{+advertiserId}/channels/{channelId}",
       hasBody: true,
     }),
     svc,
@@ -9297,7 +9297,7 @@ export const CreateAdvertisersChannelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/channels",
+      path: "v2/advertisers/{+advertiserId}/channels",
       hasBody: true,
     }),
     svc,
@@ -9338,7 +9338,7 @@ export const GetAdvertisersChannelsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/channels/{channelId}",
+      path: "v2/advertisers/{+advertiserId}/channels/{+channelId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersChannelsRequest>;
@@ -9385,7 +9385,7 @@ export const ListAdvertisersChannelsRequest =
     partnerId: Schema.optional(Schema.String).pipe(T.HttpQuery("partnerId")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/advertisers/{advertiserId}/channels" }),
+    T.Http({ method: "GET", path: "v2/advertisers/{+advertiserId}/channels" }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersChannelsRequest>;
 
@@ -9431,7 +9431,7 @@ export const DeleteAdvertisersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v2/advertisers/{advertiserId}/channels/{channelId}/sites/{urlOrAppId}",
+      path: "v2/advertisers/{advertiserId}/channels/{+channelId}/sites/{+urlOrAppId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersChannelsSitesRequest>;
@@ -9474,7 +9474,7 @@ export const CreateAdvertisersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/channels/{channelId}/sites",
+      path: "v2/advertisers/{advertiserId}/channels/{+channelId}/sites",
       hasBody: true,
     }),
     svc,
@@ -9527,7 +9527,7 @@ export const ListAdvertisersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/channels/{channelId}/sites",
+      path: "v2/advertisers/{+advertiserId}/channels/{+channelId}/sites",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersChannelsSitesRequest>;
@@ -9571,7 +9571,7 @@ export const ReplaceAdvertisersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/channels/{channelId}/sites:replace",
+      path: "v2/advertisers/{advertiserId}/channels/{+channelId}/sites:replace",
       hasBody: true,
     }),
     svc,
@@ -9612,7 +9612,7 @@ export const BulkEditAdvertisersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/channels/{channelId}/sites:bulkEdit",
+      path: "v2/advertisers/{advertiserId}/channels/{+channelId}/sites:bulkEdit",
       hasBody: true,
     }),
     svc,
@@ -9650,7 +9650,7 @@ export const GetAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/lineItems/{lineItemId}",
+      path: "v2/advertisers/{+advertiserId}/lineItems/{+lineItemId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersLineItemsRequest>;
@@ -9690,7 +9690,7 @@ export const DuplicateAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/lineItems/{lineItemId}:duplicate",
+      path: "v2/advertisers/{+advertiserId}/lineItems/{+lineItemId}:duplicate",
       hasBody: true,
     }),
     svc,
@@ -9735,7 +9735,7 @@ export const ListAdvertisersLineItemsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/advertisers/{advertiserId}/lineItems" }),
+    T.Http({ method: "GET", path: "v2/advertisers/{+advertiserId}/lineItems" }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersLineItemsRequest>;
 
@@ -9775,7 +9775,7 @@ export const CreateAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/lineItems",
+      path: "v2/advertisers/{+advertiserId}/lineItems",
       hasBody: true,
     }),
     svc,
@@ -9819,7 +9819,7 @@ export const PatchAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2/advertisers/{advertiserId}/lineItems/{lineItemId}",
+      path: "v2/advertisers/{+advertiserId}/lineItems/{+lineItemId}",
       hasBody: true,
     }),
     svc,
@@ -9857,7 +9857,7 @@ export const BulkUpdateAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/lineItems:bulkUpdate",
+      path: "v2/advertisers/{+advertiserId}/lineItems:bulkUpdate",
       hasBody: true,
     }),
     svc,
@@ -9910,7 +9910,7 @@ export const BulkListAssignedTargetingOptionsAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/lineItems:bulkListAssignedTargetingOptions",
+      path: "v2/advertisers/{+advertiserId}/lineItems:bulkListAssignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<BulkListAssignedTargetingOptionsAdvertisersLineItemsRequest>;
@@ -9953,7 +9953,7 @@ export const DeleteAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v2/advertisers/{advertiserId}/lineItems/{lineItemId}",
+      path: "v2/advertisers/{+advertiserId}/lineItems/{+lineItemId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersLineItemsRequest>;
@@ -9992,7 +9992,7 @@ export const BulkEditAssignedTargetingOptionsAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/lineItems:bulkEditAssignedTargetingOptions",
+      path: "v2/advertisers/{+advertiserId}/lineItems:bulkEditAssignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -10090,7 +10090,7 @@ export const DeleteAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsReq
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v2/advertisers/{advertiserId}/lineItems/{lineItemId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v2/advertisers/{+advertiserId}/lineItems/{+lineItemId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsRequest>;
@@ -10187,7 +10187,7 @@ export const CreateAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/lineItems/{lineItemId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v2/advertisers/{+advertiserId}/lineItems/{+lineItemId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -10287,7 +10287,7 @@ export const GetAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsReques
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/lineItems/{lineItemId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v2/advertisers/{+advertiserId}/lineItems/{+lineItemId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsRequest>;
@@ -10391,7 +10391,7 @@ export const ListAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsReque
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/lineItems/{lineItemId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v2/advertisers/{+advertiserId}/lineItems/{+lineItemId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsRequest>;
@@ -10435,7 +10435,7 @@ export const UploadAdvertisersAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/assets",
+      path: "v2/advertisers/{+advertiserId}/assets",
       hasBody: true,
     }),
     svc,
@@ -10486,7 +10486,7 @@ export const ListAdvertisersInvoicesRequest =
     issueMonth: Schema.optional(Schema.String).pipe(T.HttpQuery("issueMonth")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/advertisers/{advertiserId}/invoices" }),
+    T.Http({ method: "GET", path: "v2/advertisers/{+advertiserId}/invoices" }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersInvoicesRequest>;
 
@@ -10528,7 +10528,7 @@ export const LookupInvoiceCurrencyAdvertisersInvoicesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/invoices:lookupInvoiceCurrency",
+      path: "v2/advertisers/{+advertiserId}/invoices:lookupInvoiceCurrency",
     }),
     svc,
   ) as unknown as Schema.Schema<LookupInvoiceCurrencyAdvertisersInvoicesRequest>;
@@ -10575,7 +10575,7 @@ export const ListAdvertisersManualTriggersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/manualTriggers",
+      path: "v2/advertisers/{+advertiserId}/manualTriggers",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersManualTriggersRequest>;
@@ -10616,7 +10616,7 @@ export const CreateAdvertisersManualTriggersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/manualTriggers",
+      path: "v2/advertisers/{+advertiserId}/manualTriggers",
       hasBody: true,
     }),
     svc,
@@ -10657,7 +10657,7 @@ export const ActivateAdvertisersManualTriggersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/manualTriggers/{triggerId}:activate",
+      path: "v2/advertisers/{+advertiserId}/manualTriggers/{+triggerId}:activate",
       hasBody: true,
     }),
     svc,
@@ -10698,7 +10698,7 @@ export const DeactivateAdvertisersManualTriggersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/manualTriggers/{triggerId}:deactivate",
+      path: "v2/advertisers/{+advertiserId}/manualTriggers/{+triggerId}:deactivate",
       hasBody: true,
     }),
     svc,
@@ -10736,7 +10736,7 @@ export const GetAdvertisersManualTriggersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/manualTriggers/{triggerId}",
+      path: "v2/advertisers/{+advertiserId}/manualTriggers/{+triggerId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersManualTriggersRequest>;
@@ -10779,7 +10779,7 @@ export const PatchAdvertisersManualTriggersRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2/advertisers/{advertiserId}/manualTriggers/{triggerId}",
+      path: "v2/advertisers/{+advertiserId}/manualTriggers/{+triggerId}",
       hasBody: true,
     }),
     svc,
@@ -10817,7 +10817,7 @@ export const DeleteAdvertisersCampaignsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v2/advertisers/{advertiserId}/campaigns/{campaignId}",
+      path: "v2/advertisers/{+advertiserId}/campaigns/{+campaignId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersCampaignsRequest>;
@@ -10861,7 +10861,7 @@ export const ListAdvertisersCampaignsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/advertisers/{advertiserId}/campaigns" }),
+    T.Http({ method: "GET", path: "v2/advertisers/{+advertiserId}/campaigns" }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersCampaignsRequest>;
 
@@ -10901,7 +10901,7 @@ export const CreateAdvertisersCampaignsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/campaigns",
+      path: "v2/advertisers/{+advertiserId}/campaigns",
       hasBody: true,
     }),
     svc,
@@ -10945,7 +10945,7 @@ export const PatchAdvertisersCampaignsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2/advertisers/{advertiserId}/campaigns/{campaignId}",
+      path: "v2/advertisers/{+advertiserId}/campaigns/{+campaignId}",
       hasBody: true,
     }),
     svc,
@@ -10983,7 +10983,7 @@ export const GetAdvertisersCampaignsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/campaigns/{campaignId}",
+      path: "v2/advertisers/{+advertiserId}/campaigns/{+campaignId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersCampaignsRequest>;
@@ -11020,7 +11020,7 @@ export const GetAdvertisersYoutubeAdGroupAdsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/youtubeAdGroupAds/{youtubeAdGroupAdId}",
+      path: "v2/advertisers/{+advertiserId}/youtubeAdGroupAds/{+youtubeAdGroupAdId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersYoutubeAdGroupAdsRequest>;
@@ -11066,7 +11066,7 @@ export const ListAdvertisersYoutubeAdGroupAdsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/youtubeAdGroupAds",
+      path: "v2/advertisers/{+advertiserId}/youtubeAdGroupAds",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersYoutubeAdGroupAdsRequest>;
@@ -11163,7 +11163,7 @@ export const DeleteAdvertisersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v2/advertisers/{advertiserId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v2/advertisers/{+advertiserId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersTargetingTypesAssignedTargetingOptionsRequest>;
@@ -11255,7 +11255,7 @@ export const CreateAdvertisersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/advertisers/{advertiserId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v2/advertisers/{+advertiserId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -11350,7 +11350,7 @@ export const GetAdvertisersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v2/advertisers/{+advertiserId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersTargetingTypesAssignedTargetingOptionsRequest>;
@@ -11451,7 +11451,7 @@ export const ListAdvertisersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v2/advertisers/{+advertiserId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersTargetingTypesAssignedTargetingOptionsRequest>;
@@ -11508,7 +11508,7 @@ export const BulkListAdGroupAssignedTargetingOptionsAdvertisersYoutubeAdGroupsRe
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/youtubeAdGroups:bulkListAdGroupAssignedTargetingOptions",
+      path: "v2/advertisers/{+advertiserId}/youtubeAdGroups:bulkListAdGroupAssignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<BulkListAdGroupAssignedTargetingOptionsAdvertisersYoutubeAdGroupsRequest>;
@@ -11553,7 +11553,7 @@ export const GetAdvertisersYoutubeAdGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/youtubeAdGroups/{youtubeAdGroupId}",
+      path: "v2/advertisers/{+advertiserId}/youtubeAdGroups/{+youtubeAdGroupId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersYoutubeAdGroupsRequest>;
@@ -11599,7 +11599,7 @@ export const ListAdvertisersYoutubeAdGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/youtubeAdGroups",
+      path: "v2/advertisers/{+advertiserId}/youtubeAdGroups",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersYoutubeAdGroupsRequest>;
@@ -11699,7 +11699,7 @@ export const GetAdvertisersYoutubeAdGroupsTargetingTypesAssignedTargetingOptions
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/youtubeAdGroups/{youtubeAdGroupId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v2/advertisers/{+advertiserId}/youtubeAdGroups/{+youtubeAdGroupId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersYoutubeAdGroupsTargetingTypesAssignedTargetingOptionsRequest>;
@@ -11805,7 +11805,7 @@ export const ListAdvertisersYoutubeAdGroupsTargetingTypesAssignedTargetingOption
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/advertisers/{advertiserId}/youtubeAdGroups/{youtubeAdGroupId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v2/advertisers/{+advertiserId}/youtubeAdGroups/{+youtubeAdGroupId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersYoutubeAdGroupsTargetingTypesAssignedTargetingOptionsRequest>;
@@ -11861,7 +11861,7 @@ export const PatchGuaranteedOrdersRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2/guaranteedOrders/{guaranteedOrderId}",
+      path: "v2/guaranteedOrders/{+guaranteedOrderId}",
       hasBody: true,
     }),
     svc,
@@ -11901,7 +11901,7 @@ export const EditGuaranteedOrderReadAccessorsGuaranteedOrdersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/guaranteedOrders/{guaranteedOrderId}:editGuaranteedOrderReadAccessors",
+      path: "v2/guaranteedOrders/{+guaranteedOrderId}:editGuaranteedOrderReadAccessors",
       hasBody: true,
     }),
     svc,
@@ -11944,7 +11944,7 @@ export const GetGuaranteedOrdersRequest =
       T.HttpQuery("advertiserId"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/guaranteedOrders/{guaranteedOrderId}" }),
+    T.Http({ method: "GET", path: "v2/guaranteedOrders/{+guaranteedOrderId}" }),
     svc,
   ) as unknown as Schema.Schema<GetGuaranteedOrdersRequest>;
 
@@ -12097,7 +12097,7 @@ export const GetSdfdownloadtasksOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSdfdownloadtasksOperationsRequest>;
 
@@ -12222,7 +12222,7 @@ export const GetInventorySourcesRequest =
     partnerId: Schema.optional(Schema.String).pipe(T.HttpQuery("partnerId")),
     inventorySourceId: Schema.String.pipe(T.HttpPath("inventorySourceId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/inventorySources/{inventorySourceId}" }),
+    T.Http({ method: "GET", path: "v2/inventorySources/{+inventorySourceId}" }),
     svc,
   ) as unknown as Schema.Schema<GetInventorySourcesRequest>;
 
@@ -12269,7 +12269,7 @@ export const PatchInventorySourcesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2/inventorySources/{inventorySourceId}",
+      path: "v2/inventorySources/{+inventorySourceId}",
       hasBody: true,
     }),
     svc,
@@ -12309,7 +12309,7 @@ export const EditInventorySourceReadWriteAccessorsInventorySourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/inventorySources/{inventorySourceId}:editInventorySourceReadWriteAccessors",
+      path: "v2/inventorySources/{+inventorySourceId}:editInventorySourceReadWriteAccessors",
       hasBody: true,
     }),
     svc,
@@ -12347,7 +12347,7 @@ export const GetFloodlightGroupsRequest =
     partnerId: Schema.optional(Schema.String).pipe(T.HttpQuery("partnerId")),
     floodlightGroupId: Schema.String.pipe(T.HttpPath("floodlightGroupId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/floodlightGroups/{floodlightGroupId}" }),
+    T.Http({ method: "GET", path: "v2/floodlightGroups/{+floodlightGroupId}" }),
     svc,
   ) as unknown as Schema.Schema<GetFloodlightGroupsRequest>;
 
@@ -12432,7 +12432,7 @@ export const GetFloodlightGroupsFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/floodlightGroups/{floodlightGroupId}/floodlightActivities/{floodlightActivityId}",
+      path: "v2/floodlightGroups/{+floodlightGroupId}/floodlightActivities/{+floodlightActivityId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetFloodlightGroupsFloodlightActivitiesRequest>;
@@ -12479,7 +12479,7 @@ export const ListFloodlightGroupsFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/floodlightGroups/{floodlightGroupId}/floodlightActivities",
+      path: "v2/floodlightGroups/{+floodlightGroupId}/floodlightActivities",
     }),
     svc,
   ) as unknown as Schema.Schema<ListFloodlightGroupsFloodlightActivitiesRequest>;
@@ -12620,7 +12620,7 @@ export const DeleteInventorySourceGroupsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v2/inventorySourceGroups/{inventorySourceGroupId}",
+      path: "v2/inventorySourceGroups/{+inventorySourceGroupId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteInventorySourceGroupsRequest>;
@@ -12664,7 +12664,7 @@ export const GetInventorySourceGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/inventorySourceGroups/{inventorySourceGroupId}",
+      path: "v2/inventorySourceGroups/{+inventorySourceGroupId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetInventorySourceGroupsRequest>;
@@ -12764,7 +12764,7 @@ export const DeleteInventorySourceGroupsAssignedInventorySourcesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v2/inventorySourceGroups/{inventorySourceGroupId}/assignedInventorySources/{assignedInventorySourceId}",
+      path: "v2/inventorySourceGroups/{+inventorySourceGroupId}/assignedInventorySources/{+assignedInventorySourceId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteInventorySourceGroupsAssignedInventorySourcesRequest>;
@@ -12812,7 +12812,7 @@ export const CreateInventorySourceGroupsAssignedInventorySourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/inventorySourceGroups/{inventorySourceGroupId}/assignedInventorySources",
+      path: "v2/inventorySourceGroups/{+inventorySourceGroupId}/assignedInventorySources",
       hasBody: true,
     }),
     svc,
@@ -12871,7 +12871,7 @@ export const ListInventorySourceGroupsAssignedInventorySourcesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/inventorySourceGroups/{inventorySourceGroupId}/assignedInventorySources",
+      path: "v2/inventorySourceGroups/{+inventorySourceGroupId}/assignedInventorySources",
     }),
     svc,
   ) as unknown as Schema.Schema<ListInventorySourceGroupsAssignedInventorySourcesRequest>;
@@ -12918,7 +12918,7 @@ export const BulkEditInventorySourceGroupsAssignedInventorySourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/inventorySourceGroups/{inventorySourceGroupId}/assignedInventorySources:bulkEdit",
+      path: "v2/inventorySourceGroups/{+inventorySourceGroupId}/assignedInventorySources:bulkEdit",
       hasBody: true,
     }),
     svc,
@@ -12957,7 +12957,7 @@ export const GetCustomListsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   ),
   customListId: Schema.String.pipe(T.HttpPath("customListId")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/customLists/{customListId}" }),
+  T.Http({ method: "GET", path: "v2/customLists/{+customListId}" }),
   svc,
 ) as unknown as Schema.Schema<GetCustomListsRequest>;
 
@@ -13097,7 +13097,7 @@ export const GetTargetingTypesTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/targetingTypes/{targetingType}/targetingOptions/{targetingOptionId}",
+      path: "v2/targetingTypes/{+targetingType}/targetingOptions/{+targetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetTargetingTypesTargetingOptionsRequest>;
@@ -13198,7 +13198,7 @@ export const ListTargetingTypesTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/targetingTypes/{targetingType}/targetingOptions",
+      path: "v2/targetingTypes/{+targetingType}/targetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListTargetingTypesTargetingOptionsRequest>;
@@ -13290,7 +13290,7 @@ export const SearchTargetingTypesTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/targetingTypes/{targetingType}/targetingOptions:search",
+      path: "v2/targetingTypes/{+targetingType}/targetingOptions:search",
       hasBody: true,
     }),
     svc,
@@ -13424,7 +13424,7 @@ export const UploadScriptCustomBiddingAlgorithmsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/customBiddingAlgorithms/{customBiddingAlgorithmId}:uploadScript",
+      path: "v2/customBiddingAlgorithms/{+customBiddingAlgorithmId}:uploadScript",
     }),
     svc,
   ) as unknown as Schema.Schema<UploadScriptCustomBiddingAlgorithmsRequest>;
@@ -13467,7 +13467,7 @@ export const PatchCustomBiddingAlgorithmsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2/customBiddingAlgorithms/{customBiddingAlgorithmId}",
+      path: "v2/customBiddingAlgorithms/{+customBiddingAlgorithmId}",
       hasBody: true,
     }),
     svc,
@@ -13512,7 +13512,7 @@ export const GetCustomBiddingAlgorithmsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/customBiddingAlgorithms/{customBiddingAlgorithmId}",
+      path: "v2/customBiddingAlgorithms/{+customBiddingAlgorithmId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetCustomBiddingAlgorithmsRequest>;
@@ -13561,7 +13561,7 @@ export const GetCustomBiddingAlgorithmsScriptsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/customBiddingAlgorithms/{customBiddingAlgorithmId}/scripts/{customBiddingScriptId}",
+      path: "v2/customBiddingAlgorithms/{+customBiddingAlgorithmId}/scripts/{+customBiddingScriptId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetCustomBiddingAlgorithmsScriptsRequest>;
@@ -13614,7 +13614,7 @@ export const ListCustomBiddingAlgorithmsScriptsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/customBiddingAlgorithms/{customBiddingAlgorithmId}/scripts",
+      path: "v2/customBiddingAlgorithms/{+customBiddingAlgorithmId}/scripts",
     }),
     svc,
   ) as unknown as Schema.Schema<ListCustomBiddingAlgorithmsScriptsRequest>;
@@ -13666,7 +13666,7 @@ export const CreateCustomBiddingAlgorithmsScriptsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/customBiddingAlgorithms/{customBiddingAlgorithmId}/scripts",
+      path: "v2/customBiddingAlgorithms/{+customBiddingAlgorithmId}/scripts",
       hasBody: true,
     }),
     svc,
@@ -13707,7 +13707,7 @@ export const GetGoogleAudiencesRequest =
     ),
     googleAudienceId: Schema.String.pipe(T.HttpPath("googleAudienceId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/googleAudiences/{googleAudienceId}" }),
+    T.Http({ method: "GET", path: "v2/googleAudiences/{+googleAudienceId}" }),
     svc,
   ) as unknown as Schema.Schema<GetGoogleAudiencesRequest>;
 
@@ -13800,7 +13800,7 @@ export const GetCombinedAudiencesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/combinedAudiences/{combinedAudienceId}",
+      path: "v2/combinedAudiences/{+combinedAudienceId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetCombinedAudiencesRequest>;
@@ -13891,7 +13891,7 @@ export const EditAssignedTargetingOptionsPartnersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/partners/{partnerId}:editAssignedTargetingOptions",
+      path: "v2/partners/{+partnerId}:editAssignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -13924,7 +13924,7 @@ export interface GetPartnersRequest {
 export const GetPartnersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   partnerId: Schema.String.pipe(T.HttpPath("partnerId")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/partners/{partnerId}" }),
+  T.Http({ method: "GET", path: "v2/partners/{+partnerId}" }),
   svc,
 ) as unknown as Schema.Schema<GetPartnersRequest>;
 
@@ -14013,7 +14013,7 @@ export const PatchPartnersChannelsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2/partners/{partnerId}/channels/{channelId}",
+      path: "v2/partners/{+partnerId}/channels/{channelId}",
       hasBody: true,
     }),
     svc,
@@ -14056,7 +14056,7 @@ export const CreatePartnersChannelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/partners/{partnerId}/channels",
+      path: "v2/partners/{+partnerId}/channels",
       hasBody: true,
     }),
     svc,
@@ -14099,7 +14099,7 @@ export const GetPartnersChannelsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/partners/{partnerId}/channels/{channelId}",
+      path: "v2/partners/{+partnerId}/channels/{+channelId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetPartnersChannelsRequest>;
@@ -14147,7 +14147,7 @@ export const ListPartnersChannelsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/partners/{partnerId}/channels" }),
+    T.Http({ method: "GET", path: "v2/partners/{+partnerId}/channels" }),
     svc,
   ) as unknown as Schema.Schema<ListPartnersChannelsRequest>;
 
@@ -14190,7 +14190,7 @@ export const BulkEditPartnersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/partners/{partnerId}/channels/{channelId}/sites:bulkEdit",
+      path: "v2/partners/{partnerId}/channels/{+channelId}/sites:bulkEdit",
       hasBody: true,
     }),
     svc,
@@ -14236,7 +14236,7 @@ export const DeletePartnersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v2/partners/{partnerId}/channels/{channelId}/sites/{urlOrAppId}",
+      path: "v2/partners/{partnerId}/channels/{+channelId}/sites/{+urlOrAppId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeletePartnersChannelsSitesRequest>;
@@ -14290,7 +14290,7 @@ export const ListPartnersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/partners/{partnerId}/channels/{channelId}/sites",
+      path: "v2/partners/{+partnerId}/channels/{+channelId}/sites",
     }),
     svc,
   ) as unknown as Schema.Schema<ListPartnersChannelsSitesRequest>;
@@ -14334,7 +14334,7 @@ export const ReplacePartnersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/partners/{partnerId}/channels/{channelId}/sites:replace",
+      path: "v2/partners/{partnerId}/channels/{+channelId}/sites:replace",
       hasBody: true,
     }),
     svc,
@@ -14380,7 +14380,7 @@ export const CreatePartnersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/partners/{partnerId}/channels/{channelId}/sites",
+      path: "v2/partners/{partnerId}/channels/{+channelId}/sites",
       hasBody: true,
     }),
     svc,
@@ -14473,7 +14473,7 @@ export const GetPartnersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/partners/{partnerId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v2/partners/{+partnerId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetPartnersTargetingTypesAssignedTargetingOptionsRequest>;
@@ -14574,7 +14574,7 @@ export const ListPartnersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/partners/{partnerId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v2/partners/{+partnerId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListPartnersTargetingTypesAssignedTargetingOptionsRequest>;
@@ -14670,7 +14670,7 @@ export const CreatePartnersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/partners/{partnerId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v2/partners/{+partnerId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -14765,7 +14765,7 @@ export const DeletePartnersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v2/partners/{partnerId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v2/partners/{+partnerId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeletePartnersTargetingTypesAssignedTargetingOptionsRequest>;
@@ -14798,7 +14798,7 @@ export interface DownloadMediaRequest {
 export const DownloadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   resourceName: Schema.String.pipe(T.HttpPath("resourceName")),
 }).pipe(
-  T.Http({ method: "GET", path: "download/{resourceName}" }),
+  T.Http({ method: "GET", path: "download/{+resourceName}" }),
   svc,
 ) as unknown as Schema.Schema<DownloadMediaRequest>;
 
@@ -14831,7 +14831,7 @@ export const UploadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   resourceName: Schema.String.pipe(T.HttpPath("resourceName")),
   body: Schema.optional(GoogleBytestreamMedia).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "media/{resourceName}", hasBody: true }),
+  T.Http({ method: "POST", path: "media/{+resourceName}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<UploadMediaRequest>;
 
@@ -14867,7 +14867,7 @@ export const PatchUsersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   userId: Schema.String.pipe(T.HttpPath("userId")),
   body: Schema.optional(User).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v2/users/{userId}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v2/users/{+userId}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchUsersRequest>;
 
@@ -14902,7 +14902,7 @@ export const BulkEditAssignedUserRolesUsersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/users/{userId}:bulkEditAssignedUserRoles",
+      path: "v2/users/{+userId}:bulkEditAssignedUserRoles",
       hasBody: true,
     }),
     svc,
@@ -14935,7 +14935,7 @@ export interface GetUsersRequest {
 export const GetUsersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   userId: Schema.String.pipe(T.HttpPath("userId")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/users/{userId}" }),
+  T.Http({ method: "GET", path: "v2/users/{+userId}" }),
   svc,
 ) as unknown as Schema.Schema<GetUsersRequest>;
 
@@ -14964,7 +14964,7 @@ export interface DeleteUsersRequest {
 export const DeleteUsersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   userId: Schema.String.pipe(T.HttpPath("userId")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v2/users/{userId}" }),
+  T.Http({ method: "DELETE", path: "v2/users/{+userId}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteUsersRequest>;
 

--- a/packages/gcp/src/services/displayvideo-v3.ts
+++ b/packages/gcp/src/services/displayvideo-v3.ts
@@ -9461,7 +9461,7 @@ export const GetFirstAndThirdPartyAudiencesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/firstAndThirdPartyAudiences/{firstAndThirdPartyAudienceId}",
+      path: "v3/firstAndThirdPartyAudiences/{+firstAndThirdPartyAudienceId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetFirstAndThirdPartyAudiencesRequest>;
@@ -9541,7 +9541,7 @@ export const EditCustomerMatchMembersFirstAndThirdPartyAudiencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/firstAndThirdPartyAudiences/{firstAndThirdPartyAudienceId}:editCustomerMatchMembers",
+      path: "v3/firstAndThirdPartyAudiences/{+firstAndThirdPartyAudienceId}:editCustomerMatchMembers",
       hasBody: true,
     }),
     svc,
@@ -9591,7 +9591,7 @@ export const PatchFirstAndThirdPartyAudiencesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v3/firstAndThirdPartyAudiences/{firstAndThirdPartyAudienceId}",
+      path: "v3/firstAndThirdPartyAudiences/{+firstAndThirdPartyAudienceId}",
       hasBody: true,
     }),
     svc,
@@ -9726,7 +9726,7 @@ export const DeleteAdvertisersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     advertiserId: Schema.String.pipe(T.HttpPath("advertiserId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/advertisers/{advertiserId}" }),
+    T.Http({ method: "DELETE", path: "v3/advertisers/{+advertiserId}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersRequest>;
 
@@ -9764,7 +9764,7 @@ export const PatchAdvertisersRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v3/advertisers/{advertiserId}",
+      path: "v3/advertisers/{+advertiserId}",
       hasBody: true,
     }),
     svc,
@@ -9810,7 +9810,7 @@ export const ListAssignedTargetingOptionsAdvertisersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}:listAssignedTargetingOptions",
+      path: "v3/advertisers/{+advertiserId}:listAssignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAssignedTargetingOptionsAdvertisersRequest>;
@@ -9850,7 +9850,7 @@ export const AuditAdvertisersRequest =
     advertiserId: Schema.String.pipe(T.HttpPath("advertiserId")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/advertisers/{advertiserId}:audit" }),
+    T.Http({ method: "GET", path: "v3/advertisers/{+advertiserId}:audit" }),
     svc,
   ) as unknown as Schema.Schema<AuditAdvertisersRequest>;
 
@@ -9888,7 +9888,7 @@ export const EditAssignedTargetingOptionsAdvertisersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}:editAssignedTargetingOptions",
+      path: "v3/advertisers/{+advertiserId}:editAssignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -9921,7 +9921,7 @@ export interface GetAdvertisersRequest {
 export const GetAdvertisersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   advertiserId: Schema.String.pipe(T.HttpPath("advertiserId")),
 }).pipe(
-  T.Http({ method: "GET", path: "v3/advertisers/{advertiserId}" }),
+  T.Http({ method: "GET", path: "v3/advertisers/{+advertiserId}" }),
   svc,
 ) as unknown as Schema.Schema<GetAdvertisersRequest>;
 
@@ -9988,7 +9988,7 @@ export const BulkEditAssignedTargetingOptionsAdvertisersAdGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/adGroups:bulkEditAssignedTargetingOptions",
+      path: "v3/advertisers/{+advertiserId}/adGroups:bulkEditAssignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -10028,7 +10028,7 @@ export const GetAdvertisersAdGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/adGroups/{adGroupId}",
+      path: "v3/advertisers/{+advertiserId}/adGroups/{+adGroupId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersAdGroupsRequest>;
@@ -10065,7 +10065,7 @@ export const CreateAdvertisersAdGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/adGroups",
+      path: "v3/advertisers/{+advertiserId}/adGroups",
       hasBody: true,
     }),
     svc,
@@ -10110,7 +10110,7 @@ export const ListAdvertisersAdGroupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     advertiserId: Schema.String.pipe(T.HttpPath("advertiserId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/advertisers/{advertiserId}/adGroups" }),
+    T.Http({ method: "GET", path: "v3/advertisers/{+advertiserId}/adGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersAdGroupsRequest>;
 
@@ -10150,7 +10150,7 @@ export const DeleteAdvertisersAdGroupsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v3/advertisers/{advertiserId}/adGroups/{adGroupId}",
+      path: "v3/advertisers/{+advertiserId}/adGroups/{+adGroupId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersAdGroupsRequest>;
@@ -10193,7 +10193,7 @@ export const PatchAdvertisersAdGroupsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v3/advertisers/{advertiserId}/adGroups/{adGroupId}",
+      path: "v3/advertisers/{+advertiserId}/adGroups/{+adGroupId}",
       hasBody: true,
     }),
     svc,
@@ -10245,7 +10245,7 @@ export const BulkListAdGroupAssignedTargetingOptionsAdvertisersAdGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/adGroups:bulkListAdGroupAssignedTargetingOptions",
+      path: "v3/advertisers/{+advertiserId}/adGroups:bulkListAdGroupAssignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<BulkListAdGroupAssignedTargetingOptionsAdvertisersAdGroupsRequest>;
@@ -10347,7 +10347,7 @@ export const GetAdvertisersAdGroupsTargetingTypesAssignedTargetingOptionsRequest
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/adGroups/{adGroupId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v3/advertisers/{+advertiserId}/adGroups/{+adGroupId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersAdGroupsTargetingTypesAssignedTargetingOptionsRequest>;
@@ -10443,7 +10443,7 @@ export const CreateAdvertisersAdGroupsTargetingTypesAssignedTargetingOptionsRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/adGroups/{adGroupId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v3/advertisers/{+advertiserId}/adGroups/{+adGroupId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -10550,7 +10550,7 @@ export const ListAdvertisersAdGroupsTargetingTypesAssignedTargetingOptionsReques
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/adGroups/{adGroupId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v3/advertisers/{+advertiserId}/adGroups/{+adGroupId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersAdGroupsTargetingTypesAssignedTargetingOptionsRequest>;
@@ -10652,7 +10652,7 @@ export const DeleteAdvertisersAdGroupsTargetingTypesAssignedTargetingOptionsRequ
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v3/advertisers/{advertiserId}/adGroups/{adGroupId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v3/advertisers/{+advertiserId}/adGroups/{+adGroupId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersAdGroupsTargetingTypesAssignedTargetingOptionsRequest>;
@@ -10702,7 +10702,7 @@ export const ListAdvertisersChannelsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     partnerId: Schema.optional(Schema.String).pipe(T.HttpQuery("partnerId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/advertisers/{advertiserId}/channels" }),
+    T.Http({ method: "GET", path: "v3/advertisers/{+advertiserId}/channels" }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersChannelsRequest>;
 
@@ -10751,7 +10751,7 @@ export const PatchAdvertisersChannelsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v3/advertisers/{advertiserId}/channels/{channelId}",
+      path: "v3/advertisers/{+advertiserId}/channels/{channelId}",
       hasBody: true,
     }),
     svc,
@@ -10792,7 +10792,7 @@ export const GetAdvertisersChannelsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/channels/{channelId}",
+      path: "v3/advertisers/{+advertiserId}/channels/{+channelId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersChannelsRequest>;
@@ -10832,7 +10832,7 @@ export const CreateAdvertisersChannelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/channels",
+      path: "v3/advertisers/{+advertiserId}/channels",
       hasBody: true,
     }),
     svc,
@@ -10873,7 +10873,7 @@ export const ReplaceAdvertisersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/channels/{channelId}/sites:replace",
+      path: "v3/advertisers/{advertiserId}/channels/{+channelId}/sites:replace",
       hasBody: true,
     }),
     svc,
@@ -10917,7 +10917,7 @@ export const CreateAdvertisersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/channels/{channelId}/sites",
+      path: "v3/advertisers/{advertiserId}/channels/{+channelId}/sites",
       hasBody: true,
     }),
     svc,
@@ -10958,7 +10958,7 @@ export const BulkEditAdvertisersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/channels/{channelId}/sites:bulkEdit",
+      path: "v3/advertisers/{advertiserId}/channels/{+channelId}/sites:bulkEdit",
       hasBody: true,
     }),
     svc,
@@ -11011,7 +11011,7 @@ export const ListAdvertisersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/channels/{channelId}/sites",
+      path: "v3/advertisers/{+advertiserId}/channels/{+channelId}/sites",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersChannelsSitesRequest>;
@@ -11058,7 +11058,7 @@ export const DeleteAdvertisersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v3/advertisers/{advertiserId}/channels/{channelId}/sites/{urlOrAppId}",
+      path: "v3/advertisers/{advertiserId}/channels/{+channelId}/sites/{+urlOrAppId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersChannelsSitesRequest>;
@@ -11097,7 +11097,7 @@ export const LookupInvoiceCurrencyAdvertisersInvoicesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/invoices:lookupInvoiceCurrency",
+      path: "v3/advertisers/{+advertiserId}/invoices:lookupInvoiceCurrency",
     }),
     svc,
   ) as unknown as Schema.Schema<LookupInvoiceCurrencyAdvertisersInvoicesRequest>;
@@ -11148,7 +11148,7 @@ export const ListAdvertisersInvoicesRequest =
       T.HttpQuery("loiSapinInvoiceType"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/advertisers/{advertiserId}/invoices" }),
+    T.Http({ method: "GET", path: "v3/advertisers/{+advertiserId}/invoices" }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersInvoicesRequest>;
 
@@ -11188,7 +11188,7 @@ export const UploadAdvertisersAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/assets",
+      path: "v3/advertisers/{+advertiserId}/assets",
       hasBody: true,
     }),
     svc,
@@ -11228,7 +11228,7 @@ export const BulkEditAssignedTargetingOptionsAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/lineItems:bulkEditAssignedTargetingOptions",
+      path: "v3/advertisers/{+advertiserId}/lineItems:bulkEditAssignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -11282,7 +11282,7 @@ export const BulkListAssignedTargetingOptionsAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/lineItems:bulkListAssignedTargetingOptions",
+      path: "v3/advertisers/{+advertiserId}/lineItems:bulkListAssignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<BulkListAssignedTargetingOptionsAdvertisersLineItemsRequest>;
@@ -11325,7 +11325,7 @@ export const BulkUpdateAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/lineItems:bulkUpdate",
+      path: "v3/advertisers/{+advertiserId}/lineItems:bulkUpdate",
       hasBody: true,
     }),
     svc,
@@ -11364,7 +11364,7 @@ export const GetAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/lineItems/{lineItemId}",
+      path: "v3/advertisers/{+advertiserId}/lineItems/{+lineItemId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersLineItemsRequest>;
@@ -11401,7 +11401,7 @@ export const CreateAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/lineItems",
+      path: "v3/advertisers/{+advertiserId}/lineItems",
       hasBody: true,
     }),
     svc,
@@ -11442,7 +11442,7 @@ export const DuplicateAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/lineItems/{lineItemId}:duplicate",
+      path: "v3/advertisers/{+advertiserId}/lineItems/{+lineItemId}:duplicate",
       hasBody: true,
     }),
     svc,
@@ -11486,7 +11486,7 @@ export const PatchAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v3/advertisers/{advertiserId}/lineItems/{lineItemId}",
+      path: "v3/advertisers/{+advertiserId}/lineItems/{+lineItemId}",
       hasBody: true,
     }),
     svc,
@@ -11531,7 +11531,7 @@ export const ListAdvertisersLineItemsRequest =
     advertiserId: Schema.String.pipe(T.HttpPath("advertiserId")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/advertisers/{advertiserId}/lineItems" }),
+    T.Http({ method: "GET", path: "v3/advertisers/{+advertiserId}/lineItems" }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersLineItemsRequest>;
 
@@ -11571,7 +11571,7 @@ export const DeleteAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v3/advertisers/{advertiserId}/lineItems/{lineItemId}",
+      path: "v3/advertisers/{+advertiserId}/lineItems/{+lineItemId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersLineItemsRequest>;
@@ -11674,7 +11674,7 @@ export const ListAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsReque
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/lineItems/{lineItemId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v3/advertisers/{+advertiserId}/lineItems/{+lineItemId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsRequest>;
@@ -11777,7 +11777,7 @@ export const DeleteAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsReq
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v3/advertisers/{advertiserId}/lineItems/{lineItemId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v3/advertisers/{+advertiserId}/lineItems/{+lineItemId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsRequest>;
@@ -11877,7 +11877,7 @@ export const GetAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsReques
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/lineItems/{lineItemId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v3/advertisers/{+advertiserId}/lineItems/{+lineItemId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsRequest>;
@@ -11973,7 +11973,7 @@ export const CreateAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/lineItems/{lineItemId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v3/advertisers/{+advertiserId}/lineItems/{+lineItemId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -12021,7 +12021,7 @@ export const PatchAdvertisersCampaignsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v3/advertisers/{advertiserId}/campaigns/{campaignId}",
+      path: "v3/advertisers/{+advertiserId}/campaigns/{+campaignId}",
       hasBody: true,
     }),
     svc,
@@ -12066,7 +12066,7 @@ export const ListAdvertisersCampaignsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/advertisers/{advertiserId}/campaigns" }),
+    T.Http({ method: "GET", path: "v3/advertisers/{+advertiserId}/campaigns" }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersCampaignsRequest>;
 
@@ -12106,7 +12106,7 @@ export const DeleteAdvertisersCampaignsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v3/advertisers/{advertiserId}/campaigns/{campaignId}",
+      path: "v3/advertisers/{+advertiserId}/campaigns/{+campaignId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersCampaignsRequest>;
@@ -12143,7 +12143,7 @@ export const GetAdvertisersCampaignsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/campaigns/{campaignId}",
+      path: "v3/advertisers/{+advertiserId}/campaigns/{+campaignId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersCampaignsRequest>;
@@ -12180,7 +12180,7 @@ export const CreateAdvertisersCampaignsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/campaigns",
+      path: "v3/advertisers/{+advertiserId}/campaigns",
       hasBody: true,
     }),
     svc,
@@ -12218,7 +12218,7 @@ export const GetAdvertisersAdGroupAdsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/adGroupAds/{adGroupAdId}",
+      path: "v3/advertisers/{+advertiserId}/adGroupAds/{+adGroupAdId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersAdGroupAdsRequest>;
@@ -12255,7 +12255,7 @@ export const CreateAdvertisersAdGroupAdsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/adGroupAds",
+      path: "v3/advertisers/{+advertiserId}/adGroupAds",
       hasBody: true,
     }),
     svc,
@@ -12300,7 +12300,10 @@ export const ListAdvertisersAdGroupAdsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     advertiserId: Schema.String.pipe(T.HttpPath("advertiserId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/advertisers/{advertiserId}/adGroupAds" }),
+    T.Http({
+      method: "GET",
+      path: "v3/advertisers/{+advertiserId}/adGroupAds",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersAdGroupAdsRequest>;
 
@@ -12340,7 +12343,7 @@ export const DeleteAdvertisersAdGroupAdsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v3/advertisers/{advertiserId}/adGroupAds/{adGroupAdId}",
+      path: "v3/advertisers/{+advertiserId}/adGroupAds/{+adGroupAdId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersAdGroupAdsRequest>;
@@ -12383,7 +12386,7 @@ export const PatchAdvertisersAdGroupAdsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v3/advertisers/{advertiserId}/adGroupAds/{adGroupAdId}",
+      path: "v3/advertisers/{+advertiserId}/adGroupAds/{+adGroupAdId}",
       hasBody: true,
     }),
     svc,
@@ -12484,7 +12487,7 @@ export const ListAdvertisersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v3/advertisers/{+advertiserId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersTargetingTypesAssignedTargetingOptionsRequest>;
@@ -12583,7 +12586,7 @@ export const DeleteAdvertisersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v3/advertisers/{advertiserId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v3/advertisers/{+advertiserId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersTargetingTypesAssignedTargetingOptionsRequest>;
@@ -12678,7 +12681,7 @@ export const GetAdvertisersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v3/advertisers/{+advertiserId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersTargetingTypesAssignedTargetingOptionsRequest>;
@@ -12771,7 +12774,7 @@ export const CreateAdvertisersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v3/advertisers/{+advertiserId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -12811,7 +12814,7 @@ export const GetAdvertisersCreativesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/creatives/{creativeId}",
+      path: "v3/advertisers/{+advertiserId}/creatives/{+creativeId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersCreativesRequest>;
@@ -12848,7 +12851,7 @@ export const CreateAdvertisersCreativesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/creatives",
+      path: "v3/advertisers/{+advertiserId}/creatives",
       hasBody: true,
     }),
     svc,
@@ -12893,7 +12896,7 @@ export const ListAdvertisersCreativesRequest =
     advertiserId: Schema.String.pipe(T.HttpPath("advertiserId")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/advertisers/{advertiserId}/creatives" }),
+    T.Http({ method: "GET", path: "v3/advertisers/{+advertiserId}/creatives" }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersCreativesRequest>;
 
@@ -12933,7 +12936,7 @@ export const DeleteAdvertisersCreativesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v3/advertisers/{advertiserId}/creatives/{creativeId}",
+      path: "v3/advertisers/{+advertiserId}/creatives/{+creativeId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersCreativesRequest>;
@@ -12976,7 +12979,7 @@ export const PatchAdvertisersCreativesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v3/advertisers/{advertiserId}/creatives/{creativeId}",
+      path: "v3/advertisers/{+advertiserId}/creatives/{+creativeId}",
       hasBody: true,
     }),
     svc,
@@ -13014,7 +13017,7 @@ export const GetAdvertisersLocationListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/locationLists/{locationListId}",
+      path: "v3/advertisers/{+advertiserId}/locationLists/{+locationListId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersLocationListsRequest>;
@@ -13051,7 +13054,7 @@ export const CreateAdvertisersLocationListsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/locationLists",
+      path: "v3/advertisers/{+advertiserId}/locationLists",
       hasBody: true,
     }),
     svc,
@@ -13095,7 +13098,7 @@ export const PatchAdvertisersLocationListsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v3/advertisers/{advertiserId}/locationLists/{locationListId}",
+      path: "v3/advertisers/{+advertiserId}/locationLists/{locationListId}",
       hasBody: true,
     }),
     svc,
@@ -13142,7 +13145,7 @@ export const ListAdvertisersLocationListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/locationLists",
+      path: "v3/advertisers/{+advertiserId}/locationLists",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersLocationListsRequest>;
@@ -13240,7 +13243,7 @@ export const DeleteAdvertisersLocationListsAssignedLocationsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v3/advertisers/{advertiserId}/locationLists/{locationListId}/assignedLocations/{assignedLocationId}",
+      path: "v3/advertisers/{advertiserId}/locationLists/{locationListId}/assignedLocations/{+assignedLocationId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersLocationListsAssignedLocationsRequest>;
@@ -13281,7 +13284,7 @@ export const BulkEditAdvertisersLocationListsAssignedLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/locationLists/{locationListId}/assignedLocations:bulkEdit",
+      path: "v3/advertisers/{advertiserId}/locationLists/{+locationListId}/assignedLocations:bulkEdit",
       hasBody: true,
     }),
     svc,
@@ -13366,7 +13369,7 @@ export const GetAdvertisersNegativeKeywordListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}",
+      path: "v3/advertisers/{+advertiserId}/negativeKeywordLists/{+negativeKeywordListId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersNegativeKeywordListsRequest>;
@@ -13403,7 +13406,7 @@ export const CreateAdvertisersNegativeKeywordListsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/negativeKeywordLists",
+      path: "v3/advertisers/{+advertiserId}/negativeKeywordLists",
       hasBody: true,
     }),
     svc,
@@ -13449,7 +13452,7 @@ export const PatchAdvertisersNegativeKeywordListsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v3/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}",
+      path: "v3/advertisers/{+advertiserId}/negativeKeywordLists/{negativeKeywordListId}",
       hasBody: true,
     }),
     svc,
@@ -13490,7 +13493,7 @@ export const ListAdvertisersNegativeKeywordListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/negativeKeywordLists",
+      path: "v3/advertisers/{+advertiserId}/negativeKeywordLists",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersNegativeKeywordListsRequest>;
@@ -13534,7 +13537,7 @@ export const DeleteAdvertisersNegativeKeywordListsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v3/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}",
+      path: "v3/advertisers/{+advertiserId}/negativeKeywordLists/{+negativeKeywordListId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersNegativeKeywordListsRequest>;
@@ -13576,7 +13579,7 @@ export const BulkEditAdvertisersNegativeKeywordListsNegativeKeywordsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}/negativeKeywords:bulkEdit",
+      path: "v3/advertisers/{advertiserId}/negativeKeywordLists/{+negativeKeywordListId}/negativeKeywords:bulkEdit",
       hasBody: true,
     }),
     svc,
@@ -13630,7 +13633,7 @@ export const ListAdvertisersNegativeKeywordListsNegativeKeywordsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}/negativeKeywords",
+      path: "v3/advertisers/{+advertiserId}/negativeKeywordLists/{+negativeKeywordListId}/negativeKeywords",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersNegativeKeywordListsNegativeKeywordsRequest>;
@@ -13678,7 +13681,7 @@ export const DeleteAdvertisersNegativeKeywordListsNegativeKeywordsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v3/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}/negativeKeywords/{keywordValue}",
+      path: "v3/advertisers/{advertiserId}/negativeKeywordLists/{+negativeKeywordListId}/negativeKeywords/{+keywordValue}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersNegativeKeywordListsNegativeKeywordsRequest>;
@@ -13722,7 +13725,7 @@ export const ReplaceAdvertisersNegativeKeywordListsNegativeKeywordsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}/negativeKeywords:replace",
+      path: "v3/advertisers/{advertiserId}/negativeKeywordLists/{+negativeKeywordListId}/negativeKeywords:replace",
       hasBody: true,
     }),
     svc,
@@ -13767,7 +13770,7 @@ export const CreateAdvertisersNegativeKeywordListsNegativeKeywordsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}/negativeKeywords",
+      path: "v3/advertisers/{advertiserId}/negativeKeywordLists/{+negativeKeywordListId}/negativeKeywords",
       hasBody: true,
     }),
     svc,
@@ -13807,7 +13810,7 @@ export const GetAdvertisersInsertionOrdersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/insertionOrders/{insertionOrderId}",
+      path: "v3/advertisers/{+advertiserId}/insertionOrders/{+insertionOrderId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersInsertionOrdersRequest>;
@@ -13844,7 +13847,7 @@ export const CreateAdvertisersInsertionOrdersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/advertisers/{advertiserId}/insertionOrders",
+      path: "v3/advertisers/{+advertiserId}/insertionOrders",
       hasBody: true,
     }),
     svc,
@@ -13888,7 +13891,7 @@ export const PatchAdvertisersInsertionOrdersRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v3/advertisers/{advertiserId}/insertionOrders/{insertionOrderId}",
+      path: "v3/advertisers/{+advertiserId}/insertionOrders/{+insertionOrderId}",
       hasBody: true,
     }),
     svc,
@@ -13935,7 +13938,7 @@ export const ListAdvertisersInsertionOrdersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/advertisers/{advertiserId}/insertionOrders",
+      path: "v3/advertisers/{+advertiserId}/insertionOrders",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersInsertionOrdersRequest>;
@@ -13977,7 +13980,7 @@ export const DeleteAdvertisersInsertionOrdersRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v3/advertisers/{advertiserId}/insertionOrders/{insertionOrderId}",
+      path: "v3/advertisers/{+advertiserId}/insertionOrders/{+insertionOrderId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersInsertionOrdersRequest>;
@@ -14079,7 +14082,7 @@ export const ListTargetingTypesTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/targetingTypes/{targetingType}/targetingOptions",
+      path: "v3/targetingTypes/{+targetingType}/targetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListTargetingTypesTargetingOptionsRequest>;
@@ -14172,7 +14175,7 @@ export const SearchTargetingTypesTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/targetingTypes/{targetingType}/targetingOptions:search",
+      path: "v3/targetingTypes/{+targetingType}/targetingOptions:search",
       hasBody: true,
     }),
     svc,
@@ -14267,7 +14270,7 @@ export const GetTargetingTypesTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/targetingTypes/{targetingType}/targetingOptions/{targetingOptionId}",
+      path: "v3/targetingTypes/{+targetingType}/targetingOptions/{+targetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetTargetingTypesTargetingOptionsRequest>;
@@ -14311,7 +14314,7 @@ export const UploadRulesCustomBiddingAlgorithmsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/customBiddingAlgorithms/{customBiddingAlgorithmId}:uploadRules",
+      path: "v3/customBiddingAlgorithms/{+customBiddingAlgorithmId}:uploadRules",
     }),
     svc,
   ) as unknown as Schema.Schema<UploadRulesCustomBiddingAlgorithmsRequest>;
@@ -14407,7 +14410,7 @@ export const PatchCustomBiddingAlgorithmsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v3/customBiddingAlgorithms/{customBiddingAlgorithmId}",
+      path: "v3/customBiddingAlgorithms/{+customBiddingAlgorithmId}",
       hasBody: true,
     }),
     svc,
@@ -14452,7 +14455,7 @@ export const UploadScriptCustomBiddingAlgorithmsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/customBiddingAlgorithms/{customBiddingAlgorithmId}:uploadScript",
+      path: "v3/customBiddingAlgorithms/{+customBiddingAlgorithmId}:uploadScript",
     }),
     svc,
   ) as unknown as Schema.Schema<UploadScriptCustomBiddingAlgorithmsRequest>;
@@ -14497,7 +14500,7 @@ export const GetCustomBiddingAlgorithmsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/customBiddingAlgorithms/{customBiddingAlgorithmId}",
+      path: "v3/customBiddingAlgorithms/{+customBiddingAlgorithmId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetCustomBiddingAlgorithmsRequest>;
@@ -14585,7 +14588,7 @@ export const ListCustomBiddingAlgorithmsRulesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/customBiddingAlgorithms/{customBiddingAlgorithmId}/rules",
+      path: "v3/customBiddingAlgorithms/{+customBiddingAlgorithmId}/rules",
     }),
     svc,
   ) as unknown as Schema.Schema<ListCustomBiddingAlgorithmsRulesRequest>;
@@ -14637,7 +14640,7 @@ export const CreateCustomBiddingAlgorithmsRulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/customBiddingAlgorithms/{customBiddingAlgorithmId}/rules",
+      path: "v3/customBiddingAlgorithms/{+customBiddingAlgorithmId}/rules",
       hasBody: true,
     }),
     svc,
@@ -14688,7 +14691,7 @@ export const GetCustomBiddingAlgorithmsRulesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/customBiddingAlgorithms/{customBiddingAlgorithmId}/rules/{customBiddingAlgorithmRulesId}",
+      path: "v3/customBiddingAlgorithms/{+customBiddingAlgorithmId}/rules/{+customBiddingAlgorithmRulesId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetCustomBiddingAlgorithmsRulesRequest>;
@@ -14742,7 +14745,7 @@ export const ListCustomBiddingAlgorithmsScriptsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/customBiddingAlgorithms/{customBiddingAlgorithmId}/scripts",
+      path: "v3/customBiddingAlgorithms/{+customBiddingAlgorithmId}/scripts",
     }),
     svc,
   ) as unknown as Schema.Schema<ListCustomBiddingAlgorithmsScriptsRequest>;
@@ -14794,7 +14797,7 @@ export const CreateCustomBiddingAlgorithmsScriptsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/customBiddingAlgorithms/{customBiddingAlgorithmId}/scripts",
+      path: "v3/customBiddingAlgorithms/{+customBiddingAlgorithmId}/scripts",
       hasBody: true,
     }),
     svc,
@@ -14844,7 +14847,7 @@ export const GetCustomBiddingAlgorithmsScriptsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/customBiddingAlgorithms/{customBiddingAlgorithmId}/scripts/{customBiddingScriptId}",
+      path: "v3/customBiddingAlgorithms/{+customBiddingAlgorithmId}/scripts/{+customBiddingScriptId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetCustomBiddingAlgorithmsScriptsRequest>;
@@ -14880,7 +14883,7 @@ export const GetCustomListsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("advertiserId"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "v3/customLists/{customListId}" }),
+  T.Http({ method: "GET", path: "v3/customLists/{+customListId}" }),
   svc,
 ) as unknown as Schema.Schema<GetCustomListsRequest>;
 
@@ -14963,7 +14966,7 @@ export const GetFloodlightGroupsRequest =
     floodlightGroupId: Schema.String.pipe(T.HttpPath("floodlightGroupId")),
     partnerId: Schema.optional(Schema.String).pipe(T.HttpQuery("partnerId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/floodlightGroups/{floodlightGroupId}" }),
+    T.Http({ method: "GET", path: "v3/floodlightGroups/{+floodlightGroupId}" }),
     svc,
   ) as unknown as Schema.Schema<GetFloodlightGroupsRequest>;
 
@@ -15052,7 +15055,7 @@ export const ListFloodlightGroupsFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/floodlightGroups/{floodlightGroupId}/floodlightActivities",
+      path: "v3/floodlightGroups/{+floodlightGroupId}/floodlightActivities",
     }),
     svc,
   ) as unknown as Schema.Schema<ListFloodlightGroupsFloodlightActivitiesRequest>;
@@ -15099,7 +15102,7 @@ export const GetFloodlightGroupsFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/floodlightGroups/{floodlightGroupId}/floodlightActivities/{floodlightActivityId}",
+      path: "v3/floodlightGroups/{+floodlightGroupId}/floodlightActivities/{+floodlightActivityId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetFloodlightGroupsFloodlightActivitiesRequest>;
@@ -15179,7 +15182,7 @@ export const GetGuaranteedOrdersRequest =
     guaranteedOrderId: Schema.String.pipe(T.HttpPath("guaranteedOrderId")),
     partnerId: Schema.optional(Schema.String).pipe(T.HttpQuery("partnerId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/guaranteedOrders/{guaranteedOrderId}" }),
+    T.Http({ method: "GET", path: "v3/guaranteedOrders/{+guaranteedOrderId}" }),
     svc,
   ) as unknown as Schema.Schema<GetGuaranteedOrdersRequest>;
 
@@ -15217,7 +15220,7 @@ export const EditGuaranteedOrderReadAccessorsGuaranteedOrdersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/guaranteedOrders/{guaranteedOrderId}:editGuaranteedOrderReadAccessors",
+      path: "v3/guaranteedOrders/{+guaranteedOrderId}:editGuaranteedOrderReadAccessors",
       hasBody: true,
     }),
     svc,
@@ -15320,7 +15323,7 @@ export const PatchGuaranteedOrdersRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v3/guaranteedOrders/{guaranteedOrderId}",
+      path: "v3/guaranteedOrders/{+guaranteedOrderId}",
       hasBody: true,
     }),
     svc,
@@ -15361,7 +15364,7 @@ export const GetInventorySourcesRequest =
     inventorySourceId: Schema.String.pipe(T.HttpPath("inventorySourceId")),
     partnerId: Schema.optional(Schema.String).pipe(T.HttpQuery("partnerId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/inventorySources/{inventorySourceId}" }),
+    T.Http({ method: "GET", path: "v3/inventorySources/{+inventorySourceId}" }),
     svc,
   ) as unknown as Schema.Schema<GetInventorySourcesRequest>;
 
@@ -15438,7 +15441,7 @@ export const EditInventorySourceReadWriteAccessorsInventorySourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/inventorySources/{inventorySourceId}:editInventorySourceReadWriteAccessors",
+      path: "v3/inventorySources/{+inventorySourceId}:editInventorySourceReadWriteAccessors",
       hasBody: true,
     }),
     svc,
@@ -15489,7 +15492,7 @@ export const PatchInventorySourcesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v3/inventorySources/{inventorySourceId}",
+      path: "v3/inventorySources/{+inventorySourceId}",
       hasBody: true,
     }),
     svc,
@@ -15634,7 +15637,7 @@ export const GetGoogleAudiencesRequest =
     partnerId: Schema.optional(Schema.String).pipe(T.HttpQuery("partnerId")),
     googleAudienceId: Schema.String.pipe(T.HttpPath("googleAudienceId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/googleAudiences/{googleAudienceId}" }),
+    T.Http({ method: "GET", path: "v3/googleAudiences/{+googleAudienceId}" }),
     svc,
   ) as unknown as Schema.Schema<GetGoogleAudiencesRequest>;
 
@@ -15696,7 +15699,7 @@ export const GetSdfdownloadtasksOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSdfdownloadtasksOperationsRequest>;
 
@@ -15789,7 +15792,7 @@ export const GetCombinedAudiencesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/combinedAudiences/{combinedAudienceId}",
+      path: "v3/combinedAudiences/{+combinedAudienceId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetCombinedAudiencesRequest>;
@@ -15886,7 +15889,7 @@ export const DeleteInventorySourceGroupsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v3/inventorySourceGroups/{inventorySourceGroupId}",
+      path: "v3/inventorySourceGroups/{+inventorySourceGroupId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteInventorySourceGroupsRequest>;
@@ -15981,7 +15984,7 @@ export const GetInventorySourceGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/inventorySourceGroups/{inventorySourceGroupId}",
+      path: "v3/inventorySourceGroups/{+inventorySourceGroupId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetInventorySourceGroupsRequest>;
@@ -16067,7 +16070,7 @@ export const CreateInventorySourceGroupsAssignedInventorySourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/inventorySourceGroups/{inventorySourceGroupId}/assignedInventorySources",
+      path: "v3/inventorySourceGroups/{+inventorySourceGroupId}/assignedInventorySources",
       hasBody: true,
     }),
     svc,
@@ -16126,7 +16129,7 @@ export const ListInventorySourceGroupsAssignedInventorySourcesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/inventorySourceGroups/{inventorySourceGroupId}/assignedInventorySources",
+      path: "v3/inventorySourceGroups/{+inventorySourceGroupId}/assignedInventorySources",
     }),
     svc,
   ) as unknown as Schema.Schema<ListInventorySourceGroupsAssignedInventorySourcesRequest>;
@@ -16181,7 +16184,7 @@ export const DeleteInventorySourceGroupsAssignedInventorySourcesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v3/inventorySourceGroups/{inventorySourceGroupId}/assignedInventorySources/{assignedInventorySourceId}",
+      path: "v3/inventorySourceGroups/{+inventorySourceGroupId}/assignedInventorySources/{+assignedInventorySourceId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteInventorySourceGroupsAssignedInventorySourcesRequest>;
@@ -16223,7 +16226,7 @@ export const BulkEditInventorySourceGroupsAssignedInventorySourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/inventorySourceGroups/{inventorySourceGroupId}/assignedInventorySources:bulkEdit",
+      path: "v3/inventorySourceGroups/{+inventorySourceGroupId}/assignedInventorySources:bulkEdit",
       hasBody: true,
     }),
     svc,
@@ -16260,7 +16263,7 @@ export const UploadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   resourceName: Schema.String.pipe(T.HttpPath("resourceName")),
   body: Schema.optional(GoogleBytestreamMedia).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "media/{resourceName}", hasBody: true }),
+  T.Http({ method: "POST", path: "media/{+resourceName}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<UploadMediaRequest>;
 
@@ -16290,7 +16293,7 @@ export interface DownloadMediaRequest {
 export const DownloadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   resourceName: Schema.String.pipe(T.HttpPath("resourceName")),
 }).pipe(
-  T.Http({ method: "GET", path: "download/{resourceName}" }),
+  T.Http({ method: "GET", path: "download/{+resourceName}" }),
   svc,
 ) as unknown as Schema.Schema<DownloadMediaRequest>;
 
@@ -16320,7 +16323,7 @@ export interface GetUsersRequest {
 export const GetUsersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   userId: Schema.String.pipe(T.HttpPath("userId")),
 }).pipe(
-  T.Http({ method: "GET", path: "v3/users/{userId}" }),
+  T.Http({ method: "GET", path: "v3/users/{+userId}" }),
   svc,
 ) as unknown as Schema.Schema<GetUsersRequest>;
 
@@ -16421,7 +16424,7 @@ export interface DeleteUsersRequest {
 export const DeleteUsersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   userId: Schema.String.pipe(T.HttpPath("userId")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v3/users/{userId}" }),
+  T.Http({ method: "DELETE", path: "v3/users/{+userId}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteUsersRequest>;
 
@@ -16456,7 +16459,7 @@ export const PatchUsersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   userId: Schema.String.pipe(T.HttpPath("userId")),
   body: Schema.optional(User).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v3/users/{userId}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v3/users/{+userId}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchUsersRequest>;
 
@@ -16491,7 +16494,7 @@ export const BulkEditAssignedUserRolesUsersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/users/{userId}:bulkEditAssignedUserRoles",
+      path: "v3/users/{+userId}:bulkEditAssignedUserRoles",
       hasBody: true,
     }),
     svc,
@@ -16524,7 +16527,7 @@ export interface GetPartnersRequest {
 export const GetPartnersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   partnerId: Schema.String.pipe(T.HttpPath("partnerId")),
 }).pipe(
-  T.Http({ method: "GET", path: "v3/partners/{partnerId}" }),
+  T.Http({ method: "GET", path: "v3/partners/{+partnerId}" }),
   svc,
 ) as unknown as Schema.Schema<GetPartnersRequest>;
 
@@ -16561,7 +16564,7 @@ export const EditAssignedTargetingOptionsPartnersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/partners/{partnerId}:editAssignedTargetingOptions",
+      path: "v3/partners/{+partnerId}:editAssignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -16699,7 +16702,7 @@ export const GetPartnersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/partners/{partnerId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v3/partners/{+partnerId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetPartnersTargetingTypesAssignedTargetingOptionsRequest>;
@@ -16792,7 +16795,7 @@ export const CreatePartnersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/partners/{partnerId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v3/partners/{+partnerId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -16895,7 +16898,7 @@ export const ListPartnersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/partners/{partnerId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v3/partners/{+partnerId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListPartnersTargetingTypesAssignedTargetingOptionsRequest>;
@@ -16994,7 +16997,7 @@ export const DeletePartnersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v3/partners/{partnerId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v3/partners/{+partnerId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeletePartnersTargetingTypesAssignedTargetingOptionsRequest>;
@@ -17038,7 +17041,7 @@ export const GetPartnersChannelsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/partners/{partnerId}/channels/{channelId}",
+      path: "v3/partners/{+partnerId}/channels/{+channelId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetPartnersChannelsRequest>;
@@ -17079,7 +17082,7 @@ export const CreatePartnersChannelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/partners/{partnerId}/channels",
+      path: "v3/partners/{+partnerId}/channels",
       hasBody: true,
     }),
     svc,
@@ -17128,7 +17131,7 @@ export const PatchPartnersChannelsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v3/partners/{partnerId}/channels/{channelId}",
+      path: "v3/partners/{+partnerId}/channels/{channelId}",
       hasBody: true,
     }),
     svc,
@@ -17178,7 +17181,7 @@ export const ListPartnersChannelsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/partners/{partnerId}/channels" }),
+    T.Http({ method: "GET", path: "v3/partners/{+partnerId}/channels" }),
     svc,
   ) as unknown as Schema.Schema<ListPartnersChannelsRequest>;
 
@@ -17221,7 +17224,7 @@ export const BulkEditPartnersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/partners/{partnerId}/channels/{channelId}/sites:bulkEdit",
+      path: "v3/partners/{partnerId}/channels/{+channelId}/sites:bulkEdit",
       hasBody: true,
     }),
     svc,
@@ -17276,7 +17279,7 @@ export const ListPartnersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v3/partners/{partnerId}/channels/{channelId}/sites",
+      path: "v3/partners/{+partnerId}/channels/{+channelId}/sites",
     }),
     svc,
   ) as unknown as Schema.Schema<ListPartnersChannelsSitesRequest>;
@@ -17325,7 +17328,7 @@ export const DeletePartnersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v3/partners/{partnerId}/channels/{channelId}/sites/{urlOrAppId}",
+      path: "v3/partners/{partnerId}/channels/{+channelId}/sites/{+urlOrAppId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeletePartnersChannelsSitesRequest>;
@@ -17370,7 +17373,7 @@ export const CreatePartnersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/partners/{partnerId}/channels/{channelId}/sites",
+      path: "v3/partners/{partnerId}/channels/{+channelId}/sites",
       hasBody: true,
     }),
     svc,
@@ -17411,7 +17414,7 @@ export const ReplacePartnersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/partners/{partnerId}/channels/{channelId}/sites:replace",
+      path: "v3/partners/{partnerId}/channels/{+channelId}/sites:replace",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/displayvideo-v4.ts
+++ b/packages/gcp/src/services/displayvideo-v4.ts
@@ -9710,7 +9710,7 @@ export interface GetUsersRequest {
 export const GetUsersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   userId: Schema.String.pipe(T.HttpPath("userId")),
 }).pipe(
-  T.Http({ method: "GET", path: "v4/users/{userId}" }),
+  T.Http({ method: "GET", path: "v4/users/{+userId}" }),
   svc,
 ) as unknown as Schema.Schema<GetUsersRequest>;
 
@@ -9774,7 +9774,7 @@ export const PatchUsersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(User).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v4/users/{userId}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v4/users/{+userId}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchUsersRequest>;
 
@@ -9846,7 +9846,7 @@ export interface DeleteUsersRequest {
 export const DeleteUsersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   userId: Schema.String.pipe(T.HttpPath("userId")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v4/users/{userId}" }),
+  T.Http({ method: "DELETE", path: "v4/users/{+userId}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteUsersRequest>;
 
@@ -9881,7 +9881,7 @@ export const BulkEditAssignedUserRolesUsersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/users/{userId}:bulkEditAssignedUserRoles",
+      path: "v4/users/{+userId}:bulkEditAssignedUserRoles",
       hasBody: true,
     }),
     svc,
@@ -9980,7 +9980,7 @@ export const UploadScriptCustomBiddingAlgorithmsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/customBiddingAlgorithms/{customBiddingAlgorithmId}:uploadScript",
+      path: "v4/customBiddingAlgorithms/{+customBiddingAlgorithmId}:uploadScript",
     }),
     svc,
   ) as unknown as Schema.Schema<UploadScriptCustomBiddingAlgorithmsRequest>;
@@ -10025,7 +10025,7 @@ export const UploadRulesCustomBiddingAlgorithmsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/customBiddingAlgorithms/{customBiddingAlgorithmId}:uploadRules",
+      path: "v4/customBiddingAlgorithms/{+customBiddingAlgorithmId}:uploadRules",
     }),
     svc,
   ) as unknown as Schema.Schema<UploadRulesCustomBiddingAlgorithmsRequest>;
@@ -10070,7 +10070,7 @@ export const GetCustomBiddingAlgorithmsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/customBiddingAlgorithms/{customBiddingAlgorithmId}",
+      path: "v4/customBiddingAlgorithms/{+customBiddingAlgorithmId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetCustomBiddingAlgorithmsRequest>;
@@ -10147,7 +10147,7 @@ export const PatchCustomBiddingAlgorithmsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v4/customBiddingAlgorithms/{customBiddingAlgorithmId}",
+      path: "v4/customBiddingAlgorithms/{+customBiddingAlgorithmId}",
       hasBody: true,
     }),
     svc,
@@ -10201,7 +10201,7 @@ export const ListCustomBiddingAlgorithmsScriptsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/customBiddingAlgorithms/{customBiddingAlgorithmId}/scripts",
+      path: "v4/customBiddingAlgorithms/{+customBiddingAlgorithmId}/scripts",
     }),
     svc,
   ) as unknown as Schema.Schema<ListCustomBiddingAlgorithmsScriptsRequest>;
@@ -10253,7 +10253,7 @@ export const CreateCustomBiddingAlgorithmsScriptsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/customBiddingAlgorithms/{customBiddingAlgorithmId}/scripts",
+      path: "v4/customBiddingAlgorithms/{+customBiddingAlgorithmId}/scripts",
       hasBody: true,
     }),
     svc,
@@ -10303,7 +10303,7 @@ export const GetCustomBiddingAlgorithmsScriptsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/customBiddingAlgorithms/{customBiddingAlgorithmId}/scripts/{customBiddingScriptId}",
+      path: "v4/customBiddingAlgorithms/{+customBiddingAlgorithmId}/scripts/{+customBiddingScriptId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetCustomBiddingAlgorithmsScriptsRequest>;
@@ -10350,7 +10350,7 @@ export const CreateCustomBiddingAlgorithmsRulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/customBiddingAlgorithms/{customBiddingAlgorithmId}/rules",
+      path: "v4/customBiddingAlgorithms/{+customBiddingAlgorithmId}/rules",
       hasBody: true,
     }),
     svc,
@@ -10401,7 +10401,7 @@ export const GetCustomBiddingAlgorithmsRulesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/customBiddingAlgorithms/{customBiddingAlgorithmId}/rules/{customBiddingAlgorithmRulesId}",
+      path: "v4/customBiddingAlgorithms/{+customBiddingAlgorithmId}/rules/{+customBiddingAlgorithmRulesId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetCustomBiddingAlgorithmsRulesRequest>;
@@ -10455,7 +10455,7 @@ export const ListCustomBiddingAlgorithmsRulesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/customBiddingAlgorithms/{customBiddingAlgorithmId}/rules",
+      path: "v4/customBiddingAlgorithms/{+customBiddingAlgorithmId}/rules",
     }),
     svc,
   ) as unknown as Schema.Schema<ListCustomBiddingAlgorithmsRulesRequest>;
@@ -10523,7 +10523,7 @@ export const GetSdfdownloadtasksOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/{name}" }),
+    T.Http({ method: "GET", path: "v4/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSdfdownloadtasksOperationsRequest>;
 
@@ -10619,7 +10619,7 @@ export const DeleteInventorySourceGroupsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/inventorySourceGroups/{inventorySourceGroupId}",
+      path: "v4/inventorySourceGroups/{+inventorySourceGroupId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteInventorySourceGroupsRequest>;
@@ -10663,7 +10663,7 @@ export const GetInventorySourceGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/inventorySourceGroups/{inventorySourceGroupId}",
+      path: "v4/inventorySourceGroups/{+inventorySourceGroupId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetInventorySourceGroupsRequest>;
@@ -10800,7 +10800,7 @@ export const CreateInventorySourceGroupsAssignedInventorySourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/inventorySourceGroups/{inventorySourceGroupId}/assignedInventorySources",
+      path: "v4/inventorySourceGroups/{+inventorySourceGroupId}/assignedInventorySources",
       hasBody: true,
     }),
     svc,
@@ -10844,7 +10844,7 @@ export const BulkEditInventorySourceGroupsAssignedInventorySourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/inventorySourceGroups/{inventorySourceGroupId}/assignedInventorySources:bulkEdit",
+      path: "v4/inventorySourceGroups/{+inventorySourceGroupId}/assignedInventorySources:bulkEdit",
       hasBody: true,
     }),
     svc,
@@ -10903,7 +10903,7 @@ export const ListInventorySourceGroupsAssignedInventorySourcesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/inventorySourceGroups/{inventorySourceGroupId}/assignedInventorySources",
+      path: "v4/inventorySourceGroups/{+inventorySourceGroupId}/assignedInventorySources",
     }),
     svc,
   ) as unknown as Schema.Schema<ListInventorySourceGroupsAssignedInventorySourcesRequest>;
@@ -10958,7 +10958,7 @@ export const DeleteInventorySourceGroupsAssignedInventorySourcesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/inventorySourceGroups/{inventorySourceGroupId}/assignedInventorySources/{assignedInventorySourceId}",
+      path: "v4/inventorySourceGroups/{+inventorySourceGroupId}/assignedInventorySources/{+assignedInventorySourceId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteInventorySourceGroupsAssignedInventorySourcesRequest>;
@@ -10990,7 +10990,7 @@ export interface GetPartnersRequest {
 export const GetPartnersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   partnerId: Schema.String.pipe(T.HttpPath("partnerId")),
 }).pipe(
-  T.Http({ method: "GET", path: "v4/partners/{partnerId}" }),
+  T.Http({ method: "GET", path: "v4/partners/{+partnerId}" }),
   svc,
 ) as unknown as Schema.Schema<GetPartnersRequest>;
 
@@ -11027,7 +11027,7 @@ export const EditAssignedTargetingOptionsPartnersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/partners/{partnerId}:editAssignedTargetingOptions",
+      path: "v4/partners/{+partnerId}:editAssignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -11165,7 +11165,7 @@ export const GetPartnersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/partners/{partnerId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v4/partners/{+partnerId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetPartnersTargetingTypesAssignedTargetingOptionsRequest>;
@@ -11258,7 +11258,7 @@ export const CreatePartnersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/partners/{partnerId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v4/partners/{+partnerId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -11361,7 +11361,7 @@ export const ListPartnersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/partners/{partnerId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v4/partners/{+partnerId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListPartnersTargetingTypesAssignedTargetingOptionsRequest>;
@@ -11460,7 +11460,7 @@ export const DeletePartnersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/partners/{partnerId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v4/partners/{+partnerId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeletePartnersTargetingTypesAssignedTargetingOptionsRequest>;
@@ -11504,7 +11504,7 @@ export const GetPartnersChannelsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/partners/{partnerId}/channels/{channelId}",
+      path: "v4/partners/{+partnerId}/channels/{+channelId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetPartnersChannelsRequest>;
@@ -11545,7 +11545,7 @@ export const CreatePartnersChannelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/partners/{partnerId}/channels",
+      path: "v4/partners/{+partnerId}/channels",
       hasBody: true,
     }),
     svc,
@@ -11594,7 +11594,7 @@ export const PatchPartnersChannelsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v4/partners/{partnerId}/channels/{channelId}",
+      path: "v4/partners/{+partnerId}/channels/{channelId}",
       hasBody: true,
     }),
     svc,
@@ -11644,7 +11644,7 @@ export const ListPartnersChannelsRequest =
     partnerId: Schema.String.pipe(T.HttpPath("partnerId")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/partners/{partnerId}/channels" }),
+    T.Http({ method: "GET", path: "v4/partners/{+partnerId}/channels" }),
     svc,
   ) as unknown as Schema.Schema<ListPartnersChannelsRequest>;
 
@@ -11687,7 +11687,7 @@ export const BulkEditPartnersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/partners/{partnerId}/channels/{channelId}/sites:bulkEdit",
+      path: "v4/partners/{partnerId}/channels/{+channelId}/sites:bulkEdit",
       hasBody: true,
     }),
     svc,
@@ -11728,7 +11728,7 @@ export const ReplacePartnersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/partners/{partnerId}/channels/{channelId}/sites:replace",
+      path: "v4/partners/{partnerId}/channels/{+channelId}/sites:replace",
       hasBody: true,
     }),
     svc,
@@ -11783,7 +11783,7 @@ export const ListPartnersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/partners/{partnerId}/channels/{channelId}/sites",
+      path: "v4/partners/{+partnerId}/channels/{+channelId}/sites",
     }),
     svc,
   ) as unknown as Schema.Schema<ListPartnersChannelsSitesRequest>;
@@ -11832,7 +11832,7 @@ export const DeletePartnersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/partners/{partnerId}/channels/{channelId}/sites/{urlOrAppId}",
+      path: "v4/partners/{partnerId}/channels/{+channelId}/sites/{+urlOrAppId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeletePartnersChannelsSitesRequest>;
@@ -11877,7 +11877,7 @@ export const CreatePartnersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/partners/{partnerId}/channels/{channelId}/sites",
+      path: "v4/partners/{partnerId}/channels/{+channelId}/sites",
       hasBody: true,
     }),
     svc,
@@ -11920,7 +11920,7 @@ export const GetCombinedAudiencesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/combinedAudiences/{combinedAudienceId}",
+      path: "v4/combinedAudiences/{+combinedAudienceId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetCombinedAudiencesRequest>;
@@ -12006,7 +12006,7 @@ export const UploadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   resourceName: Schema.String.pipe(T.HttpPath("resourceName")),
   body: Schema.optional(GoogleBytestreamMedia).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "media/{resourceName}", hasBody: true }),
+  T.Http({ method: "POST", path: "media/{+resourceName}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<UploadMediaRequest>;
 
@@ -12036,7 +12036,7 @@ export interface DownloadMediaRequest {
 export const DownloadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   resourceName: Schema.String.pipe(T.HttpPath("resourceName")),
 }).pipe(
-  T.Http({ method: "GET", path: "download/{resourceName}" }),
+  T.Http({ method: "GET", path: "download/{+resourceName}" }),
   svc,
 ) as unknown as Schema.Schema<DownloadMediaRequest>;
 
@@ -12067,7 +12067,7 @@ export const GetSdfuploadtasksOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/{name}" }),
+    T.Http({ method: "GET", path: "v4/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSdfuploadtasksOperationsRequest>;
 
@@ -12145,7 +12145,7 @@ export const GetGuaranteedOrdersRequest =
     guaranteedOrderId: Schema.String.pipe(T.HttpPath("guaranteedOrderId")),
     partnerId: Schema.optional(Schema.String).pipe(T.HttpQuery("partnerId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/guaranteedOrders/{guaranteedOrderId}" }),
+    T.Http({ method: "GET", path: "v4/guaranteedOrders/{+guaranteedOrderId}" }),
     svc,
   ) as unknown as Schema.Schema<GetGuaranteedOrdersRequest>;
 
@@ -12192,7 +12192,7 @@ export const PatchGuaranteedOrdersRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v4/guaranteedOrders/{guaranteedOrderId}",
+      path: "v4/guaranteedOrders/{+guaranteedOrderId}",
       hasBody: true,
     }),
     svc,
@@ -12284,7 +12284,7 @@ export const EditGuaranteedOrderReadAccessorsGuaranteedOrdersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/guaranteedOrders/{guaranteedOrderId}:editGuaranteedOrderReadAccessors",
+      path: "v4/guaranteedOrders/{+guaranteedOrderId}:editGuaranteedOrderReadAccessors",
       hasBody: true,
     }),
     svc,
@@ -12323,7 +12323,7 @@ export const GetCustomListsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("advertiserId"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "v4/customLists/{customListId}" }),
+  T.Http({ method: "GET", path: "v4/customLists/{+customListId}" }),
   svc,
 ) as unknown as Schema.Schema<GetCustomListsRequest>;
 
@@ -12411,7 +12411,7 @@ export const GetGoogleAudiencesRequest =
     partnerId: Schema.optional(Schema.String).pipe(T.HttpQuery("partnerId")),
     googleAudienceId: Schema.String.pipe(T.HttpPath("googleAudienceId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/googleAudiences/{googleAudienceId}" }),
+    T.Http({ method: "GET", path: "v4/googleAudiences/{+googleAudienceId}" }),
     svc,
   ) as unknown as Schema.Schema<GetGoogleAudiencesRequest>;
 
@@ -12502,7 +12502,7 @@ export const GetInventorySourcesRequest =
     ),
     inventorySourceId: Schema.String.pipe(T.HttpPath("inventorySourceId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/inventorySources/{inventorySourceId}" }),
+    T.Http({ method: "GET", path: "v4/inventorySources/{+inventorySourceId}" }),
     svc,
   ) as unknown as Schema.Schema<GetInventorySourcesRequest>;
 
@@ -12588,7 +12588,7 @@ export const PatchInventorySourcesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v4/inventorySources/{inventorySourceId}",
+      path: "v4/inventorySources/{+inventorySourceId}",
       hasBody: true,
     }),
     svc,
@@ -12680,7 +12680,7 @@ export const EditInventorySourceReadWriteAccessorsInventorySourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/inventorySources/{inventorySourceId}:editInventorySourceReadWriteAccessors",
+      path: "v4/inventorySources/{+inventorySourceId}:editInventorySourceReadWriteAccessors",
       hasBody: true,
     }),
     svc,
@@ -12718,7 +12718,7 @@ export const GetFloodlightGroupsRequest =
     floodlightGroupId: Schema.String.pipe(T.HttpPath("floodlightGroupId")),
     partnerId: Schema.optional(Schema.String).pipe(T.HttpQuery("partnerId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/floodlightGroups/{floodlightGroupId}" }),
+    T.Http({ method: "GET", path: "v4/floodlightGroups/{+floodlightGroupId}" }),
     svc,
   ) as unknown as Schema.Schema<GetFloodlightGroupsRequest>;
 
@@ -12803,7 +12803,7 @@ export const GetFloodlightGroupsFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/floodlightGroups/{floodlightGroupId}/floodlightActivities/{floodlightActivityId}",
+      path: "v4/floodlightGroups/{+floodlightGroupId}/floodlightActivities/{+floodlightActivityId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetFloodlightGroupsFloodlightActivitiesRequest>;
@@ -12850,7 +12850,7 @@ export const ListFloodlightGroupsFloodlightActivitiesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/floodlightGroups/{floodlightGroupId}/floodlightActivities",
+      path: "v4/floodlightGroups/{+floodlightGroupId}/floodlightActivities",
     }),
     svc,
   ) as unknown as Schema.Schema<ListFloodlightGroupsFloodlightActivitiesRequest>;
@@ -12890,7 +12890,7 @@ export const AuditAdvertisersRequest =
     advertiserId: Schema.String.pipe(T.HttpPath("advertiserId")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/advertisers/{advertiserId}:audit" }),
+    T.Http({ method: "GET", path: "v4/advertisers/{+advertiserId}:audit" }),
     svc,
   ) as unknown as Schema.Schema<AuditAdvertisersRequest>;
 
@@ -12920,7 +12920,7 @@ export interface GetAdvertisersRequest {
 export const GetAdvertisersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   advertiserId: Schema.String.pipe(T.HttpPath("advertiserId")),
 }).pipe(
-  T.Http({ method: "GET", path: "v4/advertisers/{advertiserId}" }),
+  T.Http({ method: "GET", path: "v4/advertisers/{+advertiserId}" }),
   svc,
 ) as unknown as Schema.Schema<GetAdvertisersRequest>;
 
@@ -12988,7 +12988,7 @@ export const PatchAdvertisersRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v4/advertisers/{advertiserId}",
+      path: "v4/advertisers/{+advertiserId}",
       hasBody: true,
     }),
     svc,
@@ -13034,7 +13034,7 @@ export const ListAssignedTargetingOptionsAdvertisersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}:listAssignedTargetingOptions",
+      path: "v4/advertisers/{+advertiserId}:listAssignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAssignedTargetingOptionsAdvertisersRequest>;
@@ -13078,7 +13078,7 @@ export const EditAssignedTargetingOptionsAdvertisersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}:editAssignedTargetingOptions",
+      path: "v4/advertisers/{+advertiserId}:editAssignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -13160,7 +13160,7 @@ export const DeleteAdvertisersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     advertiserId: Schema.String.pipe(T.HttpPath("advertiserId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v4/advertisers/{advertiserId}" }),
+    T.Http({ method: "DELETE", path: "v4/advertisers/{+advertiserId}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersRequest>;
 
@@ -13195,7 +13195,7 @@ export const UploadAdvertisersAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/assets",
+      path: "v4/advertisers/{+advertiserId}/assets",
       hasBody: true,
     }),
     svc,
@@ -13242,7 +13242,7 @@ export const ListAdvertisersLocationListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/locationLists",
+      path: "v4/advertisers/{+advertiserId}/locationLists",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersLocationListsRequest>;
@@ -13283,7 +13283,7 @@ export const GetAdvertisersLocationListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/locationLists/{locationListId}",
+      path: "v4/advertisers/{+advertiserId}/locationLists/{+locationListId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersLocationListsRequest>;
@@ -13320,7 +13320,7 @@ export const CreateAdvertisersLocationListsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/locationLists",
+      path: "v4/advertisers/{+advertiserId}/locationLists",
       hasBody: true,
     }),
     svc,
@@ -13364,7 +13364,7 @@ export const PatchAdvertisersLocationListsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v4/advertisers/{advertiserId}/locationLists/{locationListId}",
+      path: "v4/advertisers/{+advertiserId}/locationLists/{locationListId}",
       hasBody: true,
     }),
     svc,
@@ -13459,7 +13459,7 @@ export const DeleteAdvertisersLocationListsAssignedLocationsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/advertisers/{advertiserId}/locationLists/{locationListId}/assignedLocations/{assignedLocationId}",
+      path: "v4/advertisers/{advertiserId}/locationLists/{locationListId}/assignedLocations/{+assignedLocationId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersLocationListsAssignedLocationsRequest>;
@@ -13500,7 +13500,7 @@ export const BulkEditAdvertisersLocationListsAssignedLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/locationLists/{locationListId}/assignedLocations:bulkEdit",
+      path: "v4/advertisers/{advertiserId}/locationLists/{+locationListId}/assignedLocations:bulkEdit",
       hasBody: true,
     }),
     svc,
@@ -13583,7 +13583,7 @@ export const GetAdvertisersInsertionOrdersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/insertionOrders/{insertionOrderId}",
+      path: "v4/advertisers/{+advertiserId}/insertionOrders/{+insertionOrderId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersInsertionOrdersRequest>;
@@ -13620,7 +13620,7 @@ export const CreateAdvertisersInsertionOrdersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/insertionOrders",
+      path: "v4/advertisers/{+advertiserId}/insertionOrders",
       hasBody: true,
     }),
     svc,
@@ -13664,7 +13664,7 @@ export const PatchAdvertisersInsertionOrdersRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v4/advertisers/{advertiserId}/insertionOrders/{insertionOrderId}",
+      path: "v4/advertisers/{+advertiserId}/insertionOrders/{+insertionOrderId}",
       hasBody: true,
     }),
     svc,
@@ -13711,7 +13711,7 @@ export const ListAdvertisersInsertionOrdersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/insertionOrders",
+      path: "v4/advertisers/{+advertiserId}/insertionOrders",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersInsertionOrdersRequest>;
@@ -13753,7 +13753,7 @@ export const DeleteAdvertisersInsertionOrdersRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/advertisers/{advertiserId}/insertionOrders/{insertionOrderId}",
+      path: "v4/advertisers/{+advertiserId}/insertionOrders/{+insertionOrderId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersInsertionOrdersRequest>;
@@ -13804,7 +13804,7 @@ export const BulkListAssignedTargetingOptionsAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/lineItems:bulkListAssignedTargetingOptions",
+      path: "v4/advertisers/{+advertiserId}/lineItems:bulkListAssignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<BulkListAssignedTargetingOptionsAdvertisersLineItemsRequest>;
@@ -13847,7 +13847,7 @@ export const CreateAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/lineItems",
+      path: "v4/advertisers/{+advertiserId}/lineItems",
       hasBody: true,
     }),
     svc,
@@ -13888,7 +13888,7 @@ export const DuplicateAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/lineItems/{lineItemId}:duplicate",
+      path: "v4/advertisers/{+advertiserId}/lineItems/{+lineItemId}:duplicate",
       hasBody: true,
     }),
     svc,
@@ -13928,7 +13928,7 @@ export const BulkEditAssignedTargetingOptionsAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/lineItems:bulkEditAssignedTargetingOptions",
+      path: "v4/advertisers/{+advertiserId}/lineItems:bulkEditAssignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -13968,7 +13968,7 @@ export const DeleteAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/advertisers/{advertiserId}/lineItems/{lineItemId}",
+      path: "v4/advertisers/{+advertiserId}/lineItems/{+lineItemId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersLineItemsRequest>;
@@ -14005,7 +14005,7 @@ export const GetAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/lineItems/{lineItemId}",
+      path: "v4/advertisers/{+advertiserId}/lineItems/{+lineItemId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersLineItemsRequest>;
@@ -14048,7 +14048,7 @@ export const PatchAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v4/advertisers/{advertiserId}/lineItems/{lineItemId}",
+      path: "v4/advertisers/{+advertiserId}/lineItems/{+lineItemId}",
       hasBody: true,
     }),
     svc,
@@ -14086,7 +14086,7 @@ export const BulkUpdateAdvertisersLineItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/lineItems:bulkUpdate",
+      path: "v4/advertisers/{+advertiserId}/lineItems:bulkUpdate",
       hasBody: true,
     }),
     svc,
@@ -14132,7 +14132,7 @@ export const ListAdvertisersLineItemsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/advertisers/{advertiserId}/lineItems" }),
+    T.Http({ method: "GET", path: "v4/advertisers/{+advertiserId}/lineItems" }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersLineItemsRequest>;
 
@@ -14231,7 +14231,7 @@ export const GetAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsReques
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/lineItems/{lineItemId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v4/advertisers/{+advertiserId}/lineItems/{+lineItemId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsRequest>;
@@ -14327,7 +14327,7 @@ export const CreateAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/lineItems/{lineItemId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v4/advertisers/{+advertiserId}/lineItems/{+lineItemId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -14435,7 +14435,7 @@ export const ListAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsReque
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/lineItems/{lineItemId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v4/advertisers/{+advertiserId}/lineItems/{+lineItemId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsRequest>;
@@ -14538,7 +14538,7 @@ export const DeleteAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsReq
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/advertisers/{advertiserId}/lineItems/{lineItemId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v4/advertisers/{+advertiserId}/lineItems/{+lineItemId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersLineItemsTargetingTypesAssignedTargetingOptionsRequest>;
@@ -14601,7 +14601,7 @@ export const ListAdvertisersLineItemsYoutubeAssetTypesYoutubeAssetAssociationsRe
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/lineItems/{lineItemId}/youtubeAssetTypes/{youtubeAssetType}/youtubeAssetAssociations",
+      path: "v4/advertisers/{+advertiserId}/lineItems/{+lineItemId}/youtubeAssetTypes/{+youtubeAssetType}/youtubeAssetAssociations",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersLineItemsYoutubeAssetTypesYoutubeAssetAssociationsRequest>;
@@ -14664,7 +14664,7 @@ export const DeleteAdvertisersLineItemsYoutubeAssetTypesYoutubeAssetAssociations
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/advertisers/{advertiserId}/lineItems/{lineItemId}/youtubeAssetTypes/{youtubeAssetType}/youtubeAssetAssociations/{youtubeAssetAssociationId}",
+      path: "v4/advertisers/{+advertiserId}/lineItems/{+lineItemId}/youtubeAssetTypes/{+youtubeAssetType}/youtubeAssetAssociations/{+youtubeAssetAssociationId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersLineItemsYoutubeAssetTypesYoutubeAssetAssociationsRequest>;
@@ -14721,7 +14721,7 @@ export const CreateAdvertisersLineItemsYoutubeAssetTypesYoutubeAssetAssociations
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/lineItems/{lineItemId}/youtubeAssetTypes/{youtubeAssetType}/youtubeAssetAssociations",
+      path: "v4/advertisers/{+advertiserId}/lineItems/{+lineItemId}/youtubeAssetTypes/{+youtubeAssetType}/youtubeAssetAssociations",
       hasBody: true,
     }),
     svc,
@@ -14770,7 +14770,7 @@ export const ListAdvertisersCampaignsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/advertisers/{advertiserId}/campaigns" }),
+    T.Http({ method: "GET", path: "v4/advertisers/{+advertiserId}/campaigns" }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersCampaignsRequest>;
 
@@ -14810,7 +14810,7 @@ export const DeleteAdvertisersCampaignsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/advertisers/{advertiserId}/campaigns/{campaignId}",
+      path: "v4/advertisers/{+advertiserId}/campaigns/{+campaignId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersCampaignsRequest>;
@@ -14847,7 +14847,7 @@ export const GetAdvertisersCampaignsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/campaigns/{campaignId}",
+      path: "v4/advertisers/{+advertiserId}/campaigns/{+campaignId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersCampaignsRequest>;
@@ -14884,7 +14884,7 @@ export const CreateAdvertisersCampaignsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/campaigns",
+      path: "v4/advertisers/{+advertiserId}/campaigns",
       hasBody: true,
     }),
     svc,
@@ -14928,7 +14928,7 @@ export const PatchAdvertisersCampaignsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v4/advertisers/{advertiserId}/campaigns/{campaignId}",
+      path: "v4/advertisers/{+advertiserId}/campaigns/{+campaignId}",
       hasBody: true,
     }),
     svc,
@@ -14966,7 +14966,7 @@ export const GetAdvertisersAdGroupAdsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/adGroupAds/{adGroupAdId}",
+      path: "v4/advertisers/{+advertiserId}/adGroupAds/{+adGroupAdId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersAdGroupAdsRequest>;
@@ -15003,7 +15003,7 @@ export const CreateAdvertisersAdGroupAdsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/adGroupAds",
+      path: "v4/advertisers/{+advertiserId}/adGroupAds",
       hasBody: true,
     }),
     svc,
@@ -15047,7 +15047,7 @@ export const PatchAdvertisersAdGroupAdsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v4/advertisers/{advertiserId}/adGroupAds/{adGroupAdId}",
+      path: "v4/advertisers/{+advertiserId}/adGroupAds/{+adGroupAdId}",
       hasBody: true,
     }),
     svc,
@@ -15092,7 +15092,10 @@ export const ListAdvertisersAdGroupAdsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/advertisers/{advertiserId}/adGroupAds" }),
+    T.Http({
+      method: "GET",
+      path: "v4/advertisers/{+advertiserId}/adGroupAds",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersAdGroupAdsRequest>;
 
@@ -15132,7 +15135,7 @@ export const DeleteAdvertisersAdGroupAdsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/advertisers/{advertiserId}/adGroupAds/{adGroupAdId}",
+      path: "v4/advertisers/{+advertiserId}/adGroupAds/{+adGroupAdId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersAdGroupAdsRequest>;
@@ -15169,7 +15172,7 @@ export const UploadAdvertisersAdAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/adAssets:uploadAdAsset",
+      path: "v4/advertisers/{+advertiserId}/adAssets:uploadAdAsset",
       hasBody: true,
     }),
     svc,
@@ -15214,7 +15217,7 @@ export const ListAdvertisersAdAssetsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/advertisers/{advertiserId}/adAssets" }),
+    T.Http({ method: "GET", path: "v4/advertisers/{+advertiserId}/adAssets" }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersAdAssetsRequest>;
 
@@ -15254,7 +15257,7 @@ export const BulkCreateAdvertisersAdAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/adAssets:bulkCreate",
+      path: "v4/advertisers/{+advertiserId}/adAssets:bulkCreate",
       hasBody: true,
     }),
     svc,
@@ -15292,7 +15295,7 @@ export const GetAdvertisersAdAssetsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/adAssets/{adAssetId}",
+      path: "v4/advertisers/{+advertiserId}/adAssets/{+adAssetId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersAdAssetsRequest>;
@@ -15329,7 +15332,7 @@ export const CreateAdvertisersAdAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/adAssets",
+      path: "v4/advertisers/{+advertiserId}/adAssets",
       hasBody: true,
     }),
     svc,
@@ -15374,7 +15377,7 @@ export const ListAdvertisersCreativesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/advertisers/{advertiserId}/creatives" }),
+    T.Http({ method: "GET", path: "v4/advertisers/{+advertiserId}/creatives" }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersCreativesRequest>;
 
@@ -15414,7 +15417,7 @@ export const DeleteAdvertisersCreativesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/advertisers/{advertiserId}/creatives/{creativeId}",
+      path: "v4/advertisers/{+advertiserId}/creatives/{+creativeId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersCreativesRequest>;
@@ -15451,7 +15454,7 @@ export const GetAdvertisersCreativesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/creatives/{creativeId}",
+      path: "v4/advertisers/{+advertiserId}/creatives/{+creativeId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersCreativesRequest>;
@@ -15488,7 +15491,7 @@ export const CreateAdvertisersCreativesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/creatives",
+      path: "v4/advertisers/{+advertiserId}/creatives",
       hasBody: true,
     }),
     svc,
@@ -15532,7 +15535,7 @@ export const PatchAdvertisersCreativesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v4/advertisers/{advertiserId}/creatives/{creativeId}",
+      path: "v4/advertisers/{+advertiserId}/creatives/{+creativeId}",
       hasBody: true,
     }),
     svc,
@@ -15573,7 +15576,7 @@ export const GetAdvertisersChannelsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/channels/{channelId}",
+      path: "v4/advertisers/{+advertiserId}/channels/{+channelId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersChannelsRequest>;
@@ -15613,7 +15616,7 @@ export const CreateAdvertisersChannelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/channels",
+      path: "v4/advertisers/{+advertiserId}/channels",
       hasBody: true,
     }),
     svc,
@@ -15660,7 +15663,7 @@ export const PatchAdvertisersChannelsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v4/advertisers/{advertiserId}/channels/{channelId}",
+      path: "v4/advertisers/{+advertiserId}/channels/{channelId}",
       hasBody: true,
     }),
     svc,
@@ -15708,7 +15711,7 @@ export const ListAdvertisersChannelsRequest =
     partnerId: Schema.optional(Schema.String).pipe(T.HttpQuery("partnerId")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/advertisers/{advertiserId}/channels" }),
+    T.Http({ method: "GET", path: "v4/advertisers/{+advertiserId}/channels" }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersChannelsRequest>;
 
@@ -15763,7 +15766,7 @@ export const ListAdvertisersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/channels/{channelId}/sites",
+      path: "v4/advertisers/{+advertiserId}/channels/{+channelId}/sites",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersChannelsSitesRequest>;
@@ -15810,7 +15813,7 @@ export const DeleteAdvertisersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/advertisers/{advertiserId}/channels/{channelId}/sites/{urlOrAppId}",
+      path: "v4/advertisers/{advertiserId}/channels/{+channelId}/sites/{+urlOrAppId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersChannelsSitesRequest>;
@@ -15850,7 +15853,7 @@ export const BulkEditAdvertisersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/channels/{channelId}/sites:bulkEdit",
+      path: "v4/advertisers/{advertiserId}/channels/{+channelId}/sites:bulkEdit",
       hasBody: true,
     }),
     svc,
@@ -15891,7 +15894,7 @@ export const ReplaceAdvertisersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/channels/{channelId}/sites:replace",
+      path: "v4/advertisers/{advertiserId}/channels/{+channelId}/sites:replace",
       hasBody: true,
     }),
     svc,
@@ -15935,7 +15938,7 @@ export const CreateAdvertisersChannelsSitesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/channels/{channelId}/sites",
+      path: "v4/advertisers/{advertiserId}/channels/{+channelId}/sites",
       hasBody: true,
     }),
     svc,
@@ -15975,7 +15978,7 @@ export const GetAdvertisersNegativeKeywordListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}",
+      path: "v4/advertisers/{+advertiserId}/negativeKeywordLists/{+negativeKeywordListId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersNegativeKeywordListsRequest>;
@@ -16012,7 +16015,7 @@ export const CreateAdvertisersNegativeKeywordListsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/negativeKeywordLists",
+      path: "v4/advertisers/{+advertiserId}/negativeKeywordLists",
       hasBody: true,
     }),
     svc,
@@ -16058,7 +16061,7 @@ export const PatchAdvertisersNegativeKeywordListsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v4/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}",
+      path: "v4/advertisers/{+advertiserId}/negativeKeywordLists/{negativeKeywordListId}",
       hasBody: true,
     }),
     svc,
@@ -16099,7 +16102,7 @@ export const ListAdvertisersNegativeKeywordListsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/negativeKeywordLists",
+      path: "v4/advertisers/{+advertiserId}/negativeKeywordLists",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersNegativeKeywordListsRequest>;
@@ -16143,7 +16146,7 @@ export const DeleteAdvertisersNegativeKeywordListsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}",
+      path: "v4/advertisers/{+advertiserId}/negativeKeywordLists/{+negativeKeywordListId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersNegativeKeywordListsRequest>;
@@ -16185,7 +16188,7 @@ export const CreateAdvertisersNegativeKeywordListsNegativeKeywordsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}/negativeKeywords",
+      path: "v4/advertisers/{advertiserId}/negativeKeywordLists/{+negativeKeywordListId}/negativeKeywords",
       hasBody: true,
     }),
     svc,
@@ -16239,7 +16242,7 @@ export const ListAdvertisersNegativeKeywordListsNegativeKeywordsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}/negativeKeywords",
+      path: "v4/advertisers/{+advertiserId}/negativeKeywordLists/{+negativeKeywordListId}/negativeKeywords",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersNegativeKeywordListsNegativeKeywordsRequest>;
@@ -16287,7 +16290,7 @@ export const DeleteAdvertisersNegativeKeywordListsNegativeKeywordsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}/negativeKeywords/{keywordValue}",
+      path: "v4/advertisers/{advertiserId}/negativeKeywordLists/{+negativeKeywordListId}/negativeKeywords/{+keywordValue}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersNegativeKeywordListsNegativeKeywordsRequest>;
@@ -16331,7 +16334,7 @@ export const BulkEditAdvertisersNegativeKeywordListsNegativeKeywordsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}/negativeKeywords:bulkEdit",
+      path: "v4/advertisers/{advertiserId}/negativeKeywordLists/{+negativeKeywordListId}/negativeKeywords:bulkEdit",
       hasBody: true,
     }),
     svc,
@@ -16376,7 +16379,7 @@ export const ReplaceAdvertisersNegativeKeywordListsNegativeKeywordsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/negativeKeywordLists/{negativeKeywordListId}/negativeKeywords:replace",
+      path: "v4/advertisers/{advertiserId}/negativeKeywordLists/{+negativeKeywordListId}/negativeKeywords:replace",
       hasBody: true,
     }),
     svc,
@@ -16472,7 +16475,7 @@ export const GetAdvertisersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v4/advertisers/{+advertiserId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersTargetingTypesAssignedTargetingOptionsRequest>;
@@ -16565,7 +16568,7 @@ export const CreateAdvertisersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v4/advertisers/{+advertiserId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -16668,7 +16671,7 @@ export const ListAdvertisersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v4/advertisers/{+advertiserId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersTargetingTypesAssignedTargetingOptionsRequest>;
@@ -16767,7 +16770,7 @@ export const DeleteAdvertisersTargetingTypesAssignedTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/advertisers/{advertiserId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v4/advertisers/{+advertiserId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersTargetingTypesAssignedTargetingOptionsRequest>;
@@ -16819,7 +16822,7 @@ export const ListAdvertisersInvoicesRequest =
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/advertisers/{advertiserId}/invoices" }),
+    T.Http({ method: "GET", path: "v4/advertisers/{+advertiserId}/invoices" }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersInvoicesRequest>;
 
@@ -16861,7 +16864,7 @@ export const LookupInvoiceCurrencyAdvertisersInvoicesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/invoices:lookupInvoiceCurrency",
+      path: "v4/advertisers/{+advertiserId}/invoices:lookupInvoiceCurrency",
     }),
     svc,
   ) as unknown as Schema.Schema<LookupInvoiceCurrencyAdvertisersInvoicesRequest>;
@@ -16913,7 +16916,7 @@ export const BulkListAssignedTargetingOptionsAdvertisersAdGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/adGroups:bulkListAssignedTargetingOptions",
+      path: "v4/advertisers/{+advertiserId}/adGroups:bulkListAssignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<BulkListAssignedTargetingOptionsAdvertisersAdGroupsRequest>;
@@ -16956,7 +16959,7 @@ export const GetAdvertisersAdGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/adGroups/{adGroupId}",
+      path: "v4/advertisers/{+advertiserId}/adGroups/{+adGroupId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersAdGroupsRequest>;
@@ -16993,7 +16996,7 @@ export const CreateAdvertisersAdGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/adGroups",
+      path: "v4/advertisers/{+advertiserId}/adGroups",
       hasBody: true,
     }),
     svc,
@@ -17037,7 +17040,7 @@ export const PatchAdvertisersAdGroupsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v4/advertisers/{advertiserId}/adGroups/{adGroupId}",
+      path: "v4/advertisers/{+advertiserId}/adGroups/{+adGroupId}",
       hasBody: true,
     }),
     svc,
@@ -17077,7 +17080,7 @@ export const BulkEditAssignedTargetingOptionsAdvertisersAdGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/adGroups:bulkEditAssignedTargetingOptions",
+      path: "v4/advertisers/{+advertiserId}/adGroups:bulkEditAssignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -17124,7 +17127,7 @@ export const ListAdvertisersAdGroupsRequest =
     advertiserId: Schema.String.pipe(T.HttpPath("advertiserId")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/advertisers/{advertiserId}/adGroups" }),
+    T.Http({ method: "GET", path: "v4/advertisers/{+advertiserId}/adGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersAdGroupsRequest>;
 
@@ -17164,7 +17167,7 @@ export const DeleteAdvertisersAdGroupsRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/advertisers/{advertiserId}/adGroups/{adGroupId}",
+      path: "v4/advertisers/{+advertiserId}/adGroups/{+adGroupId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersAdGroupsRequest>;
@@ -17260,7 +17263,7 @@ export const GetAdvertisersAdGroupsTargetingTypesAssignedTargetingOptionsRequest
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/adGroups/{adGroupId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v4/advertisers/{+advertiserId}/adGroups/{+adGroupId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetAdvertisersAdGroupsTargetingTypesAssignedTargetingOptionsRequest>;
@@ -17356,7 +17359,7 @@ export const CreateAdvertisersAdGroupsTargetingTypesAssignedTargetingOptionsRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/adGroups/{adGroupId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v4/advertisers/{+advertiserId}/adGroups/{+adGroupId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
       hasBody: true,
     }),
     svc,
@@ -17463,7 +17466,7 @@ export const ListAdvertisersAdGroupsTargetingTypesAssignedTargetingOptionsReques
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/adGroups/{adGroupId}/targetingTypes/{targetingType}/assignedTargetingOptions",
+      path: "v4/advertisers/{+advertiserId}/adGroups/{+adGroupId}/targetingTypes/{+targetingType}/assignedTargetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersAdGroupsTargetingTypesAssignedTargetingOptionsRequest>;
@@ -17565,7 +17568,7 @@ export const DeleteAdvertisersAdGroupsTargetingTypesAssignedTargetingOptionsRequ
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/advertisers/{advertiserId}/adGroups/{adGroupId}/targetingTypes/{targetingType}/assignedTargetingOptions/{assignedTargetingOptionId}",
+      path: "v4/advertisers/{+advertiserId}/adGroups/{+adGroupId}/targetingTypes/{+targetingType}/assignedTargetingOptions/{+assignedTargetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersAdGroupsTargetingTypesAssignedTargetingOptionsRequest>;
@@ -17627,7 +17630,7 @@ export const ListAdvertisersAdGroupsYoutubeAssetTypesYoutubeAssetAssociationsReq
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/advertisers/{advertiserId}/adGroups/{adGroupId}/youtubeAssetTypes/{youtubeAssetType}/youtubeAssetAssociations",
+      path: "v4/advertisers/{+advertiserId}/adGroups/{+adGroupId}/youtubeAssetTypes/{+youtubeAssetType}/youtubeAssetAssociations",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAdvertisersAdGroupsYoutubeAssetTypesYoutubeAssetAssociationsRequest>;
@@ -17690,7 +17693,7 @@ export const DeleteAdvertisersAdGroupsYoutubeAssetTypesYoutubeAssetAssociationsR
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v4/advertisers/{advertiserId}/adGroups/{adGroupId}/youtubeAssetTypes/{youtubeAssetType}/youtubeAssetAssociations/{youtubeAssetAssociationId}",
+      path: "v4/advertisers/{+advertiserId}/adGroups/{+adGroupId}/youtubeAssetTypes/{+youtubeAssetType}/youtubeAssetAssociations/{+youtubeAssetAssociationId}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdvertisersAdGroupsYoutubeAssetTypesYoutubeAssetAssociationsRequest>;
@@ -17747,7 +17750,7 @@ export const CreateAdvertisersAdGroupsYoutubeAssetTypesYoutubeAssetAssociationsR
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/advertisers/{advertiserId}/adGroups/{adGroupId}/youtubeAssetTypes/{youtubeAssetType}/youtubeAssetAssociations",
+      path: "v4/advertisers/{+advertiserId}/adGroups/{+adGroupId}/youtubeAssetTypes/{+youtubeAssetType}/youtubeAssetAssociations",
       hasBody: true,
     }),
     svc,
@@ -17854,7 +17857,7 @@ export const ListTargetingTypesTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/targetingTypes/{targetingType}/targetingOptions",
+      path: "v4/targetingTypes/{+targetingType}/targetingOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListTargetingTypesTargetingOptionsRequest>;
@@ -17952,7 +17955,7 @@ export const GetTargetingTypesTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/targetingTypes/{targetingType}/targetingOptions/{targetingOptionId}",
+      path: "v4/targetingTypes/{+targetingType}/targetingOptions/{+targetingOptionId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetTargetingTypesTargetingOptionsRequest>;
@@ -18040,7 +18043,7 @@ export const SearchTargetingTypesTargetingOptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/targetingTypes/{targetingType}/targetingOptions:search",
+      path: "v4/targetingTypes/{+targetingType}/targetingOptions:search",
       hasBody: true,
     }),
     svc,
@@ -18086,7 +18089,7 @@ export const GetFirstPartyAndPartnerAudiencesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v4/firstPartyAndPartnerAudiences/{firstPartyAndPartnerAudienceId}",
+      path: "v4/firstPartyAndPartnerAudiences/{+firstPartyAndPartnerAudienceId}",
     }),
     svc,
   ) as unknown as Schema.Schema<GetFirstPartyAndPartnerAudiencesRequest>;
@@ -18175,7 +18178,7 @@ export const PatchFirstPartyAndPartnerAudiencesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v4/firstPartyAndPartnerAudiences/{firstPartyAndPartnerAudienceId}",
+      path: "v4/firstPartyAndPartnerAudiences/{+firstPartyAndPartnerAudienceId}",
       hasBody: true,
     }),
     svc,
@@ -18216,7 +18219,7 @@ export const EditCustomerMatchMembersFirstPartyAndPartnerAudiencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/firstPartyAndPartnerAudiences/{firstPartyAndPartnerAudienceId}:editCustomerMatchMembers",
+      path: "v4/firstPartyAndPartnerAudiences/{+firstPartyAndPartnerAudienceId}:editCustomerMatchMembers",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/dlp-v2.ts
+++ b/packages/gcp/src/services/dlp-v2.ts
@@ -6381,7 +6381,7 @@ export const ListLocationsInfoTypesRequest =
     ),
     locationId: Schema.optional(Schema.String).pipe(T.HttpQuery("locationId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/infoTypes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/infoTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListLocationsInfoTypesRequest>;
 
@@ -6413,7 +6413,7 @@ export const GetProjectsLocationsTableDataProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTableDataProfilesRequest>;
 
@@ -6457,7 +6457,7 @@ export const ListProjectsLocationsTableDataProfilesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/tableDataProfiles" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/tableDataProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTableDataProfilesRequest>;
 
@@ -6493,7 +6493,7 @@ export const DeleteProjectsLocationsTableDataProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTableDataProfilesRequest>;
 
@@ -6536,7 +6536,7 @@ export const ListProjectsLocationsInfoTypesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/infoTypes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/infoTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInfoTypesRequest>;
 
@@ -6575,7 +6575,7 @@ export const CreateProjectsLocationsDeidentifyTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/deidentifyTemplates",
+      path: "v2/{+parent}/deidentifyTemplates",
       hasBody: true,
     }),
     svc,
@@ -6621,7 +6621,7 @@ export const ListProjectsLocationsDeidentifyTemplatesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     locationId: Schema.optional(Schema.String).pipe(T.HttpQuery("locationId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/deidentifyTemplates" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/deidentifyTemplates" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeidentifyTemplatesRequest>;
 
@@ -6657,7 +6657,7 @@ export const GetProjectsLocationsDeidentifyTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeidentifyTemplatesRequest>;
 
@@ -6689,7 +6689,7 @@ export const DeleteProjectsLocationsDeidentifyTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDeidentifyTemplatesRequest>;
 
@@ -6726,7 +6726,7 @@ export const PatchProjectsLocationsDeidentifyTemplatesRequest =
       GooglePrivacyDlpV2UpdateDeidentifyTemplateRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDeidentifyTemplatesRequest>;
 
@@ -6758,7 +6758,7 @@ export const GetProjectsLocationsInspectTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInspectTemplatesRequest>;
 
@@ -6802,7 +6802,7 @@ export const ListProjectsLocationsInspectTemplatesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/inspectTemplates" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/inspectTemplates" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInspectTemplatesRequest>;
 
@@ -6845,7 +6845,7 @@ export const CreateProjectsLocationsInspectTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/inspectTemplates",
+      path: "v2/{+parent}/inspectTemplates",
       hasBody: true,
     }),
     svc,
@@ -6884,7 +6884,7 @@ export const PatchProjectsLocationsInspectTemplatesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInspectTemplatesRequest>;
 
@@ -6916,7 +6916,7 @@ export const DeleteProjectsLocationsInspectTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInspectTemplatesRequest>;
 
@@ -6953,7 +6953,7 @@ export const ActivateProjectsLocationsJobTriggersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:activate", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:activate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ActivateProjectsLocationsJobTriggersRequest>;
 
@@ -6985,7 +6985,7 @@ export const DeleteProjectsLocationsJobTriggersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsJobTriggersRequest>;
 
@@ -7021,7 +7021,7 @@ export const PatchProjectsLocationsJobTriggersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsJobTriggersRequest>;
 
@@ -7058,7 +7058,7 @@ export const CreateProjectsLocationsJobTriggersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/jobTriggers", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/jobTriggers", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsJobTriggersRequest>;
 
@@ -7095,7 +7095,7 @@ export const HybridInspectProjectsLocationsJobTriggersRequest =
       GooglePrivacyDlpV2HybridInspectJobTriggerRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:hybridInspect", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:hybridInspect", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<HybridInspectProjectsLocationsJobTriggersRequest>;
 
@@ -7149,7 +7149,7 @@ export const ListProjectsLocationsJobTriggersRequest =
     type: Schema.optional(Schema.String).pipe(T.HttpQuery("type")),
     locationId: Schema.optional(Schema.String).pipe(T.HttpQuery("locationId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/jobTriggers" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/jobTriggers" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsJobTriggersRequest>;
 
@@ -7185,7 +7185,7 @@ export const GetProjectsLocationsJobTriggersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsJobTriggersRequest>;
 
@@ -7217,7 +7217,7 @@ export const GetProjectsLocationsProjectDataProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProjectDataProfilesRequest>;
 
@@ -7261,7 +7261,7 @@ export const ListProjectsLocationsProjectDataProfilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/projectDataProfiles" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/projectDataProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProjectDataProfilesRequest>;
 
@@ -7309,7 +7309,7 @@ export const ListProjectsLocationsFileStoreDataProfilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/fileStoreDataProfiles" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/fileStoreDataProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFileStoreDataProfilesRequest>;
 
@@ -7345,7 +7345,7 @@ export const DeleteProjectsLocationsFileStoreDataProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFileStoreDataProfilesRequest>;
 
@@ -7377,7 +7377,7 @@ export const GetProjectsLocationsFileStoreDataProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFileStoreDataProfilesRequest>;
 
@@ -7414,7 +7414,11 @@ export const RedactProjectsLocationsImageRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/image:redact", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+parent}/image:redact",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<RedactProjectsLocationsImageRequest>;
 
@@ -7446,7 +7450,7 @@ export const GetProjectsLocationsDlpJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDlpJobsRequest>;
 
@@ -7482,7 +7486,7 @@ export const FinishProjectsLocationsDlpJobsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:finish", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:finish", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<FinishProjectsLocationsDlpJobsRequest>;
 
@@ -7535,7 +7539,7 @@ export const ListProjectsLocationsDlpJobsRequest =
     type: Schema.optional(Schema.String).pipe(T.HttpQuery("type")),
     locationId: Schema.optional(Schema.String).pipe(T.HttpQuery("locationId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/dlpJobs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/dlpJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDlpJobsRequest>;
 
@@ -7576,7 +7580,7 @@ export const HybridInspectProjectsLocationsDlpJobsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:hybridInspect", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:hybridInspect", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<HybridInspectProjectsLocationsDlpJobsRequest>;
 
@@ -7613,7 +7617,7 @@ export const CreateProjectsLocationsDlpJobsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/dlpJobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/dlpJobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDlpJobsRequest>;
 
@@ -7644,7 +7648,7 @@ export const DeleteProjectsLocationsDlpJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDlpJobsRequest>;
 
@@ -7680,7 +7684,7 @@ export const CancelProjectsLocationsDlpJobsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDlpJobsRequest>;
 
@@ -7718,7 +7722,7 @@ export const ReidentifyProjectsLocationsContentRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/content:reidentify",
+      path: "v2/{+parent}/content:reidentify",
       hasBody: true,
     }),
     svc,
@@ -7759,7 +7763,7 @@ export const DeidentifyProjectsLocationsContentRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/content:deidentify",
+      path: "v2/{+parent}/content:deidentify",
       hasBody: true,
     }),
     svc,
@@ -7800,7 +7804,7 @@ export const InspectProjectsLocationsContentRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/content:inspect",
+      path: "v2/{+parent}/content:inspect",
       hasBody: true,
     }),
     svc,
@@ -7843,7 +7847,7 @@ export const ListProjectsLocationsConnectionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/connections" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/connections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsRequest>;
 
@@ -7879,7 +7883,7 @@ export const GetProjectsLocationsConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectionsRequest>;
 
@@ -7916,7 +7920,7 @@ export const CreateProjectsLocationsConnectionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/connections", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/connections", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsConnectionsRequest>;
 
@@ -7957,7 +7961,7 @@ export const SearchProjectsLocationsConnectionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/connections:search" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/connections:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsLocationsConnectionsRequest>;
 
@@ -7993,7 +7997,7 @@ export const DeleteProjectsLocationsConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectionsRequest>;
 
@@ -8029,7 +8033,7 @@ export const PatchProjectsLocationsConnectionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectionsRequest>;
 
@@ -8073,7 +8077,7 @@ export const ListProjectsLocationsColumnDataProfilesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/columnDataProfiles" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/columnDataProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsColumnDataProfilesRequest>;
 
@@ -8109,7 +8113,7 @@ export const GetProjectsLocationsColumnDataProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsColumnDataProfilesRequest>;
 
@@ -8150,7 +8154,7 @@ export const ListProjectsLocationsDiscoveryConfigsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/discoveryConfigs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/discoveryConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDiscoveryConfigsRequest>;
 
@@ -8186,7 +8190,7 @@ export const GetProjectsLocationsDiscoveryConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDiscoveryConfigsRequest>;
 
@@ -8225,7 +8229,7 @@ export const CreateProjectsLocationsDiscoveryConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/discoveryConfigs",
+      path: "v2/{+parent}/discoveryConfigs",
       hasBody: true,
     }),
     svc,
@@ -8259,7 +8263,7 @@ export const DeleteProjectsLocationsDiscoveryConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDiscoveryConfigsRequest>;
 
@@ -8296,7 +8300,7 @@ export const PatchProjectsLocationsDiscoveryConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDiscoveryConfigsRequest>;
 
@@ -8333,7 +8337,7 @@ export const PatchProjectsLocationsStoredInfoTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsStoredInfoTypesRequest>;
 
@@ -8365,7 +8369,7 @@ export const DeleteProjectsLocationsStoredInfoTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsStoredInfoTypesRequest>;
 
@@ -8404,7 +8408,7 @@ export const CreateProjectsLocationsStoredInfoTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/storedInfoTypes",
+      path: "v2/{+parent}/storedInfoTypes",
       hasBody: true,
     }),
     svc,
@@ -8438,7 +8442,7 @@ export const GetProjectsLocationsStoredInfoTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsStoredInfoTypesRequest>;
 
@@ -8482,7 +8486,7 @@ export const ListProjectsLocationsStoredInfoTypesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     locationId: Schema.optional(Schema.String).pipe(T.HttpQuery("locationId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/storedInfoTypes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/storedInfoTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsStoredInfoTypesRequest>;
 
@@ -8523,7 +8527,7 @@ export const CreateProjectsJobTriggersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/jobTriggers", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/jobTriggers", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsJobTriggersRequest>;
 
@@ -8576,7 +8580,7 @@ export const ListProjectsJobTriggersRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     type: Schema.optional(Schema.String).pipe(T.HttpQuery("type")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/jobTriggers" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/jobTriggers" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsJobTriggersRequest>;
 
@@ -8612,7 +8616,7 @@ export const GetProjectsJobTriggersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsJobTriggersRequest>;
 
@@ -8648,7 +8652,7 @@ export const ActivateProjectsJobTriggersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:activate", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:activate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ActivateProjectsJobTriggersRequest>;
 
@@ -8679,7 +8683,7 @@ export const DeleteProjectsJobTriggersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsJobTriggersRequest>;
 
@@ -8715,7 +8719,7 @@ export const PatchProjectsJobTriggersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsJobTriggersRequest>;
 
@@ -8753,7 +8757,7 @@ export const CreateProjectsStoredInfoTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/storedInfoTypes",
+      path: "v2/{+parent}/storedInfoTypes",
       hasBody: true,
     }),
     svc,
@@ -8799,7 +8803,7 @@ export const ListProjectsStoredInfoTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/storedInfoTypes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/storedInfoTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsStoredInfoTypesRequest>;
 
@@ -8835,7 +8839,7 @@ export const GetProjectsStoredInfoTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsStoredInfoTypesRequest>;
 
@@ -8867,7 +8871,7 @@ export const DeleteProjectsStoredInfoTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsStoredInfoTypesRequest>;
 
@@ -8903,7 +8907,7 @@ export const PatchProjectsStoredInfoTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsStoredInfoTypesRequest>;
 
@@ -8940,7 +8944,7 @@ export const PatchProjectsInspectTemplatesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsInspectTemplatesRequest>;
 
@@ -8972,7 +8976,7 @@ export const DeleteProjectsInspectTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInspectTemplatesRequest>;
 
@@ -9010,7 +9014,7 @@ export const CreateProjectsInspectTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/inspectTemplates",
+      path: "v2/{+parent}/inspectTemplates",
       hasBody: true,
     }),
     svc,
@@ -9044,7 +9048,7 @@ export const GetProjectsInspectTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInspectTemplatesRequest>;
 
@@ -9088,7 +9092,7 @@ export const ListProjectsInspectTemplatesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     locationId: Schema.optional(Schema.String).pipe(T.HttpQuery("locationId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/inspectTemplates" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/inspectTemplates" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInspectTemplatesRequest>;
 
@@ -9131,7 +9135,7 @@ export const ReidentifyProjectsContentRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/content:reidentify",
+      path: "v2/{+parent}/content:reidentify",
       hasBody: true,
     }),
     svc,
@@ -9172,7 +9176,7 @@ export const DeidentifyProjectsContentRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/content:deidentify",
+      path: "v2/{+parent}/content:deidentify",
       hasBody: true,
     }),
     svc,
@@ -9213,7 +9217,7 @@ export const InspectProjectsContentRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/content:inspect",
+      path: "v2/{+parent}/content:inspect",
       hasBody: true,
     }),
     svc,
@@ -9252,7 +9256,11 @@ export const RedactProjectsImageRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/image:redact", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+parent}/image:redact",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<RedactProjectsImageRequest>;
 
@@ -9283,7 +9291,7 @@ export const DeleteProjectsDeidentifyTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsDeidentifyTemplatesRequest>;
 
@@ -9319,7 +9327,7 @@ export const PatchProjectsDeidentifyTemplatesRequest =
       GooglePrivacyDlpV2UpdateDeidentifyTemplateRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsDeidentifyTemplatesRequest>;
 
@@ -9363,7 +9371,7 @@ export const ListProjectsDeidentifyTemplatesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     locationId: Schema.optional(Schema.String).pipe(T.HttpQuery("locationId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/deidentifyTemplates" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/deidentifyTemplates" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDeidentifyTemplatesRequest>;
 
@@ -9399,7 +9407,7 @@ export const GetProjectsDeidentifyTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDeidentifyTemplatesRequest>;
 
@@ -9438,7 +9446,7 @@ export const CreateProjectsDeidentifyTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/deidentifyTemplates",
+      path: "v2/{+parent}/deidentifyTemplates",
       hasBody: true,
     }),
     svc,
@@ -9494,7 +9502,7 @@ export const ListProjectsDlpJobsRequest =
     type: Schema.optional(Schema.String).pipe(T.HttpQuery("type")),
     locationId: Schema.optional(Schema.String).pipe(T.HttpQuery("locationId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/dlpJobs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/dlpJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDlpJobsRequest>;
 
@@ -9529,7 +9537,7 @@ export const GetProjectsDlpJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDlpJobsRequest>;
 
@@ -9565,7 +9573,7 @@ export const CreateProjectsDlpJobsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/dlpJobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/dlpJobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsDlpJobsRequest>;
 
@@ -9596,7 +9604,7 @@ export const DeleteProjectsDlpJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsDlpJobsRequest>;
 
@@ -9632,7 +9640,7 @@ export const CancelProjectsDlpJobsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsDlpJobsRequest>;
 
@@ -9663,7 +9671,7 @@ export const DeleteOrganizationsDeidentifyTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsDeidentifyTemplatesRequest>;
 
@@ -9700,7 +9708,7 @@ export const PatchOrganizationsDeidentifyTemplatesRequest =
       GooglePrivacyDlpV2UpdateDeidentifyTemplateRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsDeidentifyTemplatesRequest>;
 
@@ -9744,7 +9752,7 @@ export const ListOrganizationsDeidentifyTemplatesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/deidentifyTemplates" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/deidentifyTemplates" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsDeidentifyTemplatesRequest>;
 
@@ -9780,7 +9788,7 @@ export const GetOrganizationsDeidentifyTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsDeidentifyTemplatesRequest>;
 
@@ -9819,7 +9827,7 @@ export const CreateOrganizationsDeidentifyTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/deidentifyTemplates",
+      path: "v2/{+parent}/deidentifyTemplates",
       hasBody: true,
     }),
     svc,
@@ -9860,7 +9868,7 @@ export const CreateOrganizationsStoredInfoTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/storedInfoTypes",
+      path: "v2/{+parent}/storedInfoTypes",
       hasBody: true,
     }),
     svc,
@@ -9906,7 +9914,7 @@ export const ListOrganizationsStoredInfoTypesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/storedInfoTypes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/storedInfoTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsStoredInfoTypesRequest>;
 
@@ -9942,7 +9950,7 @@ export const GetOrganizationsStoredInfoTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsStoredInfoTypesRequest>;
 
@@ -9974,7 +9982,7 @@ export const DeleteOrganizationsStoredInfoTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsStoredInfoTypesRequest>;
 
@@ -10010,7 +10018,7 @@ export const PatchOrganizationsStoredInfoTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsStoredInfoTypesRequest>;
 
@@ -10064,7 +10072,7 @@ export const ListOrganizationsLocationsJobTriggersRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     locationId: Schema.optional(Schema.String).pipe(T.HttpQuery("locationId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/jobTriggers" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/jobTriggers" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsJobTriggersRequest>;
 
@@ -10100,7 +10108,7 @@ export const GetOrganizationsLocationsJobTriggersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsJobTriggersRequest>;
 
@@ -10137,7 +10145,7 @@ export const CreateOrganizationsLocationsJobTriggersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/jobTriggers", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/jobTriggers", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsLocationsJobTriggersRequest>;
 
@@ -10169,7 +10177,7 @@ export const DeleteOrganizationsLocationsJobTriggersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsJobTriggersRequest>;
 
@@ -10206,7 +10214,7 @@ export const PatchOrganizationsLocationsJobTriggersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsJobTriggersRequest>;
 
@@ -10238,7 +10246,7 @@ export const GetOrganizationsLocationsProjectDataProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsProjectDataProfilesRequest>;
 
@@ -10282,7 +10290,7 @@ export const ListOrganizationsLocationsProjectDataProfilesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/projectDataProfiles" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/projectDataProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsProjectDataProfilesRequest>;
 
@@ -10318,7 +10326,7 @@ export const DeleteOrganizationsLocationsStoredInfoTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsStoredInfoTypesRequest>;
 
@@ -10355,7 +10363,7 @@ export const PatchOrganizationsLocationsStoredInfoTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsStoredInfoTypesRequest>;
 
@@ -10399,7 +10407,7 @@ export const ListOrganizationsLocationsStoredInfoTypesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/storedInfoTypes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/storedInfoTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsStoredInfoTypesRequest>;
 
@@ -10435,7 +10443,7 @@ export const GetOrganizationsLocationsStoredInfoTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsStoredInfoTypesRequest>;
 
@@ -10474,7 +10482,7 @@ export const CreateOrganizationsLocationsStoredInfoTypesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/storedInfoTypes",
+      path: "v2/{+parent}/storedInfoTypes",
       hasBody: true,
     }),
     svc,
@@ -10520,7 +10528,7 @@ export const ListOrganizationsLocationsFileStoreDataProfilesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/fileStoreDataProfiles" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/fileStoreDataProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsFileStoreDataProfilesRequest>;
 
@@ -10557,7 +10565,7 @@ export const DeleteOrganizationsLocationsFileStoreDataProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsFileStoreDataProfilesRequest>;
 
@@ -10590,7 +10598,7 @@ export const GetOrganizationsLocationsFileStoreDataProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsFileStoreDataProfilesRequest>;
 
@@ -10629,7 +10637,7 @@ export const CreateOrganizationsLocationsInspectTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/inspectTemplates",
+      path: "v2/{+parent}/inspectTemplates",
       hasBody: true,
     }),
     svc,
@@ -10675,7 +10683,7 @@ export const ListOrganizationsLocationsInspectTemplatesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     locationId: Schema.optional(Schema.String).pipe(T.HttpQuery("locationId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/inspectTemplates" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/inspectTemplates" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsInspectTemplatesRequest>;
 
@@ -10711,7 +10719,7 @@ export const GetOrganizationsLocationsInspectTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsInspectTemplatesRequest>;
 
@@ -10743,7 +10751,7 @@ export const DeleteOrganizationsLocationsInspectTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsInspectTemplatesRequest>;
 
@@ -10780,7 +10788,7 @@ export const PatchOrganizationsLocationsInspectTemplatesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsInspectTemplatesRequest>;
 
@@ -10817,7 +10825,7 @@ export const PatchOrganizationsLocationsDiscoveryConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsDiscoveryConfigsRequest>;
 
@@ -10849,7 +10857,7 @@ export const DeleteOrganizationsLocationsDiscoveryConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsDiscoveryConfigsRequest>;
 
@@ -10888,7 +10896,7 @@ export const CreateOrganizationsLocationsDiscoveryConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/discoveryConfigs",
+      path: "v2/{+parent}/discoveryConfigs",
       hasBody: true,
     }),
     svc,
@@ -10922,7 +10930,7 @@ export const GetOrganizationsLocationsDiscoveryConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsDiscoveryConfigsRequest>;
 
@@ -10963,7 +10971,7 @@ export const ListOrganizationsLocationsDiscoveryConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/discoveryConfigs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/discoveryConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsDiscoveryConfigsRequest>;
 
@@ -11010,7 +11018,7 @@ export const ListOrganizationsLocationsInfoTypesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/infoTypes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/infoTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsInfoTypesRequest>;
 
@@ -11054,7 +11062,7 @@ export const ListOrganizationsLocationsColumnDataProfilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/columnDataProfiles" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/columnDataProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsColumnDataProfilesRequest>;
 
@@ -11090,7 +11098,7 @@ export const GetOrganizationsLocationsColumnDataProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsColumnDataProfilesRequest>;
 
@@ -11127,7 +11135,7 @@ export const PatchOrganizationsLocationsDeidentifyTemplatesRequest =
       GooglePrivacyDlpV2UpdateDeidentifyTemplateRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsDeidentifyTemplatesRequest>;
 
@@ -11159,7 +11167,7 @@ export const DeleteOrganizationsLocationsDeidentifyTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsDeidentifyTemplatesRequest>;
 
@@ -11199,7 +11207,7 @@ export const CreateOrganizationsLocationsDeidentifyTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/deidentifyTemplates",
+      path: "v2/{+parent}/deidentifyTemplates",
       hasBody: true,
     }),
     svc,
@@ -11234,7 +11242,7 @@ export const GetOrganizationsLocationsDeidentifyTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsDeidentifyTemplatesRequest>;
 
@@ -11278,7 +11286,7 @@ export const ListOrganizationsLocationsDeidentifyTemplatesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/deidentifyTemplates" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/deidentifyTemplates" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsDeidentifyTemplatesRequest>;
 
@@ -11319,7 +11327,7 @@ export const CreateOrganizationsLocationsConnectionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/connections", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/connections", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsLocationsConnectionsRequest>;
 
@@ -11360,7 +11368,7 @@ export const SearchOrganizationsLocationsConnectionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/connections:search" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/connections:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchOrganizationsLocationsConnectionsRequest>;
 
@@ -11396,7 +11404,7 @@ export const GetOrganizationsLocationsConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsConnectionsRequest>;
 
@@ -11437,7 +11445,7 @@ export const ListOrganizationsLocationsConnectionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/connections" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/connections" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsConnectionsRequest>;
 
@@ -11478,7 +11486,7 @@ export const PatchOrganizationsLocationsConnectionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsConnectionsRequest>;
 
@@ -11510,7 +11518,7 @@ export const DeleteOrganizationsLocationsConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsConnectionsRequest>;
 
@@ -11554,7 +11562,7 @@ export const ListOrganizationsLocationsTableDataProfilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/tableDataProfiles" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/tableDataProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsTableDataProfilesRequest>;
 
@@ -11590,7 +11598,7 @@ export const DeleteOrganizationsLocationsTableDataProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsTableDataProfilesRequest>;
 
@@ -11622,7 +11630,7 @@ export const GetOrganizationsLocationsTableDataProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsTableDataProfilesRequest>;
 
@@ -11676,7 +11684,7 @@ export const ListOrganizationsLocationsDlpJobsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     type: Schema.optional(Schema.String).pipe(T.HttpQuery("type")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/dlpJobs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/dlpJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsDlpJobsRequest>;
 
@@ -11724,7 +11732,7 @@ export const ListOrganizationsInspectTemplatesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     locationId: Schema.optional(Schema.String).pipe(T.HttpQuery("locationId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/inspectTemplates" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/inspectTemplates" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsInspectTemplatesRequest>;
 
@@ -11760,7 +11768,7 @@ export const GetOrganizationsInspectTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsInspectTemplatesRequest>;
 
@@ -11799,7 +11807,7 @@ export const CreateOrganizationsInspectTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/inspectTemplates",
+      path: "v2/{+parent}/inspectTemplates",
       hasBody: true,
     }),
     svc,
@@ -11833,7 +11841,7 @@ export const DeleteOrganizationsInspectTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsInspectTemplatesRequest>;
 
@@ -11869,7 +11877,7 @@ export const PatchOrganizationsInspectTemplatesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsInspectTemplatesRequest>;
 

--- a/packages/gcp/src/services/dns-v1.ts
+++ b/packages/gcp/src/services/dns-v1.ts
@@ -2384,7 +2384,7 @@ export const SetIamPolicyManagedZonesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "dns/v1/{resource}:setIamPolicy",
+      path: "dns/v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2511,7 +2511,7 @@ export const TestIamPermissionsManagedZonesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "dns/v1/{resource}:testIamPermissions",
+      path: "dns/v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2550,7 +2550,7 @@ export const GetIamPolicyManagedZonesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "dns/v1/{resource}:getIamPolicy",
+      path: "dns/v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/dns-v1beta2.ts
+++ b/packages/gcp/src/services/dns-v1beta2.ts
@@ -2578,7 +2578,7 @@ export const GetIamPolicyManagedZonesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "dns/v1beta2/{resource}:getIamPolicy",
+      path: "dns/v1beta2/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2618,7 +2618,7 @@ export const TestIamPermissionsManagedZonesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "dns/v1beta2/{resource}:testIamPermissions",
+      path: "dns/v1beta2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2701,7 +2701,7 @@ export const SetIamPolicyManagedZonesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "dns/v1beta2/{resource}:setIamPolicy",
+      path: "dns/v1beta2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/documentai-v1.ts
+++ b/packages/gcp/src/services/documentai-v1.ts
@@ -6421,7 +6421,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 
@@ -6452,7 +6452,7 @@ export const FetchProcessorTypesProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}:fetchProcessorTypes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}:fetchProcessorTypes" }),
     svc,
   ) as unknown as Schema.Schema<FetchProcessorTypesProjectsLocationsRequest>;
 
@@ -6498,7 +6498,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -6534,7 +6534,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -6579,7 +6579,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -6615,7 +6615,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -6646,7 +6646,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -6682,7 +6682,7 @@ export const ProcessProjectsLocationsProcessorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:process", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:process", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ProcessProjectsLocationsProcessorsRequest>;
 
@@ -6719,7 +6719,7 @@ export const BatchProcessProjectsLocationsProcessorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:batchProcess", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:batchProcess", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<BatchProcessProjectsLocationsProcessorsRequest>;
 
@@ -6757,7 +6757,7 @@ export const ListProjectsLocationsProcessorsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/processors" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/processors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProcessorsRequest>;
 
@@ -6793,7 +6793,7 @@ export const GetProjectsLocationsProcessorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProcessorsRequest>;
 
@@ -6828,7 +6828,7 @@ export const CreateProjectsLocationsProcessorsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDocumentaiV1Processor).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/processors", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/processors", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsProcessorsRequest>;
 
@@ -6860,7 +6860,7 @@ export const DeleteProjectsLocationsProcessorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsProcessorsRequest>;
 
@@ -6897,7 +6897,7 @@ export const EnableProjectsLocationsProcessorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:enable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:enable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EnableProjectsLocationsProcessorsRequest>;
 
@@ -6934,7 +6934,7 @@ export const DisableProjectsLocationsProcessorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:disable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:disable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DisableProjectsLocationsProcessorsRequest>;
 
@@ -6973,7 +6973,7 @@ export const SetDefaultProcessorVersionProjectsLocationsProcessorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{processor}:setDefaultProcessorVersion",
+      path: "v1/{+processor}:setDefaultProcessorVersion",
       hasBody: true,
     }),
     svc,
@@ -7013,7 +7013,7 @@ export const ProcessProjectsLocationsProcessorsProcessorVersionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:process", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:process", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ProcessProjectsLocationsProcessorsProcessorVersionsRequest>;
 
@@ -7051,7 +7051,7 @@ export const BatchProcessProjectsLocationsProcessorsProcessorVersionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:batchProcess", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:batchProcess", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<BatchProcessProjectsLocationsProcessorsProcessorVersionsRequest>;
 
@@ -7091,7 +7091,7 @@ export const TrainProjectsLocationsProcessorsProcessorVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/processorVersions:train",
+      path: "v1/{+parent}/processorVersions:train",
       hasBody: true,
     }),
     svc,
@@ -7126,7 +7126,7 @@ export const GetProjectsLocationsProcessorsProcessorVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProcessorsProcessorVersionsRequest>;
 
@@ -7165,7 +7165,7 @@ export const ListProjectsLocationsProcessorsProcessorVersionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/processorVersions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/processorVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProcessorsProcessorVersionsRequest>;
 
@@ -7202,7 +7202,7 @@ export const DeleteProjectsLocationsProcessorsProcessorVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsProcessorsProcessorVersionsRequest>;
 
@@ -7240,7 +7240,7 @@ export const DeployProjectsLocationsProcessorsProcessorVersionsRequest =
       GoogleCloudDocumentaiV1DeployProcessorVersionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:deploy", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:deploy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeployProjectsLocationsProcessorsProcessorVersionsRequest>;
 
@@ -7278,7 +7278,7 @@ export const UndeployProjectsLocationsProcessorsProcessorVersionsRequest =
       GoogleCloudDocumentaiV1UndeployProcessorVersionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undeploy", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undeploy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeployProjectsLocationsProcessorsProcessorVersionsRequest>;
 
@@ -7318,7 +7318,7 @@ export const EvaluateProcessorVersionProjectsLocationsProcessorsProcessorVersion
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{processorVersion}:evaluateProcessorVersion",
+      path: "v1/{+processorVersion}:evaluateProcessorVersion",
       hasBody: true,
     }),
     svc,
@@ -7355,7 +7355,7 @@ export const GetProjectsLocationsProcessorsProcessorVersionsEvaluationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProcessorsProcessorVersionsEvaluationsRequest>;
 
@@ -7394,7 +7394,7 @@ export const ListProjectsLocationsProcessorsProcessorVersionsEvaluationsRequest 
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/evaluations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/evaluations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProcessorsProcessorVersionsEvaluationsRequest>;
 
@@ -7438,7 +7438,7 @@ export const ReviewDocumentProjectsLocationsProcessorsHumanReviewConfigRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{humanReviewConfig}:reviewDocument",
+      path: "v1/{+humanReviewConfig}:reviewDocument",
       hasBody: true,
     }),
     svc,
@@ -7479,7 +7479,7 @@ export const ListProjectsLocationsProcessorTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/processorTypes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/processorTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProcessorTypesRequest>;
 
@@ -7515,7 +7515,7 @@ export const GetProjectsLocationsProcessorTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProcessorTypesRequest>;
 
@@ -7550,7 +7550,7 @@ export const CreateProjectsLocationsSchemasRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudDocumentaiV1NextSchema).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/schemas", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/schemas", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSchemasRequest>;
 
@@ -7588,7 +7588,7 @@ export const PatchProjectsLocationsSchemasRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudDocumentaiV1NextSchema).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSchemasRequest>;
 
@@ -7623,7 +7623,7 @@ export const DeleteProjectsLocationsSchemasRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSchemasRequest>;
 
@@ -7660,7 +7660,7 @@ export const ListProjectsLocationsSchemasRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/schemas" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/schemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchemasRequest>;
 
@@ -7696,7 +7696,7 @@ export const GetProjectsLocationsSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchemasRequest>;
 
@@ -7735,7 +7735,7 @@ export const CreateProjectsLocationsSchemasSchemaVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/schemaVersions",
+      path: "v1/{+parent}/schemaVersions",
       hasBody: true,
     }),
     svc,
@@ -7777,7 +7777,7 @@ export const PatchProjectsLocationsSchemasSchemaVersionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSchemasSchemaVersionsRequest>;
 
@@ -7816,7 +7816,7 @@ export const GenerateProjectsLocationsSchemasSchemaVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/schemaVersions:generate",
+      path: "v1/{+parent}/schemaVersions:generate",
       hasBody: true,
     }),
     svc,
@@ -7850,7 +7850,7 @@ export const DeleteProjectsLocationsSchemasSchemaVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSchemasSchemaVersionsRequest>;
 
@@ -7888,7 +7888,7 @@ export const ListProjectsLocationsSchemasSchemaVersionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/schemaVersions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/schemaVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchemasSchemaVersionsRequest>;
 
@@ -7924,7 +7924,7 @@ export const GetProjectsLocationsSchemasSchemaVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchemasSchemaVersionsRequest>;
 
@@ -7956,7 +7956,7 @@ export const DeleteOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOperationsRequest>;
 

--- a/packages/gcp/src/services/documentai-v1beta3.ts
+++ b/packages/gcp/src/services/documentai-v1beta3.ts
@@ -6537,7 +6537,7 @@ export const FetchProcessorTypesProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{parent}:fetchProcessorTypes" }),
+    T.Http({ method: "GET", path: "v1beta3/{+parent}:fetchProcessorTypes" }),
     svc,
   ) as unknown as Schema.Schema<FetchProcessorTypesProjectsLocationsRequest>;
 
@@ -6583,7 +6583,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta3/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -6619,7 +6619,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{name}" }),
+    T.Http({ method: "GET", path: "v1beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -6664,7 +6664,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{name}" }),
+    T.Http({ method: "GET", path: "v1beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -6700,7 +6700,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{name}" }),
+    T.Http({ method: "GET", path: "v1beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -6731,7 +6731,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta3/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta3/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -6767,7 +6767,7 @@ export const ProcessProjectsLocationsProcessorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta3/{name}:process", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta3/{+name}:process", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ProcessProjectsLocationsProcessorsRequest>;
 
@@ -6806,7 +6806,7 @@ export const BatchProcessProjectsLocationsProcessorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta3/{name}:batchProcess",
+      path: "v1beta3/{+name}:batchProcess",
       hasBody: true,
     }),
     svc,
@@ -6846,7 +6846,7 @@ export const ListProjectsLocationsProcessorsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{parent}/processors" }),
+    T.Http({ method: "GET", path: "v1beta3/{+parent}/processors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProcessorsRequest>;
 
@@ -6882,7 +6882,7 @@ export const GetProjectsLocationsProcessorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{name}" }),
+    T.Http({ method: "GET", path: "v1beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProcessorsRequest>;
 
@@ -6921,7 +6921,7 @@ export const CreateProjectsLocationsProcessorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta3/{parent}/processors",
+      path: "v1beta3/{+parent}/processors",
       hasBody: true,
     }),
     svc,
@@ -6955,7 +6955,7 @@ export const DeleteProjectsLocationsProcessorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta3/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsProcessorsRequest>;
 
@@ -6992,7 +6992,7 @@ export const EnableProjectsLocationsProcessorsRequest =
       GoogleCloudDocumentaiV1beta3EnableProcessorRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta3/{name}:enable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta3/{+name}:enable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EnableProjectsLocationsProcessorsRequest>;
 
@@ -7029,7 +7029,7 @@ export const DisableProjectsLocationsProcessorsRequest =
       GoogleCloudDocumentaiV1beta3DisableProcessorRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta3/{name}:disable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta3/{+name}:disable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DisableProjectsLocationsProcessorsRequest>;
 
@@ -7068,7 +7068,7 @@ export const SetDefaultProcessorVersionProjectsLocationsProcessorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta3/{processor}:setDefaultProcessorVersion",
+      path: "v1beta3/{+processor}:setDefaultProcessorVersion",
       hasBody: true,
     }),
     svc,
@@ -7111,7 +7111,7 @@ export const UpdateDatasetProjectsLocationsProcessorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateDatasetProjectsLocationsProcessorsRequest>;
 
@@ -7148,7 +7148,7 @@ export const ProcessProjectsLocationsProcessorsProcessorVersionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta3/{name}:process", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta3/{+name}:process", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ProcessProjectsLocationsProcessorsProcessorVersionsRequest>;
 
@@ -7188,7 +7188,7 @@ export const BatchProcessProjectsLocationsProcessorsProcessorVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta3/{name}:batchProcess",
+      path: "v1beta3/{+name}:batchProcess",
       hasBody: true,
     }),
     svc,
@@ -7230,7 +7230,7 @@ export const TrainProjectsLocationsProcessorsProcessorVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta3/{parent}/processorVersions:train",
+      path: "v1beta3/{+parent}/processorVersions:train",
       hasBody: true,
     }),
     svc,
@@ -7265,7 +7265,7 @@ export const GetProjectsLocationsProcessorsProcessorVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{name}" }),
+    T.Http({ method: "GET", path: "v1beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProcessorsProcessorVersionsRequest>;
 
@@ -7304,7 +7304,7 @@ export const ListProjectsLocationsProcessorsProcessorVersionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{parent}/processorVersions" }),
+    T.Http({ method: "GET", path: "v1beta3/{+parent}/processorVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProcessorsProcessorVersionsRequest>;
 
@@ -7341,7 +7341,7 @@ export const DeleteProjectsLocationsProcessorsProcessorVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta3/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsProcessorsProcessorVersionsRequest>;
 
@@ -7379,7 +7379,7 @@ export const DeployProjectsLocationsProcessorsProcessorVersionsRequest =
       GoogleCloudDocumentaiV1beta3DeployProcessorVersionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta3/{name}:deploy", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta3/{+name}:deploy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeployProjectsLocationsProcessorsProcessorVersionsRequest>;
 
@@ -7417,7 +7417,7 @@ export const UndeployProjectsLocationsProcessorsProcessorVersionsRequest =
       GoogleCloudDocumentaiV1beta3UndeployProcessorVersionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta3/{name}:undeploy", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta3/{+name}:undeploy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeployProjectsLocationsProcessorsProcessorVersionsRequest>;
 
@@ -7457,7 +7457,7 @@ export const EvaluateProcessorVersionProjectsLocationsProcessorsProcessorVersion
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta3/{processorVersion}:evaluateProcessorVersion",
+      path: "v1beta3/{+processorVersion}:evaluateProcessorVersion",
       hasBody: true,
     }),
     svc,
@@ -7501,7 +7501,7 @@ export const ImportProcessorVersionProjectsLocationsProcessorsProcessorVersionsR
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta3/{parent}/processorVersions:importProcessorVersion",
+      path: "v1beta3/{+parent}/processorVersions:importProcessorVersion",
       hasBody: true,
     }),
     svc,
@@ -7538,7 +7538,7 @@ export const GetProjectsLocationsProcessorsProcessorVersionsEvaluationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{name}" }),
+    T.Http({ method: "GET", path: "v1beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProcessorsProcessorVersionsEvaluationsRequest>;
 
@@ -7577,7 +7577,7 @@ export const ListProjectsLocationsProcessorsProcessorVersionsEvaluationsRequest 
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{parent}/evaluations" }),
+    T.Http({ method: "GET", path: "v1beta3/{+parent}/evaluations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProcessorsProcessorVersionsEvaluationsRequest>;
 
@@ -7621,7 +7621,7 @@ export const ReviewDocumentProjectsLocationsProcessorsHumanReviewConfigRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta3/{humanReviewConfig}:reviewDocument",
+      path: "v1beta3/{+humanReviewConfig}:reviewDocument",
       hasBody: true,
     }),
     svc,
@@ -7663,7 +7663,7 @@ export const ImportDocumentsProjectsLocationsProcessorsDatasetRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta3/{dataset}:importDocuments",
+      path: "v1beta3/{+dataset}:importDocuments",
       hasBody: true,
     }),
     svc,
@@ -7746,7 +7746,7 @@ export const GetDocumentProjectsLocationsProcessorsDatasetRequest =
       T.HttpQuery("pageRange.end"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{dataset}:getDocument" }),
+    T.Http({ method: "GET", path: "v1beta3/{+dataset}:getDocument" }),
     svc,
   ) as unknown as Schema.Schema<GetDocumentProjectsLocationsProcessorsDatasetRequest>;
 
@@ -7785,7 +7785,7 @@ export const ListDocumentsProjectsLocationsProcessorsDatasetRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta3/{dataset}:listDocuments",
+      path: "v1beta3/{+dataset}:listDocuments",
       hasBody: true,
     }),
     svc,
@@ -7827,7 +7827,7 @@ export const BatchDeleteDocumentsProjectsLocationsProcessorsDatasetRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta3/{dataset}:batchDeleteDocuments",
+      path: "v1beta3/{+dataset}:batchDeleteDocuments",
       hasBody: true,
     }),
     svc,
@@ -7867,7 +7867,7 @@ export const GetDatasetSchemaProjectsLocationsProcessorsDatasetRequest =
       T.HttpQuery("visibleFieldsOnly"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{name}" }),
+    T.Http({ method: "GET", path: "v1beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDatasetSchemaProjectsLocationsProcessorsDatasetRequest>;
 
@@ -7908,7 +7908,7 @@ export const UpdateDatasetSchemaProjectsLocationsProcessorsDatasetRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateDatasetSchemaProjectsLocationsProcessorsDatasetRequest>;
 
@@ -7947,7 +7947,7 @@ export const ListProjectsLocationsProcessorTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{parent}/processorTypes" }),
+    T.Http({ method: "GET", path: "v1beta3/{+parent}/processorTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProcessorTypesRequest>;
 
@@ -7983,7 +7983,7 @@ export const GetProjectsLocationsProcessorTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{name}" }),
+    T.Http({ method: "GET", path: "v1beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProcessorTypesRequest>;
 
@@ -8020,7 +8020,11 @@ export const CreateProjectsLocationsSchemasRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta3/{parent}/schemas", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta3/{+parent}/schemas",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSchemasRequest>;
 
@@ -8060,7 +8064,7 @@ export const PatchProjectsLocationsSchemasRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSchemasRequest>;
 
@@ -8095,7 +8099,7 @@ export const DeleteProjectsLocationsSchemasRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta3/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSchemasRequest>;
 
@@ -8132,7 +8136,7 @@ export const ListProjectsLocationsSchemasRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{parent}/schemas" }),
+    T.Http({ method: "GET", path: "v1beta3/{+parent}/schemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchemasRequest>;
 
@@ -8168,7 +8172,7 @@ export const GetProjectsLocationsSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{name}" }),
+    T.Http({ method: "GET", path: "v1beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchemasRequest>;
 
@@ -8207,7 +8211,7 @@ export const CreateProjectsLocationsSchemasSchemaVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta3/{parent}/schemaVersions",
+      path: "v1beta3/{+parent}/schemaVersions",
       hasBody: true,
     }),
     svc,
@@ -8249,7 +8253,7 @@ export const PatchProjectsLocationsSchemasSchemaVersionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSchemasSchemaVersionsRequest>;
 
@@ -8288,7 +8292,7 @@ export const GenerateProjectsLocationsSchemasSchemaVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta3/{parent}/schemaVersions:generate",
+      path: "v1beta3/{+parent}/schemaVersions:generate",
       hasBody: true,
     }),
     svc,
@@ -8322,7 +8326,7 @@ export const DeleteProjectsLocationsSchemasSchemaVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta3/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSchemasSchemaVersionsRequest>;
 
@@ -8360,7 +8364,7 @@ export const ListProjectsLocationsSchemasSchemaVersionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{parent}/schemaVersions" }),
+    T.Http({ method: "GET", path: "v1beta3/{+parent}/schemaVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchemasSchemaVersionsRequest>;
 
@@ -8396,7 +8400,7 @@ export const GetProjectsLocationsSchemasSchemaVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta3/{name}" }),
+    T.Http({ method: "GET", path: "v1beta3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchemasSchemaVersionsRequest>;
 

--- a/packages/gcp/src/services/domains-v1.ts
+++ b/packages/gcp/src/services/domains-v1.ts
@@ -1141,7 +1141,7 @@ export const ListProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1176,7 +1176,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1221,7 +1221,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1256,7 +1256,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1287,7 +1287,7 @@ export const GetProjectsLocationsRegistrationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRegistrationsRequest>;
 
@@ -1323,7 +1323,7 @@ export const GetIamPolicyProjectsLocationsRegistrationsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsRegistrationsRequest>;
 
@@ -1354,7 +1354,7 @@ export const DeleteProjectsLocationsRegistrationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRegistrationsRequest>;
 
@@ -1387,7 +1387,7 @@ export const RetrieveAuthorizationCodeProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{registration}:retrieveAuthorizationCode",
+      path: "v1/{+registration}:retrieveAuthorizationCode",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveAuthorizationCodeProjectsLocationsRegistrationsRequest>;
@@ -1426,7 +1426,7 @@ export const ResetAuthorizationCodeProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{registration}:resetAuthorizationCode",
+      path: "v1/{+registration}:resetAuthorizationCode",
       hasBody: true,
     }),
     svc,
@@ -1466,7 +1466,7 @@ export const ConfigureContactSettingsProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{registration}:configureContactSettings",
+      path: "v1/{+registration}:configureContactSettings",
       hasBody: true,
     }),
     svc,
@@ -1508,7 +1508,7 @@ export const ConfigureManagementSettingsProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{registration}:configureManagementSettings",
+      path: "v1/{+registration}:configureManagementSettings",
       hasBody: true,
     }),
     svc,
@@ -1548,7 +1548,7 @@ export const ConfigureDnsSettingsProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{registration}:configureDnsSettings",
+      path: "v1/{+registration}:configureDnsSettings",
       hasBody: true,
     }),
     svc,
@@ -1588,7 +1588,7 @@ export const RetrieveRegisterParametersProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{location}/registrations:retrieveRegisterParameters",
+      path: "v1/{+location}/registrations:retrieveRegisterParameters",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveRegisterParametersProjectsLocationsRegistrationsRequest>;
@@ -1627,7 +1627,7 @@ export const InitiatePushTransferProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{registration}:initiatePushTransfer",
+      path: "v1/{+registration}:initiatePushTransfer",
       hasBody: true,
     }),
     svc,
@@ -1665,7 +1665,7 @@ export const ExportProjectsLocationsRegistrationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportRegistrationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsRegistrationsRequest>;
 
@@ -1705,7 +1705,7 @@ export const ListProjectsLocationsRegistrationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/registrations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/registrations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRegistrationsRequest>;
 
@@ -1746,7 +1746,7 @@ export const RegisterProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/registrations:register",
+      path: "v1/{+parent}/registrations:register",
       hasBody: true,
     }),
     svc,
@@ -1784,7 +1784,7 @@ export const RenewDomainProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{registration}:renewDomain",
+      path: "v1/{+registration}:renewDomain",
       hasBody: true,
     }),
     svc,
@@ -1822,7 +1822,7 @@ export const SetIamPolicyProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1860,7 +1860,7 @@ export const SearchDomainsProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{location}/registrations:searchDomains",
+      path: "v1/{+location}/registrations:searchDomains",
     }),
     svc,
   ) as unknown as Schema.Schema<SearchDomainsProjectsLocationsRegistrationsRequest>;
@@ -1898,7 +1898,7 @@ export const RetrieveTransferParametersProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{location}/registrations:retrieveTransferParameters",
+      path: "v1/{+location}/registrations:retrieveTransferParameters",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveTransferParametersProjectsLocationsRegistrationsRequest>;
@@ -1940,7 +1940,7 @@ export const RetrieveImportableDomainsProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{location}/registrations:retrieveImportableDomains",
+      path: "v1/{+location}/registrations:retrieveImportableDomains",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveImportableDomainsProjectsLocationsRegistrationsRequest>;
@@ -1984,7 +1984,7 @@ export const PatchProjectsLocationsRegistrationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Registration).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRegistrationsRequest>;
 
@@ -2020,7 +2020,7 @@ export const TransferProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/registrations:transfer",
+      path: "v1/{+parent}/registrations:transfer",
       hasBody: true,
     }),
     svc,
@@ -2058,7 +2058,7 @@ export const TestIamPermissionsProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2098,7 +2098,7 @@ export const ImportProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/registrations:import",
+      path: "v1/{+parent}/registrations:import",
       hasBody: true,
     }),
     svc,
@@ -2139,7 +2139,7 @@ export const RetrieveGoogleDomainsDnsRecordsProjectsLocationsRegistrationsReques
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{registration}:retrieveGoogleDomainsDnsRecords",
+      path: "v1/{+registration}:retrieveGoogleDomainsDnsRecords",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveGoogleDomainsDnsRecordsProjectsLocationsRegistrationsRequest>;
@@ -2179,7 +2179,7 @@ export const RetrieveGoogleDomainsForwardingConfigProjectsLocationsRegistrations
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{registration}:retrieveGoogleDomainsForwardingConfig",
+      path: "v1/{+registration}:retrieveGoogleDomainsForwardingConfig",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveGoogleDomainsForwardingConfigProjectsLocationsRegistrationsRequest>;

--- a/packages/gcp/src/services/domains-v1alpha2.ts
+++ b/packages/gcp/src/services/domains-v1alpha2.ts
@@ -1148,7 +1148,7 @@ export const ListProjectsLocationsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha2/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1alpha2/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1183,7 +1183,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha2/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1222,7 +1222,7 @@ export const RetrieveGoogleDomainsDnsRecordsProjectsLocationsRegistrationsReques
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha2/{registration}:retrieveGoogleDomainsDnsRecords",
+      path: "v1alpha2/{+registration}:retrieveGoogleDomainsDnsRecords",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveGoogleDomainsDnsRecordsProjectsLocationsRegistrationsRequest>;
@@ -1262,7 +1262,7 @@ export const RetrieveGoogleDomainsForwardingConfigProjectsLocationsRegistrations
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha2/{registration}:retrieveGoogleDomainsForwardingConfig",
+      path: "v1alpha2/{+registration}:retrieveGoogleDomainsForwardingConfig",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveGoogleDomainsForwardingConfigProjectsLocationsRegistrationsRequest>;
@@ -1303,7 +1303,7 @@ export const SearchDomainsProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha2/{location}/registrations:searchDomains",
+      path: "v1alpha2/{+location}/registrations:searchDomains",
     }),
     svc,
   ) as unknown as Schema.Schema<SearchDomainsProjectsLocationsRegistrationsRequest>;
@@ -1341,7 +1341,7 @@ export const RetrieveTransferParametersProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha2/{location}/registrations:retrieveTransferParameters",
+      path: "v1alpha2/{+location}/registrations:retrieveTransferParameters",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveTransferParametersProjectsLocationsRegistrationsRequest>;
@@ -1383,7 +1383,7 @@ export const RetrieveImportableDomainsProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha2/{location}/registrations:retrieveImportableDomains",
+      path: "v1alpha2/{+location}/registrations:retrieveImportableDomains",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveImportableDomainsProjectsLocationsRegistrationsRequest>;
@@ -1427,7 +1427,7 @@ export const PatchProjectsLocationsRegistrationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Registration).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRegistrationsRequest>;
 
@@ -1463,7 +1463,7 @@ export const SetIamPolicyProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha2/{resource}:setIamPolicy",
+      path: "v1alpha2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1501,7 +1501,7 @@ export const RegisterProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha2/{parent}/registrations:register",
+      path: "v1alpha2/{+parent}/registrations:register",
       hasBody: true,
     }),
     svc,
@@ -1539,7 +1539,7 @@ export const RenewDomainProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha2/{registration}:renewDomain",
+      path: "v1alpha2/{+registration}:renewDomain",
       hasBody: true,
     }),
     svc,
@@ -1581,7 +1581,7 @@ export const ListProjectsLocationsRegistrationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha2/{parent}/registrations" }),
+    T.Http({ method: "GET", path: "v1alpha2/{+parent}/registrations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRegistrationsRequest>;
 
@@ -1622,7 +1622,7 @@ export const ImportProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha2/{parent}/registrations:import",
+      path: "v1alpha2/{+parent}/registrations:import",
       hasBody: true,
     }),
     svc,
@@ -1660,7 +1660,7 @@ export const TestIamPermissionsProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha2/{resource}:testIamPermissions",
+      path: "v1alpha2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1700,7 +1700,7 @@ export const TransferProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha2/{parent}/registrations:transfer",
+      path: "v1alpha2/{+parent}/registrations:transfer",
       hasBody: true,
     }),
     svc,
@@ -1738,7 +1738,7 @@ export const ConfigureDnsSettingsProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha2/{registration}:configureDnsSettings",
+      path: "v1alpha2/{+registration}:configureDnsSettings",
       hasBody: true,
     }),
     svc,
@@ -1780,7 +1780,7 @@ export const ConfigureManagementSettingsProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha2/{registration}:configureManagementSettings",
+      path: "v1alpha2/{+registration}:configureManagementSettings",
       hasBody: true,
     }),
     svc,
@@ -1818,7 +1818,7 @@ export const ExportProjectsLocationsRegistrationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportRegistrationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha2/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha2/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsRegistrationsRequest>;
 
@@ -1854,7 +1854,7 @@ export const RetrieveRegisterParametersProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha2/{location}/registrations:retrieveRegisterParameters",
+      path: "v1alpha2/{+location}/registrations:retrieveRegisterParameters",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveRegisterParametersProjectsLocationsRegistrationsRequest>;
@@ -1893,7 +1893,7 @@ export const InitiatePushTransferProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha2/{registration}:initiatePushTransfer",
+      path: "v1alpha2/{+registration}:initiatePushTransfer",
       hasBody: true,
     }),
     svc,
@@ -1933,7 +1933,7 @@ export const GetIamPolicyProjectsLocationsRegistrationsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha2/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha2/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsRegistrationsRequest>;
 
@@ -1964,7 +1964,7 @@ export const GetProjectsLocationsRegistrationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha2/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRegistrationsRequest>;
 
@@ -2000,7 +2000,7 @@ export const ConfigureContactSettingsProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha2/{registration}:configureContactSettings",
+      path: "v1alpha2/{+registration}:configureContactSettings",
       hasBody: true,
     }),
     svc,
@@ -2040,7 +2040,7 @@ export const ResetAuthorizationCodeProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha2/{registration}:resetAuthorizationCode",
+      path: "v1alpha2/{+registration}:resetAuthorizationCode",
       hasBody: true,
     }),
     svc,
@@ -2077,7 +2077,7 @@ export const RetrieveAuthorizationCodeProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha2/{registration}:retrieveAuthorizationCode",
+      path: "v1alpha2/{+registration}:retrieveAuthorizationCode",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveAuthorizationCodeProjectsLocationsRegistrationsRequest>;
@@ -2111,7 +2111,7 @@ export const DeleteProjectsLocationsRegistrationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha2/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRegistrationsRequest>;
 
@@ -2156,7 +2156,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2191,7 +2191,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha2/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/domains-v1beta1.ts
+++ b/packages/gcp/src/services/domains-v1beta1.ts
@@ -1141,7 +1141,7 @@ export const ListProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1176,7 +1176,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1221,7 +1221,7 @@ export const ListProjectsLocationsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1256,7 +1256,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1292,7 +1292,7 @@ export const TestIamPermissionsProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1332,7 +1332,7 @@ export const TransferProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/registrations:transfer",
+      path: "v1beta1/{+parent}/registrations:transfer",
       hasBody: true,
     }),
     svc,
@@ -1370,7 +1370,7 @@ export const ConfigureDnsSettingsProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{registration}:configureDnsSettings",
+      path: "v1beta1/{+registration}:configureDnsSettings",
       hasBody: true,
     }),
     svc,
@@ -1410,7 +1410,7 @@ export const ConfigureContactSettingsProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{registration}:configureContactSettings",
+      path: "v1beta1/{+registration}:configureContactSettings",
       hasBody: true,
     }),
     svc,
@@ -1454,7 +1454,7 @@ export const ListProjectsLocationsRegistrationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/registrations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/registrations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRegistrationsRequest>;
 
@@ -1495,7 +1495,7 @@ export const InitiatePushTransferProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{registration}:initiatePushTransfer",
+      path: "v1beta1/{+registration}:initiatePushTransfer",
       hasBody: true,
     }),
     svc,
@@ -1535,7 +1535,7 @@ export const ResetAuthorizationCodeProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{registration}:resetAuthorizationCode",
+      path: "v1beta1/{+registration}:resetAuthorizationCode",
       hasBody: true,
     }),
     svc,
@@ -1578,7 +1578,7 @@ export const RetrieveImportableDomainsProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{location}/registrations:retrieveImportableDomains",
+      path: "v1beta1/{+location}/registrations:retrieveImportableDomains",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveImportableDomainsProjectsLocationsRegistrationsRequest>;
@@ -1619,7 +1619,7 @@ export const ExportProjectsLocationsRegistrationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportRegistrationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsRegistrationsRequest>;
 
@@ -1655,7 +1655,7 @@ export const RetrieveTransferParametersProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{location}/registrations:retrieveTransferParameters",
+      path: "v1beta1/{+location}/registrations:retrieveTransferParameters",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveTransferParametersProjectsLocationsRegistrationsRequest>;
@@ -1694,7 +1694,7 @@ export const RetrieveRegisterParametersProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{location}/registrations:retrieveRegisterParameters",
+      path: "v1beta1/{+location}/registrations:retrieveRegisterParameters",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveRegisterParametersProjectsLocationsRegistrationsRequest>;
@@ -1733,7 +1733,7 @@ export const RegisterProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/registrations:register",
+      path: "v1beta1/{+parent}/registrations:register",
       hasBody: true,
     }),
     svc,
@@ -1768,7 +1768,7 @@ export const RetrieveGoogleDomainsForwardingConfigProjectsLocationsRegistrations
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{registration}:retrieveGoogleDomainsForwardingConfig",
+      path: "v1beta1/{+registration}:retrieveGoogleDomainsForwardingConfig",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveGoogleDomainsForwardingConfigProjectsLocationsRegistrationsRequest>;
@@ -1809,7 +1809,7 @@ export const RenewDomainProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{registration}:renewDomain",
+      path: "v1beta1/{+registration}:renewDomain",
       hasBody: true,
     }),
     svc,
@@ -1847,7 +1847,7 @@ export const SetIamPolicyProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1887,7 +1887,7 @@ export const ConfigureManagementSettingsProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{registration}:configureManagementSettings",
+      path: "v1beta1/{+registration}:configureManagementSettings",
       hasBody: true,
     }),
     svc,
@@ -1924,7 +1924,7 @@ export const RetrieveAuthorizationCodeProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{registration}:retrieveAuthorizationCode",
+      path: "v1beta1/{+registration}:retrieveAuthorizationCode",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveAuthorizationCodeProjectsLocationsRegistrationsRequest>;
@@ -1964,7 +1964,7 @@ export const PatchProjectsLocationsRegistrationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Registration).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRegistrationsRequest>;
 
@@ -2000,7 +2000,7 @@ export const ImportProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/registrations:import",
+      path: "v1beta1/{+parent}/registrations:import",
       hasBody: true,
     }),
     svc,
@@ -2033,7 +2033,7 @@ export const DeleteProjectsLocationsRegistrationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRegistrationsRequest>;
 
@@ -2072,7 +2072,7 @@ export const RetrieveGoogleDomainsDnsRecordsProjectsLocationsRegistrationsReques
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{registration}:retrieveGoogleDomainsDnsRecords",
+      path: "v1beta1/{+registration}:retrieveGoogleDomainsDnsRecords",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveGoogleDomainsDnsRecordsProjectsLocationsRegistrationsRequest>;
@@ -2115,7 +2115,7 @@ export const GetIamPolicyProjectsLocationsRegistrationsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsRegistrationsRequest>;
 
@@ -2151,7 +2151,7 @@ export const SearchDomainsProjectsLocationsRegistrationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{location}/registrations:searchDomains",
+      path: "v1beta1/{+location}/registrations:searchDomains",
     }),
     svc,
   ) as unknown as Schema.Schema<SearchDomainsProjectsLocationsRegistrationsRequest>;
@@ -2184,7 +2184,7 @@ export const GetProjectsLocationsRegistrationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRegistrationsRequest>;
 

--- a/packages/gcp/src/services/drivelabels-v2.ts
+++ b/packages/gcp/src/services/drivelabels-v2.ts
@@ -1755,7 +1755,7 @@ export const GetCapabilitiesUsersRequest =
     customer: Schema.optional(Schema.String).pipe(T.HttpQuery("customer")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCapabilitiesUsersRequest>;
 
@@ -1866,7 +1866,7 @@ export const GetLabelsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("languageCode"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{name}" }),
+  T.Http({ method: "GET", path: "v2/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetLabelsRequest>;
 
@@ -1944,7 +1944,7 @@ export const UpdateLabelEnabledAppSettingsLabelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:updateLabelEnabledAppSettings",
+      path: "v2/{+name}:updateLabelEnabledAppSettings",
       hasBody: true,
     }),
     svc,
@@ -1988,7 +1988,11 @@ export const UpdatePermissionsLabelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{parent}/permissions", hasBody: true }),
+    T.Http({
+      method: "PATCH",
+      path: "v2/{+parent}/permissions",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<UpdatePermissionsLabelsRequest>;
 
@@ -2024,7 +2028,7 @@ export const PublishLabelsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpBody(),
   ),
 }).pipe(
-  T.Http({ method: "POST", path: "v2/{name}:publish", hasBody: true }),
+  T.Http({ method: "POST", path: "v2/{+name}:publish", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PublishLabelsRequest>;
 
@@ -2059,7 +2063,7 @@ export const DisableLabelsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpBody(),
   ),
 }).pipe(
-  T.Http({ method: "POST", path: "v2/{name}:disable", hasBody: true }),
+  T.Http({ method: "POST", path: "v2/{+name}:disable", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<DisableLabelsRequest>;
 
@@ -2094,7 +2098,7 @@ export const DeltaLabelsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpBody(),
   ),
 }).pipe(
-  T.Http({ method: "POST", path: "v2/{name}:delta", hasBody: true }),
+  T.Http({ method: "POST", path: "v2/{+name}:delta", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<DeltaLabelsRequest>;
 
@@ -2133,7 +2137,7 @@ export const UpdateLabelCopyModeLabelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:updateLabelCopyMode",
+      path: "v2/{+name}:updateLabelCopyMode",
       hasBody: true,
     }),
     svc,
@@ -2175,7 +2179,7 @@ export const DeleteLabelsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("useAdminAccess"),
   ),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v2/{name}" }),
+  T.Http({ method: "DELETE", path: "v2/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteLabelsRequest>;
 
@@ -2210,7 +2214,7 @@ export const EnableLabelsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpBody(),
   ),
 }).pipe(
-  T.Http({ method: "POST", path: "v2/{name}:enable", hasBody: true }),
+  T.Http({ method: "POST", path: "v2/{+name}:enable", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<EnableLabelsRequest>;
 
@@ -2251,7 +2255,11 @@ export const UpdatePermissionsLabelsRevisionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{parent}/permissions", hasBody: true }),
+    T.Http({
+      method: "PATCH",
+      path: "v2/{+parent}/permissions",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<UpdatePermissionsLabelsRevisionsRequest>;
 
@@ -2293,7 +2301,7 @@ export const CreateLabelsRevisionsPermissionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/permissions", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/permissions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateLabelsRevisionsPermissionsRequest>;
 
@@ -2330,7 +2338,7 @@ export const DeleteLabelsRevisionsPermissionsRequest =
       T.HttpQuery("useAdminAccess"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteLabelsRevisionsPermissionsRequest>;
 
@@ -2368,7 +2376,7 @@ export const BatchDeleteLabelsRevisionsPermissionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/permissions:batchDelete",
+      path: "v2/{+parent}/permissions:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -2408,7 +2416,7 @@ export const BatchUpdateLabelsRevisionsPermissionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/permissions:batchUpdate",
+      path: "v2/{+parent}/permissions:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -2453,7 +2461,7 @@ export const ListLabelsRevisionsPermissionsRequest =
       T.HttpQuery("useAdminAccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/permissions" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/permissions" }),
     svc,
   ) as unknown as Schema.Schema<ListLabelsRevisionsPermissionsRequest>;
 
@@ -2495,7 +2503,7 @@ export const ListLabelsRevisionsLocksRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/locks" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/locks" }),
     svc,
   ) as unknown as Schema.Schema<ListLabelsRevisionsLocksRequest>;
 
@@ -2542,7 +2550,7 @@ export const ListLabelsPermissionsRequest =
       T.HttpQuery("useAdminAccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/permissions" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/permissions" }),
     svc,
   ) as unknown as Schema.Schema<ListLabelsPermissionsRequest>;
 
@@ -2585,7 +2593,7 @@ export const BatchUpdateLabelsPermissionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/permissions:batchUpdate",
+      path: "v2/{+parent}/permissions:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -2626,7 +2634,7 @@ export const BatchDeleteLabelsPermissionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/permissions:batchDelete",
+      path: "v2/{+parent}/permissions:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -2664,7 +2672,7 @@ export const DeleteLabelsPermissionsRequest =
       T.HttpQuery("useAdminAccess"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteLabelsPermissionsRequest>;
 
@@ -2705,7 +2713,7 @@ export const CreateLabelsPermissionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/permissions", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/permissions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateLabelsPermissionsRequest>;
 
@@ -2744,7 +2752,7 @@ export const ListLabelsLocksRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     parent: Schema.String.pipe(T.HttpPath("parent")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "v2/{parent}/locks" }),
+  T.Http({ method: "GET", path: "v2/{+parent}/locks" }),
   svc,
 ) as unknown as Schema.Schema<ListLabelsLocksRequest>;
 

--- a/packages/gcp/src/services/drivelabels-v2beta.ts
+++ b/packages/gcp/src/services/drivelabels-v2beta.ts
@@ -1792,7 +1792,7 @@ export const GetCapabilitiesUsersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     customer: Schema.optional(Schema.String).pipe(T.HttpQuery("customer")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCapabilitiesUsersRequest>;
 
@@ -1863,7 +1863,7 @@ export const DeleteLabelsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("writeControl.requiredRevisionId"),
   ),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v2beta/{name}" }),
+  T.Http({ method: "DELETE", path: "v2beta/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteLabelsRequest>;
 
@@ -1938,7 +1938,7 @@ export const DeltaLabelsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     GoogleAppsDriveLabelsV2betaDeltaUpdateLabelRequest,
   ).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v2beta/{name}:delta", hasBody: true }),
+  T.Http({ method: "POST", path: "v2beta/{+name}:delta", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<DeltaLabelsRequest>;
 
@@ -1974,7 +1974,7 @@ export const PublishLabelsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpBody(),
   ),
 }).pipe(
-  T.Http({ method: "POST", path: "v2beta/{name}:publish", hasBody: true }),
+  T.Http({ method: "POST", path: "v2beta/{+name}:publish", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PublishLabelsRequest>;
 
@@ -2084,7 +2084,7 @@ export const UpdatePermissionsLabelsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2beta/{parent}/permissions",
+      path: "v2beta/{+parent}/permissions",
       hasBody: true,
     }),
     svc,
@@ -2130,7 +2130,7 @@ export const GetLabelsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("languageCode"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "v2beta/{name}" }),
+  T.Http({ method: "GET", path: "v2beta/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetLabelsRequest>;
 
@@ -2165,7 +2165,7 @@ export const DisableLabelsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpBody(),
   ),
 }).pipe(
-  T.Http({ method: "POST", path: "v2beta/{name}:disable", hasBody: true }),
+  T.Http({ method: "POST", path: "v2beta/{+name}:disable", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<DisableLabelsRequest>;
 
@@ -2200,7 +2200,7 @@ export const EnableLabelsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpBody(),
   ),
 }).pipe(
-  T.Http({ method: "POST", path: "v2beta/{name}:enable", hasBody: true }),
+  T.Http({ method: "POST", path: "v2beta/{+name}:enable", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<EnableLabelsRequest>;
 
@@ -2238,7 +2238,7 @@ export const UpdateLabelCopyModeLabelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{name}:updateLabelCopyMode",
+      path: "v2beta/{+name}:updateLabelCopyMode",
       hasBody: true,
     }),
     svc,
@@ -2279,7 +2279,7 @@ export const UpdateLabelEnabledAppSettingsLabelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{name}:updateLabelEnabledAppSettings",
+      path: "v2beta/{+name}:updateLabelEnabledAppSettings",
       hasBody: true,
     }),
     svc,
@@ -2320,7 +2320,7 @@ export const ListLabelsLocksRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     parent: Schema.String.pipe(T.HttpPath("parent")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "v2beta/{parent}/locks" }),
+  T.Http({ method: "GET", path: "v2beta/{+parent}/locks" }),
   svc,
 ) as unknown as Schema.Schema<ListLabelsLocksRequest>;
 
@@ -2363,7 +2363,7 @@ export const BatchUpdateLabelsPermissionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/permissions:batchUpdate",
+      path: "v2beta/{+parent}/permissions:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -2402,7 +2402,7 @@ export const DeleteLabelsPermissionsRequest =
       T.HttpQuery("useAdminAccess"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteLabelsPermissionsRequest>;
 
@@ -2444,7 +2444,7 @@ export const ListLabelsPermissionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{parent}/permissions" }),
+    T.Http({ method: "GET", path: "v2beta/{+parent}/permissions" }),
     svc,
   ) as unknown as Schema.Schema<ListLabelsPermissionsRequest>;
 
@@ -2487,7 +2487,7 @@ export const BatchDeleteLabelsPermissionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/permissions:batchDelete",
+      path: "v2beta/{+parent}/permissions:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -2532,7 +2532,7 @@ export const CreateLabelsPermissionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/permissions",
+      path: "v2beta/{+parent}/permissions",
       hasBody: true,
     }),
     svc,
@@ -2578,7 +2578,7 @@ export const UpdatePermissionsLabelsRevisionsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2beta/{parent}/permissions",
+      path: "v2beta/{+parent}/permissions",
       hasBody: true,
     }),
     svc,
@@ -2617,7 +2617,7 @@ export const DeleteLabelsRevisionsPermissionsRequest =
       T.HttpQuery("useAdminAccess"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteLabelsRevisionsPermissionsRequest>;
 
@@ -2655,7 +2655,7 @@ export const BatchUpdateLabelsRevisionsPermissionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/permissions:batchUpdate",
+      path: "v2beta/{+parent}/permissions:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -2700,7 +2700,7 @@ export const ListLabelsRevisionsPermissionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{parent}/permissions" }),
+    T.Http({ method: "GET", path: "v2beta/{+parent}/permissions" }),
     svc,
   ) as unknown as Schema.Schema<ListLabelsRevisionsPermissionsRequest>;
 
@@ -2743,7 +2743,7 @@ export const BatchDeleteLabelsRevisionsPermissionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/permissions:batchDelete",
+      path: "v2beta/{+parent}/permissions:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -2788,7 +2788,7 @@ export const CreateLabelsRevisionsPermissionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/permissions",
+      path: "v2beta/{+parent}/permissions",
       hasBody: true,
     }),
     svc,
@@ -2828,7 +2828,7 @@ export const ListLabelsRevisionsLocksRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{parent}/locks" }),
+    T.Http({ method: "GET", path: "v2beta/{+parent}/locks" }),
     svc,
   ) as unknown as Schema.Schema<ListLabelsRevisionsLocksRequest>;
 

--- a/packages/gcp/src/services/essentialcontacts-v1.ts
+++ b/packages/gcp/src/services/essentialcontacts-v1.ts
@@ -147,7 +147,7 @@ export const CreateProjectsContactsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/contacts", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/contacts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsContactsRequest>;
 
@@ -187,7 +187,7 @@ export const PatchProjectsContactsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsContactsRequest>;
 
@@ -225,7 +225,7 @@ export const ListProjectsContactsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/contacts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/contacts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsContactsRequest>;
 
@@ -261,7 +261,7 @@ export const GetProjectsContactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsContactsRequest>;
 
@@ -292,7 +292,7 @@ export const DeleteProjectsContactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsContactsRequest>;
 
@@ -344,7 +344,7 @@ export const ComputeProjectsContactsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/contacts:compute" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/contacts:compute" }),
     svc,
   ) as unknown as Schema.Schema<ComputeProjectsContactsRequest>;
 
@@ -387,7 +387,7 @@ export const SendTestMessageProjectsContactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}/contacts:sendTestMessage",
+      path: "v1/{+resource}/contacts:sendTestMessage",
       hasBody: true,
     }),
     svc,
@@ -425,7 +425,7 @@ export const CreateFoldersContactsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/contacts", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/contacts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateFoldersContactsRequest>;
 
@@ -465,7 +465,7 @@ export const PatchFoldersContactsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersContactsRequest>;
 
@@ -503,7 +503,7 @@ export const ListFoldersContactsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/contacts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/contacts" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersContactsRequest>;
 
@@ -539,7 +539,7 @@ export const GetFoldersContactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersContactsRequest>;
 
@@ -570,7 +570,7 @@ export const DeleteFoldersContactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersContactsRequest>;
 
@@ -622,7 +622,7 @@ export const ComputeFoldersContactsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/contacts:compute" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/contacts:compute" }),
     svc,
   ) as unknown as Schema.Schema<ComputeFoldersContactsRequest>;
 
@@ -665,7 +665,7 @@ export const SendTestMessageFoldersContactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}/contacts:sendTestMessage",
+      path: "v1/{+resource}/contacts:sendTestMessage",
       hasBody: true,
     }),
     svc,
@@ -703,7 +703,7 @@ export const CreateOrganizationsContactsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/contacts", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/contacts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsContactsRequest>;
 
@@ -743,7 +743,7 @@ export const PatchOrganizationsContactsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsContactsRequest>;
 
@@ -781,7 +781,7 @@ export const ListOrganizationsContactsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/contacts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/contacts" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsContactsRequest>;
 
@@ -817,7 +817,7 @@ export const GetOrganizationsContactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsContactsRequest>;
 
@@ -849,7 +849,7 @@ export const DeleteOrganizationsContactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsContactsRequest>;
 
@@ -901,7 +901,7 @@ export const ComputeOrganizationsContactsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/contacts:compute" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/contacts:compute" }),
     svc,
   ) as unknown as Schema.Schema<ComputeOrganizationsContactsRequest>;
 
@@ -944,7 +944,7 @@ export const SendTestMessageOrganizationsContactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}/contacts:sendTestMessage",
+      path: "v1/{+resource}/contacts:sendTestMessage",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/eventarc-v1.ts
+++ b/packages/gcp/src/services/eventarc-v1.ts
@@ -1191,7 +1191,7 @@ export const UpdateGoogleChannelConfigProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleChannelConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateGoogleChannelConfigProjectsLocationsRequest>;
 
@@ -1237,7 +1237,7 @@ export const ListProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1272,7 +1272,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1303,7 +1303,7 @@ export const GetGoogleChannelConfigProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetGoogleChannelConfigProjectsLocationsRequest>;
 
@@ -1335,7 +1335,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1380,7 +1380,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1416,7 +1416,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1452,7 +1452,7 @@ export const CancelProjectsLocationsOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1499,7 +1499,7 @@ export const PatchProjectsLocationsEnrollmentsRequest =
     ),
     body: Schema.optional(Enrollment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEnrollmentsRequest>;
 
@@ -1531,7 +1531,7 @@ export const GetProjectsLocationsEnrollmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEnrollmentsRequest>;
 
@@ -1567,7 +1567,7 @@ export const SetIamPolicyProjectsLocationsEnrollmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1605,7 +1605,7 @@ export const TestIamPermissionsProjectsLocationsEnrollmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1652,7 +1652,7 @@ export const CreateProjectsLocationsEnrollmentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Enrollment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/enrollments", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/enrollments", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsEnrollmentsRequest>;
 
@@ -1697,7 +1697,7 @@ export const DeleteProjectsLocationsEnrollmentsRequest =
       T.HttpQuery("allowMissing"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEnrollmentsRequest>;
 
@@ -1741,7 +1741,7 @@ export const ListProjectsLocationsEnrollmentsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/enrollments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/enrollments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEnrollmentsRequest>;
 
@@ -1781,7 +1781,7 @@ export const GetIamPolicyProjectsLocationsEnrollmentsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsEnrollmentsRequest>;
 
@@ -1812,7 +1812,7 @@ export const GetProjectsLocationsTriggersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTriggersRequest>;
 
@@ -1859,7 +1859,7 @@ export const PatchProjectsLocationsTriggersRequest =
     ),
     body: Schema.optional(Trigger).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTriggersRequest>;
 
@@ -1895,7 +1895,7 @@ export const SetIamPolicyProjectsLocationsTriggersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1939,7 +1939,7 @@ export const CreateProjectsLocationsTriggersRequest =
     triggerId: Schema.optional(Schema.String).pipe(T.HttpQuery("triggerId")),
     body: Schema.optional(Trigger).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/triggers", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/triggers", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTriggersRequest>;
 
@@ -1976,7 +1976,7 @@ export const TestIamPermissionsProjectsLocationsTriggersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2022,7 +2022,7 @@ export const ListProjectsLocationsTriggersRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/triggers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/triggers" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTriggersRequest>;
 
@@ -2062,7 +2062,7 @@ export const GetIamPolicyProjectsLocationsTriggersRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsTriggersRequest>;
 
@@ -2106,7 +2106,7 @@ export const DeleteProjectsLocationsTriggersRequest =
       T.HttpQuery("allowMissing"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTriggersRequest>;
 
@@ -2138,7 +2138,7 @@ export const GetProjectsLocationsChannelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsChannelsRequest>;
 
@@ -2180,7 +2180,7 @@ export const PatchProjectsLocationsChannelsRequest =
     ),
     body: Schema.optional(Channel).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsChannelsRequest>;
 
@@ -2216,7 +2216,7 @@ export const SetIamPolicyProjectsLocationsChannelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2260,7 +2260,7 @@ export const CreateProjectsLocationsChannelsRequest =
     channelId: Schema.optional(Schema.String).pipe(T.HttpQuery("channelId")),
     body: Schema.optional(Channel).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/channels", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/channels", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsChannelsRequest>;
 
@@ -2297,7 +2297,7 @@ export const TestIamPermissionsProjectsLocationsChannelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2340,7 +2340,7 @@ export const ListProjectsLocationsChannelsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/channels" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/channels" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsChannelsRequest>;
 
@@ -2380,7 +2380,7 @@ export const GetIamPolicyProjectsLocationsChannelsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsChannelsRequest>;
 
@@ -2416,7 +2416,7 @@ export const DeleteProjectsLocationsChannelsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsChannelsRequest>;
 
@@ -2448,7 +2448,7 @@ export const GetProjectsLocationsGoogleApiSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGoogleApiSourcesRequest>;
 
@@ -2495,7 +2495,7 @@ export const PatchProjectsLocationsGoogleApiSourcesRequest =
     ),
     body: Schema.optional(GoogleApiSource).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGoogleApiSourcesRequest>;
 
@@ -2532,7 +2532,7 @@ export const SetIamPolicyProjectsLocationsGoogleApiSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2580,7 +2580,7 @@ export const CreateProjectsLocationsGoogleApiSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/googleApiSources",
+      path: "v1/{+parent}/googleApiSources",
       hasBody: true,
     }),
     svc,
@@ -2619,7 +2619,7 @@ export const TestIamPermissionsProjectsLocationsGoogleApiSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2666,7 +2666,7 @@ export const ListProjectsLocationsGoogleApiSourcesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/googleApiSources" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/googleApiSources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGoogleApiSourcesRequest>;
 
@@ -2707,7 +2707,7 @@ export const GetIamPolicyProjectsLocationsGoogleApiSourcesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGoogleApiSourcesRequest>;
 
@@ -2751,7 +2751,7 @@ export const DeleteProjectsLocationsGoogleApiSourcesRequest =
       T.HttpQuery("allowMissing"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGoogleApiSourcesRequest>;
 
@@ -2793,7 +2793,7 @@ export const CreateProjectsLocationsChannelConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/channelConnections",
+      path: "v1/{+parent}/channelConnections",
       hasBody: true,
     }),
     svc,
@@ -2832,7 +2832,7 @@ export const TestIamPermissionsProjectsLocationsChannelConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2873,7 +2873,7 @@ export const ListProjectsLocationsChannelConnectionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/channelConnections" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/channelConnections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsChannelConnectionsRequest>;
 
@@ -2914,7 +2914,7 @@ export const GetIamPolicyProjectsLocationsChannelConnectionsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsChannelConnectionsRequest>;
 
@@ -2946,7 +2946,7 @@ export const DeleteProjectsLocationsChannelConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsChannelConnectionsRequest>;
 
@@ -2978,7 +2978,7 @@ export const GetProjectsLocationsChannelConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsChannelConnectionsRequest>;
 
@@ -3014,7 +3014,7 @@ export const SetIamPolicyProjectsLocationsChannelConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3054,7 +3054,7 @@ export const ListEnrollmentsProjectsLocationsMessageBusesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}:listEnrollments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}:listEnrollments" }),
     svc,
   ) as unknown as Schema.Schema<ListEnrollmentsProjectsLocationsMessageBusesRequest>;
 
@@ -3103,7 +3103,11 @@ export const CreateProjectsLocationsMessageBusesRequest =
     ),
     body: Schema.optional(MessageBus).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/messageBuses", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/messageBuses",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsMessageBusesRequest>;
 
@@ -3148,7 +3152,7 @@ export const DeleteProjectsLocationsMessageBusesRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMessageBusesRequest>;
 
@@ -3192,7 +3196,7 @@ export const ListProjectsLocationsMessageBusesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/messageBuses" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/messageBuses" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMessageBusesRequest>;
 
@@ -3233,7 +3237,7 @@ export const GetIamPolicyProjectsLocationsMessageBusesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsMessageBusesRequest>;
 
@@ -3280,7 +3284,7 @@ export const PatchProjectsLocationsMessageBusesRequest =
     ),
     body: Schema.optional(MessageBus).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMessageBusesRequest>;
 
@@ -3317,7 +3321,7 @@ export const SetIamPolicyProjectsLocationsMessageBusesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3355,7 +3359,7 @@ export const TestIamPermissionsProjectsLocationsMessageBusesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3390,7 +3394,7 @@ export const GetProjectsLocationsMessageBusesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMessageBusesRequest>;
 
@@ -3421,7 +3425,7 @@ export const GetProjectsLocationsProvidersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProvidersRequest>;
 
@@ -3464,7 +3468,7 @@ export const ListProjectsLocationsProvidersRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/providers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/providers" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProvidersRequest>;
 
@@ -3504,7 +3508,7 @@ export const SetIamPolicyProjectsLocationsPipelinesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3553,7 +3557,7 @@ export const PatchProjectsLocationsPipelinesRequest =
     ),
     body: Schema.optional(Pipeline).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPipelinesRequest>;
 
@@ -3585,7 +3589,7 @@ export const GetProjectsLocationsPipelinesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPipelinesRequest>;
 
@@ -3629,7 +3633,7 @@ export const DeleteProjectsLocationsPipelinesRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPipelinesRequest>;
 
@@ -3673,7 +3677,7 @@ export const ListProjectsLocationsPipelinesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/pipelines" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/pipelines" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPipelinesRequest>;
 
@@ -3713,7 +3717,7 @@ export const GetIamPolicyProjectsLocationsPipelinesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsPipelinesRequest>;
 
@@ -3749,7 +3753,7 @@ export const TestIamPermissionsProjectsLocationsPipelinesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3794,7 +3798,7 @@ export const CreateProjectsLocationsPipelinesRequest =
     ),
     body: Schema.optional(Pipeline).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/pipelines", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/pipelines", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsPipelinesRequest>;
 

--- a/packages/gcp/src/services/factchecktools-v1alpha1.ts
+++ b/packages/gcp/src/services/factchecktools-v1alpha1.ts
@@ -389,7 +389,7 @@ export interface DeletePagesRequest {
 export const DeletePagesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+  T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeletePagesRequest>;
 
@@ -424,7 +424,7 @@ export const UpdatePagesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     GoogleFactcheckingFactchecktoolsV1alpha1ClaimReviewMarkupPage,
   ).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PUT", path: "v1alpha1/{name}", hasBody: true }),
+  T.Http({ method: "PUT", path: "v1alpha1/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<UpdatePagesRequest>;
 
@@ -455,7 +455,7 @@ export interface GetPagesRequest {
 export const GetPagesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+  T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetPagesRequest>;
 

--- a/packages/gcp/src/services/fcm-v1.ts
+++ b/packages/gcp/src/services/fcm-v1.ts
@@ -351,7 +351,7 @@ export const SendProjectsMessagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/messages:send",
+      path: "v1/{+parent}/messages:send",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/fcmdata-v1beta1.ts
+++ b/packages/gcp/src/services/fcmdata-v1beta1.ts
@@ -220,7 +220,7 @@ export const ListProjectsAndroidAppsDeliveryDataRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/deliveryData" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/deliveryData" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAndroidAppsDeliveryDataRequest>;
 

--- a/packages/gcp/src/services/file-v1.ts
+++ b/packages/gcp/src/services/file-v1.ts
@@ -1118,7 +1118,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1153,7 +1153,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1198,7 +1198,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1233,7 +1233,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1264,7 +1264,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1298,7 +1298,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1341,7 +1341,7 @@ export const ListProjectsLocationsInstancesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesRequest>;
 
@@ -1376,7 +1376,7 @@ export const GetProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesRequest>;
 
@@ -1413,7 +1413,7 @@ export const CreateProjectsLocationsInstancesRequest =
     instanceId: Schema.optional(Schema.String).pipe(T.HttpQuery("instanceId")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/instances", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/instances", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsInstancesRequest>;
 
@@ -1450,7 +1450,7 @@ export const PatchProjectsLocationsInstancesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInstancesRequest>;
 
@@ -1484,7 +1484,7 @@ export const RestoreProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestoreInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsInstancesRequest>;
 
@@ -1518,7 +1518,7 @@ export const RevertProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RevertInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:revert", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:revert", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RevertProjectsLocationsInstancesRequest>;
 
@@ -1552,7 +1552,7 @@ export const DeleteProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesRequest>;
 
@@ -1586,7 +1586,11 @@ export const PromoteReplicaProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PromoteReplicaRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:promoteReplica", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+name}:promoteReplica",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<PromoteReplicaProjectsLocationsInstancesRequest>;
 
@@ -1620,7 +1624,7 @@ export const PauseReplicaProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PauseReplicaRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:pauseReplica", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:pauseReplica", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseReplicaProjectsLocationsInstancesRequest>;
 
@@ -1654,7 +1658,7 @@ export const ResumeReplicaProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResumeReplicaRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:resumeReplica", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:resumeReplica", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeReplicaProjectsLocationsInstancesRequest>;
 
@@ -1702,7 +1706,7 @@ export const ListProjectsLocationsInstancesSnapshotsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/snapshots" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/snapshots" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesSnapshotsRequest>;
 
@@ -1738,7 +1742,7 @@ export const GetProjectsLocationsInstancesSnapshotsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesSnapshotsRequest>;
 
@@ -1775,7 +1779,7 @@ export const CreateProjectsLocationsInstancesSnapshotsRequest =
     snapshotId: Schema.optional(Schema.String).pipe(T.HttpQuery("snapshotId")),
     body: Schema.optional(Snapshot).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/snapshots", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/snapshots", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsInstancesSnapshotsRequest>;
 
@@ -1806,7 +1810,7 @@ export const DeleteProjectsLocationsInstancesSnapshotsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesSnapshotsRequest>;
 
@@ -1843,7 +1847,7 @@ export const PatchProjectsLocationsInstancesSnapshotsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Snapshot).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInstancesSnapshotsRequest>;
 
@@ -1886,7 +1890,7 @@ export const ListProjectsLocationsBackupsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupsRequest>;
 
@@ -1921,7 +1925,7 @@ export const GetProjectsLocationsBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupsRequest>;
 
@@ -1958,7 +1962,7 @@ export const CreateProjectsLocationsBackupsRequest =
     backupId: Schema.optional(Schema.String).pipe(T.HttpQuery("backupId")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/backups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/backups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackupsRequest>;
 
@@ -1989,7 +1993,7 @@ export const DeleteProjectsLocationsBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupsRequest>;
 
@@ -2026,7 +2030,7 @@ export const PatchProjectsLocationsBackupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupsRequest>;
 

--- a/packages/gcp/src/services/file-v1beta1.ts
+++ b/packages/gcp/src/services/file-v1beta1.ts
@@ -1216,7 +1216,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1251,7 +1251,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1296,7 +1296,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1331,7 +1331,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1362,7 +1362,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1396,7 +1396,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1439,7 +1439,7 @@ export const ListProjectsLocationsInstancesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesRequest>;
 
@@ -1474,7 +1474,7 @@ export const GetProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesRequest>;
 
@@ -1513,7 +1513,7 @@ export const CreateProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/instances",
+      path: "v1beta1/{+parent}/instances",
       hasBody: true,
     }),
     svc,
@@ -1552,7 +1552,7 @@ export const PatchProjectsLocationsInstancesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInstancesRequest>;
 
@@ -1586,7 +1586,7 @@ export const RestoreProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestoreInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsInstancesRequest>;
 
@@ -1620,7 +1620,7 @@ export const RevertProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RevertInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:revert", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:revert", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RevertProjectsLocationsInstancesRequest>;
 
@@ -1656,7 +1656,7 @@ export const PromoteReplicaProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:promoteReplica",
+      path: "v1beta1/{+name}:promoteReplica",
       hasBody: true,
     }),
     svc,
@@ -1694,7 +1694,7 @@ export const PauseReplicaProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:pauseReplica",
+      path: "v1beta1/{+name}:pauseReplica",
       hasBody: true,
     }),
     svc,
@@ -1732,7 +1732,7 @@ export const ResumeReplicaProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:resumeReplica",
+      path: "v1beta1/{+name}:resumeReplica",
       hasBody: true,
     }),
     svc,
@@ -1768,7 +1768,7 @@ export const DeleteProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesRequest>;
 
@@ -1816,7 +1816,7 @@ export const ListProjectsLocationsInstancesSnapshotsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/snapshots" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/snapshots" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesSnapshotsRequest>;
 
@@ -1852,7 +1852,7 @@ export const GetProjectsLocationsInstancesSnapshotsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesSnapshotsRequest>;
 
@@ -1891,7 +1891,7 @@ export const CreateProjectsLocationsInstancesSnapshotsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/snapshots",
+      path: "v1beta1/{+parent}/snapshots",
       hasBody: true,
     }),
     svc,
@@ -1924,7 +1924,7 @@ export const DeleteProjectsLocationsInstancesSnapshotsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesSnapshotsRequest>;
 
@@ -1961,7 +1961,7 @@ export const PatchProjectsLocationsInstancesSnapshotsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Snapshot).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInstancesSnapshotsRequest>;
 
@@ -2004,7 +2004,7 @@ export const ListProjectsLocationsInstancesSharesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/shares" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/shares" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesSharesRequest>;
 
@@ -2039,7 +2039,7 @@ export const GetProjectsLocationsInstancesSharesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesSharesRequest>;
 
@@ -2076,7 +2076,7 @@ export const CreateProjectsLocationsInstancesSharesRequest =
     shareId: Schema.optional(Schema.String).pipe(T.HttpQuery("shareId")),
     body: Schema.optional(Share).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/shares", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+parent}/shares", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsInstancesSharesRequest>;
 
@@ -2107,7 +2107,7 @@ export const DeleteProjectsLocationsInstancesSharesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesSharesRequest>;
 
@@ -2144,7 +2144,7 @@ export const PatchProjectsLocationsInstancesSharesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Share).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInstancesSharesRequest>;
 
@@ -2187,7 +2187,7 @@ export const ListProjectsLocationsBackupsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupsRequest>;
 
@@ -2222,7 +2222,7 @@ export const GetProjectsLocationsBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupsRequest>;
 
@@ -2259,7 +2259,11 @@ export const CreateProjectsLocationsBackupsRequest =
     backupId: Schema.optional(Schema.String).pipe(T.HttpQuery("backupId")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/backups", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/backups",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackupsRequest>;
 
@@ -2290,7 +2294,7 @@ export const DeleteProjectsLocationsBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupsRequest>;
 
@@ -2327,7 +2331,7 @@ export const PatchProjectsLocationsBackupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupsRequest>;
 

--- a/packages/gcp/src/services/firebase-v1beta1.ts
+++ b/packages/gcp/src/services/firebase-v1beta1.ts
@@ -731,7 +731,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta1/{name}" }),
+  T.Http({ method: "GET", path: "v1beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -761,7 +761,7 @@ export const GetAnalyticsDetailsProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAnalyticsDetailsProjectsRequest>;
 
@@ -791,7 +791,7 @@ export interface GetProjectsRequest {
 export const GetProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta1/{name}" }),
+  T.Http({ method: "GET", path: "v1beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetProjectsRequest>;
 
@@ -826,7 +826,7 @@ export const RemoveAnalyticsProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:removeAnalytics",
+      path: "v1beta1/{+parent}:removeAnalytics",
       hasBody: true,
     }),
     svc,
@@ -864,7 +864,7 @@ export const AddGoogleAnalyticsProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:addGoogleAnalytics",
+      path: "v1beta1/{+parent}:addGoogleAnalytics",
       hasBody: true,
     }),
     svc,
@@ -897,7 +897,7 @@ export const GetAdminSdkConfigProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAdminSdkConfigProjectsRequest>;
 
@@ -933,7 +933,7 @@ export const PatchProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(FirebaseProject).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchProjectsRequest>;
 
@@ -978,7 +978,7 @@ export const SearchAppsProjectsRequest =
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}:searchApps" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}:searchApps" }),
     svc,
   ) as unknown as Schema.Schema<SearchAppsProjectsRequest>;
 
@@ -1058,7 +1058,7 @@ export const AddFirebaseProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{project}:addFirebase",
+      path: "v1beta1/{+project}:addFirebase",
       hasBody: true,
     }),
     svc,
@@ -1094,7 +1094,7 @@ export const RemoveProjectsIosAppsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RemoveIosAppRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:remove", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:remove", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RemoveProjectsIosAppsRequest>;
 
@@ -1136,7 +1136,7 @@ export const ListProjectsIosAppsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/iosApps" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/iosApps" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsIosAppsRequest>;
 
@@ -1174,7 +1174,7 @@ export const UndeleteProjectsIosAppsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndeleteIosAppRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsIosAppsRequest>;
 
@@ -1205,7 +1205,7 @@ export const GetConfigProjectsIosAppsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigProjectsIosAppsRequest>;
 
@@ -1242,7 +1242,7 @@ export const PatchProjectsIosAppsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(IosApp).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsIosAppsRequest>;
 
@@ -1272,7 +1272,7 @@ export const GetProjectsIosAppsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsIosAppsRequest>;
 
@@ -1305,7 +1305,11 @@ export const CreateProjectsIosAppsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(IosApp).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/iosApps", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/iosApps",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsIosAppsRequest>;
 
@@ -1336,7 +1340,7 @@ export const GetConfigProjectsWebAppsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigProjectsWebAppsRequest>;
 
@@ -1367,7 +1371,7 @@ export const GetProjectsWebAppsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsWebAppsRequest>;
 
@@ -1400,7 +1404,11 @@ export const CreateProjectsWebAppsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(WebApp).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/webApps", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/webApps",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsWebAppsRequest>;
 
@@ -1437,7 +1445,7 @@ export const PatchProjectsWebAppsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(WebApp).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsWebAppsRequest>;
 
@@ -1478,7 +1486,7 @@ export const ListProjectsWebAppsRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/webApps" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/webApps" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsWebAppsRequest>;
 
@@ -1516,7 +1524,7 @@ export const RemoveProjectsWebAppsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RemoveWebAppRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:remove", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:remove", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RemoveProjectsWebAppsRequest>;
 
@@ -1550,7 +1558,7 @@ export const UndeleteProjectsWebAppsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndeleteWebAppRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsWebAppsRequest>;
 
@@ -1586,7 +1594,7 @@ export const FinalizeProjectsDefaultLocationRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/defaultLocation:finalize",
+      path: "v1beta1/{+parent}/defaultLocation:finalize",
       hasBody: true,
     }),
     svc,
@@ -1622,7 +1630,7 @@ export const UndeleteProjectsAndroidAppsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndeleteAndroidAppRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsAndroidAppsRequest>;
 
@@ -1656,7 +1664,7 @@ export const RemoveProjectsAndroidAppsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RemoveAndroidAppRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:remove", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:remove", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RemoveProjectsAndroidAppsRequest>;
 
@@ -1698,7 +1706,7 @@ export const ListProjectsAndroidAppsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/androidApps" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/androidApps" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAndroidAppsRequest>;
 
@@ -1739,7 +1747,7 @@ export const PatchProjectsAndroidAppsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AndroidApp).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAndroidAppsRequest>;
 
@@ -1770,7 +1778,7 @@ export const GetProjectsAndroidAppsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAndroidAppsRequest>;
 
@@ -1806,7 +1814,7 @@ export const CreateProjectsAndroidAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/androidApps",
+      path: "v1beta1/{+parent}/androidApps",
       hasBody: true,
     }),
     svc,
@@ -1839,7 +1847,7 @@ export const GetConfigProjectsAndroidAppsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigProjectsAndroidAppsRequest>;
 
@@ -1870,7 +1878,7 @@ export const ListProjectsAndroidAppsShaRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/sha" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/sha" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAndroidAppsShaRequest>;
 
@@ -1904,7 +1912,7 @@ export const CreateProjectsAndroidAppsShaRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(ShaCertificate).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/sha", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+parent}/sha", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsAndroidAppsShaRequest>;
 
@@ -1935,7 +1943,7 @@ export const DeleteProjectsAndroidAppsShaRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAndroidAppsShaRequest>;
 
@@ -1972,7 +1980,7 @@ export const ListProjectsAvailableLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/availableLocations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/availableLocations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAvailableLocationsRequest>;
 

--- a/packages/gcp/src/services/firebaseappcheck-v1.ts
+++ b/packages/gcp/src/services/firebaseappcheck-v1.ts
@@ -743,7 +743,7 @@ export const GetProjectsServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsServicesRequest>;
 
@@ -780,7 +780,7 @@ export const ListProjectsServicesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/services" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/services" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsServicesRequest>;
 
@@ -822,7 +822,7 @@ export const PatchProjectsServicesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleFirebaseAppcheckV1Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsServicesRequest>;
 
@@ -860,7 +860,7 @@ export const BatchUpdateProjectsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/services:batchUpdate",
+      path: "v1/{+parent}/services:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -894,7 +894,7 @@ export const GetProjectsServicesResourcePoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsServicesResourcePoliciesRequest>;
 
@@ -935,7 +935,7 @@ export const ListProjectsServicesResourcePoliciesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/resourcePolicies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/resourcePolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsServicesResourcePoliciesRequest>;
 
@@ -978,7 +978,7 @@ export const CreateProjectsServicesResourcePoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/resourcePolicies",
+      path: "v1/{+parent}/resourcePolicies",
       hasBody: true,
     }),
     svc,
@@ -1020,7 +1020,7 @@ export const PatchProjectsServicesResourcePoliciesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsServicesResourcePoliciesRequest>;
 
@@ -1055,7 +1055,7 @@ export const DeleteProjectsServicesResourcePoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsServicesResourcePoliciesRequest>;
 
@@ -1094,7 +1094,7 @@ export const BatchUpdateProjectsServicesResourcePoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/resourcePolicies:batchUpdate",
+      path: "v1/{+parent}/resourcePolicies:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -1135,7 +1135,7 @@ export const ExchangeSafetyNetTokenProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{app}:exchangeSafetyNetToken",
+      path: "v1/{+app}:exchangeSafetyNetToken",
       hasBody: true,
     }),
     svc,
@@ -1176,7 +1176,7 @@ export const GeneratePlayIntegrityChallengeProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{app}:generatePlayIntegrityChallenge",
+      path: "v1/{+app}:generatePlayIntegrityChallenge",
       hasBody: true,
     }),
     svc,
@@ -1217,7 +1217,7 @@ export const ExchangePlayIntegrityTokenProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{app}:exchangePlayIntegrityToken",
+      path: "v1/{+app}:exchangePlayIntegrityToken",
       hasBody: true,
     }),
     svc,
@@ -1258,7 +1258,7 @@ export const ExchangeDeviceCheckTokenProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{app}:exchangeDeviceCheckToken",
+      path: "v1/{+app}:exchangeDeviceCheckToken",
       hasBody: true,
     }),
     svc,
@@ -1299,7 +1299,7 @@ export const ExchangeRecaptchaV3TokenProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{app}:exchangeRecaptchaV3Token",
+      path: "v1/{+app}:exchangeRecaptchaV3Token",
       hasBody: true,
     }),
     svc,
@@ -1340,7 +1340,7 @@ export const ExchangeRecaptchaEnterpriseTokenProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{app}:exchangeRecaptchaEnterpriseToken",
+      path: "v1/{+app}:exchangeRecaptchaEnterpriseToken",
       hasBody: true,
     }),
     svc,
@@ -1381,7 +1381,7 @@ export const ExchangeCustomTokenProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{app}:exchangeCustomToken",
+      path: "v1/{+app}:exchangeCustomToken",
       hasBody: true,
     }),
     svc,
@@ -1422,7 +1422,7 @@ export const ExchangeDebugTokenProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{app}:exchangeDebugToken",
+      path: "v1/{+app}:exchangeDebugToken",
       hasBody: true,
     }),
     svc,
@@ -1463,7 +1463,7 @@ export const GenerateAppAttestChallengeProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{app}:generateAppAttestChallenge",
+      path: "v1/{+app}:generateAppAttestChallenge",
       hasBody: true,
     }),
     svc,
@@ -1504,7 +1504,7 @@ export const ExchangeAppAttestAttestationProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{app}:exchangeAppAttestAttestation",
+      path: "v1/{+app}:exchangeAppAttestAttestation",
       hasBody: true,
     }),
     svc,
@@ -1545,7 +1545,7 @@ export const ExchangeAppAttestAssertionProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{app}:exchangeAppAttestAssertion",
+      path: "v1/{+app}:exchangeAppAttestAssertion",
       hasBody: true,
     }),
     svc,
@@ -1579,7 +1579,7 @@ export const GetProjectsAppsAppAttestConfigRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsAppAttestConfigRequest>;
 
@@ -1618,7 +1618,7 @@ export const BatchGetProjectsAppsAppAttestConfigRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/apps/-/appAttestConfig:batchGet",
+      path: "v1/{+parent}/apps/-/appAttestConfig:batchGet",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetProjectsAppsAppAttestConfigRequest>;
@@ -1659,7 +1659,7 @@ export const PatchProjectsAppsAppAttestConfigRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAppsAppAttestConfigRequest>;
 
@@ -1691,7 +1691,7 @@ export const GetProjectsAppsDeviceCheckConfigRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsDeviceCheckConfigRequest>;
 
@@ -1730,7 +1730,7 @@ export const BatchGetProjectsAppsDeviceCheckConfigRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/apps/-/deviceCheckConfig:batchGet",
+      path: "v1/{+parent}/apps/-/deviceCheckConfig:batchGet",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetProjectsAppsDeviceCheckConfigRequest>;
@@ -1771,7 +1771,7 @@ export const PatchProjectsAppsDeviceCheckConfigRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAppsDeviceCheckConfigRequest>;
 
@@ -1803,7 +1803,7 @@ export const GetProjectsAppsRecaptchaV3ConfigRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsRecaptchaV3ConfigRequest>;
 
@@ -1842,7 +1842,7 @@ export const BatchGetProjectsAppsRecaptchaV3ConfigRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/apps/-/recaptchaV3Config:batchGet",
+      path: "v1/{+parent}/apps/-/recaptchaV3Config:batchGet",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetProjectsAppsRecaptchaV3ConfigRequest>;
@@ -1883,7 +1883,7 @@ export const PatchProjectsAppsRecaptchaV3ConfigRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAppsRecaptchaV3ConfigRequest>;
 
@@ -1915,7 +1915,7 @@ export const GetProjectsAppsRecaptchaEnterpriseConfigRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsRecaptchaEnterpriseConfigRequest>;
 
@@ -1954,7 +1954,7 @@ export const BatchGetProjectsAppsRecaptchaEnterpriseConfigRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/apps/-/recaptchaEnterpriseConfig:batchGet",
+      path: "v1/{+parent}/apps/-/recaptchaEnterpriseConfig:batchGet",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetProjectsAppsRecaptchaEnterpriseConfigRequest>;
@@ -1995,7 +1995,7 @@ export const PatchProjectsAppsRecaptchaEnterpriseConfigRequest =
       GoogleFirebaseAppcheckV1RecaptchaEnterpriseConfig,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAppsRecaptchaEnterpriseConfigRequest>;
 
@@ -2027,7 +2027,7 @@ export const GetProjectsAppsSafetyNetConfigRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsSafetyNetConfigRequest>;
 
@@ -2066,7 +2066,7 @@ export const BatchGetProjectsAppsSafetyNetConfigRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/apps/-/safetyNetConfig:batchGet",
+      path: "v1/{+parent}/apps/-/safetyNetConfig:batchGet",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetProjectsAppsSafetyNetConfigRequest>;
@@ -2107,7 +2107,7 @@ export const PatchProjectsAppsSafetyNetConfigRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAppsSafetyNetConfigRequest>;
 
@@ -2139,7 +2139,7 @@ export const GetProjectsAppsPlayIntegrityConfigRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsPlayIntegrityConfigRequest>;
 
@@ -2178,7 +2178,7 @@ export const BatchGetProjectsAppsPlayIntegrityConfigRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/apps/-/playIntegrityConfig:batchGet",
+      path: "v1/{+parent}/apps/-/playIntegrityConfig:batchGet",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetProjectsAppsPlayIntegrityConfigRequest>;
@@ -2219,7 +2219,7 @@ export const PatchProjectsAppsPlayIntegrityConfigRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAppsPlayIntegrityConfigRequest>;
 
@@ -2251,7 +2251,7 @@ export const GetProjectsAppsDebugTokensRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsDebugTokensRequest>;
 
@@ -2289,7 +2289,7 @@ export const ListProjectsAppsDebugTokensRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/debugTokens" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/debugTokens" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAppsDebugTokensRequest>;
 
@@ -2330,7 +2330,7 @@ export const CreateProjectsAppsDebugTokensRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/debugTokens", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/debugTokens", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsAppsDebugTokensRequest>;
 
@@ -2370,7 +2370,7 @@ export const PatchProjectsAppsDebugTokensRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAppsDebugTokensRequest>;
 
@@ -2402,7 +2402,7 @@ export const DeleteProjectsAppsDebugTokensRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAppsDebugTokensRequest>;
 
@@ -2432,7 +2432,7 @@ export interface GetJwksRequest {
 export const GetJwksRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetJwksRequest>;
 
@@ -2470,7 +2470,7 @@ export const ExchangeDebugTokenOauthClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{app}:exchangeDebugToken",
+      path: "v1/{+app}:exchangeDebugToken",
       hasBody: true,
     }),
     svc,
@@ -2511,7 +2511,7 @@ export const GenerateAppAttestChallengeOauthClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{app}:generateAppAttestChallenge",
+      path: "v1/{+app}:generateAppAttestChallenge",
       hasBody: true,
     }),
     svc,
@@ -2552,7 +2552,7 @@ export const ExchangeAppAttestAttestationOauthClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{app}:exchangeAppAttestAttestation",
+      path: "v1/{+app}:exchangeAppAttestAttestation",
       hasBody: true,
     }),
     svc,
@@ -2593,7 +2593,7 @@ export const ExchangeAppAttestAssertionOauthClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{app}:exchangeAppAttestAssertion",
+      path: "v1/{+app}:exchangeAppAttestAssertion",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/firebaseappcheck-v1beta.ts
+++ b/packages/gcp/src/services/firebaseappcheck-v1beta.ts
@@ -873,7 +873,7 @@ export interface GetJwksRequest {
 export const GetJwksRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta/{name}" }),
+  T.Http({ method: "GET", path: "v1beta/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetJwksRequest>;
 
@@ -911,7 +911,7 @@ export const ExchangeDebugTokenOauthClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{app}:exchangeDebugToken",
+      path: "v1beta/{+app}:exchangeDebugToken",
       hasBody: true,
     }),
     svc,
@@ -952,7 +952,7 @@ export const ExchangeAppAttestAttestationOauthClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{app}:exchangeAppAttestAttestation",
+      path: "v1beta/{+app}:exchangeAppAttestAttestation",
       hasBody: true,
     }),
     svc,
@@ -993,7 +993,7 @@ export const GenerateAppAttestChallengeOauthClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{app}:generateAppAttestChallenge",
+      path: "v1beta/{+app}:generateAppAttestChallenge",
       hasBody: true,
     }),
     svc,
@@ -1034,7 +1034,7 @@ export const ExchangeAppAttestAssertionOauthClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{app}:exchangeAppAttestAssertion",
+      path: "v1beta/{+app}:exchangeAppAttestAssertion",
       hasBody: true,
     }),
     svc,
@@ -1075,7 +1075,7 @@ export const VerifyAppCheckTokenProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{project}:verifyAppCheckToken",
+      path: "v1beta/{+project}:verifyAppCheckToken",
       hasBody: true,
     }),
     svc,
@@ -1116,7 +1116,7 @@ export const BatchUpdateProjectsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/services:batchUpdate",
+      path: "v1beta/{+parent}/services:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -1156,7 +1156,7 @@ export const ListProjectsServicesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/services" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/services" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsServicesRequest>;
 
@@ -1200,7 +1200,7 @@ export const PatchProjectsServicesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsServicesRequest>;
 
@@ -1231,7 +1231,7 @@ export const GetProjectsServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsServicesRequest>;
 
@@ -1265,7 +1265,7 @@ export const DeleteProjectsServicesResourcePoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsServicesResourcePoliciesRequest>;
 
@@ -1304,7 +1304,7 @@ export const BatchUpdateProjectsServicesResourcePoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/resourcePolicies:batchUpdate",
+      path: "v1beta/{+parent}/resourcePolicies:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -1338,7 +1338,7 @@ export const GetProjectsServicesResourcePoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsServicesResourcePoliciesRequest>;
 
@@ -1377,7 +1377,7 @@ export const CreateProjectsServicesResourcePoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/resourcePolicies",
+      path: "v1beta/{+parent}/resourcePolicies",
       hasBody: true,
     }),
     svc,
@@ -1420,7 +1420,7 @@ export const ListProjectsServicesResourcePoliciesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/resourcePolicies" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/resourcePolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsServicesResourcePoliciesRequest>;
 
@@ -1464,7 +1464,7 @@ export const PatchProjectsServicesResourcePoliciesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsServicesResourcePoliciesRequest>;
 
@@ -1503,7 +1503,7 @@ export const ExchangeRecaptchaV3TokenProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{app}:exchangeRecaptchaV3Token",
+      path: "v1beta/{+app}:exchangeRecaptchaV3Token",
       hasBody: true,
     }),
     svc,
@@ -1544,7 +1544,7 @@ export const ExchangeDebugTokenProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{app}:exchangeDebugToken",
+      path: "v1beta/{+app}:exchangeDebugToken",
       hasBody: true,
     }),
     svc,
@@ -1585,7 +1585,7 @@ export const ExchangePlayIntegrityTokenProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{app}:exchangePlayIntegrityToken",
+      path: "v1beta/{+app}:exchangePlayIntegrityToken",
       hasBody: true,
     }),
     svc,
@@ -1626,7 +1626,7 @@ export const ExchangeRecaptchaEnterpriseTokenProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{app}:exchangeRecaptchaEnterpriseToken",
+      path: "v1beta/{+app}:exchangeRecaptchaEnterpriseToken",
       hasBody: true,
     }),
     svc,
@@ -1667,7 +1667,7 @@ export const ExchangeAppAttestAttestationProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{app}:exchangeAppAttestAttestation",
+      path: "v1beta/{+app}:exchangeAppAttestAttestation",
       hasBody: true,
     }),
     svc,
@@ -1708,7 +1708,7 @@ export const ExchangeCustomTokenProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{app}:exchangeCustomToken",
+      path: "v1beta/{+app}:exchangeCustomToken",
       hasBody: true,
     }),
     svc,
@@ -1749,7 +1749,7 @@ export const ExchangeRecaptchaTokenProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{app}:exchangeRecaptchaToken",
+      path: "v1beta/{+app}:exchangeRecaptchaToken",
       hasBody: true,
     }),
     svc,
@@ -1790,7 +1790,7 @@ export const GeneratePlayIntegrityChallengeProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{app}:generatePlayIntegrityChallenge",
+      path: "v1beta/{+app}:generatePlayIntegrityChallenge",
       hasBody: true,
     }),
     svc,
@@ -1831,7 +1831,7 @@ export const ExchangeDeviceCheckTokenProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{app}:exchangeDeviceCheckToken",
+      path: "v1beta/{+app}:exchangeDeviceCheckToken",
       hasBody: true,
     }),
     svc,
@@ -1872,7 +1872,7 @@ export const GenerateAppAttestChallengeProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{app}:generateAppAttestChallenge",
+      path: "v1beta/{+app}:generateAppAttestChallenge",
       hasBody: true,
     }),
     svc,
@@ -1913,7 +1913,7 @@ export const ExchangeAppAttestAssertionProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{app}:exchangeAppAttestAssertion",
+      path: "v1beta/{+app}:exchangeAppAttestAssertion",
       hasBody: true,
     }),
     svc,
@@ -1954,7 +1954,7 @@ export const ExchangeSafetyNetTokenProjectsAppsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{app}:exchangeSafetyNetToken",
+      path: "v1beta/{+app}:exchangeSafetyNetToken",
       hasBody: true,
     }),
     svc,
@@ -1996,7 +1996,7 @@ export const PatchProjectsAppsDeviceCheckConfigRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAppsDeviceCheckConfigRequest>;
 
@@ -2035,7 +2035,7 @@ export const BatchGetProjectsAppsDeviceCheckConfigRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta/{parent}/apps/-/deviceCheckConfig:batchGet",
+      path: "v1beta/{+parent}/apps/-/deviceCheckConfig:batchGet",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetProjectsAppsDeviceCheckConfigRequest>;
@@ -2068,7 +2068,7 @@ export const GetProjectsAppsDeviceCheckConfigRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsDeviceCheckConfigRequest>;
 
@@ -2107,7 +2107,7 @@ export const BatchGetProjectsAppsRecaptchaEnterpriseConfigRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta/{parent}/apps/-/recaptchaEnterpriseConfig:batchGet",
+      path: "v1beta/{+parent}/apps/-/recaptchaEnterpriseConfig:batchGet",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetProjectsAppsRecaptchaEnterpriseConfigRequest>;
@@ -2148,7 +2148,7 @@ export const PatchProjectsAppsRecaptchaEnterpriseConfigRequest =
       GoogleFirebaseAppcheckV1betaRecaptchaEnterpriseConfig,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAppsRecaptchaEnterpriseConfigRequest>;
 
@@ -2180,7 +2180,7 @@ export const GetProjectsAppsRecaptchaEnterpriseConfigRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsRecaptchaEnterpriseConfigRequest>;
 
@@ -2218,7 +2218,7 @@ export const ListProjectsAppsDebugTokensRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/debugTokens" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/debugTokens" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAppsDebugTokensRequest>;
 
@@ -2262,7 +2262,7 @@ export const PatchProjectsAppsDebugTokensRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAppsDebugTokensRequest>;
 
@@ -2294,7 +2294,7 @@ export const GetProjectsAppsDebugTokensRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsDebugTokensRequest>;
 
@@ -2333,7 +2333,7 @@ export const CreateProjectsAppsDebugTokensRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/debugTokens",
+      path: "v1beta/{+parent}/debugTokens",
       hasBody: true,
     }),
     svc,
@@ -2370,7 +2370,7 @@ export const DeleteProjectsAppsDebugTokensRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAppsDebugTokensRequest>;
 
@@ -2408,7 +2408,7 @@ export const BatchGetProjectsAppsAppAttestConfigRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta/{parent}/apps/-/appAttestConfig:batchGet",
+      path: "v1beta/{+parent}/apps/-/appAttestConfig:batchGet",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetProjectsAppsAppAttestConfigRequest>;
@@ -2449,7 +2449,7 @@ export const PatchProjectsAppsAppAttestConfigRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAppsAppAttestConfigRequest>;
 
@@ -2481,7 +2481,7 @@ export const GetProjectsAppsAppAttestConfigRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsAppAttestConfigRequest>;
 
@@ -2513,7 +2513,7 @@ export const GetProjectsAppsRecaptchaConfigRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsRecaptchaConfigRequest>;
 
@@ -2553,7 +2553,7 @@ export const PatchProjectsAppsRecaptchaConfigRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAppsRecaptchaConfigRequest>;
 
@@ -2592,7 +2592,7 @@ export const BatchGetProjectsAppsRecaptchaConfigRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta/{parent}/apps/-/recaptchaConfig:batchGet",
+      path: "v1beta/{+parent}/apps/-/recaptchaConfig:batchGet",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetProjectsAppsRecaptchaConfigRequest>;
@@ -2633,7 +2633,7 @@ export const PatchProjectsAppsRecaptchaV3ConfigRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAppsRecaptchaV3ConfigRequest>;
 
@@ -2672,7 +2672,7 @@ export const BatchGetProjectsAppsRecaptchaV3ConfigRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta/{parent}/apps/-/recaptchaV3Config:batchGet",
+      path: "v1beta/{+parent}/apps/-/recaptchaV3Config:batchGet",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetProjectsAppsRecaptchaV3ConfigRequest>;
@@ -2705,7 +2705,7 @@ export const GetProjectsAppsRecaptchaV3ConfigRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsRecaptchaV3ConfigRequest>;
 
@@ -2745,7 +2745,7 @@ export const PatchProjectsAppsSafetyNetConfigRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAppsSafetyNetConfigRequest>;
 
@@ -2784,7 +2784,7 @@ export const BatchGetProjectsAppsSafetyNetConfigRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta/{parent}/apps/-/safetyNetConfig:batchGet",
+      path: "v1beta/{+parent}/apps/-/safetyNetConfig:batchGet",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetProjectsAppsSafetyNetConfigRequest>;
@@ -2817,7 +2817,7 @@ export const GetProjectsAppsSafetyNetConfigRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsSafetyNetConfigRequest>;
 
@@ -2849,7 +2849,7 @@ export const GetProjectsAppsPlayIntegrityConfigRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsPlayIntegrityConfigRequest>;
 
@@ -2889,7 +2889,7 @@ export const PatchProjectsAppsPlayIntegrityConfigRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAppsPlayIntegrityConfigRequest>;
 
@@ -2928,7 +2928,7 @@ export const BatchGetProjectsAppsPlayIntegrityConfigRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta/{parent}/apps/-/playIntegrityConfig:batchGet",
+      path: "v1beta/{+parent}/apps/-/playIntegrityConfig:batchGet",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetProjectsAppsPlayIntegrityConfigRequest>;

--- a/packages/gcp/src/services/firebaseappdistribution-v1.ts
+++ b/packages/gcp/src/services/firebaseappdistribution-v1.ts
@@ -782,7 +782,7 @@ export const ListProjectsGroupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/groups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/groups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsGroupsRequest>;
 
@@ -823,7 +823,7 @@ export const BatchLeaveProjectsGroupsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{group}:batchLeave", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+group}:batchLeave", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<BatchLeaveProjectsGroupsRequest>;
 
@@ -854,7 +854,7 @@ export const DeleteProjectsGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsGroupsRequest>;
 
@@ -885,7 +885,7 @@ export const GetProjectsGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsGroupsRequest>;
 
@@ -922,7 +922,7 @@ export const CreateProjectsGroupsRequest =
     groupId: Schema.optional(Schema.String).pipe(T.HttpQuery("groupId")),
     body: Schema.optional(GoogleFirebaseAppdistroV1Group).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/groups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/groups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsGroupsRequest>;
 
@@ -959,7 +959,7 @@ export const PatchProjectsGroupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleFirebaseAppdistroV1Group).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsGroupsRequest>;
 
@@ -995,7 +995,7 @@ export const BatchJoinProjectsGroupsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{group}:batchJoin", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+group}:batchJoin", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<BatchJoinProjectsGroupsRequest>;
 
@@ -1035,7 +1035,7 @@ export const ListProjectsTestersRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/testers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/testers" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTestersRequest>;
 
@@ -1078,7 +1078,7 @@ export const BatchRemoveProjectsTestersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{project}/testers:batchRemove",
+      path: "v1/{+project}/testers:batchRemove",
       hasBody: true,
     }),
     svc,
@@ -1118,7 +1118,7 @@ export const PatchProjectsTestersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleFirebaseAppdistroV1Tester).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsTestersRequest>;
 
@@ -1156,7 +1156,7 @@ export const BatchAddProjectsTestersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{project}/testers:batchAdd",
+      path: "v1/{+project}/testers:batchAdd",
       hasBody: true,
     }),
     svc,
@@ -1190,7 +1190,7 @@ export const GetAabInfoProjectsAppsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAabInfoProjectsAppsRequest>;
 
@@ -1221,7 +1221,7 @@ export const GetProjectsAppsReleasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsReleasesRequest>;
 
@@ -1259,7 +1259,7 @@ export const BatchDeleteProjectsAppsReleasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/releases:batchDelete",
+      path: "v1/{+parent}/releases:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -1304,7 +1304,7 @@ export const ListProjectsAppsReleasesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/releases" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/releases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAppsReleasesRequest>;
 
@@ -1346,7 +1346,7 @@ export const PatchProjectsAppsReleasesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleFirebaseAppdistroV1Release).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAppsReleasesRequest>;
 
@@ -1383,7 +1383,7 @@ export const DistributeProjectsAppsReleasesRequest =
       GoogleFirebaseAppdistroV1DistributeReleaseRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:distribute", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:distribute", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DistributeProjectsAppsReleasesRequest>;
 
@@ -1420,7 +1420,7 @@ export const WaitProjectsAppsReleasesOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsAppsReleasesOperationsRequest>;
 
@@ -1457,7 +1457,7 @@ export const CancelProjectsAppsReleasesOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsAppsReleasesOperationsRequest>;
 
@@ -1488,7 +1488,7 @@ export const DeleteProjectsAppsReleasesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAppsReleasesOperationsRequest>;
 
@@ -1519,7 +1519,7 @@ export const GetProjectsAppsReleasesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsReleasesOperationsRequest>;
 
@@ -1565,7 +1565,7 @@ export const ListProjectsAppsReleasesOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAppsReleasesOperationsRequest>;
 
@@ -1607,7 +1607,7 @@ export const ListProjectsAppsReleasesFeedbackReportsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/feedbackReports" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/feedbackReports" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAppsReleasesFeedbackReportsRequest>;
 
@@ -1643,7 +1643,7 @@ export const GetProjectsAppsReleasesFeedbackReportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsReleasesFeedbackReportsRequest>;
 
@@ -1675,7 +1675,7 @@ export const DeleteProjectsAppsReleasesFeedbackReportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAppsReleasesFeedbackReportsRequest>;
 
@@ -1711,7 +1711,7 @@ export const UploadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpBody(),
   ),
 }).pipe(
-  T.Http({ method: "POST", path: "v1/{app}/releases:upload", hasBody: true }),
+  T.Http({ method: "POST", path: "v1/{+app}/releases:upload", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<UploadMediaRequest>;
 

--- a/packages/gcp/src/services/firebaseappdistribution-v1alpha.ts
+++ b/packages/gcp/src/services/firebaseappdistribution-v1alpha.ts
@@ -1370,7 +1370,7 @@ export const GetTestQuotaProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTestQuotaProjectsRequest>;
 
@@ -1407,7 +1407,7 @@ export const GetUdidsProjectsTestersRequest =
       T.HttpQuery("mobilesdkAppId"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{project}/testers:udids" }),
+    T.Http({ method: "GET", path: "v1alpha/{+project}/testers:udids" }),
     svc,
   ) as unknown as Schema.Schema<GetUdidsProjectsTestersRequest>;
 
@@ -1447,7 +1447,7 @@ export const UpdateTestConfigProjectsAppsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateTestConfigProjectsAppsRequest>;
 
@@ -1479,7 +1479,7 @@ export const GetTestConfigProjectsAppsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTestConfigProjectsAppsRequest>;
 
@@ -1521,7 +1521,7 @@ export const CreateProjectsAppsReleasesTestsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{parent}/tests", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+parent}/tests", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsAppsReleasesTestsRequest>;
 
@@ -1566,7 +1566,7 @@ export const ListProjectsAppsReleasesTestsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/tests" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/tests" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAppsReleasesTestsRequest>;
 
@@ -1602,7 +1602,7 @@ export const CancelProjectsAppsReleasesTestsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}:cancel" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}:cancel" }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsAppsReleasesTestsRequest>;
 
@@ -1634,7 +1634,7 @@ export const GetProjectsAppsReleasesTestsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsReleasesTestsRequest>;
 
@@ -1673,7 +1673,7 @@ export const ClearTestCaseCacheProjectsAppsTestCasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{testCase}:clearTestCaseCache",
+      path: "v1alpha/{+testCase}:clearTestCaseCache",
       hasBody: true,
     }),
     svc,
@@ -1707,7 +1707,7 @@ export const DeleteProjectsAppsTestCasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAppsTestCasesRequest>;
 
@@ -1738,7 +1738,7 @@ export const GetProjectsAppsTestCasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAppsTestCasesRequest>;
 
@@ -1777,7 +1777,7 @@ export const BatchUpdateProjectsAppsTestCasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/testCases:batchUpdate",
+      path: "v1alpha/{+parent}/testCases:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -1821,7 +1821,7 @@ export const CreateProjectsAppsTestCasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/testCases",
+      path: "v1alpha/{+parent}/testCases",
       hasBody: true,
     }),
     svc,
@@ -1861,7 +1861,7 @@ export const ListProjectsAppsTestCasesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/testCases" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/testCases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAppsTestCasesRequest>;
 
@@ -1907,7 +1907,7 @@ export const PatchProjectsAppsTestCasesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAppsTestCasesRequest>;
 
@@ -1946,7 +1946,7 @@ export const BatchDeleteProjectsAppsTestCasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/testCases:batchDelete",
+      path: "v1alpha/{+parent}/testCases:batchDelete",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/firebaseapphosting-v1.ts
+++ b/packages/gcp/src/services/firebaseapphosting-v1.ts
@@ -1036,7 +1036,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1071,7 +1071,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1116,7 +1116,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1151,7 +1151,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1182,7 +1182,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1216,7 +1216,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1264,7 +1264,7 @@ export const ListProjectsLocationsBackendsRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backends" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backends" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackendsRequest>;
 
@@ -1299,7 +1299,7 @@ export const GetProjectsLocationsBackendsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackendsRequest>;
 
@@ -1344,7 +1344,7 @@ export const CreateProjectsLocationsBackendsRequest =
     ),
     body: Schema.optional(Backend).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/backends", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/backends", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackendsRequest>;
 
@@ -1394,7 +1394,7 @@ export const PatchProjectsLocationsBackendsRequest =
     ),
     body: Schema.optional(Backend).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackendsRequest>;
 
@@ -1439,7 +1439,7 @@ export const DeleteProjectsLocationsBackendsRequest =
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackendsRequest>;
 
@@ -1470,7 +1470,7 @@ export const GetProjectsLocationsBackendsTrafficRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackendsTrafficRequest>;
 
@@ -1515,7 +1515,7 @@ export const PatchProjectsLocationsBackendsTrafficRequest =
     ),
     body: Schema.optional(Traffic).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackendsTrafficRequest>;
 
@@ -1563,7 +1563,7 @@ export const ListProjectsLocationsBackendsBuildsRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/builds" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/builds" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackendsBuildsRequest>;
 
@@ -1598,7 +1598,7 @@ export const GetProjectsLocationsBackendsBuildsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackendsBuildsRequest>;
 
@@ -1643,7 +1643,7 @@ export const CreateProjectsLocationsBackendsBuildsRequest =
     ),
     body: Schema.optional(Build).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/builds", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/builds", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackendsBuildsRequest>;
 
@@ -1685,7 +1685,7 @@ export const DeleteProjectsLocationsBackendsBuildsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackendsBuildsRequest>;
 
@@ -1733,7 +1733,7 @@ export const ListProjectsLocationsBackendsRolloutsRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/rollouts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/rollouts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackendsRolloutsRequest>;
 
@@ -1769,7 +1769,7 @@ export const GetProjectsLocationsBackendsRolloutsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackendsRolloutsRequest>;
 
@@ -1814,7 +1814,7 @@ export const CreateProjectsLocationsBackendsRolloutsRequest =
     ),
     body: Schema.optional(Rollout).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/rollouts", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/rollouts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackendsRolloutsRequest>;
 
@@ -1862,7 +1862,7 @@ export const ListProjectsLocationsBackendsDomainsRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/domains" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/domains" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackendsDomainsRequest>;
 
@@ -1897,7 +1897,7 @@ export const GetProjectsLocationsBackendsDomainsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackendsDomainsRequest>;
 
@@ -1942,7 +1942,7 @@ export const CreateProjectsLocationsBackendsDomainsRequest =
     ),
     body: Schema.optional(Domain).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/domains", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/domains", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackendsDomainsRequest>;
 
@@ -1992,7 +1992,7 @@ export const PatchProjectsLocationsBackendsDomainsRequest =
     ),
     body: Schema.optional(Domain).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackendsDomainsRequest>;
 
@@ -2034,7 +2034,7 @@ export const DeleteProjectsLocationsBackendsDomainsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackendsDomainsRequest>;
 

--- a/packages/gcp/src/services/firebaseapphosting-v1beta.ts
+++ b/packages/gcp/src/services/firebaseapphosting-v1beta.ts
@@ -1046,7 +1046,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1081,7 +1081,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1126,7 +1126,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1161,7 +1161,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1192,7 +1192,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1223,7 +1223,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1271,7 +1271,7 @@ export const ListProjectsLocationsBackendsRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/backends" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/backends" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackendsRequest>;
 
@@ -1306,7 +1306,7 @@ export const GetProjectsLocationsBackendsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackendsRequest>;
 
@@ -1351,7 +1351,11 @@ export const CreateProjectsLocationsBackendsRequest =
     ),
     body: Schema.optional(Backend).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/backends", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/backends",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackendsRequest>;
 
@@ -1401,7 +1405,7 @@ export const PatchProjectsLocationsBackendsRequest =
     ),
     body: Schema.optional(Backend).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackendsRequest>;
 
@@ -1446,7 +1450,7 @@ export const DeleteProjectsLocationsBackendsRequest =
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackendsRequest>;
 
@@ -1477,7 +1481,7 @@ export const GetProjectsLocationsBackendsTrafficRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackendsTrafficRequest>;
 
@@ -1522,7 +1526,7 @@ export const PatchProjectsLocationsBackendsTrafficRequest =
     ),
     body: Schema.optional(Traffic).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackendsTrafficRequest>;
 
@@ -1570,7 +1574,7 @@ export const ListProjectsLocationsBackendsBuildsRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/builds" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/builds" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackendsBuildsRequest>;
 
@@ -1605,7 +1609,7 @@ export const GetProjectsLocationsBackendsBuildsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackendsBuildsRequest>;
 
@@ -1650,7 +1654,7 @@ export const CreateProjectsLocationsBackendsBuildsRequest =
     ),
     body: Schema.optional(Build).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/builds", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/builds", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackendsBuildsRequest>;
 
@@ -1692,7 +1696,7 @@ export const DeleteProjectsLocationsBackendsBuildsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackendsBuildsRequest>;
 
@@ -1740,7 +1744,7 @@ export const ListProjectsLocationsBackendsRolloutsRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/rollouts" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/rollouts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackendsRolloutsRequest>;
 
@@ -1776,7 +1780,7 @@ export const GetProjectsLocationsBackendsRolloutsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackendsRolloutsRequest>;
 
@@ -1821,7 +1825,11 @@ export const CreateProjectsLocationsBackendsRolloutsRequest =
     ),
     body: Schema.optional(Rollout).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/rollouts", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/rollouts",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackendsRolloutsRequest>;
 
@@ -1869,7 +1877,7 @@ export const ListProjectsLocationsBackendsDomainsRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/domains" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/domains" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackendsDomainsRequest>;
 
@@ -1904,7 +1912,7 @@ export const GetProjectsLocationsBackendsDomainsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackendsDomainsRequest>;
 
@@ -1949,7 +1957,7 @@ export const CreateProjectsLocationsBackendsDomainsRequest =
     ),
     body: Schema.optional(Domain).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/domains", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/domains", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackendsDomainsRequest>;
 
@@ -1999,7 +2007,7 @@ export const PatchProjectsLocationsBackendsDomainsRequest =
     ),
     body: Schema.optional(Domain).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackendsDomainsRequest>;
 
@@ -2041,7 +2049,7 @@ export const DeleteProjectsLocationsBackendsDomainsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackendsDomainsRequest>;
 

--- a/packages/gcp/src/services/firebasedatabase-v1beta.ts
+++ b/packages/gcp/src/services/firebasedatabase-v1beta.ts
@@ -102,7 +102,7 @@ export const DisableProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DisableDatabaseInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:disable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:disable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DisableProjectsLocationsInstancesRequest>;
 
@@ -136,7 +136,7 @@ export const UndeleteProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndeleteDatabaseInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsLocationsInstancesRequest>;
 
@@ -167,7 +167,7 @@ export const DeleteProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesRequest>;
 
@@ -211,7 +211,7 @@ export const CreateProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/instances",
+      path: "v1beta/{+parent}/instances",
       hasBody: true,
     }),
     svc,
@@ -247,7 +247,7 @@ export const ReenableProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ReenableDatabaseInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:reenable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:reenable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReenableProjectsLocationsInstancesRequest>;
 
@@ -278,7 +278,7 @@ export const GetProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesRequest>;
 
@@ -320,7 +320,7 @@ export const ListProjectsLocationsInstancesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesRequest>;
 

--- a/packages/gcp/src/services/firebasedataconnect-v1.ts
+++ b/packages/gcp/src/services/firebasedataconnect-v1.ts
@@ -686,7 +686,7 @@ export const ListProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -721,7 +721,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -755,7 +755,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -786,7 +786,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -831,7 +831,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -866,7 +866,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -902,7 +902,7 @@ export const ExecuteGraphqlReadProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:executeGraphqlRead",
+      path: "v1/{+name}:executeGraphqlRead",
       hasBody: true,
     }),
     svc,
@@ -948,7 +948,7 @@ export const ListProjectsLocationsServicesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/services" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/services" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesRequest>;
 
@@ -983,7 +983,7 @@ export const GetProjectsLocationsServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesRequest>;
 
@@ -1028,7 +1028,7 @@ export const CreateProjectsLocationsServicesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/services", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/services", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsServicesRequest>;
 
@@ -1062,7 +1062,11 @@ export const ExecuteGraphqlProjectsLocationsServicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GraphqlRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:executeGraphql", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+name}:executeGraphql",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<ExecuteGraphqlProjectsLocationsServicesRequest>;
 
@@ -1112,7 +1116,7 @@ export const DeleteProjectsLocationsServicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesRequest>;
 
@@ -1162,7 +1166,7 @@ export const PatchProjectsLocationsServicesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServicesRequest>;
 
@@ -1198,7 +1202,7 @@ export const IntrospectGraphqlProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:introspectGraphql",
+      path: "v1/{+name}:introspectGraphql",
       hasBody: true,
     }),
     svc,
@@ -1235,7 +1239,7 @@ export const ExecuteQueryProjectsLocationsServicesConnectorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExecuteQueryRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:executeQuery", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:executeQuery", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteQueryProjectsLocationsServicesConnectorsRequest>;
 
@@ -1273,7 +1277,7 @@ export const ExecuteMutationProjectsLocationsServicesConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:executeMutation",
+      path: "v1/{+name}:executeMutation",
       hasBody: true,
     }),
     svc,
@@ -1327,7 +1331,7 @@ export const PatchProjectsLocationsServicesConnectorsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Connector).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServicesConnectorsRequest>;
 
@@ -1377,7 +1381,7 @@ export const DeleteProjectsLocationsServicesConnectorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesConnectorsRequest>;
 
@@ -1413,7 +1417,7 @@ export const ImpersonateMutationProjectsLocationsServicesConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:impersonateMutation",
+      path: "v1/{+name}:impersonateMutation",
       hasBody: true,
     }),
     svc,
@@ -1460,7 +1464,7 @@ export const ListProjectsLocationsServicesConnectorsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/connectors" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/connectors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesConnectorsRequest>;
 
@@ -1496,7 +1500,7 @@ export const GetProjectsLocationsServicesConnectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesConnectorsRequest>;
 
@@ -1543,7 +1547,7 @@ export const CreateProjectsLocationsServicesConnectorsRequest =
     ),
     body: Schema.optional(Connector).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/connectors", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/connectors", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsServicesConnectorsRequest>;
 
@@ -1579,7 +1583,7 @@ export const ImpersonateQueryProjectsLocationsServicesConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:impersonateQuery",
+      path: "v1/{+name}:impersonateQuery",
       hasBody: true,
     }),
     svc,
@@ -1614,7 +1618,7 @@ export const GetProjectsLocationsServicesSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesSchemasRequest>;
 
@@ -1658,7 +1662,7 @@ export const ListProjectsLocationsServicesSchemasRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/schemas" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/schemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesSchemasRequest>;
 
@@ -1707,7 +1711,7 @@ export const CreateProjectsLocationsServicesSchemasRequest =
     ),
     body: Schema.optional(Firebasedataconnect_Schema).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/schemas", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/schemas", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsServicesSchemasRequest>;
 
@@ -1757,7 +1761,7 @@ export const PatchProjectsLocationsServicesSchemasRequest =
     ),
     body: Schema.optional(Firebasedataconnect_Schema).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServicesSchemasRequest>;
 
@@ -1807,7 +1811,7 @@ export const DeleteProjectsLocationsServicesSchemasRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesSchemasRequest>;
 

--- a/packages/gcp/src/services/firebasedataconnect-v1beta.ts
+++ b/packages/gcp/src/services/firebasedataconnect-v1beta.ts
@@ -686,7 +686,7 @@ export const ListProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -721,7 +721,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -766,7 +766,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -801,7 +801,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -832,7 +832,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -866,7 +866,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -902,7 +902,7 @@ export const ExecuteGraphqlReadProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{name}:executeGraphqlRead",
+      path: "v1beta/{+name}:executeGraphqlRead",
       hasBody: true,
     }),
     svc,
@@ -948,7 +948,7 @@ export const ListProjectsLocationsServicesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/services" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/services" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesRequest>;
 
@@ -983,7 +983,7 @@ export const GetProjectsLocationsServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesRequest>;
 
@@ -1028,7 +1028,11 @@ export const CreateProjectsLocationsServicesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/services", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/services",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsServicesRequest>;
 
@@ -1064,7 +1068,7 @@ export const ExecuteGraphqlProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{name}:executeGraphql",
+      path: "v1beta/{+name}:executeGraphql",
       hasBody: true,
     }),
     svc,
@@ -1116,7 +1120,7 @@ export const DeleteProjectsLocationsServicesRequest =
       T.HttpQuery("allowMissing"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesRequest>;
 
@@ -1166,7 +1170,7 @@ export const PatchProjectsLocationsServicesRequest =
     ),
     body: Schema.optional(Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServicesRequest>;
 
@@ -1202,7 +1206,7 @@ export const IntrospectGraphqlProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{name}:introspectGraphql",
+      path: "v1beta/{+name}:introspectGraphql",
       hasBody: true,
     }),
     svc,
@@ -1236,7 +1240,7 @@ export const GetProjectsLocationsServicesConnectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesConnectorsRequest>;
 
@@ -1285,7 +1289,7 @@ export const CreateProjectsLocationsServicesConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/connectors",
+      path: "v1beta/{+parent}/connectors",
       hasBody: true,
     }),
     svc,
@@ -1323,7 +1327,7 @@ export const ImpersonateQueryProjectsLocationsServicesConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{name}:impersonateQuery",
+      path: "v1beta/{+name}:impersonateQuery",
       hasBody: true,
     }),
     svc,
@@ -1363,7 +1367,7 @@ export const ImpersonateMutationProjectsLocationsServicesConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{name}:impersonateMutation",
+      path: "v1beta/{+name}:impersonateMutation",
       hasBody: true,
     }),
     svc,
@@ -1410,7 +1414,7 @@ export const ListProjectsLocationsServicesConnectorsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/connectors" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/connectors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesConnectorsRequest>;
 
@@ -1451,7 +1455,7 @@ export const ExecuteMutationProjectsLocationsServicesConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{name}:executeMutation",
+      path: "v1beta/{+name}:executeMutation",
       hasBody: true,
     }),
     svc,
@@ -1505,7 +1509,7 @@ export const PatchProjectsLocationsServicesConnectorsRequest =
     ),
     body: Schema.optional(Connector).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServicesConnectorsRequest>;
 
@@ -1555,7 +1559,7 @@ export const DeleteProjectsLocationsServicesConnectorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesConnectorsRequest>;
 
@@ -1591,7 +1595,7 @@ export const ExecuteQueryProjectsLocationsServicesConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{name}:executeQuery",
+      path: "v1beta/{+name}:executeQuery",
       hasBody: true,
     }),
     svc,
@@ -1645,7 +1649,7 @@ export const PatchProjectsLocationsServicesSchemasRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Firebasedataconnect_Schema).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServicesSchemasRequest>;
 
@@ -1695,7 +1699,7 @@ export const DeleteProjectsLocationsServicesSchemasRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesSchemasRequest>;
 
@@ -1726,7 +1730,7 @@ export const GetProjectsLocationsServicesSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesSchemasRequest>;
 
@@ -1770,7 +1774,7 @@ export const ListProjectsLocationsServicesSchemasRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/schemas" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/schemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesSchemasRequest>;
 
@@ -1819,7 +1823,7 @@ export const CreateProjectsLocationsServicesSchemasRequest =
     ),
     body: Schema.optional(Firebasedataconnect_Schema).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/schemas", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/schemas", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsServicesSchemasRequest>;
 

--- a/packages/gcp/src/services/firebasehosting-v1.ts
+++ b/packages/gcp/src/services/firebasehosting-v1.ts
@@ -275,7 +275,7 @@ export const ListOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("returnPartialSuccess"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<ListOperationsRequest>;
 
@@ -310,7 +310,7 @@ export const DeleteOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOperationsRequest>;
 
@@ -343,7 +343,7 @@ export const CancelOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOperationsRequest>;
 
@@ -373,7 +373,7 @@ export const DeleteProjectsSitesCustomDomainsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsSitesCustomDomainsOperationsRequest>;
 
@@ -407,7 +407,7 @@ export const CancelProjectsSitesCustomDomainsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsSitesCustomDomainsOperationsRequest>;
 

--- a/packages/gcp/src/services/firebasehosting-v1beta1.ts
+++ b/packages/gcp/src/services/firebasehosting-v1beta1.ts
@@ -916,7 +916,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 
@@ -947,7 +947,7 @@ export const GetConfigProjectsSitesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigProjectsSitesRequest>;
 
@@ -984,7 +984,7 @@ export const UpdateConfigProjectsSitesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SiteConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigProjectsSitesRequest>;
 
@@ -1026,7 +1026,7 @@ export const CreateProjectsSitesRequest =
     ),
     body: Schema.optional(Site).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/sites", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+parent}/sites", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsSitesRequest>;
 
@@ -1062,7 +1062,7 @@ export const PatchProjectsSitesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Site).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsSitesRequest>;
 
@@ -1092,7 +1092,7 @@ export const GetProjectsSitesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSitesRequest>;
 
@@ -1128,7 +1128,7 @@ export const ListProjectsSitesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/sites" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/sites" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSitesRequest>;
 
@@ -1163,7 +1163,7 @@ export const DeleteProjectsSitesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsSitesRequest>;
 
@@ -1208,7 +1208,7 @@ export const CreateProjectsSitesCustomDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/customDomains",
+      path: "v1beta1/{+parent}/customDomains",
       hasBody: true,
     }),
     svc,
@@ -1257,7 +1257,7 @@ export const PatchProjectsSitesCustomDomainsRequest =
     ),
     body: Schema.optional(CustomDomain).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsSitesCustomDomainsRequest>;
 
@@ -1288,7 +1288,7 @@ export const GetProjectsSitesCustomDomainsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSitesCustomDomainsRequest>;
 
@@ -1330,7 +1330,7 @@ export const ListProjectsSitesCustomDomainsRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/customDomains" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/customDomains" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSitesCustomDomainsRequest>;
 
@@ -1378,7 +1378,7 @@ export const DeleteProjectsSitesCustomDomainsRequest =
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsSitesCustomDomainsRequest>;
 
@@ -1412,7 +1412,7 @@ export const UndeleteProjectsSitesCustomDomainsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndeleteCustomDomainRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsSitesCustomDomainsRequest>;
 
@@ -1457,7 +1457,7 @@ export const ListProjectsSitesCustomDomainsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSitesCustomDomainsOperationsRequest>;
 
@@ -1493,7 +1493,7 @@ export const GetProjectsSitesCustomDomainsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSitesCustomDomainsOperationsRequest>;
 
@@ -1530,7 +1530,7 @@ export const ListProjectsSitesDomainsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/domains" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/domains" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSitesDomainsRequest>;
 
@@ -1565,7 +1565,7 @@ export const GetProjectsSitesDomainsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSitesDomainsRequest>;
 
@@ -1599,7 +1599,11 @@ export const CreateProjectsSitesDomainsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Domain).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/domains", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/domains",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsSitesDomainsRequest>;
 
@@ -1633,7 +1637,7 @@ export const UpdateProjectsSitesDomainsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Domain).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsSitesDomainsRequest>;
 
@@ -1664,7 +1668,7 @@ export const DeleteProjectsSitesDomainsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsSitesDomainsRequest>;
 
@@ -1706,7 +1710,7 @@ export const CreateProjectsSitesVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/versions",
+      path: "v1beta1/{+parent}/versions",
       hasBody: true,
     }),
     svc,
@@ -1745,7 +1749,7 @@ export const PatchProjectsSitesVersionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Version).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsSitesVersionsRequest>;
 
@@ -1776,7 +1780,7 @@ export const DeleteProjectsSitesVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsSitesVersionsRequest>;
 
@@ -1812,7 +1816,7 @@ export const PopulateFilesProjectsSitesVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:populateFiles",
+      path: "v1beta1/{+parent}:populateFiles",
       hasBody: true,
     }),
     svc,
@@ -1855,7 +1859,7 @@ export const ListProjectsSitesVersionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSitesVersionsRequest>;
 
@@ -1890,7 +1894,7 @@ export const GetProjectsSitesVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSitesVersionsRequest>;
 
@@ -1926,7 +1930,7 @@ export const CloneProjectsSitesVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/versions:clone",
+      path: "v1beta1/{+parent}/versions:clone",
       hasBody: true,
     }),
     svc,
@@ -1968,7 +1972,7 @@ export const ListProjectsSitesVersionsFilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/files" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/files" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSitesVersionsFilesRequest>;
 
@@ -2009,7 +2013,7 @@ export const ListProjectsSitesReleasesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/releases" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/releases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSitesReleasesRequest>;
 
@@ -2044,7 +2048,7 @@ export const GetProjectsSitesReleasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSitesReleasesRequest>;
 
@@ -2085,7 +2089,7 @@ export const CreateProjectsSitesReleasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/releases",
+      path: "v1beta1/{+parent}/releases",
       hasBody: true,
     }),
     svc,
@@ -2124,7 +2128,7 @@ export const ListProjectsSitesChannelsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/channels" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/channels" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSitesChannelsRequest>;
 
@@ -2167,7 +2171,7 @@ export const CreateProjectsSitesChannelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/channels",
+      path: "v1beta1/{+parent}/channels",
       hasBody: true,
     }),
     svc,
@@ -2200,7 +2204,7 @@ export const GetProjectsSitesChannelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSitesChannelsRequest>;
 
@@ -2237,7 +2241,7 @@ export const PatchProjectsSitesChannelsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Channel).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsSitesChannelsRequest>;
 
@@ -2268,7 +2272,7 @@ export const DeleteProjectsSitesChannelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsSitesChannelsRequest>;
 
@@ -2305,7 +2309,7 @@ export const ListProjectsSitesChannelsReleasesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/releases" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/releases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSitesChannelsReleasesRequest>;
 
@@ -2340,7 +2344,7 @@ export const GetProjectsSitesChannelsReleasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSitesChannelsReleasesRequest>;
 
@@ -2381,7 +2385,7 @@ export const CreateProjectsSitesChannelsReleasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/releases",
+      path: "v1beta1/{+parent}/releases",
       hasBody: true,
     }),
     svc,
@@ -2413,7 +2417,7 @@ export interface GetConfigSitesRequest {
 export const GetConfigSitesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta1/{name}" }),
+  T.Http({ method: "GET", path: "v1beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetConfigSitesRequest>;
 
@@ -2449,7 +2453,7 @@ export const UpdateConfigSitesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SiteConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigSitesRequest>;
 
@@ -2485,7 +2489,7 @@ export const ListSitesDomainsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/domains" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/domains" }),
     svc,
   ) as unknown as Schema.Schema<ListSitesDomainsRequest>;
 
@@ -2521,7 +2525,7 @@ export const GetSitesDomainsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     name: Schema.String.pipe(T.HttpPath("name")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "v1beta1/{name}" }),
+  T.Http({ method: "GET", path: "v1beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetSitesDomainsRequest>;
 
@@ -2554,7 +2558,11 @@ export const CreateSitesDomainsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Domain).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/domains", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/domains",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateSitesDomainsRequest>;
 
@@ -2587,7 +2595,7 @@ export const UpdateSitesDomainsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Domain).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSitesDomainsRequest>;
 
@@ -2617,7 +2625,7 @@ export const DeleteSitesDomainsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteSitesDomainsRequest>;
 
@@ -2658,7 +2666,7 @@ export const CreateSitesVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/versions",
+      path: "v1beta1/{+parent}/versions",
       hasBody: true,
     }),
     svc,
@@ -2696,7 +2704,7 @@ export const PatchSitesVersionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Version).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchSitesVersionsRequest>;
 
@@ -2726,7 +2734,7 @@ export const DeleteSitesVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteSitesVersionsRequest>;
 
@@ -2761,7 +2769,7 @@ export const PopulateFilesSitesVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:populateFiles",
+      path: "v1beta1/{+parent}:populateFiles",
       hasBody: true,
     }),
     svc,
@@ -2803,7 +2811,7 @@ export const ListSitesVersionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListSitesVersionsRequest>;
 
@@ -2838,7 +2846,7 @@ export const GetSitesVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSitesVersionsRequest>;
 
@@ -2873,7 +2881,7 @@ export const CloneSitesVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/versions:clone",
+      path: "v1beta1/{+parent}/versions:clone",
       hasBody: true,
     }),
     svc,
@@ -2914,7 +2922,7 @@ export const ListSitesVersionsFilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/files" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/files" }),
     svc,
   ) as unknown as Schema.Schema<ListSitesVersionsFilesRequest>;
 
@@ -2955,7 +2963,7 @@ export const ListSitesReleasesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/releases" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/releases" }),
     svc,
   ) as unknown as Schema.Schema<ListSitesReleasesRequest>;
 
@@ -2990,7 +2998,7 @@ export const GetSitesReleasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSitesReleasesRequest>;
 
@@ -3030,7 +3038,7 @@ export const CreateSitesReleasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/releases",
+      path: "v1beta1/{+parent}/releases",
       hasBody: true,
     }),
     svc,
@@ -3068,7 +3076,7 @@ export const ListSitesChannelsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/channels" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/channels" }),
     svc,
   ) as unknown as Schema.Schema<ListSitesChannelsRequest>;
 
@@ -3111,7 +3119,7 @@ export const CreateSitesChannelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/channels",
+      path: "v1beta1/{+parent}/channels",
       hasBody: true,
     }),
     svc,
@@ -3143,7 +3151,7 @@ export const GetSitesChannelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSitesChannelsRequest>;
 
@@ -3179,7 +3187,7 @@ export const PatchSitesChannelsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Channel).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchSitesChannelsRequest>;
 
@@ -3209,7 +3217,7 @@ export const DeleteSitesChannelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteSitesChannelsRequest>;
 
@@ -3245,7 +3253,7 @@ export const ListSitesChannelsReleasesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/releases" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/releases" }),
     svc,
   ) as unknown as Schema.Schema<ListSitesChannelsReleasesRequest>;
 
@@ -3280,7 +3288,7 @@ export const GetSitesChannelsReleasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSitesChannelsReleasesRequest>;
 
@@ -3321,7 +3329,7 @@ export const CreateSitesChannelsReleasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/releases",
+      path: "v1beta1/{+parent}/releases",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/firebaseml-v1.ts
+++ b/packages/gcp/src/services/firebaseml-v1.ts
@@ -119,7 +119,7 @@ export const DeleteOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOperationsRequest>;
 
@@ -162,7 +162,7 @@ export const ListOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("returnPartialSuccess"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<ListOperationsRequest>;
 
@@ -200,7 +200,7 @@ export const CancelOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOperationsRequest>;
 

--- a/packages/gcp/src/services/firebaseml-v1beta2.ts
+++ b/packages/gcp/src/services/firebaseml-v1beta2.ts
@@ -189,7 +189,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 
@@ -220,7 +220,7 @@ export const DownloadProjectsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:download" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:download" }),
     svc,
   ) as unknown as Schema.Schema<DownloadProjectsModelsRequest>;
 
@@ -254,7 +254,7 @@ export const CreateProjectsModelsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Model).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta2/{parent}/models", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta2/{+parent}/models", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsModelsRequest>;
 
@@ -294,7 +294,7 @@ export const ListProjectsModelsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{parent}/models" }),
+    T.Http({ method: "GET", path: "v1beta2/{+parent}/models" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsModelsRequest>;
 
@@ -335,7 +335,7 @@ export const PatchProjectsModelsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Model).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsModelsRequest>;
 
@@ -366,7 +366,7 @@ export const GetProjectsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsModelsRequest>;
 
@@ -396,7 +396,7 @@ export const DeleteProjectsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta2/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsModelsRequest>;
 

--- a/packages/gcp/src/services/firebaseml-v2beta.ts
+++ b/packages/gcp/src/services/firebaseml-v2beta.ts
@@ -2347,7 +2347,7 @@ export const GenerateContentProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{model}:generateContent",
+      path: "v2beta/{+model}:generateContent",
       hasBody: true,
     }),
     svc,
@@ -2389,7 +2389,7 @@ export const StreamGenerateContentProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{model}:streamGenerateContent",
+      path: "v2beta/{+model}:streamGenerateContent",
       hasBody: true,
     }),
     svc,
@@ -2431,7 +2431,7 @@ export const CountTokensProjectsLocationsPublishersModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{endpoint}:countTokens",
+      path: "v2beta/{+endpoint}:countTokens",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/firebaserules-v1.ts
+++ b/packages/gcp/src/services/firebaserules-v1.ts
@@ -410,7 +410,7 @@ export const TestProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(TestRulesetRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v1/{name}:test", hasBody: true }),
+  T.Http({ method: "POST", path: "v1/{+name}:test", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<TestProjectsRequest>;
 
@@ -444,7 +444,7 @@ export const CreateProjectsRulesetsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Ruleset).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}/rulesets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}/rulesets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsRulesetsRequest>;
 
@@ -475,7 +475,7 @@ export const GetProjectsRulesetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsRulesetsRequest>;
 
@@ -514,7 +514,7 @@ export const ListProjectsRulesetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/rulesets" }),
+    T.Http({ method: "GET", path: "v1/{+name}/rulesets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsRulesetsRequest>;
 
@@ -549,7 +549,7 @@ export const DeleteProjectsRulesetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsRulesetsRequest>;
 
@@ -582,7 +582,7 @@ export const CreateProjectsReleasesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Release).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}/releases", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}/releases", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsReleasesRequest>;
 
@@ -616,7 +616,7 @@ export const PatchProjectsReleasesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateReleaseRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsReleasesRequest>;
 
@@ -647,7 +647,7 @@ export const GetProjectsReleasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsReleasesRequest>;
 
@@ -686,7 +686,7 @@ export const ListProjectsReleasesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/releases" }),
+    T.Http({ method: "GET", path: "v1/{+name}/releases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsReleasesRequest>;
 
@@ -721,7 +721,7 @@ export const DeleteProjectsReleasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsReleasesRequest>;
 
@@ -760,7 +760,7 @@ export const GetExecutableProjectsReleasesRequest =
       T.HttpQuery("executableVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getExecutable" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getExecutable" }),
     svc,
   ) as unknown as Schema.Schema<GetExecutableProjectsReleasesRequest>;
 

--- a/packages/gcp/src/services/firebasestorage-v1beta.ts
+++ b/packages/gcp/src/services/firebasestorage-v1beta.ts
@@ -92,7 +92,7 @@ export const DeleteDefaultBucketProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDefaultBucketProjectsRequest>;
 
@@ -123,7 +123,7 @@ export const GetDefaultBucketProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDefaultBucketProjectsRequest>;
 
@@ -154,7 +154,7 @@ export const GetProjectsBucketsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsBucketsRequest>;
 
@@ -190,7 +190,7 @@ export const ListProjectsBucketsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/buckets" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/buckets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsBucketsRequest>;
 
@@ -230,7 +230,7 @@ export const AddFirebaseProjectsBucketsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{bucket}:addFirebase",
+      path: "v1beta/{+bucket}:addFirebase",
       hasBody: true,
     }),
     svc,
@@ -268,7 +268,7 @@ export const RemoveFirebaseProjectsBucketsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{bucket}:removeFirebase",
+      path: "v1beta/{+bucket}:removeFirebase",
       hasBody: true,
     }),
     svc,
@@ -306,7 +306,7 @@ export const CreateProjectsDefaultBucketRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/defaultBucket",
+      path: "v1beta/{+parent}/defaultBucket",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/firestore-v1.ts
+++ b/packages/gcp/src/services/firestore-v1.ts
@@ -2414,7 +2414,7 @@ export const RestoreProjectsDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/databases:restore",
+      path: "v1/{+parent}/databases:restore",
       hasBody: true,
     }),
     svc,
@@ -2454,7 +2454,7 @@ export const ImportDocumentsProjectsDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:importDocuments",
+      path: "v1/{+name}:importDocuments",
       hasBody: true,
     }),
     svc,
@@ -2495,7 +2495,7 @@ export const BulkDeleteDocumentsProjectsDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:bulkDeleteDocuments",
+      path: "v1/{+name}:bulkDeleteDocuments",
       hasBody: true,
     }),
     svc,
@@ -2536,7 +2536,7 @@ export const ExportDocumentsProjectsDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:exportDocuments",
+      path: "v1/{+name}:exportDocuments",
       hasBody: true,
     }),
     svc,
@@ -2570,7 +2570,7 @@ export const GetProjectsDatabasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatabasesRequest>;
 
@@ -2604,7 +2604,7 @@ export const DeleteProjectsDatabasesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsDatabasesRequest>;
 
@@ -2641,7 +2641,7 @@ export const PatchProjectsDatabasesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleFirestoreAdminV1Database).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsDatabasesRequest>;
 
@@ -2678,7 +2678,7 @@ export const CreateProjectsDatabasesRequest =
     databaseId: Schema.optional(Schema.String).pipe(T.HttpQuery("databaseId")),
     body: Schema.optional(GoogleFirestoreAdminV1Database).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/databases", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/databases", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsDatabasesRequest>;
 
@@ -2716,7 +2716,7 @@ export const CloneProjectsDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/databases:clone",
+      path: "v1/{+parent}/databases:clone",
       hasBody: true,
     }),
     svc,
@@ -2754,7 +2754,7 @@ export const ListProjectsDatabasesRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/databases" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/databases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDatabasesRequest>;
 
@@ -2800,7 +2800,7 @@ export const ListProjectsDatabasesOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDatabasesOperationsRequest>;
 
@@ -2836,7 +2836,7 @@ export const GetProjectsDatabasesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatabasesOperationsRequest>;
 
@@ -2872,7 +2872,7 @@ export const CancelProjectsDatabasesOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsDatabasesOperationsRequest>;
 
@@ -2903,7 +2903,7 @@ export const DeleteProjectsDatabasesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsDatabasesOperationsRequest>;
 
@@ -2942,7 +2942,7 @@ export const PatchProjectsDatabasesBackupSchedulesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsDatabasesBackupSchedulesRequest>;
 
@@ -2981,7 +2981,7 @@ export const CreateProjectsDatabasesBackupSchedulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/backupSchedules",
+      path: "v1/{+parent}/backupSchedules",
       hasBody: true,
     }),
     svc,
@@ -3015,7 +3015,7 @@ export const GetProjectsDatabasesBackupSchedulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatabasesBackupSchedulesRequest>;
 
@@ -3047,7 +3047,7 @@ export const ListProjectsDatabasesBackupSchedulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backupSchedules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backupSchedules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDatabasesBackupSchedulesRequest>;
 
@@ -3079,7 +3079,7 @@ export const DeleteProjectsDatabasesBackupSchedulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsDatabasesBackupSchedulesRequest>;
 
@@ -3115,7 +3115,7 @@ export const EnableProjectsDatabasesUserCredsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:enable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:enable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EnableProjectsDatabasesUserCredsRequest>;
 
@@ -3152,7 +3152,7 @@ export const ResetPasswordProjectsDatabasesUserCredsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:resetPassword", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:resetPassword", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResetPasswordProjectsDatabasesUserCredsRequest>;
 
@@ -3184,7 +3184,7 @@ export const DeleteProjectsDatabasesUserCredsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsDatabasesUserCredsRequest>;
 
@@ -3215,7 +3215,7 @@ export const GetProjectsDatabasesUserCredsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatabasesUserCredsRequest>;
 
@@ -3247,7 +3247,7 @@ export const ListProjectsDatabasesUserCredsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/userCreds" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/userCreds" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDatabasesUserCredsRequest>;
 
@@ -3284,7 +3284,7 @@ export const DisableProjectsDatabasesUserCredsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:disable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:disable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DisableProjectsDatabasesUserCredsRequest>;
 
@@ -3324,7 +3324,7 @@ export const CreateProjectsDatabasesUserCredsRequest =
     ),
     body: Schema.optional(GoogleFirestoreAdminV1UserCreds).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/userCreds", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/userCreds", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsDatabasesUserCredsRequest>;
 
@@ -3361,7 +3361,7 @@ export const BatchGetProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{database}/documents:batchGet",
+      path: "v1/{+database}/documents:batchGet",
       hasBody: true,
     }),
     svc,
@@ -3400,7 +3400,7 @@ export const BeginTransactionProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{database}/documents:beginTransaction",
+      path: "v1/{+database}/documents:beginTransaction",
       hasBody: true,
     }),
     svc,
@@ -3439,7 +3439,7 @@ export const CommitProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{database}/documents:commit",
+      path: "v1/{+database}/documents:commit",
       hasBody: true,
     }),
     svc,
@@ -3502,7 +3502,7 @@ export const ListProjectsDatabasesDocumentsRequest =
     readTime: Schema.optional(Schema.String).pipe(T.HttpQuery("readTime")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/{collectionId}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/{collectionId}" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDatabasesDocumentsRequest>;
 
@@ -3542,7 +3542,7 @@ export const ListCollectionIdsProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:listCollectionIds",
+      path: "v1/{+parent}:listCollectionIds",
       hasBody: true,
     }),
     svc,
@@ -3581,7 +3581,7 @@ export const RollbackProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{database}/documents:rollback",
+      path: "v1/{+database}/documents:rollback",
       hasBody: true,
     }),
     svc,
@@ -3617,7 +3617,7 @@ export const RunQueryProjectsDatabasesDocumentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(RunQueryRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:runQuery", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}:runQuery", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunQueryProjectsDatabasesDocumentsRequest>;
 
@@ -3661,7 +3661,7 @@ export const GetProjectsDatabasesDocumentsRequest =
       T.HttpQuery("transaction"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatabasesDocumentsRequest>;
 
@@ -3722,7 +3722,7 @@ export const ListDocumentsProjectsDatabasesDocumentsRequest =
       T.HttpQuery("showMissing"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/{collectionId}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/{collectionId}" }),
     svc,
   ) as unknown as Schema.Schema<ListDocumentsProjectsDatabasesDocumentsRequest>;
 
@@ -3774,7 +3774,7 @@ export const CreateDocumentProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/{collectionId}",
+      path: "v1/{+parent}/{collectionId}",
       hasBody: true,
     }),
     svc,
@@ -3812,7 +3812,7 @@ export const ExecutePipelineProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{database}/documents:executePipeline",
+      path: "v1/{+database}/documents:executePipeline",
       hasBody: true,
     }),
     svc,
@@ -3851,7 +3851,7 @@ export const PartitionQueryProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:partitionQuery",
+      path: "v1/{+parent}:partitionQuery",
       hasBody: true,
     }),
     svc,
@@ -3890,7 +3890,7 @@ export const WriteProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{database}/documents:write",
+      path: "v1/{+database}/documents:write",
       hasBody: true,
     }),
     svc,
@@ -3933,7 +3933,7 @@ export const DeleteProjectsDatabasesDocumentsRequest =
       T.HttpQuery("currentDocument.exists"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsDatabasesDocumentsRequest>;
 
@@ -3969,7 +3969,7 @@ export const ListenProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{database}/documents:listen",
+      path: "v1/{+database}/documents:listen",
       hasBody: true,
     }),
     svc,
@@ -4007,7 +4007,7 @@ export const BatchWriteProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{database}/documents:batchWrite",
+      path: "v1/{+database}/documents:batchWrite",
       hasBody: true,
     }),
     svc,
@@ -4063,7 +4063,7 @@ export const PatchProjectsDatabasesDocumentsRequest =
     ),
     body: Schema.optional(Document).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsDatabasesDocumentsRequest>;
 
@@ -4099,7 +4099,7 @@ export const RunAggregationQueryProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:runAggregationQuery",
+      path: "v1/{+parent}:runAggregationQuery",
       hasBody: true,
     }),
     svc,
@@ -4136,7 +4136,7 @@ export const CreateProjectsDatabasesCollectionGroupsIndexesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleFirestoreAdminV1Index).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/indexes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/indexes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsDatabasesCollectionGroupsIndexesRequest>;
 
@@ -4177,7 +4177,7 @@ export const ListProjectsDatabasesCollectionGroupsIndexesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/indexes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/indexes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDatabasesCollectionGroupsIndexesRequest>;
 
@@ -4213,7 +4213,7 @@ export const GetProjectsDatabasesCollectionGroupsIndexesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatabasesCollectionGroupsIndexesRequest>;
 
@@ -4245,7 +4245,7 @@ export const DeleteProjectsDatabasesCollectionGroupsIndexesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsDatabasesCollectionGroupsIndexesRequest>;
 
@@ -4276,7 +4276,7 @@ export const GetProjectsDatabasesCollectionGroupsFieldsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatabasesCollectionGroupsFieldsRequest>;
 
@@ -4317,7 +4317,7 @@ export const ListProjectsDatabasesCollectionGroupsFieldsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/fields" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/fields" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDatabasesCollectionGroupsFieldsRequest>;
 
@@ -4359,7 +4359,7 @@ export const PatchProjectsDatabasesCollectionGroupsFieldsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleFirestoreAdminV1Field).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsDatabasesCollectionGroupsFieldsRequest>;
 
@@ -4405,7 +4405,7 @@ export const ListProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -4440,7 +4440,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -4471,7 +4471,7 @@ export const GetProjectsLocationsBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupsRequest>;
 
@@ -4505,7 +4505,7 @@ export const ListProjectsLocationsBackupsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupsRequest>;
 
@@ -4537,7 +4537,7 @@ export const DeleteProjectsLocationsBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupsRequest>;
 

--- a/packages/gcp/src/services/firestore-v1beta1.ts
+++ b/packages/gcp/src/services/firestore-v1beta1.ts
@@ -1644,7 +1644,7 @@ export const ImportDocumentsProjectsDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:importDocuments",
+      path: "v1beta1/{+name}:importDocuments",
       hasBody: true,
     }),
     svc,
@@ -1685,7 +1685,7 @@ export const ExportDocumentsProjectsDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:exportDocuments",
+      path: "v1beta1/{+name}:exportDocuments",
       hasBody: true,
     }),
     svc,
@@ -1729,7 +1729,7 @@ export const DeleteProjectsDatabasesDocumentsRequest =
       T.HttpQuery("currentDocument.updateTime"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsDatabasesDocumentsRequest>;
 
@@ -1765,7 +1765,7 @@ export const RollbackProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{database}/documents:rollback",
+      path: "v1beta1/{+database}/documents:rollback",
       hasBody: true,
     }),
     svc,
@@ -1803,7 +1803,7 @@ export const WriteProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{database}/documents:write",
+      path: "v1beta1/{+database}/documents:write",
       hasBody: true,
     }),
     svc,
@@ -1841,7 +1841,7 @@ export const BeginTransactionProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{database}/documents:beginTransaction",
+      path: "v1beta1/{+database}/documents:beginTransaction",
       hasBody: true,
     }),
     svc,
@@ -1888,7 +1888,7 @@ export const GetProjectsDatabasesDocumentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     readTime: Schema.optional(Schema.String).pipe(T.HttpQuery("readTime")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatabasesDocumentsRequest>;
 
@@ -1924,7 +1924,7 @@ export const CommitProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{database}/documents:commit",
+      path: "v1beta1/{+database}/documents:commit",
       hasBody: true,
     }),
     svc,
@@ -1962,7 +1962,7 @@ export const RunAggregationQueryProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:runAggregationQuery",
+      path: "v1beta1/{+parent}:runAggregationQuery",
       hasBody: true,
     }),
     svc,
@@ -2001,7 +2001,7 @@ export const PartitionQueryProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:partitionQuery",
+      path: "v1beta1/{+parent}:partitionQuery",
       hasBody: true,
     }),
     svc,
@@ -2040,7 +2040,7 @@ export const BatchWriteProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{database}/documents:batchWrite",
+      path: "v1beta1/{+database}/documents:batchWrite",
       hasBody: true,
     }),
     svc,
@@ -2089,7 +2089,7 @@ export const CreateDocumentProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/{collectionId}",
+      path: "v1beta1/{+parent}/{collectionId}",
       hasBody: true,
     }),
     svc,
@@ -2145,7 +2145,7 @@ export const PatchProjectsDatabasesDocumentsRequest =
     ),
     body: Schema.optional(Document).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsDatabasesDocumentsRequest>;
 
@@ -2181,7 +2181,7 @@ export const ExecutePipelineProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{database}/documents:executePipeline",
+      path: "v1beta1/{+database}/documents:executePipeline",
       hasBody: true,
     }),
     svc,
@@ -2220,7 +2220,7 @@ export const ListCollectionIdsProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:listCollectionIds",
+      path: "v1beta1/{+parent}:listCollectionIds",
       hasBody: true,
     }),
     svc,
@@ -2284,7 +2284,7 @@ export const ListProjectsDatabasesDocumentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     readTime: Schema.optional(Schema.String).pipe(T.HttpQuery("readTime")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/{collectionId}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/{collectionId}" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDatabasesDocumentsRequest>;
 
@@ -2324,7 +2324,7 @@ export const BatchGetProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{database}/documents:batchGet",
+      path: "v1beta1/{+database}/documents:batchGet",
       hasBody: true,
     }),
     svc,
@@ -2388,7 +2388,7 @@ export const ListDocumentsProjectsDatabasesDocumentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     readTime: Schema.optional(Schema.String).pipe(T.HttpQuery("readTime")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/{collectionId}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/{collectionId}" }),
     svc,
   ) as unknown as Schema.Schema<ListDocumentsProjectsDatabasesDocumentsRequest>;
 
@@ -2429,7 +2429,7 @@ export const RunQueryProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:runQuery",
+      path: "v1beta1/{+parent}:runQuery",
       hasBody: true,
     }),
     svc,
@@ -2467,7 +2467,7 @@ export const ListenProjectsDatabasesDocumentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{database}/documents:listen",
+      path: "v1beta1/{+database}/documents:listen",
       hasBody: true,
     }),
     svc,
@@ -2508,7 +2508,7 @@ export const ListProjectsDatabasesIndexesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/indexes" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/indexes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDatabasesIndexesRequest>;
 
@@ -2547,7 +2547,11 @@ export const CreateProjectsDatabasesIndexesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleFirestoreAdminV1beta1Index).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/indexes", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/indexes",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsDatabasesIndexesRequest>;
 
@@ -2578,7 +2582,7 @@ export const GetProjectsDatabasesIndexesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatabasesIndexesRequest>;
 
@@ -2610,7 +2614,7 @@ export const DeleteProjectsDatabasesIndexesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsDatabasesIndexesRequest>;
 

--- a/packages/gcp/src/services/firestore-v1beta2.ts
+++ b/packages/gcp/src/services/firestore-v1beta2.ts
@@ -574,7 +574,7 @@ export const ImportDocumentsProjectsDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{name}:importDocuments",
+      path: "v1beta2/{+name}:importDocuments",
       hasBody: true,
     }),
     svc,
@@ -615,7 +615,7 @@ export const ExportDocumentsProjectsDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{name}:exportDocuments",
+      path: "v1beta2/{+name}:exportDocuments",
       hasBody: true,
     }),
     svc,
@@ -658,7 +658,7 @@ export const ListProjectsDatabasesCollectionGroupsIndexesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{parent}/indexes" }),
+    T.Http({ method: "GET", path: "v1beta2/{+parent}/indexes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDatabasesCollectionGroupsIndexesRequest>;
 
@@ -697,7 +697,11 @@ export const CreateProjectsDatabasesCollectionGroupsIndexesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleFirestoreAdminV1beta2Index).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta2/{parent}/indexes", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta2/{+parent}/indexes",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsDatabasesCollectionGroupsIndexesRequest>;
 
@@ -729,7 +733,7 @@ export const GetProjectsDatabasesCollectionGroupsIndexesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatabasesCollectionGroupsIndexesRequest>;
 
@@ -761,7 +765,7 @@ export const DeleteProjectsDatabasesCollectionGroupsIndexesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta2/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsDatabasesCollectionGroupsIndexesRequest>;
 
@@ -792,7 +796,7 @@ export const GetProjectsDatabasesCollectionGroupsFieldsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDatabasesCollectionGroupsFieldsRequest>;
 
@@ -830,7 +834,7 @@ export const PatchProjectsDatabasesCollectionGroupsFieldsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleFirestoreAdminV1beta2Field).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsDatabasesCollectionGroupsFieldsRequest>;
 
@@ -871,7 +875,7 @@ export const ListProjectsDatabasesCollectionGroupsFieldsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{parent}/fields" }),
+    T.Http({ method: "GET", path: "v1beta2/{+parent}/fields" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDatabasesCollectionGroupsFieldsRequest>;
 

--- a/packages/gcp/src/services/gkebackup-v1.ts
+++ b/packages/gcp/src/services/gkebackup-v1.ts
@@ -1798,7 +1798,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1833,7 +1833,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1876,7 +1876,7 @@ export const ListProjectsLocationsBackupPlansRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backupPlans" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backupPlans" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupPlansRequest>;
 
@@ -1911,7 +1911,7 @@ export const GetTagsProjectsLocationsBackupPlansRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getTags" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getTags" }),
     svc,
   ) as unknown as Schema.Schema<GetTagsProjectsLocationsBackupPlansRequest>;
 
@@ -1942,7 +1942,7 @@ export const GetProjectsLocationsBackupPlansRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupPlansRequest>;
 
@@ -1976,7 +1976,7 @@ export const SetTagsProjectsLocationsBackupPlansRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetTagsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setTags", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setTags", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetTagsProjectsLocationsBackupPlansRequest>;
 
@@ -2012,7 +2012,7 @@ export const TestIamPermissionsProjectsLocationsBackupPlansRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2052,7 +2052,7 @@ export const PatchProjectsLocationsBackupPlansRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(BackupPlan).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupPlansRequest>;
 
@@ -2087,7 +2087,7 @@ export const DeleteProjectsLocationsBackupPlansRequest =
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupPlansRequest>;
 
@@ -2124,7 +2124,7 @@ export const SetIamPolicyProjectsLocationsBackupPlansRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2165,7 +2165,7 @@ export const CreateProjectsLocationsBackupPlansRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(BackupPlan).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/backupPlans", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/backupPlans", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackupPlansRequest>;
 
@@ -2202,7 +2202,7 @@ export const GetIamPolicyProjectsLocationsBackupPlansRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsBackupPlansRequest>;
 
@@ -2238,7 +2238,7 @@ export const SetIamPolicyProjectsLocationsBackupPlansBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2278,7 +2278,7 @@ export const CreateProjectsLocationsBackupPlansBackupsRequest =
     backupId: Schema.optional(Schema.String).pipe(T.HttpQuery("backupId")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/backups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/backups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackupPlansBackupsRequest>;
 
@@ -2315,7 +2315,7 @@ export const GetIamPolicyProjectsLocationsBackupPlansBackupsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsBackupPlansBackupsRequest>;
 
@@ -2353,7 +2353,7 @@ export const PatchProjectsLocationsBackupPlansBackupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupPlansBackupsRequest>;
 
@@ -2391,7 +2391,7 @@ export const DeleteProjectsLocationsBackupPlansBackupsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupPlansBackupsRequest>;
 
@@ -2423,7 +2423,7 @@ export const GetProjectsLocationsBackupPlansBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupPlansBackupsRequest>;
 
@@ -2459,7 +2459,7 @@ export const TestIamPermissionsProjectsLocationsBackupPlansBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2494,7 +2494,7 @@ export const GetBackupIndexDownloadUrlProjectsLocationsBackupPlansBackupsRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     backup: Schema.String.pipe(T.HttpPath("backup")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{backup}:getBackupIndexDownloadUrl" }),
+    T.Http({ method: "GET", path: "v1/{+backup}:getBackupIndexDownloadUrl" }),
     svc,
   ) as unknown as Schema.Schema<GetBackupIndexDownloadUrlProjectsLocationsBackupPlansBackupsRequest>;
 
@@ -2544,7 +2544,7 @@ export const ListProjectsLocationsBackupPlansBackupsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupPlansBackupsRequest>;
 
@@ -2580,7 +2580,7 @@ export const GetProjectsLocationsBackupPlansBackupsVolumeBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupPlansBackupsVolumeBackupsRequest>;
 
@@ -2618,7 +2618,7 @@ export const TestIamPermissionsProjectsLocationsBackupPlansBackupsVolumeBackupsR
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2660,7 +2660,7 @@ export const SetIamPolicyProjectsLocationsBackupPlansBackupsVolumeBackupsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2700,7 +2700,7 @@ export const GetIamPolicyProjectsLocationsBackupPlansBackupsVolumeBackupsRequest
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsBackupPlansBackupsVolumeBackupsRequest>;
 
@@ -2745,7 +2745,7 @@ export const ListProjectsLocationsBackupPlansBackupsVolumeBackupsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/volumeBackups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/volumeBackups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupPlansBackupsVolumeBackupsRequest>;
 
@@ -2796,7 +2796,7 @@ export const ListProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2832,7 +2832,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2868,7 +2868,7 @@ export const CancelProjectsLocationsOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2899,7 +2899,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2940,7 +2940,7 @@ export const CreateProjectsLocationsRestoreChannelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/restoreChannels",
+      path: "v1/{+parent}/restoreChannels",
       hasBody: true,
     }),
     svc,
@@ -2986,7 +2986,7 @@ export const ListProjectsLocationsRestoreChannelsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/restoreChannels" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/restoreChannels" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRestoreChannelsRequest>;
 
@@ -3028,7 +3028,7 @@ export const PatchProjectsLocationsRestoreChannelsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(RestoreChannel).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRestoreChannelsRequest>;
 
@@ -3063,7 +3063,7 @@ export const DeleteProjectsLocationsRestoreChannelsRequest =
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRestoreChannelsRequest>;
 
@@ -3095,7 +3095,7 @@ export const GetProjectsLocationsRestoreChannelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRestoreChannelsRequest>;
 
@@ -3138,7 +3138,7 @@ export const ListProjectsLocationsRestoreChannelsRestorePlanBindingsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/restorePlanBindings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/restorePlanBindings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRestoreChannelsRestorePlanBindingsRequest>;
 
@@ -3175,7 +3175,7 @@ export const GetProjectsLocationsRestoreChannelsRestorePlanBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRestoreChannelsRestorePlanBindingsRequest>;
 
@@ -3220,7 +3220,7 @@ export const ListProjectsLocationsRestorePlansRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/restorePlans" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/restorePlans" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRestorePlansRequest>;
 
@@ -3256,7 +3256,7 @@ export const GetTagsProjectsLocationsRestorePlansRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getTags" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getTags" }),
     svc,
   ) as unknown as Schema.Schema<GetTagsProjectsLocationsRestorePlansRequest>;
 
@@ -3293,7 +3293,7 @@ export const PatchProjectsLocationsRestorePlansRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(RestorePlan).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRestorePlansRequest>;
 
@@ -3331,7 +3331,7 @@ export const DeleteProjectsLocationsRestorePlansRequest =
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRestorePlansRequest>;
 
@@ -3363,7 +3363,7 @@ export const GetProjectsLocationsRestorePlansRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRestorePlansRequest>;
 
@@ -3397,7 +3397,7 @@ export const SetTagsProjectsLocationsRestorePlansRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetTagsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setTags", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setTags", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetTagsProjectsLocationsRestorePlansRequest>;
 
@@ -3433,7 +3433,7 @@ export const TestIamPermissionsProjectsLocationsRestorePlansRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3473,7 +3473,7 @@ export const SetIamPolicyProjectsLocationsRestorePlansRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3514,7 +3514,11 @@ export const CreateProjectsLocationsRestorePlansRequest =
     ),
     body: Schema.optional(RestorePlan).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/restorePlans", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/restorePlans",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRestorePlansRequest>;
 
@@ -3551,7 +3555,7 @@ export const GetIamPolicyProjectsLocationsRestorePlansRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsRestorePlansRequest>;
 
@@ -3587,7 +3591,7 @@ export const SetIamPolicyProjectsLocationsRestorePlansRestoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3627,7 +3631,7 @@ export const CreateProjectsLocationsRestorePlansRestoresRequest =
     restoreId: Schema.optional(Schema.String).pipe(T.HttpQuery("restoreId")),
     body: Schema.optional(Restore).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/restores", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/restores", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRestorePlansRestoresRequest>;
 
@@ -3664,7 +3668,7 @@ export const GetIamPolicyProjectsLocationsRestorePlansRestoresRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsRestorePlansRestoresRequest>;
 
@@ -3708,7 +3712,7 @@ export const ListProjectsLocationsRestorePlansRestoresRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/restores" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/restores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRestorePlansRestoresRequest>;
 
@@ -3750,7 +3754,7 @@ export const PatchProjectsLocationsRestorePlansRestoresRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Restore).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRestorePlansRestoresRequest>;
 
@@ -3788,7 +3792,7 @@ export const DeleteProjectsLocationsRestorePlansRestoresRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRestorePlansRestoresRequest>;
 
@@ -3820,7 +3824,7 @@ export const GetProjectsLocationsRestorePlansRestoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRestorePlansRestoresRequest>;
 
@@ -3856,7 +3860,7 @@ export const TestIamPermissionsProjectsLocationsRestorePlansRestoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3896,7 +3900,7 @@ export const TestIamPermissionsProjectsLocationsRestorePlansRestoresVolumeRestor
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3933,7 +3937,7 @@ export const GetProjectsLocationsRestorePlansRestoresVolumeRestoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRestorePlansRestoresVolumeRestoresRequest>;
 
@@ -3971,7 +3975,7 @@ export const GetIamPolicyProjectsLocationsRestorePlansRestoresVolumeRestoresRequ
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsRestorePlansRestoresVolumeRestoresRequest>;
 
@@ -4010,7 +4014,7 @@ export const SetIamPolicyProjectsLocationsRestorePlansRestoresVolumeRestoresRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4058,7 +4062,7 @@ export const ListProjectsLocationsRestorePlansRestoresVolumeRestoresRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/volumeRestores" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/volumeRestores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRestorePlansRestoresVolumeRestoresRequest>;
 
@@ -4095,7 +4099,7 @@ export const GetProjectsLocationsBackupChannelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupChannelsRequest>;
 
@@ -4132,7 +4136,7 @@ export const PatchProjectsLocationsBackupChannelsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(BackupChannel).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupChannelsRequest>;
 
@@ -4170,7 +4174,7 @@ export const DeleteProjectsLocationsBackupChannelsRequest =
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupChannelsRequest>;
 
@@ -4214,7 +4218,7 @@ export const ListProjectsLocationsBackupChannelsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backupChannels" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backupChannels" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupChannelsRequest>;
 
@@ -4260,7 +4264,7 @@ export const CreateProjectsLocationsBackupChannelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/backupChannels",
+      path: "v1/{+parent}/backupChannels",
       hasBody: true,
     }),
     svc,
@@ -4306,7 +4310,7 @@ export const ListProjectsLocationsBackupChannelsBackupPlanBindingsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backupPlanBindings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backupPlanBindings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupChannelsBackupPlanBindingsRequest>;
 
@@ -4343,7 +4347,7 @@ export const GetProjectsLocationsBackupChannelsBackupPlanBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupChannelsBackupPlanBindingsRequest>;
 

--- a/packages/gcp/src/services/gkehub-v1.ts
+++ b/packages/gcp/src/services/gkehub-v1.ts
@@ -3279,7 +3279,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -3324,7 +3324,7 @@ export const ListProjectsLocationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -3368,7 +3368,7 @@ export const PatchProjectsLocationsFeaturesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Feature).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFeaturesRequest>;
 
@@ -3404,7 +3404,7 @@ export const GetIamPolicyProjectsLocationsFeaturesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsFeaturesRequest>;
 
@@ -3440,7 +3440,7 @@ export const TestIamPermissionsProjectsLocationsFeaturesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3479,7 +3479,7 @@ export const GetProjectsLocationsFeaturesRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeaturesRequest>;
 
@@ -3519,7 +3519,7 @@ export const CreateProjectsLocationsFeaturesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Feature).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/features", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/features", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsFeaturesRequest>;
 
@@ -3555,7 +3555,7 @@ export const SetIamPolicyProjectsLocationsFeaturesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3605,7 +3605,7 @@ export const ListProjectsLocationsFeaturesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/features" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/features" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeaturesRequest>;
 
@@ -3646,7 +3646,7 @@ export const DeleteProjectsLocationsFeaturesRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeaturesRequest>;
 
@@ -3682,7 +3682,7 @@ export const SetIamPolicyProjectsLocationsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3724,7 +3724,7 @@ export const PatchProjectsLocationsMembershipsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Membership).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMembershipsRequest>;
 
@@ -3760,7 +3760,7 @@ export const GetIamPolicyProjectsLocationsMembershipsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsMembershipsRequest>;
 
@@ -3803,7 +3803,7 @@ export const ListProjectsLocationsMembershipsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/memberships" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/memberships" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMembershipsRequest>;
 
@@ -3844,7 +3844,7 @@ export const DeleteProjectsLocationsMembershipsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMembershipsRequest>;
 
@@ -3875,7 +3875,7 @@ export const GetProjectsLocationsMembershipsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMembershipsRequest>;
 
@@ -3917,7 +3917,7 @@ export const CreateProjectsLocationsMembershipsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Membership).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/memberships", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/memberships", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsMembershipsRequest>;
 
@@ -3953,7 +3953,7 @@ export const TestIamPermissionsProjectsLocationsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4007,7 +4007,7 @@ export const GenerateConnectManifestProjectsLocationsMembershipsRequest =
     proxy: Schema.optional(Schema.String).pipe(T.HttpQuery("proxy")),
     namespace: Schema.optional(Schema.String).pipe(T.HttpQuery("namespace")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:generateConnectManifest" }),
+    T.Http({ method: "GET", path: "v1/{+name}:generateConnectManifest" }),
     svc,
   ) as unknown as Schema.Schema<GenerateConnectManifestProjectsLocationsMembershipsRequest>;
 
@@ -4040,7 +4040,7 @@ export const DeleteProjectsLocationsMembershipsRbacrolebindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMembershipsRbacrolebindingsRequest>;
 
@@ -4079,7 +4079,7 @@ export const PatchProjectsLocationsMembershipsRbacrolebindingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(RBACRoleBinding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMembershipsRbacrolebindingsRequest>;
 
@@ -4112,7 +4112,7 @@ export const GetProjectsLocationsMembershipsRbacrolebindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMembershipsRbacrolebindingsRequest>;
 
@@ -4155,7 +4155,7 @@ export const CreateProjectsLocationsMembershipsRbacrolebindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/rbacrolebindings",
+      path: "v1/{+parent}/rbacrolebindings",
       hasBody: true,
     }),
     svc,
@@ -4196,7 +4196,7 @@ export const ListProjectsLocationsMembershipsRbacrolebindingsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/rbacrolebindings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/rbacrolebindings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMembershipsRbacrolebindingsRequest>;
 
@@ -4243,7 +4243,7 @@ export const GenerateMembershipRBACRoleBindingYAMLProjectsLocationsMembershipsRb
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/rbacrolebindings:generateMembershipRBACRoleBindingYAML",
+      path: "v1/{+parent}/rbacrolebindings:generateMembershipRBACRoleBindingYAML",
       hasBody: true,
     }),
     svc,
@@ -4280,7 +4280,7 @@ export const DeleteProjectsLocationsMembershipsBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMembershipsBindingsRequest>;
 
@@ -4320,7 +4320,7 @@ export const ListProjectsLocationsMembershipsBindingsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/bindings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/bindings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMembershipsBindingsRequest>;
 
@@ -4356,7 +4356,7 @@ export const GetProjectsLocationsMembershipsBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMembershipsBindingsRequest>;
 
@@ -4395,7 +4395,7 @@ export const CreateProjectsLocationsMembershipsBindingsRequest =
     ),
     body: Schema.optional(MembershipBinding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/bindings", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/bindings", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsMembershipsBindingsRequest>;
 
@@ -4432,7 +4432,7 @@ export const PatchProjectsLocationsMembershipsBindingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(MembershipBinding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMembershipsBindingsRequest>;
 
@@ -4466,7 +4466,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -4497,7 +4497,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -4542,7 +4542,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -4577,7 +4577,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -4617,7 +4617,7 @@ export const ListMembershipsProjectsLocationsScopesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{scopeName}:listMemberships" }),
+    T.Http({ method: "GET", path: "v1/{+scopeName}:listMemberships" }),
     svc,
   ) as unknown as Schema.Schema<ListMembershipsProjectsLocationsScopesRequest>;
 
@@ -4659,7 +4659,7 @@ export const PatchProjectsLocationsScopesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Scope).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsScopesRequest>;
 
@@ -4695,7 +4695,7 @@ export const GetIamPolicyProjectsLocationsScopesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsScopesRequest>;
 
@@ -4731,7 +4731,7 @@ export const SetIamPolicyProjectsLocationsScopesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4770,7 +4770,7 @@ export const ListProjectsLocationsScopesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/scopes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/scopes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsScopesRequest>;
 
@@ -4805,7 +4805,7 @@ export const DeleteProjectsLocationsScopesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsScopesRequest>;
 
@@ -4841,7 +4841,7 @@ export const TestIamPermissionsProjectsLocationsScopesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4875,7 +4875,7 @@ export const GetProjectsLocationsScopesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsScopesRequest>;
 
@@ -4912,7 +4912,7 @@ export const CreateProjectsLocationsScopesRequest =
     scopeId: Schema.optional(Schema.String).pipe(T.HttpQuery("scopeId")),
     body: Schema.optional(Scope).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/scopes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/scopes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsScopesRequest>;
 
@@ -4949,7 +4949,7 @@ export const ListPermittedProjectsLocationsScopesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/scopes:listPermitted" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/scopes:listPermitted" }),
     svc,
   ) as unknown as Schema.Schema<ListPermittedProjectsLocationsScopesRequest>;
 
@@ -4991,7 +4991,7 @@ export const ListProjectsLocationsScopesNamespacesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/namespaces" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/namespaces" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsScopesNamespacesRequest>;
 
@@ -5027,7 +5027,7 @@ export const GetProjectsLocationsScopesNamespacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsScopesNamespacesRequest>;
 
@@ -5066,7 +5066,7 @@ export const CreateProjectsLocationsScopesNamespacesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Namespace).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/namespaces", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/namespaces", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsScopesNamespacesRequest>;
 
@@ -5103,7 +5103,7 @@ export const PatchProjectsLocationsScopesNamespacesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Namespace).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsScopesNamespacesRequest>;
 
@@ -5134,7 +5134,7 @@ export const DeleteProjectsLocationsScopesNamespacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsScopesNamespacesRequest>;
 
@@ -5165,7 +5165,7 @@ export const DeleteProjectsLocationsScopesRbacrolebindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsScopesRbacrolebindingsRequest>;
 
@@ -5202,7 +5202,7 @@ export const ListProjectsLocationsScopesRbacrolebindingsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/rbacrolebindings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/rbacrolebindings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsScopesRbacrolebindingsRequest>;
 
@@ -5238,7 +5238,7 @@ export const GetProjectsLocationsScopesRbacrolebindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsScopesRbacrolebindingsRequest>;
 
@@ -5280,7 +5280,7 @@ export const CreateProjectsLocationsScopesRbacrolebindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/rbacrolebindings",
+      path: "v1/{+parent}/rbacrolebindings",
       hasBody: true,
     }),
     svc,
@@ -5319,7 +5319,7 @@ export const PatchProjectsLocationsScopesRbacrolebindingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(RBACRoleBinding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsScopesRbacrolebindingsRequest>;
 
@@ -5356,7 +5356,7 @@ export const ListProjectsLocationsFleetsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/fleets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/fleets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFleetsRequest>;
 
@@ -5397,7 +5397,7 @@ export const PatchProjectsLocationsFleetsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Fleet).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFleetsRequest>;
 
@@ -5431,7 +5431,7 @@ export const CreateProjectsLocationsFleetsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Fleet).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/fleets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/fleets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsFleetsRequest>;
 
@@ -5462,7 +5462,7 @@ export const GetProjectsLocationsFleetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFleetsRequest>;
 
@@ -5493,7 +5493,7 @@ export const DeleteProjectsLocationsFleetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFleetsRequest>;
 
@@ -5530,7 +5530,7 @@ export const ListOrganizationsLocationsFleetsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/fleets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/fleets" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsFleetsRequest>;
 

--- a/packages/gcp/src/services/gkehub-v1alpha.ts
+++ b/packages/gcp/src/services/gkehub-v1alpha.ts
@@ -4029,7 +4029,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -4074,7 +4074,7 @@ export const ListProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -4126,7 +4126,7 @@ export const ListProjectsLocationsFeaturesRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/features" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/features" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeaturesRequest>;
 
@@ -4166,7 +4166,7 @@ export const GetProjectsLocationsFeaturesRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeaturesRequest>;
 
@@ -4208,7 +4208,7 @@ export const CreateProjectsLocationsFeaturesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/features",
+      path: "v1alpha/{+parent}/features",
       hasBody: true,
     }),
     svc,
@@ -4246,7 +4246,7 @@ export const SetIamPolicyProjectsLocationsFeaturesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4288,7 +4288,7 @@ export const PatchProjectsLocationsFeaturesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Feature).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFeaturesRequest>;
 
@@ -4324,7 +4324,7 @@ export const GetIamPolicyProjectsLocationsFeaturesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsFeaturesRequest>;
 
@@ -4360,7 +4360,7 @@ export const TestIamPermissionsProjectsLocationsFeaturesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:testIamPermissions",
+      path: "v1alpha/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4400,7 +4400,7 @@ export const DeleteProjectsLocationsFeaturesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeaturesRequest>;
 
@@ -4440,7 +4440,7 @@ export const ListProjectsLocationsRolloutsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/rollouts" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/rollouts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRolloutsRequest>;
 
@@ -4475,7 +4475,7 @@ export const GetProjectsLocationsRolloutsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRolloutsRequest>;
 
@@ -4516,7 +4516,7 @@ export const GenerateExclusivityManifestProjectsLocationsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{name}:generateExclusivityManifest",
+      path: "v1alpha/{+name}:generateExclusivityManifest",
     }),
     svc,
   ) as unknown as Schema.Schema<GenerateExclusivityManifestProjectsLocationsMembershipsRequest>;
@@ -4562,7 +4562,7 @@ export const ListProjectsLocationsMembershipsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/memberships" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/memberships" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMembershipsRequest>;
 
@@ -4606,7 +4606,7 @@ export const PatchProjectsLocationsMembershipsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Membership).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMembershipsRequest>;
 
@@ -4642,7 +4642,7 @@ export const GetIamPolicyProjectsLocationsMembershipsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsMembershipsRequest>;
 
@@ -4678,7 +4678,7 @@ export const SetIamPolicyProjectsLocationsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4716,7 +4716,7 @@ export const ValidateCreateProjectsLocationsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/memberships:validateCreate",
+      path: "v1alpha/{+parent}/memberships:validateCreate",
       hasBody: true,
     }),
     svc,
@@ -4755,7 +4755,7 @@ export const TestIamPermissionsProjectsLocationsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:testIamPermissions",
+      path: "v1alpha/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4789,7 +4789,7 @@ export const GetProjectsLocationsMembershipsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMembershipsRequest>;
 
@@ -4826,7 +4826,7 @@ export const DeleteProjectsLocationsMembershipsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMembershipsRequest>;
 
@@ -4867,7 +4867,7 @@ export const ValidateExclusivityProjectsLocationsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}/memberships:validateExclusivity",
+      path: "v1alpha/{+parent}/memberships:validateExclusivity",
     }),
     svc,
   ) as unknown as Schema.Schema<ValidateExclusivityProjectsLocationsMembershipsRequest>;
@@ -4921,7 +4921,7 @@ export const GenerateConnectManifestProjectsLocationsMembershipsRequest =
     proxy: Schema.optional(Schema.String).pipe(T.HttpQuery("proxy")),
     namespace: Schema.optional(Schema.String).pipe(T.HttpQuery("namespace")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}:generateConnectManifest" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}:generateConnectManifest" }),
     svc,
   ) as unknown as Schema.Schema<GenerateConnectManifestProjectsLocationsMembershipsRequest>;
 
@@ -4966,7 +4966,7 @@ export const ListAdminProjectsLocationsMembershipsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/memberships:listAdmin" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/memberships:listAdmin" }),
     svc,
   ) as unknown as Schema.Schema<ListAdminProjectsLocationsMembershipsRequest>;
 
@@ -5015,7 +5015,7 @@ export const CreateProjectsLocationsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/memberships",
+      path: "v1alpha/{+parent}/memberships",
       hasBody: true,
     }),
     svc,
@@ -5054,7 +5054,7 @@ export const PatchProjectsLocationsMembershipsBindingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(MembershipBinding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMembershipsBindingsRequest>;
 
@@ -5085,7 +5085,7 @@ export const GetProjectsLocationsMembershipsBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMembershipsBindingsRequest>;
 
@@ -5126,7 +5126,7 @@ export const CreateProjectsLocationsMembershipsBindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/bindings",
+      path: "v1alpha/{+parent}/bindings",
       hasBody: true,
     }),
     svc,
@@ -5168,7 +5168,7 @@ export const ListProjectsLocationsMembershipsBindingsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/bindings" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/bindings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMembershipsBindingsRequest>;
 
@@ -5204,7 +5204,7 @@ export const DeleteProjectsLocationsMembershipsBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMembershipsBindingsRequest>;
 
@@ -5235,7 +5235,7 @@ export const DeleteProjectsLocationsMembershipsRbacrolebindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMembershipsRbacrolebindingsRequest>;
 
@@ -5268,7 +5268,7 @@ export const GetProjectsLocationsMembershipsRbacrolebindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMembershipsRbacrolebindingsRequest>;
 
@@ -5311,7 +5311,7 @@ export const CreateProjectsLocationsMembershipsRbacrolebindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/rbacrolebindings",
+      path: "v1alpha/{+parent}/rbacrolebindings",
       hasBody: true,
     }),
     svc,
@@ -5352,7 +5352,7 @@ export const PatchProjectsLocationsMembershipsRbacrolebindingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(RBACRoleBinding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMembershipsRbacrolebindingsRequest>;
 
@@ -5395,7 +5395,7 @@ export const GenerateMembershipRBACRoleBindingYAMLProjectsLocationsMembershipsRb
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/rbacrolebindings:generateMembershipRBACRoleBindingYAML",
+      path: "v1alpha/{+parent}/rbacrolebindings:generateMembershipRBACRoleBindingYAML",
       hasBody: true,
     }),
     svc,
@@ -5438,7 +5438,7 @@ export const ListProjectsLocationsMembershipsRbacrolebindingsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/rbacrolebindings" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/rbacrolebindings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMembershipsRbacrolebindingsRequest>;
 
@@ -5475,7 +5475,7 @@ export const DeleteProjectsLocationsFleetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFleetsRequest>;
 
@@ -5509,7 +5509,7 @@ export const CreateProjectsLocationsFleetsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Fleet).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{parent}/fleets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+parent}/fleets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsFleetsRequest>;
 
@@ -5540,7 +5540,7 @@ export const GetProjectsLocationsFleetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFleetsRequest>;
 
@@ -5577,7 +5577,7 @@ export const PatchProjectsLocationsFleetsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Fleet).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFleetsRequest>;
 
@@ -5614,7 +5614,7 @@ export const ListProjectsLocationsFleetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/fleets" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/fleets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFleetsRequest>;
 
@@ -5659,7 +5659,7 @@ export const CreateProjectsLocationsRolloutSequencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/rolloutSequences",
+      path: "v1alpha/{+parent}/rolloutSequences",
       hasBody: true,
     }),
     svc,
@@ -5692,7 +5692,7 @@ export const GetProjectsLocationsRolloutSequencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRolloutSequencesRequest>;
 
@@ -5729,7 +5729,7 @@ export const PatchProjectsLocationsRolloutSequencesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(RolloutSequence).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRolloutSequencesRequest>;
 
@@ -5769,7 +5769,7 @@ export const ListProjectsLocationsRolloutSequencesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/rolloutSequences" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/rolloutSequences" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRolloutSequencesRequest>;
 
@@ -5805,7 +5805,7 @@ export const DeleteProjectsLocationsRolloutSequencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRolloutSequencesRequest>;
 
@@ -5850,7 +5850,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -5885,7 +5885,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -5919,7 +5919,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -5950,7 +5950,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -5981,7 +5981,7 @@ export const DeleteProjectsLocationsScopesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsScopesRequest>;
 
@@ -6018,7 +6018,7 @@ export const ListProjectsLocationsScopesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/scopes" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/scopes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsScopesRequest>;
 
@@ -6062,7 +6062,7 @@ export const ListMembershipsProjectsLocationsScopesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{scopeName}:listMemberships" }),
+    T.Http({ method: "GET", path: "v1alpha/{+scopeName}:listMemberships" }),
     svc,
   ) as unknown as Schema.Schema<ListMembershipsProjectsLocationsScopesRequest>;
 
@@ -6104,7 +6104,7 @@ export const PatchProjectsLocationsScopesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Scope).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsScopesRequest>;
 
@@ -6140,7 +6140,7 @@ export const GetIamPolicyProjectsLocationsScopesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsScopesRequest>;
 
@@ -6176,7 +6176,7 @@ export const SetIamPolicyProjectsLocationsScopesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -6215,7 +6215,7 @@ export const ListPermittedProjectsLocationsScopesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/scopes:listPermitted" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/scopes:listPermitted" }),
     svc,
   ) as unknown as Schema.Schema<ListPermittedProjectsLocationsScopesRequest>;
 
@@ -6256,7 +6256,7 @@ export const TestIamPermissionsProjectsLocationsScopesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:testIamPermissions",
+      path: "v1alpha/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -6290,7 +6290,7 @@ export const GetProjectsLocationsScopesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsScopesRequest>;
 
@@ -6327,7 +6327,7 @@ export const CreateProjectsLocationsScopesRequest =
     scopeId: Schema.optional(Schema.String).pipe(T.HttpQuery("scopeId")),
     body: Schema.optional(Scope).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{parent}/scopes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+parent}/scopes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsScopesRequest>;
 
@@ -6358,7 +6358,7 @@ export const DeleteProjectsLocationsScopesNamespacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsScopesNamespacesRequest>;
 
@@ -6395,7 +6395,7 @@ export const PatchProjectsLocationsScopesNamespacesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Namespace).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsScopesNamespacesRequest>;
 
@@ -6426,7 +6426,7 @@ export const GetProjectsLocationsScopesNamespacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsScopesNamespacesRequest>;
 
@@ -6467,7 +6467,7 @@ export const CreateProjectsLocationsScopesNamespacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/namespaces",
+      path: "v1alpha/{+parent}/namespaces",
       hasBody: true,
     }),
     svc,
@@ -6506,7 +6506,7 @@ export const ListProjectsLocationsScopesNamespacesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/namespaces" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/namespaces" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsScopesNamespacesRequest>;
 
@@ -6548,7 +6548,7 @@ export const ListProjectsLocationsScopesRbacrolebindingsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/rbacrolebindings" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/rbacrolebindings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsScopesRbacrolebindingsRequest>;
 
@@ -6590,7 +6590,7 @@ export const PatchProjectsLocationsScopesRbacrolebindingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(RBACRoleBinding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsScopesRbacrolebindingsRequest>;
 
@@ -6621,7 +6621,7 @@ export const GetProjectsLocationsScopesRbacrolebindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsScopesRbacrolebindingsRequest>;
 
@@ -6663,7 +6663,7 @@ export const CreateProjectsLocationsScopesRbacrolebindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/rbacrolebindings",
+      path: "v1alpha/{+parent}/rbacrolebindings",
       hasBody: true,
     }),
     svc,
@@ -6696,7 +6696,7 @@ export const DeleteProjectsLocationsScopesRbacrolebindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsScopesRbacrolebindingsRequest>;
 
@@ -6733,7 +6733,7 @@ export const ListOrganizationsLocationsFleetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/fleets" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/fleets" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsFleetsRequest>;
 

--- a/packages/gcp/src/services/gkehub-v1beta.ts
+++ b/packages/gcp/src/services/gkehub-v1beta.ts
@@ -3655,7 +3655,7 @@ export const ListProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -3690,7 +3690,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -3721,7 +3721,7 @@ export const GetProjectsLocationsRolloutSequencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRolloutSequencesRequest>;
 
@@ -3762,7 +3762,7 @@ export const CreateProjectsLocationsRolloutSequencesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/rolloutSequences",
+      path: "v1beta/{+parent}/rolloutSequences",
       hasBody: true,
     }),
     svc,
@@ -3804,7 +3804,7 @@ export const ListProjectsLocationsRolloutSequencesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/rolloutSequences" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/rolloutSequences" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRolloutSequencesRequest>;
 
@@ -3846,7 +3846,7 @@ export const PatchProjectsLocationsRolloutSequencesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(RolloutSequence).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRolloutSequencesRequest>;
 
@@ -3877,7 +3877,7 @@ export const DeleteProjectsLocationsRolloutSequencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRolloutSequencesRequest>;
 
@@ -3928,7 +3928,7 @@ export const GenerateConnectManifestProjectsLocationsMembershipsRequest =
       T.HttpQuery("imagePullSecretContent"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}:generateConnectManifest" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}:generateConnectManifest" }),
     svc,
   ) as unknown as Schema.Schema<GenerateConnectManifestProjectsLocationsMembershipsRequest>;
 
@@ -3974,7 +3974,7 @@ export const CreateProjectsLocationsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/memberships",
+      path: "v1beta/{+parent}/memberships",
       hasBody: true,
     }),
     svc,
@@ -4012,7 +4012,7 @@ export const GetIamPolicyProjectsLocationsMembershipsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsMembershipsRequest>;
 
@@ -4043,7 +4043,7 @@ export const GetProjectsLocationsMembershipsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMembershipsRequest>;
 
@@ -4086,7 +4086,7 @@ export const ListProjectsLocationsMembershipsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/memberships" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/memberships" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMembershipsRequest>;
 
@@ -4126,7 +4126,7 @@ export const SetIamPolicyProjectsLocationsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:setIamPolicy",
+      path: "v1beta/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4164,7 +4164,7 @@ export const TestIamPermissionsProjectsLocationsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:testIamPermissions",
+      path: "v1beta/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4204,7 +4204,7 @@ export const DeleteProjectsLocationsMembershipsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMembershipsRequest>;
 
@@ -4244,7 +4244,7 @@ export const PatchProjectsLocationsMembershipsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Membership).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMembershipsRequest>;
 
@@ -4275,7 +4275,7 @@ export const GetProjectsLocationsMembershipsBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMembershipsBindingsRequest>;
 
@@ -4314,7 +4314,11 @@ export const CreateProjectsLocationsMembershipsBindingsRequest =
     ),
     body: Schema.optional(MembershipBinding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/bindings", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/bindings",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsMembershipsBindingsRequest>;
 
@@ -4354,7 +4358,7 @@ export const ListProjectsLocationsMembershipsBindingsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/bindings" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/bindings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMembershipsBindingsRequest>;
 
@@ -4396,7 +4400,7 @@ export const PatchProjectsLocationsMembershipsBindingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(MembershipBinding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMembershipsBindingsRequest>;
 
@@ -4427,7 +4431,7 @@ export const DeleteProjectsLocationsMembershipsBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMembershipsBindingsRequest>;
 
@@ -4468,7 +4472,7 @@ export const CreateProjectsLocationsMembershipsRbacrolebindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/rbacrolebindings",
+      path: "v1beta/{+parent}/rbacrolebindings",
       hasBody: true,
     }),
     svc,
@@ -4509,7 +4513,7 @@ export const ListProjectsLocationsMembershipsRbacrolebindingsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/rbacrolebindings" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/rbacrolebindings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMembershipsRbacrolebindingsRequest>;
 
@@ -4546,7 +4550,7 @@ export const GetProjectsLocationsMembershipsRbacrolebindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMembershipsRbacrolebindingsRequest>;
 
@@ -4589,7 +4593,7 @@ export const GenerateMembershipRBACRoleBindingYAMLProjectsLocationsMembershipsRb
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/rbacrolebindings:generateMembershipRBACRoleBindingYAML",
+      path: "v1beta/{+parent}/rbacrolebindings:generateMembershipRBACRoleBindingYAML",
       hasBody: true,
     }),
     svc,
@@ -4632,7 +4636,7 @@ export const PatchProjectsLocationsMembershipsRbacrolebindingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(RBACRoleBinding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMembershipsRbacrolebindingsRequest>;
 
@@ -4665,7 +4669,7 @@ export const DeleteProjectsLocationsMembershipsRbacrolebindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMembershipsRbacrolebindingsRequest>;
 
@@ -4704,7 +4708,7 @@ export const DeleteProjectsLocationsFeaturesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFeaturesRequest>;
 
@@ -4744,7 +4748,7 @@ export const PatchProjectsLocationsFeaturesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Feature).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFeaturesRequest>;
 
@@ -4780,7 +4784,7 @@ export const GetIamPolicyProjectsLocationsFeaturesRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsFeaturesRequest>;
 
@@ -4816,7 +4820,7 @@ export const SetIamPolicyProjectsLocationsFeaturesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:setIamPolicy",
+      path: "v1beta/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4854,7 +4858,7 @@ export const TestIamPermissionsProjectsLocationsFeaturesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:testIamPermissions",
+      path: "v1beta/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4893,7 +4897,7 @@ export const GetProjectsLocationsFeaturesRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFeaturesRequest>;
 
@@ -4941,7 +4945,7 @@ export const ListProjectsLocationsFeaturesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/features" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/features" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFeaturesRequest>;
 
@@ -4985,7 +4989,11 @@ export const CreateProjectsLocationsFeaturesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Feature).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/features", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/features",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsFeaturesRequest>;
 
@@ -5022,7 +5030,7 @@ export const PatchProjectsLocationsFleetsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Fleet).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFleetsRequest>;
 
@@ -5053,7 +5061,7 @@ export const DeleteProjectsLocationsFleetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFleetsRequest>;
 
@@ -5087,7 +5095,7 @@ export const CreateProjectsLocationsFleetsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Fleet).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/fleets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/fleets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsFleetsRequest>;
 
@@ -5124,7 +5132,7 @@ export const ListProjectsLocationsFleetsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/fleets" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/fleets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFleetsRequest>;
 
@@ -5159,7 +5167,7 @@ export const GetProjectsLocationsFleetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFleetsRequest>;
 
@@ -5190,7 +5198,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -5235,7 +5243,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -5270,7 +5278,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -5304,7 +5312,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -5344,7 +5352,7 @@ export const ListProjectsLocationsRolloutsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/rollouts" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/rollouts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRolloutsRequest>;
 
@@ -5379,7 +5387,7 @@ export const GetProjectsLocationsRolloutsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRolloutsRequest>;
 
@@ -5419,7 +5427,7 @@ export const ListMembershipsProjectsLocationsScopesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{scopeName}:listMemberships" }),
+    T.Http({ method: "GET", path: "v1beta/{+scopeName}:listMemberships" }),
     svc,
   ) as unknown as Schema.Schema<ListMembershipsProjectsLocationsScopesRequest>;
 
@@ -5460,7 +5468,7 @@ export const TestIamPermissionsProjectsLocationsScopesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:testIamPermissions",
+      path: "v1beta/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5500,7 +5508,7 @@ export const ListPermittedProjectsLocationsScopesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/scopes:listPermitted" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/scopes:listPermitted" }),
     svc,
   ) as unknown as Schema.Schema<ListPermittedProjectsLocationsScopesRequest>;
 
@@ -5541,7 +5549,7 @@ export const SetIamPolicyProjectsLocationsScopesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:setIamPolicy",
+      path: "v1beta/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5580,7 +5588,7 @@ export const ListProjectsLocationsScopesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/scopes" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/scopes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsScopesRequest>;
 
@@ -5615,7 +5623,7 @@ export const GetProjectsLocationsScopesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsScopesRequest>;
 
@@ -5652,7 +5660,7 @@ export const PatchProjectsLocationsScopesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Scope).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsScopesRequest>;
 
@@ -5683,7 +5691,7 @@ export const DeleteProjectsLocationsScopesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsScopesRequest>;
 
@@ -5720,7 +5728,7 @@ export const CreateProjectsLocationsScopesRequest =
     scopeId: Schema.optional(Schema.String).pipe(T.HttpQuery("scopeId")),
     body: Schema.optional(Scope).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/scopes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/scopes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsScopesRequest>;
 
@@ -5756,7 +5764,7 @@ export const GetIamPolicyProjectsLocationsScopesRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsScopesRequest>;
 
@@ -5797,7 +5805,7 @@ export const CreateProjectsLocationsScopesRbacrolebindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/rbacrolebindings",
+      path: "v1beta/{+parent}/rbacrolebindings",
       hasBody: true,
     }),
     svc,
@@ -5836,7 +5844,7 @@ export const ListProjectsLocationsScopesRbacrolebindingsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/rbacrolebindings" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/rbacrolebindings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsScopesRbacrolebindingsRequest>;
 
@@ -5872,7 +5880,7 @@ export const GetProjectsLocationsScopesRbacrolebindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsScopesRbacrolebindingsRequest>;
 
@@ -5910,7 +5918,7 @@ export const PatchProjectsLocationsScopesRbacrolebindingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(RBACRoleBinding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsScopesRbacrolebindingsRequest>;
 
@@ -5941,7 +5949,7 @@ export const DeleteProjectsLocationsScopesRbacrolebindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsScopesRbacrolebindingsRequest>;
 
@@ -5982,7 +5990,7 @@ export const CreateProjectsLocationsScopesNamespacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/namespaces",
+      path: "v1beta/{+parent}/namespaces",
       hasBody: true,
     }),
     svc,
@@ -6021,7 +6029,7 @@ export const ListProjectsLocationsScopesNamespacesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/namespaces" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/namespaces" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsScopesNamespacesRequest>;
 
@@ -6057,7 +6065,7 @@ export const GetProjectsLocationsScopesNamespacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsScopesNamespacesRequest>;
 
@@ -6094,7 +6102,7 @@ export const PatchProjectsLocationsScopesNamespacesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Namespace).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsScopesNamespacesRequest>;
 
@@ -6125,7 +6133,7 @@ export const DeleteProjectsLocationsScopesNamespacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsScopesNamespacesRequest>;
 
@@ -6162,7 +6170,7 @@ export const ListOrganizationsLocationsFleetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/fleets" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/fleets" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsFleetsRequest>;
 

--- a/packages/gcp/src/services/gkehub-v1beta1.ts
+++ b/packages/gcp/src/services/gkehub-v1beta1.ts
@@ -651,7 +651,7 @@ export const ListProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -686,7 +686,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -731,7 +731,7 @@ export const ListProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -769,7 +769,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -800,7 +800,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -831,7 +831,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -875,7 +875,7 @@ export const CreateProjectsLocationsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/memberships",
+      path: "v1beta1/{+parent}/memberships",
       hasBody: true,
     }),
     svc,
@@ -914,7 +914,7 @@ export const DeleteProjectsLocationsMembershipsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMembershipsRequest>;
 
@@ -954,7 +954,7 @@ export const PatchProjectsLocationsMembershipsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Membership).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMembershipsRequest>;
 
@@ -995,7 +995,7 @@ export const GenerateExclusivityManifestProjectsLocationsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{name}:generateExclusivityManifest",
+      path: "v1beta1/{+name}:generateExclusivityManifest",
     }),
     svc,
   ) as unknown as Schema.Schema<GenerateExclusivityManifestProjectsLocationsMembershipsRequest>;
@@ -1034,7 +1034,7 @@ export const SetIamPolicyProjectsLocationsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1067,7 +1067,7 @@ export const GetProjectsLocationsMembershipsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMembershipsRequest>;
 
@@ -1108,7 +1108,7 @@ export const ValidateExclusivityProjectsLocationsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/memberships:validateExclusivity",
+      path: "v1beta1/{+parent}/memberships:validateExclusivity",
     }),
     svc,
   ) as unknown as Schema.Schema<ValidateExclusivityProjectsLocationsMembershipsRequest>;
@@ -1147,7 +1147,7 @@ export const GetIamPolicyProjectsLocationsMembershipsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsMembershipsRequest>;
 
@@ -1183,7 +1183,7 @@ export const TestIamPermissionsProjectsLocationsMembershipsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1229,7 +1229,7 @@ export const ListProjectsLocationsMembershipsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/memberships" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/memberships" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMembershipsRequest>;
 
@@ -1293,7 +1293,7 @@ export const GenerateConnectManifestProjectsLocationsMembershipsRequest =
       T.HttpQuery("connectAgent.name"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:generateConnectManifest" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:generateConnectManifest" }),
     svc,
   ) as unknown as Schema.Schema<GenerateConnectManifestProjectsLocationsMembershipsRequest>;
 

--- a/packages/gcp/src/services/gkehub-v2.ts
+++ b/packages/gcp/src/services/gkehub-v2.ts
@@ -2099,7 +2099,7 @@ export const ListProjectsLocationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2134,7 +2134,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2179,7 +2179,7 @@ export const ListProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2214,7 +2214,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2248,7 +2248,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2291,7 +2291,7 @@ export const ListProjectsLocationsMembershipsFeaturesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/features" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/features" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMembershipsFeaturesRequest>;
 
@@ -2336,7 +2336,7 @@ export const CreateProjectsLocationsMembershipsFeaturesRequest =
     featureId: Schema.optional(Schema.String).pipe(T.HttpQuery("featureId")),
     body: Schema.optional(MembershipFeature).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/features", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/features", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsMembershipsFeaturesRequest>;
 
@@ -2367,7 +2367,7 @@ export const GetProjectsLocationsMembershipsFeaturesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMembershipsFeaturesRequest>;
 
@@ -2401,7 +2401,7 @@ export const DeleteProjectsLocationsMembershipsFeaturesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMembershipsFeaturesRequest>;
 
@@ -2446,7 +2446,7 @@ export const PatchProjectsLocationsMembershipsFeaturesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(MembershipFeature).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMembershipsFeaturesRequest>;
 

--- a/packages/gcp/src/services/gkehub-v2alpha.ts
+++ b/packages/gcp/src/services/gkehub-v2alpha.ts
@@ -2099,7 +2099,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2134,7 +2134,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2179,7 +2179,7 @@ export const ListProjectsLocationsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2214,7 +2214,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2248,7 +2248,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2alpha/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2alpha/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2293,7 +2293,7 @@ export const PatchProjectsLocationsMembershipsFeaturesRequest =
     ),
     body: Schema.optional(MembershipFeature).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMembershipsFeaturesRequest>;
 
@@ -2335,7 +2335,7 @@ export const CreateProjectsLocationsMembershipsFeaturesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{parent}/features",
+      path: "v2alpha/{+parent}/features",
       hasBody: true,
     }),
     svc,
@@ -2371,7 +2371,7 @@ export const DeleteProjectsLocationsMembershipsFeaturesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMembershipsFeaturesRequest>;
 
@@ -2402,7 +2402,7 @@ export const GetProjectsLocationsMembershipsFeaturesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMembershipsFeaturesRequest>;
 
@@ -2445,7 +2445,7 @@ export const ListProjectsLocationsMembershipsFeaturesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{parent}/features" }),
+    T.Http({ method: "GET", path: "v2alpha/{+parent}/features" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMembershipsFeaturesRequest>;
 

--- a/packages/gcp/src/services/gkehub-v2beta.ts
+++ b/packages/gcp/src/services/gkehub-v2beta.ts
@@ -2099,7 +2099,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2134,7 +2134,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2168,7 +2168,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2213,7 +2213,7 @@ export const ListProjectsLocationsOperationsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2248,7 +2248,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2279,7 +2279,7 @@ export const GetProjectsLocationsMembershipsFeaturesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMembershipsFeaturesRequest>;
 
@@ -2322,7 +2322,7 @@ export const ListProjectsLocationsMembershipsFeaturesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{parent}/features" }),
+    T.Http({ method: "GET", path: "v2beta/{+parent}/features" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMembershipsFeaturesRequest>;
 
@@ -2372,7 +2372,7 @@ export const PatchProjectsLocationsMembershipsFeaturesRequest =
     ),
     body: Schema.optional(MembershipFeature).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMembershipsFeaturesRequest>;
 
@@ -2412,7 +2412,11 @@ export const CreateProjectsLocationsMembershipsFeaturesRequest =
     featureId: Schema.optional(Schema.String).pipe(T.HttpQuery("featureId")),
     body: Schema.optional(MembershipFeature).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta/{parent}/features", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2beta/{+parent}/features",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsMembershipsFeaturesRequest>;
 
@@ -2446,7 +2450,7 @@ export const DeleteProjectsLocationsMembershipsFeaturesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMembershipsFeaturesRequest>;
 

--- a/packages/gcp/src/services/gkeonprem-v1.ts
+++ b/packages/gcp/src/services/gkeonprem-v1.ts
@@ -2853,7 +2853,7 @@ export const ListProjectsLocationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2888,7 +2888,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2919,7 +2919,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2953,7 +2953,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2998,7 +2998,7 @@ export const ListProjectsLocationsOperationsRequest =
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -3033,7 +3033,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -3082,7 +3082,7 @@ export const UnenrollProjectsLocationsVmwareAdminClustersRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}:unenroll" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}:unenroll" }),
     svc,
   ) as unknown as Schema.Schema<UnenrollProjectsLocationsVmwareAdminClustersRequest>;
 
@@ -3129,7 +3129,7 @@ export const PatchProjectsLocationsVmwareAdminClustersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(VmwareAdminCluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsVmwareAdminClustersRequest>;
 
@@ -3168,7 +3168,7 @@ export const GetProjectsLocationsVmwareAdminClustersRequest =
     ),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVmwareAdminClustersRequest>;
 
@@ -3205,7 +3205,7 @@ export const EnrollProjectsLocationsVmwareAdminClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/vmwareAdminClusters:enroll",
+      path: "v1/{+parent}/vmwareAdminClusters:enroll",
       hasBody: true,
     }),
     svc,
@@ -3252,7 +3252,7 @@ export const ListProjectsLocationsVmwareAdminClustersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/vmwareAdminClusters" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/vmwareAdminClusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVmwareAdminClustersRequest>;
 
@@ -3293,7 +3293,7 @@ export const SetIamPolicyProjectsLocationsVmwareAdminClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3352,7 +3352,7 @@ export const CreateProjectsLocationsVmwareAdminClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/vmwareAdminClusters",
+      path: "v1/{+parent}/vmwareAdminClusters",
       hasBody: true,
     }),
     svc,
@@ -3390,7 +3390,7 @@ export const GetIamPolicyProjectsLocationsVmwareAdminClustersRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsVmwareAdminClustersRequest>;
 
@@ -3427,7 +3427,7 @@ export const TestIamPermissionsProjectsLocationsVmwareAdminClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3476,7 +3476,7 @@ export const ListProjectsLocationsVmwareAdminClustersOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVmwareAdminClustersOperationsRequest>;
 
@@ -3513,7 +3513,7 @@ export const GetProjectsLocationsVmwareAdminClustersOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVmwareAdminClustersOperationsRequest>;
 
@@ -3566,7 +3566,7 @@ export const CreateProjectsLocationsBareMetalClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/bareMetalClusters",
+      path: "v1/{+parent}/bareMetalClusters",
       hasBody: true,
     }),
     svc,
@@ -3620,7 +3620,7 @@ export const DeleteProjectsLocationsBareMetalClustersRequest =
       T.HttpQuery("allowMissing"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBareMetalClustersRequest>;
 
@@ -3656,7 +3656,7 @@ export const GetIamPolicyProjectsLocationsBareMetalClustersRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsBareMetalClustersRequest>;
 
@@ -3692,7 +3692,7 @@ export const TestIamPermissionsProjectsLocationsBareMetalClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3744,7 +3744,7 @@ export const ListProjectsLocationsBareMetalClustersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/bareMetalClusters" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/bareMetalClusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBareMetalClustersRequest>;
 
@@ -3797,7 +3797,7 @@ export const QueryVersionConfigProjectsLocationsBareMetalClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/bareMetalClusters:queryVersionConfig",
+      path: "v1/{+parent}/bareMetalClusters:queryVersionConfig",
       hasBody: true,
     }),
     svc,
@@ -3837,7 +3837,7 @@ export const SetIamPolicyProjectsLocationsBareMetalClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3875,7 +3875,7 @@ export const EnrollProjectsLocationsBareMetalClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/bareMetalClusters:enroll",
+      path: "v1/{+parent}/bareMetalClusters:enroll",
       hasBody: true,
     }),
     svc,
@@ -3924,7 +3924,7 @@ export const UnenrollProjectsLocationsBareMetalClustersRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}:unenroll" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}:unenroll" }),
     svc,
   ) as unknown as Schema.Schema<UnenrollProjectsLocationsBareMetalClustersRequest>;
 
@@ -3971,7 +3971,7 @@ export const PatchProjectsLocationsBareMetalClustersRequest =
     ),
     body: Schema.optional(BareMetalCluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBareMetalClustersRequest>;
 
@@ -4010,7 +4010,7 @@ export const GetProjectsLocationsBareMetalClustersRequest =
       T.HttpQuery("allowMissing"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBareMetalClustersRequest>;
 
@@ -4046,7 +4046,7 @@ export const EnrollProjectsLocationsBareMetalClustersBareMetalNodePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/bareMetalNodePools:enroll",
+      path: "v1/{+parent}/bareMetalNodePools:enroll",
       hasBody: true,
     }),
     svc,
@@ -4094,7 +4094,7 @@ export const UnenrollProjectsLocationsBareMetalClustersBareMetalNodePoolsRequest
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}:unenroll" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}:unenroll" }),
     svc,
   ) as unknown as Schema.Schema<UnenrollProjectsLocationsBareMetalClustersBareMetalNodePoolsRequest>;
 
@@ -4130,7 +4130,7 @@ export const GetProjectsLocationsBareMetalClustersBareMetalNodePoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBareMetalClustersBareMetalNodePoolsRequest>;
 
@@ -4179,7 +4179,7 @@ export const PatchProjectsLocationsBareMetalClustersBareMetalNodePoolsRequest =
     ),
     body: Schema.optional(BareMetalNodePool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBareMetalClustersBareMetalNodePoolsRequest>;
 
@@ -4227,7 +4227,7 @@ export const CreateProjectsLocationsBareMetalClustersBareMetalNodePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/bareMetalNodePools",
+      path: "v1/{+parent}/bareMetalNodePools",
       hasBody: true,
     }),
     svc,
@@ -4280,7 +4280,7 @@ export const DeleteProjectsLocationsBareMetalClustersBareMetalNodePoolsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBareMetalClustersBareMetalNodePoolsRequest>;
 
@@ -4318,7 +4318,7 @@ export const GetIamPolicyProjectsLocationsBareMetalClustersBareMetalNodePoolsReq
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsBareMetalClustersBareMetalNodePoolsRequest>;
 
@@ -4358,7 +4358,7 @@ export const TestIamPermissionsProjectsLocationsBareMetalClustersBareMetalNodePo
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4404,7 +4404,7 @@ export const ListProjectsLocationsBareMetalClustersBareMetalNodePoolsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/bareMetalNodePools" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/bareMetalNodePools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBareMetalClustersBareMetalNodePoolsRequest>;
 
@@ -4446,7 +4446,7 @@ export const SetIamPolicyProjectsLocationsBareMetalClustersBareMetalNodePoolsReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4497,7 +4497,7 @@ export const ListProjectsLocationsBareMetalClustersBareMetalNodePoolsOperationsR
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBareMetalClustersBareMetalNodePoolsOperationsRequest>;
 
@@ -4536,7 +4536,7 @@ export const GetProjectsLocationsBareMetalClustersBareMetalNodePoolsOperationsRe
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBareMetalClustersBareMetalNodePoolsOperationsRequest>;
 
@@ -4585,7 +4585,7 @@ export const ListProjectsLocationsBareMetalClustersOperationsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBareMetalClustersOperationsRequest>;
 
@@ -4622,7 +4622,7 @@ export const GetProjectsLocationsBareMetalClustersOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBareMetalClustersOperationsRequest>;
 
@@ -4659,7 +4659,7 @@ export const GetIamPolicyProjectsLocationsVmwareClustersRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsVmwareClustersRequest>;
 
@@ -4695,7 +4695,7 @@ export const TestIamPermissionsProjectsLocationsVmwareClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4755,7 +4755,7 @@ export const CreateProjectsLocationsVmwareClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/vmwareClusters",
+      path: "v1/{+parent}/vmwareClusters",
       hasBody: true,
     }),
     svc,
@@ -4809,7 +4809,7 @@ export const DeleteProjectsLocationsVmwareClustersRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsVmwareClustersRequest>;
 
@@ -4845,7 +4845,7 @@ export const SetIamPolicyProjectsLocationsVmwareClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4895,7 +4895,7 @@ export const ListProjectsLocationsVmwareClustersRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/vmwareClusters" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/vmwareClusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVmwareClustersRequest>;
 
@@ -4948,7 +4948,7 @@ export const QueryVersionConfigProjectsLocationsVmwareClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/vmwareClusters:queryVersionConfig",
+      path: "v1/{+parent}/vmwareClusters:queryVersionConfig",
       hasBody: true,
     }),
     svc,
@@ -4988,7 +4988,7 @@ export const EnrollProjectsLocationsVmwareClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/vmwareClusters:enroll",
+      path: "v1/{+parent}/vmwareClusters:enroll",
       hasBody: true,
     }),
     svc,
@@ -5036,7 +5036,7 @@ export const PatchProjectsLocationsVmwareClustersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(VmwareCluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsVmwareClustersRequest>;
 
@@ -5075,7 +5075,7 @@ export const GetProjectsLocationsVmwareClustersRequest =
     ),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVmwareClustersRequest>;
 
@@ -5122,7 +5122,7 @@ export const UnenrollProjectsLocationsVmwareClustersRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}:unenroll" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}:unenroll" }),
     svc,
   ) as unknown as Schema.Schema<UnenrollProjectsLocationsVmwareClustersRequest>;
 
@@ -5167,7 +5167,7 @@ export const ListProjectsLocationsVmwareClustersOperationsRequest =
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVmwareClustersOperationsRequest>;
 
@@ -5203,7 +5203,7 @@ export const GetProjectsLocationsVmwareClustersOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVmwareClustersOperationsRequest>;
 
@@ -5239,7 +5239,7 @@ export const EnrollProjectsLocationsVmwareClustersVmwareNodePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/vmwareNodePools:enroll",
+      path: "v1/{+parent}/vmwareNodePools:enroll",
       hasBody: true,
     }),
     svc,
@@ -5277,7 +5277,7 @@ export const GetProjectsLocationsVmwareClustersVmwareNodePoolsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVmwareClustersVmwareNodePoolsRequest>;
 
@@ -5321,7 +5321,7 @@ export const PatchProjectsLocationsVmwareClustersVmwareNodePoolsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(VmwareNodePool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsVmwareClustersVmwareNodePoolsRequest>;
 
@@ -5367,7 +5367,7 @@ export const UnenrollProjectsLocationsVmwareClustersVmwareNodePoolsRequest =
       T.HttpQuery("allowMissing"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}:unenroll" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}:unenroll" }),
     svc,
   ) as unknown as Schema.Schema<UnenrollProjectsLocationsVmwareClustersVmwareNodePoolsRequest>;
 
@@ -5405,7 +5405,7 @@ export const GetIamPolicyProjectsLocationsVmwareClustersVmwareNodePoolsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsVmwareClustersVmwareNodePoolsRequest>;
 
@@ -5443,7 +5443,7 @@ export const TestIamPermissionsProjectsLocationsVmwareClustersVmwareNodePoolsReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5495,7 +5495,7 @@ export const CreateProjectsLocationsVmwareClustersVmwareNodePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/vmwareNodePools",
+      path: "v1/{+parent}/vmwareNodePools",
       hasBody: true,
     }),
     svc,
@@ -5548,7 +5548,7 @@ export const DeleteProjectsLocationsVmwareClustersVmwareNodePoolsRequest =
       T.HttpQuery("ignoreErrors"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsVmwareClustersVmwareNodePoolsRequest>;
 
@@ -5586,7 +5586,7 @@ export const SetIamPolicyProjectsLocationsVmwareClustersVmwareNodePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5630,7 +5630,7 @@ export const ListProjectsLocationsVmwareClustersVmwareNodePoolsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/vmwareNodePools" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/vmwareNodePools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVmwareClustersVmwareNodePoolsRequest>;
 
@@ -5681,7 +5681,7 @@ export const ListProjectsLocationsVmwareClustersVmwareNodePoolsOperationsRequest
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVmwareClustersVmwareNodePoolsOperationsRequest>;
 
@@ -5718,7 +5718,7 @@ export const GetProjectsLocationsVmwareClustersVmwareNodePoolsOperationsRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVmwareClustersVmwareNodePoolsOperationsRequest>;
 
@@ -5765,7 +5765,7 @@ export const ListProjectsLocationsBareMetalAdminClustersRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/bareMetalAdminClusters" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/bareMetalAdminClusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBareMetalAdminClustersRequest>;
 
@@ -5808,7 +5808,7 @@ export const QueryVersionConfigProjectsLocationsBareMetalAdminClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/bareMetalAdminClusters:queryVersionConfig",
+      path: "v1/{+parent}/bareMetalAdminClusters:queryVersionConfig",
       hasBody: true,
     }),
     svc,
@@ -5848,7 +5848,7 @@ export const SetIamPolicyProjectsLocationsBareMetalAdminClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5903,7 +5903,7 @@ export const CreateProjectsLocationsBareMetalAdminClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/bareMetalAdminClusters",
+      path: "v1/{+parent}/bareMetalAdminClusters",
       hasBody: true,
     }),
     svc,
@@ -5941,7 +5941,7 @@ export const GetIamPolicyProjectsLocationsBareMetalAdminClustersRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsBareMetalAdminClustersRequest>;
 
@@ -5979,7 +5979,7 @@ export const TestIamPermissionsProjectsLocationsBareMetalAdminClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -6032,7 +6032,7 @@ export const UnenrollProjectsLocationsBareMetalAdminClustersRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}:unenroll" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}:unenroll" }),
     svc,
   ) as unknown as Schema.Schema<UnenrollProjectsLocationsBareMetalAdminClustersRequest>;
 
@@ -6072,7 +6072,7 @@ export const GetProjectsLocationsBareMetalAdminClustersRequest =
       T.HttpQuery("allowMissing"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBareMetalAdminClustersRequest>;
 
@@ -6115,7 +6115,7 @@ export const PatchProjectsLocationsBareMetalAdminClustersRequest =
     ),
     body: Schema.optional(BareMetalAdminCluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBareMetalAdminClustersRequest>;
 
@@ -6153,7 +6153,7 @@ export const EnrollProjectsLocationsBareMetalAdminClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/bareMetalAdminClusters:enroll",
+      path: "v1/{+parent}/bareMetalAdminClusters:enroll",
       hasBody: true,
     }),
     svc,
@@ -6200,7 +6200,7 @@ export const ListProjectsLocationsBareMetalAdminClustersOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBareMetalAdminClustersOperationsRequest>;
 
@@ -6237,7 +6237,7 @@ export const GetProjectsLocationsBareMetalAdminClustersOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBareMetalAdminClustersOperationsRequest>;
 

--- a/packages/gcp/src/services/gmailpostmastertools-v1.ts
+++ b/packages/gcp/src/services/gmailpostmastertools-v1.ts
@@ -194,7 +194,7 @@ export interface GetDomainsRequest {
 export const GetDomainsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetDomainsRequest>;
 
@@ -261,7 +261,7 @@ export const GetDomainsTrafficStatsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDomainsTrafficStatsRequest>;
 
@@ -328,7 +328,7 @@ export const ListDomainsTrafficStatsRequest =
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/trafficStats" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/trafficStats" }),
     svc,
   ) as unknown as Schema.Schema<ListDomainsTrafficStatsRequest>;
 

--- a/packages/gcp/src/services/gmailpostmastertools-v1beta1.ts
+++ b/packages/gcp/src/services/gmailpostmastertools-v1beta1.ts
@@ -197,7 +197,7 @@ export interface GetDomainsRequest {
 export const GetDomainsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta1/{name}" }),
+  T.Http({ method: "GET", path: "v1beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetDomainsRequest>;
 
@@ -300,7 +300,7 @@ export const ListDomainsTrafficStatsRequest =
       T.HttpQuery("endDate.day"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/trafficStats" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/trafficStats" }),
     svc,
   ) as unknown as Schema.Schema<ListDomainsTrafficStatsRequest>;
 
@@ -335,7 +335,7 @@ export const GetDomainsTrafficStatsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDomainsTrafficStatsRequest>;
 

--- a/packages/gcp/src/services/gmailpostmastertools-v2.ts
+++ b/packages/gcp/src/services/gmailpostmastertools-v2.ts
@@ -451,7 +451,7 @@ export const GetComplianceStatusDomainsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetComplianceStatusDomainsRequest>;
 
@@ -481,7 +481,7 @@ export interface GetDomainsRequest {
 export const GetDomainsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{name}" }),
+  T.Http({ method: "GET", path: "v2/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetDomainsRequest>;
 
@@ -516,7 +516,7 @@ export const QueryDomainsDomainStatsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/domainStats:query",
+      path: "v2/{+parent}/domainStats:query",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/health-v4.ts
+++ b/packages/gcp/src/services/health-v4.ts
@@ -2085,7 +2085,7 @@ export const GetSettingsUsersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/{name}" }),
+    T.Http({ method: "GET", path: "v4/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSettingsUsersRequest>;
 
@@ -2115,7 +2115,7 @@ export const GetIdentityUsersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/{name}" }),
+    T.Http({ method: "GET", path: "v4/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetIdentityUsersRequest>;
 
@@ -2151,7 +2151,7 @@ export const UpdateSettingsUsersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Settings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v4/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v4/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSettingsUsersRequest>;
 
@@ -2182,7 +2182,7 @@ export const GetProfileUsersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     name: Schema.String.pipe(T.HttpPath("name")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "v4/{name}" }),
+  T.Http({ method: "GET", path: "v4/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetProfileUsersRequest>;
 
@@ -2218,7 +2218,7 @@ export const UpdateProfileUsersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Profile).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v4/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v4/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProfileUsersRequest>;
 
@@ -2251,7 +2251,7 @@ export const CreateUsersDataTypesDataPointsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(DataPoint).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v4/{parent}/dataPoints", hasBody: true }),
+    T.Http({ method: "POST", path: "v4/{+parent}/dataPoints", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateUsersDataTypesDataPointsRequest>;
 
@@ -2291,7 +2291,7 @@ export const ListUsersDataTypesDataPointsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/{parent}/dataPoints" }),
+    T.Http({ method: "GET", path: "v4/{+parent}/dataPoints" }),
     svc,
   ) as unknown as Schema.Schema<ListUsersDataTypesDataPointsRequest>;
 
@@ -2331,7 +2331,7 @@ export const DailyRollUpUsersDataTypesDataPointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/{parent}/dataPoints:dailyRollUp",
+      path: "v4/{+parent}/dataPoints:dailyRollUp",
       hasBody: true,
     }),
     svc,
@@ -2370,7 +2370,7 @@ export const ExportExerciseTcxUsersDataTypesDataPointsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/{name}:exportExerciseTcx" }),
+    T.Http({ method: "GET", path: "v4/{+name}:exportExerciseTcx" }),
     svc,
   ) as unknown as Schema.Schema<ExportExerciseTcxUsersDataTypesDataPointsRequest>;
 
@@ -2407,7 +2407,7 @@ export const RollUpUsersDataTypesDataPointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/{parent}/dataPoints:rollUp",
+      path: "v4/{+parent}/dataPoints:rollUp",
       hasBody: true,
     }),
     svc,
@@ -2443,7 +2443,7 @@ export const PatchUsersDataTypesDataPointsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DataPoint).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v4/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v4/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchUsersDataTypesDataPointsRequest>;
 
@@ -2479,7 +2479,7 @@ export const BatchDeleteUsersDataTypesDataPointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/{parent}/dataPoints:batchDelete",
+      path: "v4/{+parent}/dataPoints:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -2526,7 +2526,7 @@ export const ReconcileUsersDataTypesDataPointsRequest =
     ),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/{parent}/dataPoints:reconcile" }),
+    T.Http({ method: "GET", path: "v4/{+parent}/dataPoints:reconcile" }),
     svc,
   ) as unknown as Schema.Schema<ReconcileUsersDataTypesDataPointsRequest>;
 

--- a/packages/gcp/src/services/healthcare-v1.ts
+++ b/packages/gcp/src/services/healthcare-v1.ts
@@ -2798,7 +2798,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2833,7 +2833,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2869,7 +2869,7 @@ export const SetIamPolicyProjectsLocationsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2907,7 +2907,7 @@ export const GetIamPolicyProjectsLocationsDatasetsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDatasetsRequest>;
 
@@ -2943,7 +2943,7 @@ export const TestIamPermissionsProjectsLocationsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2983,7 +2983,7 @@ export const CreateProjectsLocationsDatasetsRequest =
     datasetId: Schema.optional(Schema.String).pipe(T.HttpQuery("datasetId")),
     body: Schema.optional(Dataset).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/datasets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/datasets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDatasetsRequest>;
 
@@ -3020,7 +3020,7 @@ export const ListProjectsLocationsDatasetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/datasets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/datasets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsRequest>;
 
@@ -3055,7 +3055,7 @@ export const DeleteProjectsLocationsDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsRequest>;
 
@@ -3086,7 +3086,7 @@ export const GetProjectsLocationsDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsRequest>;
 
@@ -3123,7 +3123,7 @@ export const PatchProjectsLocationsDatasetsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Dataset).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsRequest>;
 
@@ -3159,7 +3159,7 @@ export const DeidentifyProjectsLocationsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{sourceDataset}:deidentify",
+      path: "v1/{+sourceDataset}:deidentify",
       hasBody: true,
     }),
     svc,
@@ -3197,7 +3197,7 @@ export const SetIamPolicyProjectsLocationsDatasetsConsentStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3236,7 +3236,7 @@ export const GetIamPolicyProjectsLocationsDatasetsConsentStoresRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDatasetsConsentStoresRequest>;
 
@@ -3273,7 +3273,7 @@ export const TestIamPermissionsProjectsLocationsDatasetsConsentStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3318,7 +3318,7 @@ export const CreateProjectsLocationsDatasetsConsentStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/consentStores",
+      path: "v1/{+parent}/consentStores",
       hasBody: true,
     }),
     svc,
@@ -3351,7 +3351,7 @@ export const GetProjectsLocationsDatasetsConsentStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsConsentStoresRequest>;
 
@@ -3382,7 +3382,7 @@ export const DeleteProjectsLocationsDatasetsConsentStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsConsentStoresRequest>;
 
@@ -3419,7 +3419,7 @@ export const PatchProjectsLocationsDatasetsConsentStoresRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ConsentStore).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsConsentStoresRequest>;
 
@@ -3459,7 +3459,7 @@ export const ListProjectsLocationsDatasetsConsentStoresRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/consentStores" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/consentStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsConsentStoresRequest>;
 
@@ -3500,7 +3500,7 @@ export const CheckDataAccessProjectsLocationsDatasetsConsentStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{consentStore}:checkDataAccess",
+      path: "v1/{+consentStore}:checkDataAccess",
       hasBody: true,
     }),
     svc,
@@ -3540,7 +3540,7 @@ export const QueryAccessibleDataProjectsLocationsDatasetsConsentStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{consentStore}:queryAccessibleData",
+      path: "v1/{+consentStore}:queryAccessibleData",
       hasBody: true,
     }),
     svc,
@@ -3580,7 +3580,7 @@ export const EvaluateUserConsentsProjectsLocationsDatasetsConsentStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{consentStore}:evaluateUserConsents",
+      path: "v1/{+consentStore}:evaluateUserConsents",
       hasBody: true,
     }),
     svc,
@@ -3625,7 +3625,7 @@ export const CreateProjectsLocationsDatasetsConsentStoresAttributeDefinitionsReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/attributeDefinitions",
+      path: "v1/{+parent}/attributeDefinitions",
       hasBody: true,
     }),
     svc,
@@ -3662,7 +3662,7 @@ export const GetProjectsLocationsDatasetsConsentStoresAttributeDefinitionsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsConsentStoresAttributeDefinitionsRequest>;
 
@@ -3695,7 +3695,7 @@ export const DeleteProjectsLocationsDatasetsConsentStoresAttributeDefinitionsReq
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsConsentStoresAttributeDefinitionsRequest>;
 
@@ -3736,7 +3736,7 @@ export const PatchProjectsLocationsDatasetsConsentStoresAttributeDefinitionsRequ
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AttributeDefinition).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsConsentStoresAttributeDefinitionsRequest>;
 
@@ -3779,7 +3779,7 @@ export const ListProjectsLocationsDatasetsConsentStoresAttributeDefinitionsReque
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/attributeDefinitions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/attributeDefinitions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsConsentStoresAttributeDefinitionsRequest>;
 
@@ -3822,7 +3822,7 @@ export const CreateProjectsLocationsDatasetsConsentStoresConsentArtifactsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/consentArtifacts",
+      path: "v1/{+parent}/consentArtifacts",
       hasBody: true,
     }),
     svc,
@@ -3857,7 +3857,7 @@ export const GetProjectsLocationsDatasetsConsentStoresConsentArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsConsentStoresConsentArtifactsRequest>;
 
@@ -3890,7 +3890,7 @@ export const DeleteProjectsLocationsDatasetsConsentStoresConsentArtifactsRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsConsentStoresConsentArtifactsRequest>;
 
@@ -3932,7 +3932,7 @@ export const ListProjectsLocationsDatasetsConsentStoresConsentArtifactsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/consentArtifacts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/consentArtifacts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsConsentStoresConsentArtifactsRequest>;
 
@@ -3972,7 +3972,7 @@ export const CreateProjectsLocationsDatasetsConsentStoresConsentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Consent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/consents", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/consents", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -4005,7 +4005,7 @@ export const GetProjectsLocationsDatasetsConsentStoresConsentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -4037,7 +4037,7 @@ export const DeleteProjectsLocationsDatasetsConsentStoresConsentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -4070,7 +4070,7 @@ export const DeleteRevisionProjectsLocationsDatasetsConsentStoresConsentsRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}:deleteRevision" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}:deleteRevision" }),
     svc,
   ) as unknown as Schema.Schema<DeleteRevisionProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -4109,7 +4109,7 @@ export const PatchProjectsLocationsDatasetsConsentStoresConsentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Consent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -4145,7 +4145,7 @@ export const ActivateProjectsLocationsDatasetsConsentStoresConsentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ActivateConsentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:activate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:activate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ActivateProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -4181,7 +4181,7 @@ export const RejectProjectsLocationsDatasetsConsentStoresConsentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RejectConsentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:reject", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:reject", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RejectProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -4223,7 +4223,7 @@ export const ListProjectsLocationsDatasetsConsentStoresConsentsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/consents" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/consents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -4269,7 +4269,7 @@ export const ListRevisionsProjectsLocationsDatasetsConsentStoresConsentsRequest 
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:listRevisions" }),
+    T.Http({ method: "GET", path: "v1/{+name}:listRevisions" }),
     svc,
   ) as unknown as Schema.Schema<ListRevisionsProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -4309,7 +4309,7 @@ export const RevokeProjectsLocationsDatasetsConsentStoresConsentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RevokeConsentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:revoke", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:revoke", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RevokeProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -4347,7 +4347,7 @@ export const CreateProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/userDataMappings",
+      path: "v1/{+parent}/userDataMappings",
       hasBody: true,
     }),
     svc,
@@ -4382,7 +4382,7 @@ export const GetProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest>;
 
@@ -4415,7 +4415,7 @@ export const DeleteProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest>;
 
@@ -4454,7 +4454,7 @@ export const PatchProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest 
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(UserDataMapping).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest>;
 
@@ -4496,7 +4496,7 @@ export const ListProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/userDataMappings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/userDataMappings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest>;
 
@@ -4536,7 +4536,7 @@ export const ArchiveProjectsLocationsDatasetsConsentStoresUserDataMappingsReques
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ArchiveUserDataMappingRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:archive", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:archive", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ArchiveProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest>;
 
@@ -4574,7 +4574,7 @@ export const SetIamPolicyProjectsLocationsDatasetsDataMapperWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4614,7 +4614,7 @@ export const GetIamPolicyProjectsLocationsDatasetsDataMapperWorkspacesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDatasetsDataMapperWorkspacesRequest>;
 
@@ -4652,7 +4652,7 @@ export const TestIamPermissionsProjectsLocationsDatasetsDataMapperWorkspacesRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4693,7 +4693,7 @@ export const SetIamPolicyProjectsLocationsDatasetsDicomStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4732,7 +4732,7 @@ export const GetIamPolicyProjectsLocationsDatasetsDicomStoresRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -4769,7 +4769,7 @@ export const TestIamPermissionsProjectsLocationsDatasetsDicomStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4809,7 +4809,7 @@ export const DeidentifyProjectsLocationsDatasetsDicomStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{sourceStore}:deidentify",
+      path: "v1/{+sourceStore}:deidentify",
       hasBody: true,
     }),
     svc,
@@ -4847,7 +4847,7 @@ export const SetBlobStorageSettingsProjectsLocationsDatasetsDicomStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setBlobStorageSettings",
+      path: "v1/{+resource}:setBlobStorageSettings",
       hasBody: true,
     }),
     svc,
@@ -4890,7 +4890,7 @@ export const CreateProjectsLocationsDatasetsDicomStoresRequest =
     ),
     body: Schema.optional(DicomStore).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/dicomStores", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/dicomStores", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -4921,7 +4921,7 @@ export const GetProjectsLocationsDatasetsDicomStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -4952,7 +4952,7 @@ export const DeleteProjectsLocationsDatasetsDicomStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -4989,7 +4989,7 @@ export const PatchProjectsLocationsDatasetsDicomStoresRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(DicomStore).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -5029,7 +5029,7 @@ export const ListProjectsLocationsDatasetsDicomStoresRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dicomStores" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dicomStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -5068,7 +5068,7 @@ export const ImportProjectsLocationsDatasetsDicomStoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ImportDicomDataRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:import", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:import", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -5102,7 +5102,7 @@ export const ExportProjectsLocationsDatasetsDicomStoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportDicomDataRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -5133,7 +5133,7 @@ export const GetDICOMStoreMetricsProjectsLocationsDatasetsDicomStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getDICOMStoreMetrics" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getDICOMStoreMetrics" }),
     svc,
   ) as unknown as Schema.Schema<GetDICOMStoreMetricsProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -5169,7 +5169,7 @@ export const SearchForStudiesProjectsLocationsDatasetsDicomStoresRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<SearchForStudiesProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -5205,7 +5205,7 @@ export const SearchForSeriesProjectsLocationsDatasetsDicomStoresRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<SearchForSeriesProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -5241,7 +5241,7 @@ export const SearchForInstancesProjectsLocationsDatasetsDicomStoresRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<SearchForInstancesProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -5282,7 +5282,7 @@ export const StoreInstancesProjectsLocationsDatasetsDicomStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/dicomWeb/{dicomWebPath}",
+      path: "v1/{+parent}/dicomWeb/{+dicomWebPath}",
       hasBody: true,
     }),
     svc,
@@ -5322,7 +5322,7 @@ export const SetBlobStorageSettingsProjectsLocationsDatasetsDicomStoresDicomWebS
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setBlobStorageSettings",
+      path: "v1/{+resource}:setBlobStorageSettings",
       hasBody: true,
     }),
     svc,
@@ -5359,7 +5359,7 @@ export const GetStudyMetricsProjectsLocationsDatasetsDicomStoresDicomWebStudiesR
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     study: Schema.String.pipe(T.HttpPath("study")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{study}:getStudyMetrics" }),
+    T.Http({ method: "GET", path: "v1/{+study}:getStudyMetrics" }),
     svc,
   ) as unknown as Schema.Schema<GetStudyMetricsProjectsLocationsDatasetsDicomStoresDicomWebStudiesRequest>;
 
@@ -5394,7 +5394,7 @@ export const GetSeriesMetricsProjectsLocationsDatasetsDicomStoresDicomWebStudies
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     series: Schema.String.pipe(T.HttpPath("series")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{series}:getSeriesMetrics" }),
+    T.Http({ method: "GET", path: "v1/{+series}:getSeriesMetrics" }),
     svc,
   ) as unknown as Schema.Schema<GetSeriesMetricsProjectsLocationsDatasetsDicomStoresDicomWebStudiesSeriesRequest>;
 
@@ -5429,7 +5429,7 @@ export const GetStorageInfoProjectsLocationsDatasetsDicomStoresDicomWebStudiesSe
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getStorageInfo" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getStorageInfo" }),
     svc,
   ) as unknown as Schema.Schema<GetStorageInfoProjectsLocationsDatasetsDicomStoresDicomWebStudiesSeriesInstancesRequest>;
 
@@ -5467,7 +5467,7 @@ export const RetrieveStudyProjectsLocationsDatasetsDicomStoresStudiesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<RetrieveStudyProjectsLocationsDatasetsDicomStoresStudiesRequest>;
 
@@ -5503,7 +5503,7 @@ export const RetrieveMetadataProjectsLocationsDatasetsDicomStoresStudiesRequest 
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<RetrieveMetadataProjectsLocationsDatasetsDicomStoresStudiesRequest>;
 
@@ -5539,7 +5539,7 @@ export const SearchForSeriesProjectsLocationsDatasetsDicomStoresStudiesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<SearchForSeriesProjectsLocationsDatasetsDicomStoresStudiesRequest>;
 
@@ -5575,7 +5575,7 @@ export const SearchForInstancesProjectsLocationsDatasetsDicomStoresStudiesReques
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<SearchForInstancesProjectsLocationsDatasetsDicomStoresStudiesRequest>;
 
@@ -5610,7 +5610,7 @@ export const DeleteProjectsLocationsDatasetsDicomStoresStudiesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "DELETE", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsDicomStoresStudiesRequest>;
 
@@ -5651,7 +5651,7 @@ export const StoreInstancesProjectsLocationsDatasetsDicomStoresStudiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/dicomWeb/{dicomWebPath}",
+      path: "v1/{+parent}/dicomWeb/{+dicomWebPath}",
       hasBody: true,
     }),
     svc,
@@ -5689,7 +5689,7 @@ export const RetrieveSeriesProjectsLocationsDatasetsDicomStoresStudiesSeriesRequ
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<RetrieveSeriesProjectsLocationsDatasetsDicomStoresStudiesSeriesRequest>;
 
@@ -5726,7 +5726,7 @@ export const RetrieveMetadataProjectsLocationsDatasetsDicomStoresStudiesSeriesRe
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<RetrieveMetadataProjectsLocationsDatasetsDicomStoresStudiesSeriesRequest>;
 
@@ -5764,7 +5764,7 @@ export const SearchForInstancesProjectsLocationsDatasetsDicomStoresStudiesSeries
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<SearchForInstancesProjectsLocationsDatasetsDicomStoresStudiesSeriesRequest>;
 
@@ -5802,7 +5802,7 @@ export const DeleteProjectsLocationsDatasetsDicomStoresStudiesSeriesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "DELETE", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsDicomStoresStudiesSeriesRequest>;
 
@@ -5838,7 +5838,7 @@ export const RetrieveInstanceProjectsLocationsDatasetsDicomStoresStudiesSeriesIn
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<RetrieveInstanceProjectsLocationsDatasetsDicomStoresStudiesSeriesInstancesRequest>;
 
@@ -5879,7 +5879,7 @@ export const RetrieveRenderedProjectsLocationsDatasetsDicomStoresStudiesSeriesIn
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
     viewport: Schema.optional(Schema.String).pipe(T.HttpQuery("viewport")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<RetrieveRenderedProjectsLocationsDatasetsDicomStoresStudiesSeriesInstancesRequest>;
 
@@ -5917,7 +5917,7 @@ export const RetrieveMetadataProjectsLocationsDatasetsDicomStoresStudiesSeriesIn
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<RetrieveMetadataProjectsLocationsDatasetsDicomStoresStudiesSeriesInstancesRequest>;
 
@@ -5955,7 +5955,7 @@ export const DeleteProjectsLocationsDatasetsDicomStoresStudiesSeriesInstancesReq
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "DELETE", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsDicomStoresStudiesSeriesInstancesRequest>;
 
@@ -5993,7 +5993,7 @@ export const RetrieveFramesProjectsLocationsDatasetsDicomStoresStudiesSeriesInst
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<RetrieveFramesProjectsLocationsDatasetsDicomStoresStudiesSeriesInstancesFramesRequest>;
 
@@ -6034,7 +6034,7 @@ export const RetrieveRenderedProjectsLocationsDatasetsDicomStoresStudiesSeriesIn
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
     viewport: Schema.optional(Schema.String).pipe(T.HttpQuery("viewport")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<RetrieveRenderedProjectsLocationsDatasetsDicomStoresStudiesSeriesInstancesFramesRequest>;
 
@@ -6072,7 +6072,7 @@ export const RetrieveBulkdataProjectsLocationsDatasetsDicomStoresStudiesSeriesIn
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dicomWeb/{+dicomWebPath}" }),
     svc,
   ) as unknown as Schema.Schema<RetrieveBulkdataProjectsLocationsDatasetsDicomStoresStudiesSeriesInstancesBulkdataRequest>;
 
@@ -6112,7 +6112,7 @@ export const SetIamPolicyProjectsLocationsDatasetsHl7V2StoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -6151,7 +6151,7 @@ export const GetIamPolicyProjectsLocationsDatasetsHl7V2StoresRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -6188,7 +6188,7 @@ export const TestIamPermissionsProjectsLocationsDatasetsHl7V2StoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -6231,7 +6231,7 @@ export const CreateProjectsLocationsDatasetsHl7V2StoresRequest =
     ),
     body: Schema.optional(Hl7V2Store).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/hl7V2Stores", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/hl7V2Stores", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -6262,7 +6262,7 @@ export const GetProjectsLocationsDatasetsHl7V2StoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -6293,7 +6293,7 @@ export const DeleteProjectsLocationsDatasetsHl7V2StoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -6333,7 +6333,7 @@ export const ListProjectsLocationsDatasetsHl7V2StoresRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/hl7V2Stores" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/hl7V2Stores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -6375,7 +6375,7 @@ export const PatchProjectsLocationsDatasetsHl7V2StoresRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Hl7V2Store).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -6409,7 +6409,7 @@ export const ExportProjectsLocationsDatasetsHl7V2StoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportMessagesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -6443,7 +6443,7 @@ export const ImportProjectsLocationsDatasetsHl7V2StoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ImportMessagesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:import", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:import", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -6474,7 +6474,7 @@ export const GetHL7v2StoreMetricsProjectsLocationsDatasetsHl7V2StoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getHL7v2StoreMetrics" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getHL7v2StoreMetrics" }),
     svc,
   ) as unknown as Schema.Schema<GetHL7v2StoreMetricsProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -6510,7 +6510,7 @@ export const RollbackProjectsLocationsDatasetsHl7V2StoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RollbackHl7V2MessagesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:rollback", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:rollback", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RollbackProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -6546,7 +6546,7 @@ export const IngestProjectsLocationsDatasetsHl7V2StoresMessagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/messages:ingest",
+      path: "v1/{+parent}/messages:ingest",
       hasBody: true,
     }),
     svc,
@@ -6584,7 +6584,7 @@ export const CreateProjectsLocationsDatasetsHl7V2StoresMessagesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateMessageRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/messages", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/messages", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDatasetsHl7V2StoresMessagesRequest>;
 
@@ -6627,7 +6627,7 @@ export const GetProjectsLocationsDatasetsHl7V2StoresMessagesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsHl7V2StoresMessagesRequest>;
 
@@ -6659,7 +6659,7 @@ export const DeleteProjectsLocationsDatasetsHl7V2StoresMessagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsHl7V2StoresMessagesRequest>;
 
@@ -6713,7 +6713,7 @@ export const ListProjectsLocationsDatasetsHl7V2StoresMessagesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/messages" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/messages" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsHl7V2StoresMessagesRequest>;
 
@@ -6756,7 +6756,7 @@ export const PatchProjectsLocationsDatasetsHl7V2StoresMessagesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Message).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsHl7V2StoresMessagesRequest>;
 
@@ -6793,7 +6793,7 @@ export const SetIamPolicyProjectsLocationsDatasetsFhirStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -6832,7 +6832,7 @@ export const GetIamPolicyProjectsLocationsDatasetsFhirStoresRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -6869,7 +6869,7 @@ export const TestIamPermissionsProjectsLocationsDatasetsFhirStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -6909,7 +6909,7 @@ export const DeidentifyProjectsLocationsDatasetsFhirStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{sourceStore}:deidentify",
+      path: "v1/{+sourceStore}:deidentify",
       hasBody: true,
     }),
     svc,
@@ -6958,7 +6958,7 @@ export const Bulk_export_groupProjectsLocationsDatasetsFhirStoresRequest =
       T.HttpQuery("organizeOutputBy"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/$export" }),
+    T.Http({ method: "GET", path: "v1/{+name}/$export" }),
     svc,
   ) as unknown as Schema.Schema<Bulk_export_groupProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -6999,7 +6999,7 @@ export const CreateProjectsLocationsDatasetsFhirStoresRequest =
     ),
     body: Schema.optional(FhirStore).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/fhirStores", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/fhirStores", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -7030,7 +7030,7 @@ export const GetProjectsLocationsDatasetsFhirStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -7067,7 +7067,7 @@ export const PatchProjectsLocationsDatasetsFhirStoresRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(FhirStore).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -7098,7 +7098,7 @@ export const DeleteProjectsLocationsDatasetsFhirStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -7138,7 +7138,7 @@ export const ListProjectsLocationsDatasetsFhirStoresRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/fhirStores" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/fhirStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -7177,7 +7177,7 @@ export const ImportProjectsLocationsDatasetsFhirStoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ImportResourcesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:import", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:import", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -7211,7 +7211,7 @@ export const ApplyConsentsProjectsLocationsDatasetsFhirStoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ApplyConsentsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:applyConsents", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:applyConsents", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ApplyConsentsProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -7249,7 +7249,7 @@ export const ApplyAdminConsentsProjectsLocationsDatasetsFhirStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:applyAdminConsents",
+      path: "v1/{+name}:applyAdminConsents",
       hasBody: true,
     }),
     svc,
@@ -7287,7 +7287,7 @@ export const ExplainDataAccessProjectsLocationsDatasetsFhirStoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     resourceId: Schema.optional(Schema.String).pipe(T.HttpQuery("resourceId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:explainDataAccess" }),
+    T.Http({ method: "GET", path: "v1/{+name}:explainDataAccess" }),
     svc,
   ) as unknown as Schema.Schema<ExplainDataAccessProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -7323,7 +7323,7 @@ export const ExportProjectsLocationsDatasetsFhirStoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportResourcesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -7357,7 +7357,7 @@ export const BulkDeleteProjectsLocationsDatasetsFhirStoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(BulkDeleteResourcesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:bulkDelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:bulkDelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<BulkDeleteProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -7388,7 +7388,7 @@ export const GetFHIRStoreMetricsProjectsLocationsDatasetsFhirStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getFHIRStoreMetrics" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getFHIRStoreMetrics" }),
     svc,
   ) as unknown as Schema.Schema<GetFHIRStoreMetricsProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -7424,7 +7424,7 @@ export const RollbackProjectsLocationsDatasetsFhirStoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RollbackFhirResourcesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:rollback", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:rollback", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RollbackProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -7461,7 +7461,11 @@ export const CreateProjectsLocationsDatasetsFhirStoresFhirRequest =
     type: Schema.String.pipe(T.HttpPath("type")),
     body: Schema.optional(HttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/fhir/{type}", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/fhir/{+type}",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7495,7 +7499,7 @@ export const Binary_createProjectsLocationsDatasetsFhirStoresFhirRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(HttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/fhir/Binary", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/fhir/Binary", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<Binary_createProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7528,7 +7532,7 @@ export const ReadProjectsLocationsDatasetsFhirStoresFhirRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ReadProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7559,7 +7563,7 @@ export const Binary_readProjectsLocationsDatasetsFhirStoresFhirRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<Binary_readProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7592,7 +7596,7 @@ export const VreadProjectsLocationsDatasetsFhirStoresFhirRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<VreadProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7623,7 +7627,7 @@ export const Binary_vreadProjectsLocationsDatasetsFhirStoresFhirRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<Binary_vreadProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7656,7 +7660,7 @@ export const DeleteProjectsLocationsDatasetsFhirStoresFhirRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7690,7 +7694,7 @@ export const ConditionalDeleteProjectsLocationsDatasetsFhirStoresFhirRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     type: Schema.String.pipe(T.HttpPath("type")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{parent}/fhir/{type}" }),
+    T.Http({ method: "DELETE", path: "v1/{+parent}/fhir/{+type}" }),
     svc,
   ) as unknown as Schema.Schema<ConditionalDeleteProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7726,7 +7730,7 @@ export const Binary_updateProjectsLocationsDatasetsFhirStoresFhirRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(HttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<Binary_updateProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7762,7 +7766,7 @@ export const UpdateProjectsLocationsDatasetsFhirStoresFhirRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(HttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7799,7 +7803,7 @@ export const ConditionalUpdateProjectsLocationsDatasetsFhirStoresFhirRequest =
     type: Schema.String.pipe(T.HttpPath("type")),
     body: Schema.optional(HttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{parent}/fhir/{type}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+parent}/fhir/{+type}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ConditionalUpdateProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7835,7 +7839,7 @@ export const PatchProjectsLocationsDatasetsFhirStoresFhirRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(HttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7872,7 +7876,11 @@ export const ConditionalPatchProjectsLocationsDatasetsFhirStoresFhirRequest =
     type: Schema.String.pipe(T.HttpPath("type")),
     body: Schema.optional(HttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{parent}/fhir/{type}", hasBody: true }),
+    T.Http({
+      method: "PATCH",
+      path: "v1/{+parent}/fhir/{+type}",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<ConditionalPatchProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7913,7 +7921,11 @@ export const SearchProjectsLocationsDatasetsFhirStoresFhirRequest =
     ),
     body: Schema.optional(HttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/fhir/_search", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/fhir/_search",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7952,7 +7964,7 @@ export const Search_typeProjectsLocationsDatasetsFhirStoresFhirRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/fhir/{resourceType}/_search",
+      path: "v1/{+parent}/fhir/{resourceType}/_search",
       hasBody: true,
     }),
     svc,
@@ -8007,7 +8019,7 @@ export const Patient_everythingProjectsLocationsDatasetsFhirStoresFhirRequest =
     _since: Schema.optional(Schema.String).pipe(T.HttpQuery("_since")),
     _type: Schema.optional(Schema.String).pipe(T.HttpQuery("_type")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/$everything" }),
+    T.Http({ method: "GET", path: "v1/{+name}/$everything" }),
     svc,
   ) as unknown as Schema.Schema<Patient_everythingProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -8040,7 +8052,7 @@ export const CapabilitiesProjectsLocationsDatasetsFhirStoresFhirRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/fhir/metadata" }),
+    T.Http({ method: "GET", path: "v1/{+name}/fhir/metadata" }),
     svc,
   ) as unknown as Schema.Schema<CapabilitiesProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -8076,7 +8088,7 @@ export const ExecuteBundleProjectsLocationsDatasetsFhirStoresFhirRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(HttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/fhir", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/fhir", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteBundleProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -8123,7 +8135,7 @@ export const HistoryProjectsLocationsDatasetsFhirStoresFhirRequest =
       T.HttpQuery("_page_token"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/_history" }),
+    T.Http({ method: "GET", path: "v1/{+name}/_history" }),
     svc,
   ) as unknown as Schema.Schema<HistoryProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -8154,7 +8166,7 @@ export const Resource_purgeProjectsLocationsDatasetsFhirStoresFhirRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}/$purge" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}/$purge" }),
     svc,
   ) as unknown as Schema.Schema<Resource_purgeProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -8198,7 +8210,7 @@ export const Bulk_exportProjectsLocationsDatasetsFhirStoresFhirRequest =
       T.HttpQuery("outputFormat"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/fhir/$export" }),
+    T.Http({ method: "GET", path: "v1/{+name}/fhir/$export" }),
     svc,
   ) as unknown as Schema.Schema<Bulk_exportProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -8242,7 +8254,7 @@ export const Resource_validateProjectsLocationsDatasetsFhirStoresFhirRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/fhir/{type}/$validate",
+      path: "v1/{+parent}/fhir/{+type}/$validate",
       hasBody: true,
     }),
     svc,
@@ -8277,7 +8289,7 @@ export const Consent_enforcement_statusProjectsLocationsDatasetsFhirStoresFhirRe
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/$consent-enforcement-status" }),
+    T.Http({ method: "GET", path: "v1/{+name}/$consent-enforcement-status" }),
     svc,
   ) as unknown as Schema.Schema<Consent_enforcement_statusProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -8320,7 +8332,7 @@ export const Patient_consent_enforcement_statusProjectsLocationsDatasetsFhirStor
       T.HttpQuery("_page_token"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/$consent-enforcement-status" }),
+    T.Http({ method: "GET", path: "v1/{+name}/$consent-enforcement-status" }),
     svc,
   ) as unknown as Schema.Schema<Patient_consent_enforcement_statusProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -8355,7 +8367,7 @@ export const Get_fhir_operation_statusProjectsLocationsDatasetsFhirStoresOperati
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<Get_fhir_operation_statusProjectsLocationsDatasetsFhirStoresOperationsRequest>;
 
@@ -8390,7 +8402,7 @@ export const Delete_fhir_operationProjectsLocationsDatasetsFhirStoresOperationsR
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<Delete_fhir_operationProjectsLocationsDatasetsFhirStoresOperationsRequest>;
 
@@ -8439,7 +8451,7 @@ export const ListProjectsLocationsDatasetsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsOperationsRequest>;
 
@@ -8475,7 +8487,7 @@ export const GetProjectsLocationsDatasetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsOperationsRequest>;
 
@@ -8509,7 +8521,7 @@ export const CancelProjectsLocationsDatasetsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDatasetsOperationsRequest>;
 
@@ -8545,7 +8557,7 @@ export const AnalyzeEntitiesProjectsLocationsServicesNlpRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{nlpService}:analyzeEntities",
+      path: "v1/{+nlpService}:analyzeEntities",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/healthcare-v1beta1.ts
+++ b/packages/gcp/src/services/healthcare-v1beta1.ts
@@ -3246,7 +3246,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -3281,7 +3281,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -3317,7 +3317,7 @@ export const SetIamPolicyProjectsLocationsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3355,7 +3355,7 @@ export const GetIamPolicyProjectsLocationsDatasetsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDatasetsRequest>;
 
@@ -3391,7 +3391,7 @@ export const TestIamPermissionsProjectsLocationsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3433,7 +3433,7 @@ export const CreateProjectsLocationsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/datasets",
+      path: "v1beta1/{+parent}/datasets",
       hasBody: true,
     }),
     svc,
@@ -3472,7 +3472,7 @@ export const ListProjectsLocationsDatasetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/datasets" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/datasets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsRequest>;
 
@@ -3507,7 +3507,7 @@ export const DeleteProjectsLocationsDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsRequest>;
 
@@ -3538,7 +3538,7 @@ export const GetProjectsLocationsDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsRequest>;
 
@@ -3575,7 +3575,7 @@ export const PatchProjectsLocationsDatasetsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Dataset).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsRequest>;
 
@@ -3611,7 +3611,7 @@ export const DeidentifyProjectsLocationsDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{sourceDataset}:deidentify",
+      path: "v1beta1/{+sourceDataset}:deidentify",
       hasBody: true,
     }),
     svc,
@@ -3649,7 +3649,7 @@ export const SetIamPolicyProjectsLocationsDatasetsDicomStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3688,7 +3688,7 @@ export const GetIamPolicyProjectsLocationsDatasetsDicomStoresRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -3725,7 +3725,7 @@ export const TestIamPermissionsProjectsLocationsDatasetsDicomStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3765,7 +3765,7 @@ export const DeidentifyProjectsLocationsDatasetsDicomStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{sourceStore}:deidentify",
+      path: "v1beta1/{+sourceStore}:deidentify",
       hasBody: true,
     }),
     svc,
@@ -3803,7 +3803,7 @@ export const SetBlobStorageSettingsProjectsLocationsDatasetsDicomStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setBlobStorageSettings",
+      path: "v1beta1/{+resource}:setBlobStorageSettings",
       hasBody: true,
     }),
     svc,
@@ -3848,7 +3848,7 @@ export const CreateProjectsLocationsDatasetsDicomStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/dicomStores",
+      path: "v1beta1/{+parent}/dicomStores",
       hasBody: true,
     }),
     svc,
@@ -3881,7 +3881,7 @@ export const GetProjectsLocationsDatasetsDicomStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -3912,7 +3912,7 @@ export const DeleteProjectsLocationsDatasetsDicomStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -3949,7 +3949,7 @@ export const PatchProjectsLocationsDatasetsDicomStoresRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(DicomStore).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -3989,7 +3989,7 @@ export const ListProjectsLocationsDatasetsDicomStoresRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dicomStores" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/dicomStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -4028,7 +4028,7 @@ export const ImportProjectsLocationsDatasetsDicomStoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ImportDicomDataRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:import", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:import", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -4062,7 +4062,7 @@ export const ExportProjectsLocationsDatasetsDicomStoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportDicomDataRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -4093,7 +4093,7 @@ export const GetDICOMStoreMetricsProjectsLocationsDatasetsDicomStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:getDICOMStoreMetrics" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:getDICOMStoreMetrics" }),
     svc,
   ) as unknown as Schema.Schema<GetDICOMStoreMetricsProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -4129,7 +4129,10 @@ export const SearchForStudiesProjectsLocationsDatasetsDicomStoresRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
+    }),
     svc,
   ) as unknown as Schema.Schema<SearchForStudiesProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -4165,7 +4168,10 @@ export const SearchForSeriesProjectsLocationsDatasetsDicomStoresRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
+    }),
     svc,
   ) as unknown as Schema.Schema<SearchForSeriesProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -4201,7 +4207,10 @@ export const SearchForInstancesProjectsLocationsDatasetsDicomStoresRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
+    }),
     svc,
   ) as unknown as Schema.Schema<SearchForInstancesProjectsLocationsDatasetsDicomStoresRequest>;
 
@@ -4242,7 +4251,7 @@ export const UpdateInstancesProjectsLocationsDatasetsDicomStoresRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
       hasBody: true,
     }),
     svc,
@@ -4285,7 +4294,7 @@ export const StoreInstancesProjectsLocationsDatasetsDicomStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
       hasBody: true,
     }),
     svc,
@@ -4325,7 +4334,7 @@ export const SetBlobStorageSettingsProjectsLocationsDatasetsDicomStoresDicomWebS
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setBlobStorageSettings",
+      path: "v1beta1/{+resource}:setBlobStorageSettings",
       hasBody: true,
     }),
     svc,
@@ -4362,7 +4371,7 @@ export const GetStudyMetricsProjectsLocationsDatasetsDicomStoresDicomWebStudiesR
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     study: Schema.String.pipe(T.HttpPath("study")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{study}:getStudyMetrics" }),
+    T.Http({ method: "GET", path: "v1beta1/{+study}:getStudyMetrics" }),
     svc,
   ) as unknown as Schema.Schema<GetStudyMetricsProjectsLocationsDatasetsDicomStoresDicomWebStudiesRequest>;
 
@@ -4397,7 +4406,7 @@ export const GetSeriesMetricsProjectsLocationsDatasetsDicomStoresDicomWebStudies
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     series: Schema.String.pipe(T.HttpPath("series")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{series}:getSeriesMetrics" }),
+    T.Http({ method: "GET", path: "v1beta1/{+series}:getSeriesMetrics" }),
     svc,
   ) as unknown as Schema.Schema<GetSeriesMetricsProjectsLocationsDatasetsDicomStoresDicomWebStudiesSeriesRequest>;
 
@@ -4432,7 +4441,7 @@ export const GetStorageInfoProjectsLocationsDatasetsDicomStoresDicomWebStudiesSe
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getStorageInfo" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getStorageInfo" }),
     svc,
   ) as unknown as Schema.Schema<GetStorageInfoProjectsLocationsDatasetsDicomStoresDicomWebStudiesSeriesInstancesRequest>;
 
@@ -4470,7 +4479,10 @@ export const RetrieveStudyProjectsLocationsDatasetsDicomStoresStudiesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
+    }),
     svc,
   ) as unknown as Schema.Schema<RetrieveStudyProjectsLocationsDatasetsDicomStoresStudiesRequest>;
 
@@ -4506,7 +4518,10 @@ export const RetrieveMetadataProjectsLocationsDatasetsDicomStoresStudiesRequest 
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
+    }),
     svc,
   ) as unknown as Schema.Schema<RetrieveMetadataProjectsLocationsDatasetsDicomStoresStudiesRequest>;
 
@@ -4542,7 +4557,10 @@ export const SearchForSeriesProjectsLocationsDatasetsDicomStoresStudiesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
+    }),
     svc,
   ) as unknown as Schema.Schema<SearchForSeriesProjectsLocationsDatasetsDicomStoresStudiesRequest>;
 
@@ -4578,7 +4596,10 @@ export const SearchForInstancesProjectsLocationsDatasetsDicomStoresStudiesReques
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
+    }),
     svc,
   ) as unknown as Schema.Schema<SearchForInstancesProjectsLocationsDatasetsDicomStoresStudiesRequest>;
 
@@ -4619,7 +4640,7 @@ export const UpdateInstancesProjectsLocationsDatasetsDicomStoresStudiesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
       hasBody: true,
     }),
     svc,
@@ -4662,7 +4683,7 @@ export const UpdateMetadataProjectsLocationsDatasetsDicomStoresStudiesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}/metadata",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}/metadata",
       hasBody: true,
     }),
     svc,
@@ -4701,7 +4722,7 @@ export const DeleteProjectsLocationsDatasetsDicomStoresStudiesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsDicomStoresStudiesRequest>;
@@ -4743,7 +4764,7 @@ export const StoreInstancesProjectsLocationsDatasetsDicomStoresStudiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
       hasBody: true,
     }),
     svc,
@@ -4781,7 +4802,10 @@ export const RetrieveSeriesProjectsLocationsDatasetsDicomStoresStudiesSeriesRequ
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
+    }),
     svc,
   ) as unknown as Schema.Schema<RetrieveSeriesProjectsLocationsDatasetsDicomStoresStudiesSeriesRequest>;
 
@@ -4818,7 +4842,10 @@ export const RetrieveMetadataProjectsLocationsDatasetsDicomStoresStudiesSeriesRe
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
+    }),
     svc,
   ) as unknown as Schema.Schema<RetrieveMetadataProjectsLocationsDatasetsDicomStoresStudiesSeriesRequest>;
 
@@ -4856,7 +4883,10 @@ export const SearchForInstancesProjectsLocationsDatasetsDicomStoresStudiesSeries
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
+    }),
     svc,
   ) as unknown as Schema.Schema<SearchForInstancesProjectsLocationsDatasetsDicomStoresStudiesSeriesRequest>;
 
@@ -4899,7 +4929,7 @@ export const UpdateMetadataProjectsLocationsDatasetsDicomStoresStudiesSeriesRequ
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}/metadata",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}/metadata",
       hasBody: true,
     }),
     svc,
@@ -4940,7 +4970,7 @@ export const DeleteProjectsLocationsDatasetsDicomStoresStudiesSeriesRequest =
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsDicomStoresStudiesSeriesRequest>;
@@ -4977,7 +5007,10 @@ export const RetrieveInstanceProjectsLocationsDatasetsDicomStoresStudiesSeriesIn
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
+    }),
     svc,
   ) as unknown as Schema.Schema<RetrieveInstanceProjectsLocationsDatasetsDicomStoresStudiesSeriesInstancesRequest>;
 
@@ -5018,7 +5051,10 @@ export const RetrieveRenderedProjectsLocationsDatasetsDicomStoresStudiesSeriesIn
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
     viewport: Schema.optional(Schema.String).pipe(T.HttpQuery("viewport")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
+    }),
     svc,
   ) as unknown as Schema.Schema<RetrieveRenderedProjectsLocationsDatasetsDicomStoresStudiesSeriesInstancesRequest>;
 
@@ -5056,7 +5092,10 @@ export const RetrieveMetadataProjectsLocationsDatasetsDicomStoresStudiesSeriesIn
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
+    }),
     svc,
   ) as unknown as Schema.Schema<RetrieveMetadataProjectsLocationsDatasetsDicomStoresStudiesSeriesInstancesRequest>;
 
@@ -5099,7 +5138,7 @@ export const UpdateMetadataProjectsLocationsDatasetsDicomStoresStudiesSeriesInst
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}/metadata",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}/metadata",
       hasBody: true,
     }),
     svc,
@@ -5141,7 +5180,7 @@ export const DeleteProjectsLocationsDatasetsDicomStoresStudiesSeriesInstancesReq
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
     }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsDicomStoresStudiesSeriesInstancesRequest>;
@@ -5180,7 +5219,10 @@ export const RetrieveFramesProjectsLocationsDatasetsDicomStoresStudiesSeriesInst
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
+    }),
     svc,
   ) as unknown as Schema.Schema<RetrieveFramesProjectsLocationsDatasetsDicomStoresStudiesSeriesInstancesFramesRequest>;
 
@@ -5221,7 +5263,10 @@ export const RetrieveRenderedProjectsLocationsDatasetsDicomStoresStudiesSeriesIn
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
     viewport: Schema.optional(Schema.String).pipe(T.HttpQuery("viewport")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
+    }),
     svc,
   ) as unknown as Schema.Schema<RetrieveRenderedProjectsLocationsDatasetsDicomStoresStudiesSeriesInstancesFramesRequest>;
 
@@ -5259,7 +5304,10 @@ export const RetrieveBulkdataProjectsLocationsDatasetsDicomStoresStudiesSeriesIn
     parent: Schema.String.pipe(T.HttpPath("parent")),
     dicomWebPath: Schema.String.pipe(T.HttpPath("dicomWebPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dicomWeb/{dicomWebPath}" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/dicomWeb/{+dicomWebPath}",
+    }),
     svc,
   ) as unknown as Schema.Schema<RetrieveBulkdataProjectsLocationsDatasetsDicomStoresStudiesSeriesInstancesBulkdataRequest>;
 
@@ -5299,7 +5347,7 @@ export const SetIamPolicyProjectsLocationsDatasetsHl7V2StoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5338,7 +5386,7 @@ export const GetIamPolicyProjectsLocationsDatasetsHl7V2StoresRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -5375,7 +5423,7 @@ export const TestIamPermissionsProjectsLocationsDatasetsHl7V2StoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5420,7 +5468,7 @@ export const CreateProjectsLocationsDatasetsHl7V2StoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/hl7V2Stores",
+      path: "v1beta1/{+parent}/hl7V2Stores",
       hasBody: true,
     }),
     svc,
@@ -5453,7 +5501,7 @@ export const GetProjectsLocationsDatasetsHl7V2StoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -5484,7 +5532,7 @@ export const DeleteProjectsLocationsDatasetsHl7V2StoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -5524,7 +5572,7 @@ export const ListProjectsLocationsDatasetsHl7V2StoresRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/hl7V2Stores" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/hl7V2Stores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -5566,7 +5614,7 @@ export const PatchProjectsLocationsDatasetsHl7V2StoresRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Hl7V2Store).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -5600,7 +5648,7 @@ export const ExportProjectsLocationsDatasetsHl7V2StoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportMessagesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -5634,7 +5682,7 @@ export const ImportProjectsLocationsDatasetsHl7V2StoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ImportMessagesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:import", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:import", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -5665,7 +5713,7 @@ export const GetHL7v2StoreMetricsProjectsLocationsDatasetsHl7V2StoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:getHL7v2StoreMetrics" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:getHL7v2StoreMetrics" }),
     svc,
   ) as unknown as Schema.Schema<GetHL7v2StoreMetricsProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -5701,7 +5749,7 @@ export const RollbackProjectsLocationsDatasetsHl7V2StoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RollbackHl7V2MessagesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:rollback", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:rollback", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RollbackProjectsLocationsDatasetsHl7V2StoresRequest>;
 
@@ -5737,7 +5785,7 @@ export const IngestProjectsLocationsDatasetsHl7V2StoresMessagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/messages:ingest",
+      path: "v1beta1/{+parent}/messages:ingest",
       hasBody: true,
     }),
     svc,
@@ -5777,7 +5825,7 @@ export const CreateProjectsLocationsDatasetsHl7V2StoresMessagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/messages",
+      path: "v1beta1/{+parent}/messages",
       hasBody: true,
     }),
     svc,
@@ -5822,7 +5870,7 @@ export const GetProjectsLocationsDatasetsHl7V2StoresMessagesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsHl7V2StoresMessagesRequest>;
 
@@ -5867,7 +5915,7 @@ export const BatchGetProjectsLocationsDatasetsHl7V2StoresMessagesRequest =
     ids: Schema.optional(Schema.Array(Schema.String)).pipe(T.HttpQuery("ids")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/messages:batchGet" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/messages:batchGet" }),
     svc,
   ) as unknown as Schema.Schema<BatchGetProjectsLocationsDatasetsHl7V2StoresMessagesRequest>;
 
@@ -5900,7 +5948,7 @@ export const DeleteProjectsLocationsDatasetsHl7V2StoresMessagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsHl7V2StoresMessagesRequest>;
 
@@ -5954,7 +6002,7 @@ export const ListProjectsLocationsDatasetsHl7V2StoresMessagesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/messages" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/messages" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsHl7V2StoresMessagesRequest>;
 
@@ -5997,7 +6045,7 @@ export const PatchProjectsLocationsDatasetsHl7V2StoresMessagesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Message).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsHl7V2StoresMessagesRequest>;
 
@@ -6034,7 +6082,7 @@ export const SetIamPolicyProjectsLocationsDatasetsFhirStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -6073,7 +6121,7 @@ export const GetIamPolicyProjectsLocationsDatasetsFhirStoresRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -6110,7 +6158,7 @@ export const TestIamPermissionsProjectsLocationsDatasetsFhirStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -6150,7 +6198,7 @@ export const DeidentifyProjectsLocationsDatasetsFhirStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{sourceStore}:deidentify",
+      path: "v1beta1/{+sourceStore}:deidentify",
       hasBody: true,
     }),
     svc,
@@ -6199,7 +6247,7 @@ export const Bulk_export_groupProjectsLocationsDatasetsFhirStoresRequest =
       T.HttpQuery("organizeOutputBy"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/$export" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/$export" }),
     svc,
   ) as unknown as Schema.Schema<Bulk_export_groupProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -6242,7 +6290,7 @@ export const CreateProjectsLocationsDatasetsFhirStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/fhirStores",
+      path: "v1beta1/{+parent}/fhirStores",
       hasBody: true,
     }),
     svc,
@@ -6275,7 +6323,7 @@ export const GetProjectsLocationsDatasetsFhirStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -6312,7 +6360,7 @@ export const PatchProjectsLocationsDatasetsFhirStoresRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(FhirStore).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -6343,7 +6391,7 @@ export const DeleteProjectsLocationsDatasetsFhirStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -6383,7 +6431,7 @@ export const ListProjectsLocationsDatasetsFhirStoresRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/fhirStores" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/fhirStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -6422,7 +6470,7 @@ export const ImportProjectsLocationsDatasetsFhirStoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ImportResourcesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:import", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:import", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -6458,7 +6506,7 @@ export const ImportHistoryProjectsLocationsDatasetsFhirStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:importHistory",
+      path: "v1beta1/{+name}:importHistory",
       hasBody: true,
     }),
     svc,
@@ -6496,7 +6544,7 @@ export const ExportProjectsLocationsDatasetsFhirStoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportResourcesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -6532,7 +6580,7 @@ export const ExportHistoryProjectsLocationsDatasetsFhirStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:exportHistory",
+      path: "v1beta1/{+name}:exportHistory",
       hasBody: true,
     }),
     svc,
@@ -6572,7 +6620,7 @@ export const BulkDeleteProjectsLocationsDatasetsFhirStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:bulkDelete",
+      path: "v1beta1/{+name}:bulkDelete",
       hasBody: true,
     }),
     svc,
@@ -6610,7 +6658,7 @@ export const ConfigureSearchProjectsLocationsDatasetsFhirStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:configureSearch",
+      path: "v1beta1/{+name}:configureSearch",
       hasBody: true,
     }),
     svc,
@@ -6650,7 +6698,7 @@ export const ApplyConsentsProjectsLocationsDatasetsFhirStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:applyConsents",
+      path: "v1beta1/{+name}:applyConsents",
       hasBody: true,
     }),
     svc,
@@ -6690,7 +6738,7 @@ export const ApplyAdminConsentsProjectsLocationsDatasetsFhirStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:applyAdminConsents",
+      path: "v1beta1/{+name}:applyAdminConsents",
       hasBody: true,
     }),
     svc,
@@ -6728,7 +6776,7 @@ export const ExplainDataAccessProjectsLocationsDatasetsFhirStoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     resourceId: Schema.optional(Schema.String).pipe(T.HttpQuery("resourceId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:explainDataAccess" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:explainDataAccess" }),
     svc,
   ) as unknown as Schema.Schema<ExplainDataAccessProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -6761,7 +6809,7 @@ export const GetFHIRStoreMetricsProjectsLocationsDatasetsFhirStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:getFHIRStoreMetrics" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:getFHIRStoreMetrics" }),
     svc,
   ) as unknown as Schema.Schema<GetFHIRStoreMetricsProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -6797,7 +6845,7 @@ export const RollbackProjectsLocationsDatasetsFhirStoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RollbackFhirResourcesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:rollback", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:rollback", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RollbackProjectsLocationsDatasetsFhirStoresRequest>;
 
@@ -6836,7 +6884,7 @@ export const CreateProjectsLocationsDatasetsFhirStoresFhirRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/fhir/{type}",
+      path: "v1beta1/{+parent}/fhir/{+type}",
       hasBody: true,
     }),
     svc,
@@ -6874,7 +6922,7 @@ export const Binary_createProjectsLocationsDatasetsFhirStoresFhirRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/fhir/Binary",
+      path: "v1beta1/{+parent}/fhir/Binary",
       hasBody: true,
     }),
     svc,
@@ -6909,7 +6957,7 @@ export const ReadProjectsLocationsDatasetsFhirStoresFhirRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ReadProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -6940,7 +6988,7 @@ export const Binary_readProjectsLocationsDatasetsFhirStoresFhirRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<Binary_readProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -6973,7 +7021,7 @@ export const VreadProjectsLocationsDatasetsFhirStoresFhirRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<VreadProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7004,7 +7052,7 @@ export const Binary_vreadProjectsLocationsDatasetsFhirStoresFhirRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<Binary_vreadProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7037,7 +7085,7 @@ export const DeleteProjectsLocationsDatasetsFhirStoresFhirRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7071,7 +7119,7 @@ export const ConditionalDeleteProjectsLocationsDatasetsFhirStoresFhirRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     type: Schema.String.pipe(T.HttpPath("type")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{parent}/fhir/{type}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+parent}/fhir/{+type}" }),
     svc,
   ) as unknown as Schema.Schema<ConditionalDeleteProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7107,7 +7155,7 @@ export const Binary_updateProjectsLocationsDatasetsFhirStoresFhirRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(HttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<Binary_updateProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7143,7 +7191,7 @@ export const UpdateProjectsLocationsDatasetsFhirStoresFhirRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(HttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7182,7 +7230,7 @@ export const ConditionalUpdateProjectsLocationsDatasetsFhirStoresFhirRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "v1beta1/{parent}/fhir/{type}",
+      path: "v1beta1/{+parent}/fhir/{+type}",
       hasBody: true,
     }),
     svc,
@@ -7220,7 +7268,7 @@ export const PatchProjectsLocationsDatasetsFhirStoresFhirRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(HttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7259,7 +7307,7 @@ export const ConditionalPatchProjectsLocationsDatasetsFhirStoresFhirRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1beta1/{parent}/fhir/{type}",
+      path: "v1beta1/{+parent}/fhir/{+type}",
       hasBody: true,
     }),
     svc,
@@ -7304,7 +7352,7 @@ export const SearchProjectsLocationsDatasetsFhirStoresFhirRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/fhir/_search",
+      path: "v1beta1/{+parent}/fhir/_search",
       hasBody: true,
     }),
     svc,
@@ -7345,7 +7393,7 @@ export const Search_typeProjectsLocationsDatasetsFhirStoresFhirRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/fhir/{resourceType}/_search",
+      path: "v1beta1/{+parent}/fhir/{resourceType}/_search",
       hasBody: true,
     }),
     svc,
@@ -7400,7 +7448,7 @@ export const Patient_everythingProjectsLocationsDatasetsFhirStoresFhirRequest =
     _since: Schema.optional(Schema.String).pipe(T.HttpQuery("_since")),
     _type: Schema.optional(Schema.String).pipe(T.HttpQuery("_type")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/$everything" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/$everything" }),
     svc,
   ) as unknown as Schema.Schema<Patient_everythingProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7447,7 +7495,7 @@ export const Encounter_everythingProjectsLocationsDatasetsFhirStoresFhirRequest 
     _since: Schema.optional(Schema.String).pipe(T.HttpQuery("_since")),
     _type: Schema.optional(Schema.String).pipe(T.HttpQuery("_type")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/$everything" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/$everything" }),
     svc,
   ) as unknown as Schema.Schema<Encounter_everythingProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7480,7 +7528,10 @@ export const Observation_lastnProjectsLocationsDatasetsFhirStoresFhirRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/fhir/Observation/$lastn" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/fhir/Observation/$lastn",
+    }),
     svc,
   ) as unknown as Schema.Schema<Observation_lastnProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7530,7 +7581,7 @@ export const Resource_incoming_referencesProjectsLocationsDatasetsFhirStoresFhir
     _summary: Schema.optional(Schema.String).pipe(T.HttpQuery("_summary")),
     _type: Schema.optional(Schema.String).pipe(T.HttpQuery("_type")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/fhir/$references" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/fhir/$references" }),
     svc,
   ) as unknown as Schema.Schema<Resource_incoming_referencesProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7565,7 +7616,7 @@ export const CapabilitiesProjectsLocationsDatasetsFhirStoresFhirRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/fhir/metadata" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/fhir/metadata" }),
     svc,
   ) as unknown as Schema.Schema<CapabilitiesProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7601,7 +7652,7 @@ export const ExecuteBundleProjectsLocationsDatasetsFhirStoresFhirRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(HttpBody).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/fhir", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+parent}/fhir", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteBundleProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7648,7 +7699,7 @@ export const HistoryProjectsLocationsDatasetsFhirStoresFhirRequest =
       T.HttpQuery("_page_token"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/_history" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/_history" }),
     svc,
   ) as unknown as Schema.Schema<HistoryProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7679,7 +7730,7 @@ export const Resource_purgeProjectsLocationsDatasetsFhirStoresFhirRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}/$purge" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}/$purge" }),
     svc,
   ) as unknown as Schema.Schema<Resource_purgeProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7723,7 +7774,7 @@ export const Bulk_exportProjectsLocationsDatasetsFhirStoresFhirRequest =
       T.HttpQuery("outputFormat"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/fhir/$export" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/fhir/$export" }),
     svc,
   ) as unknown as Schema.Schema<Bulk_exportProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7767,7 +7818,7 @@ export const ConceptMap_translateProjectsLocationsDatasetsFhirStoresFhirRequest 
       T.HttpQuery("conceptMapVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/$translate" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/$translate" }),
     svc,
   ) as unknown as Schema.Schema<ConceptMap_translateProjectsLocationsDatasetsFhirStoresFhirRequest>;
 
@@ -7822,7 +7873,7 @@ export const ConceptMap_search_translateProjectsLocationsDatasetsFhirStoresFhirR
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/fhir/ConceptMap/$translate",
+      path: "v1beta1/{+parent}/fhir/ConceptMap/$translate",
     }),
     svc,
   ) as unknown as Schema.Schema<ConceptMap_search_translateProjectsLocationsDatasetsFhirStoresFhirRequest>;
@@ -7869,7 +7920,7 @@ export const Resource_validateProjectsLocationsDatasetsFhirStoresFhirRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/fhir/{type}/$validate",
+      path: "v1beta1/{+parent}/fhir/{+type}/$validate",
       hasBody: true,
     }),
     svc,
@@ -7906,7 +7957,7 @@ export const Consent_enforcement_statusProjectsLocationsDatasetsFhirStoresFhirRe
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{name}/$consent-enforcement-status",
+      path: "v1beta1/{+name}/$consent-enforcement-status",
     }),
     svc,
   ) as unknown as Schema.Schema<Consent_enforcement_statusProjectsLocationsDatasetsFhirStoresFhirRequest>;
@@ -7952,7 +8003,7 @@ export const Patient_consent_enforcement_statusProjectsLocationsDatasetsFhirStor
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{name}/$consent-enforcement-status",
+      path: "v1beta1/{+name}/$consent-enforcement-status",
     }),
     svc,
   ) as unknown as Schema.Schema<Patient_consent_enforcement_statusProjectsLocationsDatasetsFhirStoresFhirRequest>;
@@ -7988,7 +8039,7 @@ export const Get_fhir_operation_statusProjectsLocationsDatasetsFhirStoresOperati
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<Get_fhir_operation_statusProjectsLocationsDatasetsFhirStoresOperationsRequest>;
 
@@ -8023,7 +8074,7 @@ export const Delete_fhir_operationProjectsLocationsDatasetsFhirStoresOperationsR
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<Delete_fhir_operationProjectsLocationsDatasetsFhirStoresOperationsRequest>;
 
@@ -8063,7 +8114,7 @@ export const SetIamPolicyProjectsLocationsDatasetsConsentStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -8102,7 +8153,7 @@ export const GetIamPolicyProjectsLocationsDatasetsConsentStoresRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDatasetsConsentStoresRequest>;
 
@@ -8139,7 +8190,7 @@ export const TestIamPermissionsProjectsLocationsDatasetsConsentStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -8184,7 +8235,7 @@ export const CreateProjectsLocationsDatasetsConsentStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/consentStores",
+      path: "v1beta1/{+parent}/consentStores",
       hasBody: true,
     }),
     svc,
@@ -8217,7 +8268,7 @@ export const GetProjectsLocationsDatasetsConsentStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsConsentStoresRequest>;
 
@@ -8248,7 +8299,7 @@ export const DeleteProjectsLocationsDatasetsConsentStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsConsentStoresRequest>;
 
@@ -8285,7 +8336,7 @@ export const PatchProjectsLocationsDatasetsConsentStoresRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ConsentStore).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsConsentStoresRequest>;
 
@@ -8325,7 +8376,7 @@ export const ListProjectsLocationsDatasetsConsentStoresRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/consentStores" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/consentStores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsConsentStoresRequest>;
 
@@ -8366,7 +8417,7 @@ export const CheckDataAccessProjectsLocationsDatasetsConsentStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{consentStore}:checkDataAccess",
+      path: "v1beta1/{+consentStore}:checkDataAccess",
       hasBody: true,
     }),
     svc,
@@ -8406,7 +8457,7 @@ export const QueryAccessibleDataProjectsLocationsDatasetsConsentStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{consentStore}:queryAccessibleData",
+      path: "v1beta1/{+consentStore}:queryAccessibleData",
       hasBody: true,
     }),
     svc,
@@ -8446,7 +8497,7 @@ export const EvaluateUserConsentsProjectsLocationsDatasetsConsentStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{consentStore}:evaluateUserConsents",
+      path: "v1beta1/{+consentStore}:evaluateUserConsents",
       hasBody: true,
     }),
     svc,
@@ -8491,7 +8542,7 @@ export const CreateProjectsLocationsDatasetsConsentStoresAttributeDefinitionsReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/attributeDefinitions",
+      path: "v1beta1/{+parent}/attributeDefinitions",
       hasBody: true,
     }),
     svc,
@@ -8528,7 +8579,7 @@ export const GetProjectsLocationsDatasetsConsentStoresAttributeDefinitionsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsConsentStoresAttributeDefinitionsRequest>;
 
@@ -8561,7 +8612,7 @@ export const DeleteProjectsLocationsDatasetsConsentStoresAttributeDefinitionsReq
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsConsentStoresAttributeDefinitionsRequest>;
 
@@ -8602,7 +8653,7 @@ export const PatchProjectsLocationsDatasetsConsentStoresAttributeDefinitionsRequ
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AttributeDefinition).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsConsentStoresAttributeDefinitionsRequest>;
 
@@ -8645,7 +8696,7 @@ export const ListProjectsLocationsDatasetsConsentStoresAttributeDefinitionsReque
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/attributeDefinitions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/attributeDefinitions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsConsentStoresAttributeDefinitionsRequest>;
 
@@ -8688,7 +8739,7 @@ export const CreateProjectsLocationsDatasetsConsentStoresConsentArtifactsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/consentArtifacts",
+      path: "v1beta1/{+parent}/consentArtifacts",
       hasBody: true,
     }),
     svc,
@@ -8723,7 +8774,7 @@ export const GetProjectsLocationsDatasetsConsentStoresConsentArtifactsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsConsentStoresConsentArtifactsRequest>;
 
@@ -8756,7 +8807,7 @@ export const DeleteProjectsLocationsDatasetsConsentStoresConsentArtifactsRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsConsentStoresConsentArtifactsRequest>;
 
@@ -8798,7 +8849,7 @@ export const ListProjectsLocationsDatasetsConsentStoresConsentArtifactsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/consentArtifacts" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/consentArtifacts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsConsentStoresConsentArtifactsRequest>;
 
@@ -8840,7 +8891,7 @@ export const CreateProjectsLocationsDatasetsConsentStoresConsentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/consents",
+      path: "v1beta1/{+parent}/consents",
       hasBody: true,
     }),
     svc,
@@ -8875,7 +8926,7 @@ export const GetProjectsLocationsDatasetsConsentStoresConsentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -8907,7 +8958,7 @@ export const DeleteProjectsLocationsDatasetsConsentStoresConsentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -8940,7 +8991,7 @@ export const DeleteRevisionProjectsLocationsDatasetsConsentStoresConsentsRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}:deleteRevision" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}:deleteRevision" }),
     svc,
   ) as unknown as Schema.Schema<DeleteRevisionProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -8979,7 +9030,7 @@ export const PatchProjectsLocationsDatasetsConsentStoresConsentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Consent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -9015,7 +9066,7 @@ export const ActivateProjectsLocationsDatasetsConsentStoresConsentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ActivateConsentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:activate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:activate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ActivateProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -9051,7 +9102,7 @@ export const RejectProjectsLocationsDatasetsConsentStoresConsentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RejectConsentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:reject", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:reject", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RejectProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -9093,7 +9144,7 @@ export const ListProjectsLocationsDatasetsConsentStoresConsentsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/consents" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/consents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -9139,7 +9190,7 @@ export const ListRevisionsProjectsLocationsDatasetsConsentStoresConsentsRequest 
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:listRevisions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:listRevisions" }),
     svc,
   ) as unknown as Schema.Schema<ListRevisionsProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -9179,7 +9230,7 @@ export const RevokeProjectsLocationsDatasetsConsentStoresConsentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RevokeConsentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:revoke", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:revoke", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RevokeProjectsLocationsDatasetsConsentStoresConsentsRequest>;
 
@@ -9217,7 +9268,7 @@ export const CreateProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/userDataMappings",
+      path: "v1beta1/{+parent}/userDataMappings",
       hasBody: true,
     }),
     svc,
@@ -9252,7 +9303,7 @@ export const GetProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest>;
 
@@ -9285,7 +9336,7 @@ export const DeleteProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest>;
 
@@ -9324,7 +9375,7 @@ export const PatchProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest 
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(UserDataMapping).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest>;
 
@@ -9366,7 +9417,7 @@ export const ListProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/userDataMappings" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/userDataMappings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest>;
 
@@ -9406,7 +9457,7 @@ export const ArchiveProjectsLocationsDatasetsConsentStoresUserDataMappingsReques
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ArchiveUserDataMappingRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:archive", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:archive", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ArchiveProjectsLocationsDatasetsConsentStoresUserDataMappingsRequest>;
 
@@ -9444,7 +9495,7 @@ export const SetIamPolicyProjectsLocationsDatasetsDataMapperWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -9484,7 +9535,7 @@ export const GetIamPolicyProjectsLocationsDatasetsDataMapperWorkspacesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsDatasetsDataMapperWorkspacesRequest>;
 
@@ -9522,7 +9573,7 @@ export const TestIamPermissionsProjectsLocationsDatasetsDataMapperWorkspacesRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -9572,7 +9623,7 @@ export const ListProjectsLocationsDatasetsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsOperationsRequest>;
 
@@ -9608,7 +9659,7 @@ export const GetProjectsLocationsDatasetsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsOperationsRequest>;
 
@@ -9642,7 +9693,7 @@ export const CancelProjectsLocationsDatasetsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsDatasetsOperationsRequest>;
 
@@ -9678,7 +9729,7 @@ export const AnalyzeEntitiesProjectsLocationsServicesNlpRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{nlpService}:analyzeEntities",
+      path: "v1beta1/{+nlpService}:analyzeEntities",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/homegraph-v1.ts
+++ b/packages/gcp/src/services/homegraph-v1.ts
@@ -309,7 +309,7 @@ export const DeleteAgentUsersRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     agentUserId: Schema.String.pipe(T.HttpPath("agentUserId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{agentUserId}" }),
+    T.Http({ method: "DELETE", path: "v1/{+agentUserId}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAgentUsersRequest>;
 

--- a/packages/gcp/src/services/hypercomputecluster-v1.ts
+++ b/packages/gcp/src/services/hypercomputecluster-v1.ts
@@ -1004,7 +1004,7 @@ export const ListProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1039,7 +1039,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1070,7 +1070,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1115,7 +1115,7 @@ export const ListProjectsLocationsOperationsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1150,7 +1150,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1184,7 +1184,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1227,7 +1227,7 @@ export const ListProjectsLocationsClustersRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/clusters" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/clusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersRequest>;
 
@@ -1271,7 +1271,7 @@ export const PatchProjectsLocationsClustersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Cluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsClustersRequest>;
 
@@ -1311,7 +1311,7 @@ export const CreateProjectsLocationsClustersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Cluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/clusters", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/clusters", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsClustersRequest>;
 
@@ -1345,7 +1345,7 @@ export const DeleteProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersRequest>;
 
@@ -1376,7 +1376,7 @@ export const GetProjectsLocationsClustersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersRequest>;
 

--- a/packages/gcp/src/services/iam-v1.ts
+++ b/packages/gcp/src/services/iam-v1.ts
@@ -1839,7 +1839,7 @@ export const UndeleteProjectsServiceAccountsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndeleteServiceAccountRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsServiceAccountsRequest>;
 
@@ -1874,7 +1874,7 @@ export const SignJwtProjectsServiceAccountsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SignJwtRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:signJwt", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:signJwt", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SignJwtProjectsServiceAccountsRequest>;
 
@@ -1908,7 +1908,7 @@ export const PatchProjectsServiceAccountsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PatchServiceAccountRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsServiceAccountsRequest>;
 
@@ -1945,7 +1945,7 @@ export const ListProjectsServiceAccountsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/serviceAccounts" }),
+    T.Http({ method: "GET", path: "v1/{+name}/serviceAccounts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsServiceAccountsRequest>;
 
@@ -1985,7 +1985,7 @@ export const CreateProjectsServiceAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}/serviceAccounts",
+      path: "v1/{+name}/serviceAccounts",
       hasBody: true,
     }),
     svc,
@@ -2025,7 +2025,7 @@ export const GetIamPolicyProjectsServiceAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2058,7 +2058,7 @@ export const DeleteProjectsServiceAccountsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsServiceAccountsRequest>;
 
@@ -2089,7 +2089,7 @@ export const GetProjectsServiceAccountsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsServiceAccountsRequest>;
 
@@ -2123,7 +2123,7 @@ export const UpdateProjectsServiceAccountsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ServiceAccount).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsServiceAccountsRequest>;
 
@@ -2159,7 +2159,7 @@ export const TestIamPermissionsProjectsServiceAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2196,7 +2196,7 @@ export const EnableProjectsServiceAccountsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EnableServiceAccountRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:enable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:enable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EnableProjectsServiceAccountsRequest>;
 
@@ -2232,7 +2232,7 @@ export const SetIamPolicyProjectsServiceAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2268,7 +2268,7 @@ export const DisableProjectsServiceAccountsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DisableServiceAccountRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:disable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:disable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DisableProjectsServiceAccountsRequest>;
 
@@ -2302,7 +2302,7 @@ export const SignBlobProjectsServiceAccountsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SignBlobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:signBlob", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:signBlob", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SignBlobProjectsServiceAccountsRequest>;
 
@@ -2342,7 +2342,7 @@ export const GetProjectsServiceAccountsKeysRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsServiceAccountsKeysRequest>;
 
@@ -2376,7 +2376,7 @@ export const CreateProjectsServiceAccountsKeysRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CreateServiceAccountKeyRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}/keys", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}/keys", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsServiceAccountsKeysRequest>;
 
@@ -2410,7 +2410,7 @@ export const EnableProjectsServiceAccountsKeysRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EnableServiceAccountKeyRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:enable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:enable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EnableProjectsServiceAccountsKeysRequest>;
 
@@ -2450,7 +2450,7 @@ export const ListProjectsServiceAccountsKeysRequest =
       T.HttpQuery("keyTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/keys" }),
+    T.Http({ method: "GET", path: "v1/{+name}/keys" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsServiceAccountsKeysRequest>;
 
@@ -2482,7 +2482,7 @@ export const DeleteProjectsServiceAccountsKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsServiceAccountsKeysRequest>;
 
@@ -2516,7 +2516,7 @@ export const UploadProjectsServiceAccountsKeysRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UploadServiceAccountKeyRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}/keys:upload", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}/keys:upload", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UploadProjectsServiceAccountsKeysRequest>;
 
@@ -2550,7 +2550,7 @@ export const DisableProjectsServiceAccountsKeysRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DisableServiceAccountKeyRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:disable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:disable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DisableProjectsServiceAccountsKeysRequest>;
 
@@ -2586,7 +2586,7 @@ export const UndeleteProjectsLocationsWorkloadIdentityPoolsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsLocationsWorkloadIdentityPoolsRequest>;
 
@@ -2623,7 +2623,7 @@ export const PatchProjectsLocationsWorkloadIdentityPoolsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(WorkloadIdentityPool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsWorkloadIdentityPoolsRequest>;
 
@@ -2659,7 +2659,7 @@ export const GetIamPolicyProjectsLocationsWorkloadIdentityPoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2704,7 +2704,7 @@ export const ListProjectsLocationsWorkloadIdentityPoolsRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/workloadIdentityPools" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/workloadIdentityPools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkloadIdentityPoolsRequest>;
 
@@ -2745,7 +2745,7 @@ export const RemoveAttestationRuleProjectsLocationsWorkloadIdentityPoolsRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:removeAttestationRule",
+      path: "v1/{+resource}:removeAttestationRule",
       hasBody: true,
     }),
     svc,
@@ -2785,7 +2785,7 @@ export const SetAttestationRulesProjectsLocationsWorkloadIdentityPoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setAttestationRules",
+      path: "v1/{+resource}:setAttestationRules",
       hasBody: true,
     }),
     svc,
@@ -2830,7 +2830,7 @@ export const CreateProjectsLocationsWorkloadIdentityPoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/workloadIdentityPools",
+      path: "v1/{+parent}/workloadIdentityPools",
       hasBody: true,
     }),
     svc,
@@ -2868,7 +2868,7 @@ export const AddAttestationRuleProjectsLocationsWorkloadIdentityPoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:addAttestationRule",
+      path: "v1/{+resource}:addAttestationRule",
       hasBody: true,
     }),
     svc,
@@ -2903,7 +2903,7 @@ export const DeleteProjectsLocationsWorkloadIdentityPoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWorkloadIdentityPoolsRequest>;
 
@@ -2934,7 +2934,7 @@ export const GetProjectsLocationsWorkloadIdentityPoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkloadIdentityPoolsRequest>;
 
@@ -2975,7 +2975,7 @@ export const ListAttestationRulesProjectsLocationsWorkloadIdentityPoolsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:listAttestationRules" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:listAttestationRules" }),
     svc,
   ) as unknown as Schema.Schema<ListAttestationRulesProjectsLocationsWorkloadIdentityPoolsRequest>;
 
@@ -3017,7 +3017,7 @@ export const TestIamPermissionsProjectsLocationsWorkloadIdentityPoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3057,7 +3057,7 @@ export const SetIamPolicyProjectsLocationsWorkloadIdentityPoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3091,7 +3091,7 @@ export const GetProjectsLocationsWorkloadIdentityPoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkloadIdentityPoolsOperationsRequest>;
 
@@ -3135,7 +3135,7 @@ export const ListProjectsLocationsWorkloadIdentityPoolsNamespacesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/namespaces" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/namespaces" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkloadIdentityPoolsNamespacesRequest>;
 
@@ -3172,7 +3172,7 @@ export const DeleteProjectsLocationsWorkloadIdentityPoolsNamespacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWorkloadIdentityPoolsNamespacesRequest>;
 
@@ -3205,7 +3205,7 @@ export const GetProjectsLocationsWorkloadIdentityPoolsNamespacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkloadIdentityPoolsNamespacesRequest>;
 
@@ -3246,7 +3246,7 @@ export const CreateProjectsLocationsWorkloadIdentityPoolsNamespacesRequest =
     ),
     body: Schema.optional(WorkloadIdentityPoolNamespace).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/namespaces", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/namespaces", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsWorkloadIdentityPoolsNamespacesRequest>;
 
@@ -3284,7 +3284,7 @@ export const UndeleteProjectsLocationsWorkloadIdentityPoolsNamespacesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsLocationsWorkloadIdentityPoolsNamespacesRequest>;
 
@@ -3323,7 +3323,7 @@ export const PatchProjectsLocationsWorkloadIdentityPoolsNamespacesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(WorkloadIdentityPoolNamespace).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsWorkloadIdentityPoolsNamespacesRequest>;
 
@@ -3356,7 +3356,7 @@ export const DeleteProjectsLocationsWorkloadIdentityPoolsNamespacesManagedIdenti
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWorkloadIdentityPoolsNamespacesManagedIdentitiesRequest>;
 
@@ -3391,7 +3391,7 @@ export const GetProjectsLocationsWorkloadIdentityPoolsNamespacesManagedIdentitie
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkloadIdentityPoolsNamespacesManagedIdentitiesRequest>;
 
@@ -3435,7 +3435,7 @@ export const ListAttestationRulesProjectsLocationsWorkloadIdentityPoolsNamespace
     resource: Schema.String.pipe(T.HttpPath("resource")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:listAttestationRules" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:listAttestationRules" }),
     svc,
   ) as unknown as Schema.Schema<ListAttestationRulesProjectsLocationsWorkloadIdentityPoolsNamespacesManagedIdentitiesRequest>;
 
@@ -3479,7 +3479,7 @@ export const UndeleteProjectsLocationsWorkloadIdentityPoolsNamespacesManagedIden
       UndeleteWorkloadIdentityPoolManagedIdentityRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsLocationsWorkloadIdentityPoolsNamespacesManagedIdentitiesRequest>;
 
@@ -3522,7 +3522,7 @@ export const PatchProjectsLocationsWorkloadIdentityPoolsNamespacesManagedIdentit
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsWorkloadIdentityPoolsNamespacesManagedIdentitiesRequest>;
 
@@ -3568,7 +3568,7 @@ export const ListProjectsLocationsWorkloadIdentityPoolsNamespacesManagedIdentiti
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/managedIdentities" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/managedIdentities" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkloadIdentityPoolsNamespacesManagedIdentitiesRequest>;
 
@@ -3612,7 +3612,7 @@ export const RemoveAttestationRuleProjectsLocationsWorkloadIdentityPoolsNamespac
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:removeAttestationRule",
+      path: "v1/{+resource}:removeAttestationRule",
       hasBody: true,
     }),
     svc,
@@ -3654,7 +3654,7 @@ export const SetAttestationRulesProjectsLocationsWorkloadIdentityPoolsNamespaces
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setAttestationRules",
+      path: "v1/{+resource}:setAttestationRules",
       hasBody: true,
     }),
     svc,
@@ -3703,7 +3703,7 @@ export const CreateProjectsLocationsWorkloadIdentityPoolsNamespacesManagedIdenti
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/managedIdentities",
+      path: "v1/{+parent}/managedIdentities",
       hasBody: true,
     }),
     svc,
@@ -3745,7 +3745,7 @@ export const AddAttestationRuleProjectsLocationsWorkloadIdentityPoolsNamespacesM
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:addAttestationRule",
+      path: "v1/{+resource}:addAttestationRule",
       hasBody: true,
     }),
     svc,
@@ -3782,7 +3782,7 @@ export const GetProjectsLocationsWorkloadIdentityPoolsNamespacesManagedIdentitie
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkloadIdentityPoolsNamespacesManagedIdentitiesOperationsRequest>;
 
@@ -3817,7 +3817,7 @@ export const GetProjectsLocationsWorkloadIdentityPoolsNamespacesManagedIdentitie
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkloadIdentityPoolsNamespacesManagedIdentitiesWorkloadSourcesOperationsRequest>;
 
@@ -3852,7 +3852,7 @@ export const GetProjectsLocationsWorkloadIdentityPoolsNamespacesOperationsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkloadIdentityPoolsNamespacesOperationsRequest>;
 
@@ -3885,7 +3885,7 @@ export const GetProjectsLocationsWorkloadIdentityPoolsProvidersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkloadIdentityPoolsProvidersRequest>;
 
@@ -3926,7 +3926,7 @@ export const CreateProjectsLocationsWorkloadIdentityPoolsProvidersRequest =
     ),
     body: Schema.optional(WorkloadIdentityPoolProvider).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/providers", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/providers", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsWorkloadIdentityPoolsProvidersRequest>;
 
@@ -3970,7 +3970,7 @@ export const ListProjectsLocationsWorkloadIdentityPoolsProvidersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/providers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/providers" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkloadIdentityPoolsProvidersRequest>;
 
@@ -4007,7 +4007,7 @@ export const DeleteProjectsLocationsWorkloadIdentityPoolsProvidersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWorkloadIdentityPoolsProvidersRequest>;
 
@@ -4046,7 +4046,7 @@ export const PatchProjectsLocationsWorkloadIdentityPoolsProvidersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(WorkloadIdentityPoolProvider).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsWorkloadIdentityPoolsProvidersRequest>;
 
@@ -4084,7 +4084,7 @@ export const UndeleteProjectsLocationsWorkloadIdentityPoolsProvidersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsLocationsWorkloadIdentityPoolsProvidersRequest>;
 
@@ -4122,7 +4122,7 @@ export const UndeleteProjectsLocationsWorkloadIdentityPoolsProvidersKeysRequest 
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsLocationsWorkloadIdentityPoolsProvidersKeysRequest>;
 
@@ -4155,7 +4155,7 @@ export const GetProjectsLocationsWorkloadIdentityPoolsProvidersKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkloadIdentityPoolsProvidersKeysRequest>;
 
@@ -4196,7 +4196,7 @@ export const CreateProjectsLocationsWorkloadIdentityPoolsProvidersKeysRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(WorkloadIdentityPoolProviderKey).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/keys", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/keys", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsWorkloadIdentityPoolsProvidersKeysRequest>;
 
@@ -4240,7 +4240,7 @@ export const ListProjectsLocationsWorkloadIdentityPoolsProvidersKeysRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/keys" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/keys" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkloadIdentityPoolsProvidersKeysRequest>;
 
@@ -4277,7 +4277,7 @@ export const DeleteProjectsLocationsWorkloadIdentityPoolsProvidersKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWorkloadIdentityPoolsProvidersKeysRequest>;
 
@@ -4310,7 +4310,7 @@ export const GetProjectsLocationsWorkloadIdentityPoolsProvidersKeysOperationsReq
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkloadIdentityPoolsProvidersKeysOperationsRequest>;
 
@@ -4345,7 +4345,7 @@ export const GetProjectsLocationsWorkloadIdentityPoolsProvidersOperationsRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkloadIdentityPoolsProvidersOperationsRequest>;
 
@@ -4381,7 +4381,7 @@ export const UndeleteProjectsLocationsOauthClientsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndeleteOauthClientRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsLocationsOauthClientsRequest>;
 
@@ -4418,7 +4418,7 @@ export const PatchProjectsLocationsOauthClientsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(OauthClient).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsOauthClientsRequest>;
 
@@ -4460,7 +4460,7 @@ export const ListProjectsLocationsOauthClientsRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/oauthClients" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/oauthClients" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOauthClientsRequest>;
 
@@ -4496,7 +4496,7 @@ export const DeleteProjectsLocationsOauthClientsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOauthClientsRequest>;
 
@@ -4535,7 +4535,11 @@ export const CreateProjectsLocationsOauthClientsRequest =
     ),
     body: Schema.optional(OauthClient).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/oauthClients", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/oauthClients",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsOauthClientsRequest>;
 
@@ -4566,7 +4570,7 @@ export const GetProjectsLocationsOauthClientsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOauthClientsRequest>;
 
@@ -4603,7 +4607,7 @@ export const PatchProjectsLocationsOauthClientsCredentialsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(OauthClientCredential).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsOauthClientsCredentialsRequest>;
 
@@ -4635,7 +4639,7 @@ export const ListProjectsLocationsOauthClientsCredentialsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/credentials" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/credentials" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOauthClientsCredentialsRequest>;
 
@@ -4667,7 +4671,7 @@ export const DeleteProjectsLocationsOauthClientsCredentialsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOauthClientsCredentialsRequest>;
 
@@ -4698,7 +4702,7 @@ export const GetProjectsLocationsOauthClientsCredentialsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOauthClientsCredentialsRequest>;
 
@@ -4738,7 +4742,7 @@ export const CreateProjectsLocationsOauthClientsCredentialsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(OauthClientCredential).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/credentials", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/credentials", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsOauthClientsCredentialsRequest>;
 
@@ -4773,7 +4777,7 @@ export const UndeleteProjectsRolesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndeleteRoleRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsRolesRequest>;
 
@@ -4809,7 +4813,7 @@ export const PatchProjectsRolesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Role).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsRolesRequest>;
 
@@ -4853,7 +4857,7 @@ export const ListProjectsRolesRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/roles" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/roles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsRolesRequest>;
 
@@ -4891,7 +4895,7 @@ export const DeleteProjectsRolesRequest =
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsRolesRequest>;
 
@@ -4921,7 +4925,7 @@ export const GetProjectsRolesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsRolesRequest>;
 
@@ -4954,7 +4958,7 @@ export const CreateProjectsRolesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateRoleRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/roles", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/roles", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsRolesRequest>;
 
@@ -4984,7 +4988,7 @@ export const DeleteLocationsWorkforcePoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteLocationsWorkforcePoolsRequest>;
 
@@ -5015,7 +5019,7 @@ export const GetLocationsWorkforcePoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLocationsWorkforcePoolsRequest>;
 
@@ -5049,7 +5053,7 @@ export const UndeleteLocationsWorkforcePoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndeleteWorkforcePoolRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteLocationsWorkforcePoolsRequest>;
 
@@ -5086,7 +5090,7 @@ export const PatchLocationsWorkforcePoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(WorkforcePool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchLocationsWorkforcePoolsRequest>;
 
@@ -5122,7 +5126,7 @@ export const TestIamPermissionsLocationsWorkforcePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5170,7 +5174,7 @@ export const ListLocationsWorkforcePoolsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.optional(Schema.String).pipe(T.HttpQuery("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{location}/workforcePools" }),
+    T.Http({ method: "GET", path: "v1/{+location}/workforcePools" }),
     svc,
   ) as unknown as Schema.Schema<ListLocationsWorkforcePoolsRequest>;
 
@@ -5215,7 +5219,7 @@ export const CreateLocationsWorkforcePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{location}/workforcePools",
+      path: "v1/{+location}/workforcePools",
       hasBody: true,
     }),
     svc,
@@ -5253,7 +5257,7 @@ export const SetIamPolicyLocationsWorkforcePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5291,7 +5295,7 @@ export const GetIamPolicyLocationsWorkforcePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5324,7 +5328,7 @@ export const GetLocationsWorkforcePoolsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLocationsWorkforcePoolsOperationsRequest>;
 
@@ -5361,7 +5365,7 @@ export const PatchLocationsWorkforcePoolsProvidersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(WorkforcePoolProvider).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchLocationsWorkforcePoolsProvidersRequest>;
 
@@ -5397,7 +5401,7 @@ export const UndeleteLocationsWorkforcePoolsProvidersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteLocationsWorkforcePoolsProvidersRequest>;
 
@@ -5436,7 +5440,7 @@ export const CreateLocationsWorkforcePoolsProvidersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(WorkforcePoolProvider).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/providers", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/providers", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateLocationsWorkforcePoolsProvidersRequest>;
 
@@ -5467,7 +5471,7 @@ export const GetLocationsWorkforcePoolsProvidersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLocationsWorkforcePoolsProvidersRequest>;
 
@@ -5509,7 +5513,7 @@ export const ListLocationsWorkforcePoolsProvidersRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/providers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/providers" }),
     svc,
   ) as unknown as Schema.Schema<ListLocationsWorkforcePoolsProvidersRequest>;
 
@@ -5545,7 +5549,7 @@ export const DeleteLocationsWorkforcePoolsProvidersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteLocationsWorkforcePoolsProvidersRequest>;
 
@@ -5581,7 +5585,7 @@ export const UndeleteLocationsWorkforcePoolsProvidersKeysRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteLocationsWorkforcePoolsProvidersKeysRequest>;
 
@@ -5623,7 +5627,7 @@ export const ListLocationsWorkforcePoolsProvidersKeysRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/keys" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/keys" }),
     svc,
   ) as unknown as Schema.Schema<ListLocationsWorkforcePoolsProvidersKeysRequest>;
 
@@ -5659,7 +5663,7 @@ export const DeleteLocationsWorkforcePoolsProvidersKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteLocationsWorkforcePoolsProvidersKeysRequest>;
 
@@ -5690,7 +5694,7 @@ export const GetLocationsWorkforcePoolsProvidersKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLocationsWorkforcePoolsProvidersKeysRequest>;
 
@@ -5730,7 +5734,7 @@ export const CreateLocationsWorkforcePoolsProvidersKeysRequest =
     ),
     body: Schema.optional(WorkforcePoolProviderKey).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/keys", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/keys", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateLocationsWorkforcePoolsProvidersKeysRequest>;
 
@@ -5761,7 +5765,7 @@ export const GetLocationsWorkforcePoolsProvidersKeysOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLocationsWorkforcePoolsProvidersKeysOperationsRequest>;
 
@@ -5794,7 +5798,7 @@ export const GetLocationsWorkforcePoolsProvidersOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLocationsWorkforcePoolsProvidersOperationsRequest>;
 
@@ -5833,7 +5837,7 @@ export const CreateLocationsWorkforcePoolsProvidersScimTenantsRequest =
     ),
     body: Schema.optional(WorkforcePoolProviderScimTenant).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/scimTenants", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/scimTenants", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateLocationsWorkforcePoolsProvidersScimTenantsRequest>;
 
@@ -5866,7 +5870,7 @@ export const GetLocationsWorkforcePoolsProvidersScimTenantsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLocationsWorkforcePoolsProvidersScimTenantsRequest>;
 
@@ -5909,7 +5913,7 @@ export const ListLocationsWorkforcePoolsProvidersScimTenantsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/scimTenants" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/scimTenants" }),
     svc,
   ) as unknown as Schema.Schema<ListLocationsWorkforcePoolsProvidersScimTenantsRequest>;
 
@@ -5949,7 +5953,7 @@ export const DeleteLocationsWorkforcePoolsProvidersScimTenantsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     hardDelete: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("hardDelete")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteLocationsWorkforcePoolsProvidersScimTenantsRequest>;
 
@@ -5988,7 +5992,7 @@ export const PatchLocationsWorkforcePoolsProvidersScimTenantsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(WorkforcePoolProviderScimTenant).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchLocationsWorkforcePoolsProvidersScimTenantsRequest>;
 
@@ -6026,7 +6030,7 @@ export const UndeleteLocationsWorkforcePoolsProvidersScimTenantsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteLocationsWorkforcePoolsProvidersScimTenantsRequest>;
 
@@ -6059,7 +6063,7 @@ export const GetLocationsWorkforcePoolsProvidersScimTenantsTokensRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLocationsWorkforcePoolsProvidersScimTenantsTokensRequest>;
 
@@ -6100,7 +6104,7 @@ export const CreateLocationsWorkforcePoolsProvidersScimTenantsTokensRequest =
     ),
     body: Schema.optional(WorkforcePoolProviderScimToken).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/tokens", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/tokens", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateLocationsWorkforcePoolsProvidersScimTenantsTokensRequest>;
 
@@ -6144,7 +6148,7 @@ export const ListLocationsWorkforcePoolsProvidersScimTenantsTokensRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/tokens" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/tokens" }),
     svc,
   ) as unknown as Schema.Schema<ListLocationsWorkforcePoolsProvidersScimTenantsTokensRequest>;
 
@@ -6181,7 +6185,7 @@ export const DeleteLocationsWorkforcePoolsProvidersScimTenantsTokensRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteLocationsWorkforcePoolsProvidersScimTenantsTokensRequest>;
 
@@ -6220,7 +6224,7 @@ export const PatchLocationsWorkforcePoolsProvidersScimTenantsTokensRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(WorkforcePoolProviderScimToken).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchLocationsWorkforcePoolsProvidersScimTenantsTokensRequest>;
 
@@ -6258,7 +6262,7 @@ export const UndeleteLocationsWorkforcePoolsSubjectsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteLocationsWorkforcePoolsSubjectsRequest>;
 
@@ -6289,7 +6293,7 @@ export const DeleteLocationsWorkforcePoolsSubjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteLocationsWorkforcePoolsSubjectsRequest>;
 
@@ -6320,7 +6324,7 @@ export const GetLocationsWorkforcePoolsSubjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLocationsWorkforcePoolsSubjectsOperationsRequest>;
 
@@ -6467,7 +6471,7 @@ export interface GetRolesRequest {
 export const GetRolesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetRolesRequest>;
 
@@ -6500,7 +6504,7 @@ export const CreateOrganizationsRolesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateRoleRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/roles", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/roles", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsRolesRequest>;
 
@@ -6531,7 +6535,7 @@ export const GetOrganizationsRolesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsRolesRequest>;
 
@@ -6575,7 +6579,7 @@ export const ListOrganizationsRolesRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/roles" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/roles" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsRolesRequest>;
 
@@ -6613,7 +6617,7 @@ export const DeleteOrganizationsRolesRequest =
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsRolesRequest>;
 
@@ -6650,7 +6654,7 @@ export const PatchOrganizationsRolesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Role).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsRolesRequest>;
 
@@ -6683,7 +6687,7 @@ export const UndeleteOrganizationsRolesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndeleteRoleRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteOrganizationsRolesRequest>;
 

--- a/packages/gcp/src/services/iam-v2.ts
+++ b/packages/gcp/src/services/iam-v2.ts
@@ -419,7 +419,7 @@ export const CreatePolicyPoliciesRequest =
     policyId: Schema.optional(Schema.String).pipe(T.HttpQuery("policyId")),
     body: Schema.optional(GoogleIamV2Policy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreatePolicyPoliciesRequest>;
 
@@ -452,7 +452,7 @@ export const DeletePoliciesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v2/{name}" }),
+  T.Http({ method: "DELETE", path: "v2/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeletePoliciesRequest>;
 
@@ -489,7 +489,7 @@ export const ListPoliciesPoliciesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}" }),
+    T.Http({ method: "GET", path: "v2/{+parent}" }),
     svc,
   ) as unknown as Schema.Schema<ListPoliciesPoliciesRequest>;
 
@@ -526,7 +526,7 @@ export const UpdatePoliciesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(GoogleIamV2Policy).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PUT", path: "v2/{name}", hasBody: true }),
+  T.Http({ method: "PUT", path: "v2/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<UpdatePoliciesRequest>;
 
@@ -556,7 +556,7 @@ export interface GetPoliciesRequest {
 export const GetPoliciesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{name}" }),
+  T.Http({ method: "GET", path: "v2/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetPoliciesRequest>;
 
@@ -587,7 +587,7 @@ export const GetPoliciesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPoliciesOperationsRequest>;
 

--- a/packages/gcp/src/services/iam-v2beta.ts
+++ b/packages/gcp/src/services/iam-v2beta.ts
@@ -417,7 +417,7 @@ export const DeletePoliciesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v2beta/{name}" }),
+  T.Http({ method: "DELETE", path: "v2beta/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeletePoliciesRequest>;
 
@@ -447,7 +447,7 @@ export interface GetPoliciesRequest {
 export const GetPoliciesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2beta/{name}" }),
+  T.Http({ method: "GET", path: "v2beta/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetPoliciesRequest>;
 
@@ -484,7 +484,7 @@ export const CreatePolicyPoliciesRequest =
     policyId: Schema.optional(Schema.String).pipe(T.HttpQuery("policyId")),
     body: Schema.optional(GoogleIamV2betaPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta/{parent}", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta/{+parent}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreatePolicyPoliciesRequest>;
 
@@ -517,7 +517,7 @@ export const UpdatePoliciesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(GoogleIamV2betaPolicy).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PUT", path: "v2beta/{name}", hasBody: true }),
+  T.Http({ method: "PUT", path: "v2beta/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<UpdatePoliciesRequest>;
 
@@ -554,7 +554,7 @@ export const ListPoliciesPoliciesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{parent}" }),
+    T.Http({ method: "GET", path: "v2beta/{+parent}" }),
     svc,
   ) as unknown as Schema.Schema<ListPoliciesPoliciesRequest>;
 
@@ -589,7 +589,7 @@ export const GetPoliciesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPoliciesOperationsRequest>;
 

--- a/packages/gcp/src/services/iamcredentials-v1.ts
+++ b/packages/gcp/src/services/iamcredentials-v1.ts
@@ -181,7 +181,7 @@ export const GetAllowedLocationsProjectsLocationsWorkloadIdentityPoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/allowedLocations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/allowedLocations" }),
     svc,
   ) as unknown as Schema.Schema<GetAllowedLocationsProjectsLocationsWorkloadIdentityPoolsRequest>;
 
@@ -214,7 +214,7 @@ export const GetAllowedLocationsProjectsServiceAccountsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/allowedLocations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/allowedLocations" }),
     svc,
   ) as unknown as Schema.Schema<GetAllowedLocationsProjectsServiceAccountsRequest>;
 
@@ -251,7 +251,7 @@ export const GenerateAccessTokenProjectsServiceAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:generateAccessToken",
+      path: "v1/{+name}:generateAccessToken",
       hasBody: true,
     }),
     svc,
@@ -288,7 +288,7 @@ export const SignBlobProjectsServiceAccountsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SignBlobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:signBlob", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:signBlob", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SignBlobProjectsServiceAccountsRequest>;
 
@@ -324,7 +324,7 @@ export const GenerateIdTokenProjectsServiceAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:generateIdToken",
+      path: "v1/{+name}:generateIdToken",
       hasBody: true,
     }),
     svc,
@@ -361,7 +361,7 @@ export const SignJwtProjectsServiceAccountsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SignJwtRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:signJwt", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:signJwt", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SignJwtProjectsServiceAccountsRequest>;
 
@@ -392,7 +392,7 @@ export const GetAllowedLocationsLocationsWorkforcePoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/allowedLocations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/allowedLocations" }),
     svc,
   ) as unknown as Schema.Schema<GetAllowedLocationsLocationsWorkforcePoolsRequest>;
 

--- a/packages/gcp/src/services/iap-v1.ts
+++ b/packages/gcp/src/services/iap-v1.ts
@@ -565,7 +565,7 @@ export const GetIapSettingsV1Request =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:iapSettings" }),
+    T.Http({ method: "GET", path: "v1/{+name}:iapSettings" }),
     svc,
   ) as unknown as Schema.Schema<GetIapSettingsV1Request>;
 
@@ -601,7 +601,7 @@ export const UpdateIapSettingsV1Request =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(IapSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}:iapSettings", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}:iapSettings", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateIapSettingsV1Request>;
 
@@ -637,7 +637,7 @@ export const ValidateAttributeExpressionV1Request =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:validateAttributeExpression",
+      path: "v1/{+name}:validateAttributeExpression",
       hasBody: true,
     }),
     svc,
@@ -673,7 +673,11 @@ export const SetIamPolicyV1Request = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   resource: Schema.String.pipe(T.HttpPath("resource")),
   body: Schema.optional(SetIamPolicyRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v1/{resource}:setIamPolicy", hasBody: true }),
+  T.Http({
+    method: "POST",
+    path: "v1/{+resource}:setIamPolicy",
+    hasBody: true,
+  }),
   svc,
 ) as unknown as Schema.Schema<SetIamPolicyV1Request>;
 
@@ -705,7 +709,11 @@ export const GetIamPolicyV1Request = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   resource: Schema.String.pipe(T.HttpPath("resource")),
   body: Schema.optional(GetIamPolicyRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v1/{resource}:getIamPolicy", hasBody: true }),
+  T.Http({
+    method: "POST",
+    path: "v1/{+resource}:getIamPolicy",
+    hasBody: true,
+  }),
   svc,
 ) as unknown as Schema.Schema<GetIamPolicyV1Request>;
 
@@ -740,7 +748,7 @@ export const TestIamPermissionsV1Request =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -779,7 +787,7 @@ export const ListProjectsIap_tunnelLocationsDestGroupsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/destGroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/destGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsIap_tunnelLocationsDestGroupsRequest>;
 
@@ -815,7 +823,7 @@ export const DeleteProjectsIap_tunnelLocationsDestGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsIap_tunnelLocationsDestGroupsRequest>;
 
@@ -852,7 +860,7 @@ export const PatchProjectsIap_tunnelLocationsDestGroupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(TunnelDestGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsIap_tunnelLocationsDestGroupsRequest>;
 
@@ -884,7 +892,7 @@ export const GetProjectsIap_tunnelLocationsDestGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsIap_tunnelLocationsDestGroupsRequest>;
 
@@ -923,7 +931,7 @@ export const CreateProjectsIap_tunnelLocationsDestGroupsRequest =
     ),
     body: Schema.optional(TunnelDestGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/destGroups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/destGroups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsIap_tunnelLocationsDestGroupsRequest>;
 
@@ -955,7 +963,7 @@ export const GetProjectsBrandsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsBrandsRequest>;
 
@@ -988,7 +996,7 @@ export const CreateProjectsBrandsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Brand).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/brands", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/brands", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsBrandsRequest>;
 
@@ -1018,7 +1026,7 @@ export const ListProjectsBrandsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/brands" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/brands" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsBrandsRequest>;
 
@@ -1054,7 +1062,7 @@ export const CreateProjectsBrandsIdentityAwareProxyClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/identityAwareProxyClients",
+      path: "v1/{+parent}/identityAwareProxyClients",
       hasBody: true,
     }),
     svc,
@@ -1093,7 +1101,7 @@ export const ResetSecretProjectsBrandsIdentityAwareProxyClientsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:resetSecret", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:resetSecret", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResetSecretProjectsBrandsIdentityAwareProxyClientsRequest>;
 
@@ -1126,7 +1134,7 @@ export const GetProjectsBrandsIdentityAwareProxyClientsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsBrandsIdentityAwareProxyClientsRequest>;
 
@@ -1164,7 +1172,7 @@ export const ListProjectsBrandsIdentityAwareProxyClientsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/identityAwareProxyClients" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/identityAwareProxyClients" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsBrandsIdentityAwareProxyClientsRequest>;
 
@@ -1200,7 +1208,7 @@ export const DeleteProjectsBrandsIdentityAwareProxyClientsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsBrandsIdentityAwareProxyClientsRequest>;
 

--- a/packages/gcp/src/services/iap-v1beta1.ts
+++ b/packages/gcp/src/services/iap-v1beta1.ts
@@ -135,7 +135,7 @@ export const GetIamPolicyV1beta1Request =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -172,7 +172,7 @@ export const TestIamPermissionsV1beta1Request =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -210,7 +210,7 @@ export const SetIamPolicyV1beta1Request =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/identitytoolkit-v1.ts
+++ b/packages/gcp/src/services/identitytoolkit-v1.ts
@@ -1995,7 +1995,7 @@ export const AccountsProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}/accounts",
+      path: "v1/projects/{+targetProjectId}/accounts",
       hasBody: true,
     }),
     svc,
@@ -2036,7 +2036,7 @@ export const QueryAccountsProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}:queryAccounts",
+      path: "v1/projects/{+targetProjectId}:queryAccounts",
       hasBody: true,
     }),
     svc,
@@ -2077,7 +2077,7 @@ export const CreateSessionCookieProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}:createSessionCookie",
+      path: "v1/projects/{+targetProjectId}:createSessionCookie",
       hasBody: true,
     }),
     svc,
@@ -2128,7 +2128,7 @@ export const BatchGetProjectsAccountsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/projects/{targetProjectId}/accounts:batchGet",
+      path: "v1/projects/{+targetProjectId}/accounts:batchGet",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetProjectsAccountsRequest>;
@@ -2168,7 +2168,7 @@ export const DeleteProjectsAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}/accounts:delete",
+      path: "v1/projects/{+targetProjectId}/accounts:delete",
       hasBody: true,
     }),
     svc,
@@ -2209,7 +2209,7 @@ export const SendOobCodeProjectsAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}/accounts:sendOobCode",
+      path: "v1/projects/{+targetProjectId}/accounts:sendOobCode",
       hasBody: true,
     }),
     svc,
@@ -2250,7 +2250,7 @@ export const UpdateProjectsAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}/accounts:update",
+      path: "v1/projects/{+targetProjectId}/accounts:update",
       hasBody: true,
     }),
     svc,
@@ -2291,7 +2291,7 @@ export const BatchDeleteProjectsAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}/accounts:batchDelete",
+      path: "v1/projects/{+targetProjectId}/accounts:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -2332,7 +2332,7 @@ export const QueryProjectsAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}/accounts:query",
+      path: "v1/projects/{+targetProjectId}/accounts:query",
       hasBody: true,
     }),
     svc,
@@ -2373,7 +2373,7 @@ export const BatchCreateProjectsAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}/accounts:batchCreate",
+      path: "v1/projects/{+targetProjectId}/accounts:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -2414,7 +2414,7 @@ export const LookupProjectsAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}/accounts:lookup",
+      path: "v1/projects/{+targetProjectId}/accounts:lookup",
       hasBody: true,
     }),
     svc,
@@ -2458,7 +2458,7 @@ export const CreateSessionCookieProjectsTenantsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}/tenants/{tenantId}:createSessionCookie",
+      path: "v1/projects/{+targetProjectId}/tenants/{+tenantId}:createSessionCookie",
       hasBody: true,
     }),
     svc,
@@ -2502,7 +2502,7 @@ export const AccountsProjectsTenantsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}/tenants/{tenantId}/accounts",
+      path: "v1/projects/{+targetProjectId}/tenants/{+tenantId}/accounts",
       hasBody: true,
     }),
     svc,
@@ -2546,7 +2546,7 @@ export const UpdateProjectsTenantsAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}/tenants/{tenantId}/accounts:update",
+      path: "v1/projects/{+targetProjectId}/tenants/{+tenantId}/accounts:update",
       hasBody: true,
     }),
     svc,
@@ -2590,7 +2590,7 @@ export const BatchDeleteProjectsTenantsAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}/tenants/{tenantId}/accounts:batchDelete",
+      path: "v1/projects/{+targetProjectId}/tenants/{+tenantId}/accounts:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -2641,7 +2641,7 @@ export const BatchGetProjectsTenantsAccountsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/projects/{targetProjectId}/tenants/{tenantId}/accounts:batchGet",
+      path: "v1/projects/{+targetProjectId}/tenants/{+tenantId}/accounts:batchGet",
     }),
     svc,
   ) as unknown as Schema.Schema<BatchGetProjectsTenantsAccountsRequest>;
@@ -2684,7 +2684,7 @@ export const DeleteProjectsTenantsAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}/tenants/{tenantId}/accounts:delete",
+      path: "v1/projects/{+targetProjectId}/tenants/{+tenantId}/accounts:delete",
       hasBody: true,
     }),
     svc,
@@ -2728,7 +2728,7 @@ export const SendOobCodeProjectsTenantsAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}/tenants/{tenantId}/accounts:sendOobCode",
+      path: "v1/projects/{+targetProjectId}/tenants/{+tenantId}/accounts:sendOobCode",
       hasBody: true,
     }),
     svc,
@@ -2772,7 +2772,7 @@ export const LookupProjectsTenantsAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}/tenants/{tenantId}/accounts:lookup",
+      path: "v1/projects/{+targetProjectId}/tenants/{+tenantId}/accounts:lookup",
       hasBody: true,
     }),
     svc,
@@ -2816,7 +2816,7 @@ export const QueryProjectsTenantsAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}/tenants/{tenantId}/accounts:query",
+      path: "v1/projects/{+targetProjectId}/tenants/{+tenantId}/accounts:query",
       hasBody: true,
     }),
     svc,
@@ -2860,7 +2860,7 @@ export const BatchCreateProjectsTenantsAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{targetProjectId}/tenants/{tenantId}/accounts:batchCreate",
+      path: "v1/projects/{+targetProjectId}/tenants/{+tenantId}/accounts:batchCreate",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/identitytoolkit-v2.ts
+++ b/packages/gcp/src/services/identitytoolkit-v2.ts
@@ -2026,7 +2026,7 @@ export const GetConfigProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigProjectsRequest>;
 
@@ -2065,7 +2065,7 @@ export const UpdateConfigProjectsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigProjectsRequest>;
 
@@ -2102,7 +2102,7 @@ export const GetIamPolicyProjectsTenantsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:getIamPolicy",
+      path: "v2/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2142,7 +2142,7 @@ export const TestIamPermissionsProjectsTenantsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2176,7 +2176,7 @@ export const GetProjectsTenantsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsTenantsRequest>;
 
@@ -2213,7 +2213,7 @@ export const CreateProjectsTenantsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/tenants", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/tenants", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsTenantsRequest>;
 
@@ -2245,7 +2245,7 @@ export const DeleteProjectsTenantsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsTenantsRequest>;
 
@@ -2284,7 +2284,7 @@ export const PatchProjectsTenantsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsTenantsRequest>;
 
@@ -2322,7 +2322,7 @@ export const ListProjectsTenantsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/tenants" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/tenants" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTenantsRequest>;
 
@@ -2363,7 +2363,7 @@ export const SetIamPolicyProjectsTenantsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2396,7 +2396,7 @@ export const GetProjectsTenantsDefaultSupportedIdpConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsTenantsDefaultSupportedIdpConfigsRequest>;
 
@@ -2438,7 +2438,7 @@ export const CreateProjectsTenantsDefaultSupportedIdpConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/defaultSupportedIdpConfigs",
+      path: "v2/{+parent}/defaultSupportedIdpConfigs",
       hasBody: true,
     }),
     svc,
@@ -2473,7 +2473,7 @@ export const DeleteProjectsTenantsDefaultSupportedIdpConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsTenantsDefaultSupportedIdpConfigsRequest>;
 
@@ -2514,7 +2514,7 @@ export const PatchProjectsTenantsDefaultSupportedIdpConfigsRequest =
       GoogleCloudIdentitytoolkitAdminV2DefaultSupportedIdpConfig,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsTenantsDefaultSupportedIdpConfigsRequest>;
 
@@ -2552,7 +2552,7 @@ export const ListProjectsTenantsDefaultSupportedIdpConfigsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/defaultSupportedIdpConfigs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/defaultSupportedIdpConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTenantsDefaultSupportedIdpConfigsRequest>;
 
@@ -2600,7 +2600,7 @@ export const CreateProjectsTenantsInboundSamlConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/inboundSamlConfigs",
+      path: "v2/{+parent}/inboundSamlConfigs",
       hasBody: true,
     }),
     svc,
@@ -2634,7 +2634,7 @@ export const DeleteProjectsTenantsInboundSamlConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsTenantsInboundSamlConfigsRequest>;
 
@@ -2674,7 +2674,7 @@ export const PatchProjectsTenantsInboundSamlConfigsRequest =
       GoogleCloudIdentitytoolkitAdminV2InboundSamlConfig,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsTenantsInboundSamlConfigsRequest>;
 
@@ -2706,7 +2706,7 @@ export const GetProjectsTenantsInboundSamlConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsTenantsInboundSamlConfigsRequest>;
 
@@ -2744,7 +2744,7 @@ export const ListProjectsTenantsInboundSamlConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/inboundSamlConfigs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/inboundSamlConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTenantsInboundSamlConfigsRequest>;
 
@@ -2780,7 +2780,7 @@ export const GetProjectsTenantsOauthIdpConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsTenantsOauthIdpConfigsRequest>;
 
@@ -2824,7 +2824,7 @@ export const CreateProjectsTenantsOauthIdpConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/oauthIdpConfigs",
+      path: "v2/{+parent}/oauthIdpConfigs",
       hasBody: true,
     }),
     svc,
@@ -2858,7 +2858,7 @@ export const DeleteProjectsTenantsOauthIdpConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsTenantsOauthIdpConfigsRequest>;
 
@@ -2897,7 +2897,7 @@ export const PatchProjectsTenantsOauthIdpConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsTenantsOauthIdpConfigsRequest>;
 
@@ -2935,7 +2935,7 @@ export const ListProjectsTenantsOauthIdpConfigsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/oauthIdpConfigs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/oauthIdpConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTenantsOauthIdpConfigsRequest>;
 
@@ -2977,7 +2977,7 @@ export const ListProjectsOauthIdpConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/oauthIdpConfigs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/oauthIdpConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsOauthIdpConfigsRequest>;
 
@@ -3025,7 +3025,7 @@ export const CreateProjectsOauthIdpConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/oauthIdpConfigs",
+      path: "v2/{+parent}/oauthIdpConfigs",
       hasBody: true,
     }),
     svc,
@@ -3059,7 +3059,7 @@ export const DeleteProjectsOauthIdpConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsOauthIdpConfigsRequest>;
 
@@ -3098,7 +3098,7 @@ export const PatchProjectsOauthIdpConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsOauthIdpConfigsRequest>;
 
@@ -3130,7 +3130,7 @@ export const GetProjectsOauthIdpConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOauthIdpConfigsRequest>;
 
@@ -3168,7 +3168,7 @@ export const ListProjectsDefaultSupportedIdpConfigsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/defaultSupportedIdpConfigs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/defaultSupportedIdpConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDefaultSupportedIdpConfigsRequest>;
 
@@ -3204,7 +3204,7 @@ export const GetProjectsDefaultSupportedIdpConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDefaultSupportedIdpConfigsRequest>;
 
@@ -3246,7 +3246,7 @@ export const CreateProjectsDefaultSupportedIdpConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/defaultSupportedIdpConfigs",
+      path: "v2/{+parent}/defaultSupportedIdpConfigs",
       hasBody: true,
     }),
     svc,
@@ -3280,7 +3280,7 @@ export const DeleteProjectsDefaultSupportedIdpConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsDefaultSupportedIdpConfigsRequest>;
 
@@ -3320,7 +3320,7 @@ export const PatchProjectsDefaultSupportedIdpConfigsRequest =
       GoogleCloudIdentitytoolkitAdminV2DefaultSupportedIdpConfig,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsDefaultSupportedIdpConfigsRequest>;
 
@@ -3359,7 +3359,7 @@ export const InitializeAuthProjectsIdentityPlatformRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{project}/identityPlatform:initializeAuth",
+      path: "v2/{+project}/identityPlatform:initializeAuth",
       hasBody: true,
     }),
     svc,
@@ -3405,7 +3405,7 @@ export const CreateProjectsInboundSamlConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/inboundSamlConfigs",
+      path: "v2/{+parent}/inboundSamlConfigs",
       hasBody: true,
     }),
     svc,
@@ -3439,7 +3439,7 @@ export const DeleteProjectsInboundSamlConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInboundSamlConfigsRequest>;
 
@@ -3478,7 +3478,7 @@ export const PatchProjectsInboundSamlConfigsRequest =
       GoogleCloudIdentitytoolkitAdminV2InboundSamlConfig,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsInboundSamlConfigsRequest>;
 
@@ -3510,7 +3510,7 @@ export const GetProjectsInboundSamlConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInboundSamlConfigsRequest>;
 
@@ -3548,7 +3548,7 @@ export const ListProjectsInboundSamlConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/inboundSamlConfigs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/inboundSamlConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInboundSamlConfigsRequest>;
 

--- a/packages/gcp/src/services/ids-v1.ts
+++ b/packages/gcp/src/services/ids-v1.ts
@@ -252,7 +252,7 @@ export const ListProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -287,7 +287,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -327,7 +327,7 @@ export const PatchProjectsLocationsEndpointsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Endpoint).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEndpointsRequest>;
 
@@ -367,7 +367,7 @@ export const CreateProjectsLocationsEndpointsRequest =
     endpointId: Schema.optional(Schema.String).pipe(T.HttpQuery("endpointId")),
     body: Schema.optional(Endpoint).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/endpoints", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/endpoints", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsEndpointsRequest>;
 
@@ -410,7 +410,7 @@ export const ListProjectsLocationsEndpointsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/endpoints" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/endpoints" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEndpointsRequest>;
 
@@ -445,7 +445,7 @@ export const GetProjectsLocationsEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEndpointsRequest>;
 
@@ -479,7 +479,7 @@ export const DeleteProjectsLocationsEndpointsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEndpointsRequest>;
 
@@ -510,7 +510,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -544,7 +544,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -589,7 +589,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -624,7 +624,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/integrations-v1.ts
+++ b/packages/gcp/src/services/integrations-v1.ts
@@ -7729,7 +7729,7 @@ export const GetClientmetadataProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/clientmetadata" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/clientmetadata" }),
     svc,
   ) as unknown as Schema.Schema<GetClientmetadataProjectsRequest>;
 
@@ -7761,7 +7761,7 @@ export const GetClientsProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/clients" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/clients" }),
     svc,
   ) as unknown as Schema.Schema<GetClientsProjectsLocationsRequest>;
 
@@ -7800,7 +7800,7 @@ export const GenerateOpenApiSpecProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:generateOpenApiSpec",
+      path: "v1/{+name}:generateOpenApiSpec",
       hasBody: true,
     }),
     svc,
@@ -7841,7 +7841,7 @@ export const LinkProjectsLocationsAppsScriptProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/appsScriptProjects:link",
+      path: "v1/{+parent}/appsScriptProjects:link",
       hasBody: true,
     }),
     svc,
@@ -7882,7 +7882,7 @@ export const CreateProjectsLocationsAppsScriptProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/appsScriptProjects",
+      path: "v1/{+parent}/appsScriptProjects",
       hasBody: true,
     }),
     svc,
@@ -7923,7 +7923,7 @@ export const ProvisionProjectsLocationsClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/clients:provision",
+      path: "v1/{+parent}/clients:provision",
       hasBody: true,
     }),
     svc,
@@ -7963,7 +7963,7 @@ export const ProvisionClientPostProcessorProjectsLocationsClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/clients:provisionClientPostProcessor",
+      path: "v1/{+parent}/clients:provisionClientPostProcessor",
       hasBody: true,
     }),
     svc,
@@ -8005,7 +8005,7 @@ export const DeprovisionProjectsLocationsClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/clients:deprovision",
+      path: "v1/{+parent}/clients:deprovision",
       hasBody: true,
     }),
     svc,
@@ -8045,7 +8045,7 @@ export const ChangeConfigProjectsLocationsClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/clients:changeConfig",
+      path: "v1/{+parent}/clients:changeConfig",
       hasBody: true,
     }),
     svc,
@@ -8086,7 +8086,7 @@ export const SwitchProjectsLocationsClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/clients:switch",
+      path: "v1/{+parent}/clients:switch",
       hasBody: true,
     }),
     svc,
@@ -8126,7 +8126,7 @@ export const ReplaceProjectsLocationsClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/clients:replace",
+      path: "v1/{+parent}/clients:replace",
       hasBody: true,
     }),
     svc,
@@ -8166,7 +8166,7 @@ export const SwitchVariableMaskingProjectsLocationsClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/clients:switchVariableMasking",
+      path: "v1/{+parent}/clients:switchVariableMasking",
       hasBody: true,
     }),
     svc,
@@ -8207,7 +8207,7 @@ export const ToggleHttpProjectsLocationsClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/clients:toggleHttp",
+      path: "v1/{+parent}/clients:toggleHttp",
       hasBody: true,
     }),
     svc,
@@ -8247,7 +8247,7 @@ export const CreateProjectsLocationsProductsCloudFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/cloudFunctions",
+      path: "v1/{+parent}/cloudFunctions",
       hasBody: true,
     }),
     svc,
@@ -8293,7 +8293,7 @@ export const ListProjectsLocationsProductsCertificatesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/certificates" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/certificates" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProductsCertificatesRequest>;
 
@@ -8329,7 +8329,7 @@ export const GetProjectsLocationsProductsCertificatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProductsCertificatesRequest>;
 
@@ -8366,7 +8366,11 @@ export const CreateProjectsLocationsProductsCertificatesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/certificates", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/certificates",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsProductsCertificatesRequest>;
 
@@ -8406,7 +8410,7 @@ export const PatchProjectsLocationsProductsCertificatesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsProductsCertificatesRequest>;
 
@@ -8438,7 +8442,7 @@ export const DeleteProjectsLocationsProductsCertificatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsProductsCertificatesRequest>;
 
@@ -8490,7 +8494,7 @@ export const CreateProjectsLocationsProductsAuthConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/authConfigs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/authConfigs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsProductsAuthConfigsRequest>;
 
@@ -8545,7 +8549,7 @@ export const PatchProjectsLocationsProductsAuthConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsProductsAuthConfigsRequest>;
 
@@ -8577,7 +8581,7 @@ export const DeleteProjectsLocationsProductsAuthConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsProductsAuthConfigsRequest>;
 
@@ -8609,7 +8613,7 @@ export const GetProjectsLocationsProductsAuthConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProductsAuthConfigsRequest>;
 
@@ -8653,7 +8657,7 @@ export const ListProjectsLocationsProductsAuthConfigsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/authConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/authConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProductsAuthConfigsRequest>;
 
@@ -8694,7 +8698,7 @@ export const ExecuteProjectsLocationsProductsIntegrationsRequest =
       GoogleCloudIntegrationsV1alphaExecuteIntegrationsRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:execute", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:execute", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteProjectsLocationsProductsIntegrationsRequest>;
 
@@ -8731,7 +8735,7 @@ export const ScheduleProjectsLocationsProductsIntegrationsRequest =
       GoogleCloudIntegrationsV1alphaScheduleIntegrationsRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:schedule", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:schedule", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ScheduleProjectsLocationsProductsIntegrationsRequest>;
 
@@ -8768,7 +8772,7 @@ export const TestProjectsLocationsProductsIntegrationsRequest =
       GoogleCloudIntegrationsV1alphaTestIntegrationsRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:test", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:test", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TestProjectsLocationsProductsIntegrationsRequest>;
 
@@ -8812,7 +8816,7 @@ export const ListProjectsLocationsProductsIntegrationsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/integrations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/integrations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProductsIntegrationsRequest>;
 
@@ -8863,7 +8867,7 @@ export const ListProjectsLocationsProductsIntegrationsVersionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     fieldMask: Schema.optional(Schema.String).pipe(T.HttpQuery("fieldMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProductsIntegrationsVersionsRequest>;
 
@@ -8915,7 +8919,7 @@ export const CreateProjectsLocationsProductsIntegrationsVersionsRequest =
       GoogleCloudIntegrationsV1alphaIntegrationVersion,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/versions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/versions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsProductsIntegrationsVersionsRequest>;
 
@@ -8956,7 +8960,7 @@ export const PatchProjectsLocationsProductsIntegrationsVersionsRequest =
       GoogleCloudIntegrationsV1alphaIntegrationVersion,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsProductsIntegrationsVersionsRequest>;
 
@@ -8989,7 +8993,7 @@ export const GetProjectsLocationsProductsIntegrationsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProductsIntegrationsVersionsRequest>;
 
@@ -9027,7 +9031,7 @@ export const PublishProjectsLocationsProductsIntegrationsVersionsRequest =
       GoogleCloudIntegrationsV1alphaPublishIntegrationVersionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:publish", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:publish", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PublishProjectsLocationsProductsIntegrationsVersionsRequest>;
 
@@ -9060,7 +9064,7 @@ export const DeleteProjectsLocationsProductsIntegrationsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsProductsIntegrationsVersionsRequest>;
 
@@ -9100,7 +9104,7 @@ export const UploadProjectsLocationsProductsIntegrationsVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/versions:upload",
+      path: "v1/{+parent}/versions:upload",
       hasBody: true,
     }),
     svc,
@@ -9147,7 +9151,7 @@ export const DownloadProjectsLocationsProductsIntegrationsVersionsRequest =
       T.HttpQuery("files"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:download" }),
+    T.Http({ method: "GET", path: "v1/{+name}:download" }),
     svc,
   ) as unknown as Schema.Schema<DownloadProjectsLocationsProductsIntegrationsVersionsRequest>;
 
@@ -9187,7 +9191,7 @@ export const TakeoverEditLockProjectsLocationsProductsIntegrationsVersionsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{integrationVersion}:takeoverEditLock",
+      path: "v1/{+integrationVersion}:takeoverEditLock",
       hasBody: true,
     }),
     svc,
@@ -9227,7 +9231,7 @@ export const UnpublishProjectsLocationsProductsIntegrationsVersionsRequest =
       GoogleCloudIntegrationsV1alphaUnpublishIntegrationVersionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:unpublish", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:unpublish", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UnpublishProjectsLocationsProductsIntegrationsVersionsRequest>;
 
@@ -9348,7 +9352,7 @@ export const ListProjectsLocationsProductsIntegrationsExecutionsRequest =
       T.HttpQuery("snapshotMetadataWithoutParams"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/executions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/executions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProductsIntegrationsExecutionsRequest>;
 
@@ -9385,7 +9389,7 @@ export const GetProjectsLocationsProductsIntegrationsExecutionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProductsIntegrationsExecutionsRequest>;
 
@@ -9418,7 +9422,7 @@ export const DownloadProjectsLocationsProductsIntegrationsExecutionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:download" }),
+    T.Http({ method: "GET", path: "v1/{+name}:download" }),
     svc,
   ) as unknown as Schema.Schema<DownloadProjectsLocationsProductsIntegrationsExecutionsRequest>;
 
@@ -9456,7 +9460,7 @@ export const ResolveProjectsLocationsProductsIntegrationsExecutionsSuspensionsRe
       GoogleCloudIntegrationsV1alphaResolveSuspensionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:resolve", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:resolve", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResolveProjectsLocationsProductsIntegrationsExecutionsSuspensionsRequest>;
 
@@ -9503,7 +9507,7 @@ export const ListProjectsLocationsProductsIntegrationsExecutionsSuspensionsReque
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/suspensions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/suspensions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProductsIntegrationsExecutionsSuspensionsRequest>;
 
@@ -9546,7 +9550,7 @@ export const LiftProjectsLocationsProductsIntegrationsExecutionsSuspensionsReque
       GoogleCloudIntegrationsV1alphaLiftSuspensionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:lift", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:lift", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<LiftProjectsLocationsProductsIntegrationsExecutionsSuspensionsRequest>;
 
@@ -9587,7 +9591,7 @@ export const CreateProjectsLocationsProductsSfdcInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/sfdcInstances",
+      path: "v1/{+parent}/sfdcInstances",
       hasBody: true,
     }),
     svc,
@@ -9629,7 +9633,7 @@ export const PatchProjectsLocationsProductsSfdcInstancesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsProductsSfdcInstancesRequest>;
 
@@ -9661,7 +9665,7 @@ export const DeleteProjectsLocationsProductsSfdcInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsProductsSfdcInstancesRequest>;
 
@@ -9693,7 +9697,7 @@ export const GetProjectsLocationsProductsSfdcInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProductsSfdcInstancesRequest>;
 
@@ -9737,7 +9741,7 @@ export const ListProjectsLocationsProductsSfdcInstancesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sfdcInstances" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sfdcInstances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProductsSfdcInstancesRequest>;
 
@@ -9778,7 +9782,11 @@ export const CreateProjectsLocationsProductsSfdcInstancesSfdcChannelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/sfdcChannels", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/sfdcChannels",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsProductsSfdcInstancesSfdcChannelsRequest>;
 
@@ -9819,7 +9827,7 @@ export const PatchProjectsLocationsProductsSfdcInstancesSfdcChannelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsProductsSfdcInstancesSfdcChannelsRequest>;
 
@@ -9852,7 +9860,7 @@ export const DeleteProjectsLocationsProductsSfdcInstancesSfdcChannelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsProductsSfdcInstancesSfdcChannelsRequest>;
 
@@ -9885,7 +9893,7 @@ export const GetProjectsLocationsProductsSfdcInstancesSfdcChannelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProductsSfdcInstancesSfdcChannelsRequest>;
 
@@ -9930,7 +9938,7 @@ export const ListProjectsLocationsProductsSfdcInstancesSfdcChannelsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sfdcChannels" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sfdcChannels" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProductsSfdcInstancesSfdcChannelsRequest>;
 
@@ -9974,7 +9982,7 @@ export const CreateProjectsLocationsCloudFunctionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/cloudFunctions",
+      path: "v1/{+parent}/cloudFunctions",
       hasBody: true,
     }),
     svc,
@@ -10020,7 +10028,7 @@ export const ListProjectsLocationsCertificatesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/certificates" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/certificates" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCertificatesRequest>;
 
@@ -10056,7 +10064,7 @@ export const GetProjectsLocationsCertificatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCertificatesRequest>;
 
@@ -10093,7 +10101,11 @@ export const CreateProjectsLocationsCertificatesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/certificates", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/certificates",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCertificatesRequest>;
 
@@ -10133,7 +10145,7 @@ export const PatchProjectsLocationsCertificatesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCertificatesRequest>;
 
@@ -10165,7 +10177,7 @@ export const DeleteProjectsLocationsCertificatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCertificatesRequest>;
 
@@ -10216,7 +10228,7 @@ export const CreateProjectsLocationsAuthConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/authConfigs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/authConfigs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAuthConfigsRequest>;
 
@@ -10271,7 +10283,7 @@ export const PatchProjectsLocationsAuthConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAuthConfigsRequest>;
 
@@ -10303,7 +10315,7 @@ export const DeleteProjectsLocationsAuthConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAuthConfigsRequest>;
 
@@ -10334,7 +10346,7 @@ export const GetProjectsLocationsAuthConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAuthConfigsRequest>;
 
@@ -10378,7 +10390,7 @@ export const ListProjectsLocationsAuthConfigsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/authConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/authConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAuthConfigsRequest>;
 
@@ -10426,7 +10438,7 @@ export const ListProjectsLocationsConnectionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/connections" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/connections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsRequest>;
 
@@ -10462,7 +10474,7 @@ export const GetConnectionSchemaMetadataProjectsLocationsConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConnectionSchemaMetadataProjectsLocationsConnectionsRequest>;
 
@@ -10504,7 +10516,7 @@ export const ListProjectsLocationsConnectionsRuntimeEntitySchemasRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/runtimeEntitySchemas" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/runtimeEntitySchemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsRuntimeEntitySchemasRequest>;
 
@@ -10550,7 +10562,7 @@ export const ListProjectsLocationsConnectionsRuntimeActionSchemasRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/runtimeActionSchemas" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/runtimeActionSchemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectionsRuntimeActionSchemasRequest>;
 
@@ -10592,7 +10604,7 @@ export const ExecuteProjectsLocationsIntegrationsRequest =
       GoogleCloudIntegrationsV1alphaExecuteIntegrationsRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:execute", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:execute", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteProjectsLocationsIntegrationsRequest>;
 
@@ -10629,7 +10641,7 @@ export const ScheduleProjectsLocationsIntegrationsRequest =
       GoogleCloudIntegrationsV1alphaScheduleIntegrationsRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:schedule", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:schedule", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ScheduleProjectsLocationsIntegrationsRequest>;
 
@@ -10664,7 +10676,7 @@ export const ExecuteEventProjectsLocationsIntegrationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     triggerId: Schema.optional(Schema.String).pipe(T.HttpQuery("triggerId")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:executeEvent", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:executeEvent", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteEventProjectsLocationsIntegrationsRequest>;
 
@@ -10701,7 +10713,7 @@ export const TestProjectsLocationsIntegrationsRequest =
       GoogleCloudIntegrationsV1alphaTestIntegrationsRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:test", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:test", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TestProjectsLocationsIntegrationsRequest>;
 
@@ -10745,7 +10757,7 @@ export const ListProjectsLocationsIntegrationsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/integrations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/integrations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIntegrationsRequest>;
 
@@ -10798,7 +10810,7 @@ export const SearchProjectsLocationsIntegrationsRequest =
       Schema.Boolean,
     ).pipe(T.HttpQuery("enableNaturalLanguageQueryUnderstanding")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/integrations:search" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/integrations:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsLocationsIntegrationsRequest>;
 
@@ -10834,7 +10846,7 @@ export const DeleteProjectsLocationsIntegrationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsIntegrationsRequest>;
 
@@ -10880,7 +10892,7 @@ export const ListProjectsLocationsIntegrationsVersionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     fieldMask: Schema.optional(Schema.String).pipe(T.HttpQuery("fieldMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIntegrationsVersionsRequest>;
 
@@ -10931,7 +10943,7 @@ export const CreateProjectsLocationsIntegrationsVersionsRequest =
       GoogleCloudIntegrationsV1alphaIntegrationVersion,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/versions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/versions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsIntegrationsVersionsRequest>;
 
@@ -10971,7 +10983,7 @@ export const PatchProjectsLocationsIntegrationsVersionsRequest =
       GoogleCloudIntegrationsV1alphaIntegrationVersion,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsIntegrationsVersionsRequest>;
 
@@ -11003,7 +11015,7 @@ export const GetProjectsLocationsIntegrationsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIntegrationsVersionsRequest>;
 
@@ -11040,7 +11052,7 @@ export const PublishProjectsLocationsIntegrationsVersionsRequest =
       GoogleCloudIntegrationsV1alphaPublishIntegrationVersionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:publish", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:publish", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PublishProjectsLocationsIntegrationsVersionsRequest>;
 
@@ -11072,7 +11084,7 @@ export const DeleteProjectsLocationsIntegrationsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsIntegrationsVersionsRequest>;
 
@@ -11111,7 +11123,7 @@ export const UploadProjectsLocationsIntegrationsVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/versions:upload",
+      path: "v1/{+parent}/versions:upload",
       hasBody: true,
     }),
     svc,
@@ -11157,7 +11169,7 @@ export const DownloadProjectsLocationsIntegrationsVersionsRequest =
       T.HttpQuery("files"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:download" }),
+    T.Http({ method: "GET", path: "v1/{+name}:download" }),
     svc,
   ) as unknown as Schema.Schema<DownloadProjectsLocationsIntegrationsVersionsRequest>;
 
@@ -11198,7 +11210,7 @@ export const DownloadJsonPackageProjectsLocationsIntegrationsVersionsRequest =
       T.HttpQuery("files"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:downloadJsonPackage" }),
+    T.Http({ method: "GET", path: "v1/{+name}:downloadJsonPackage" }),
     svc,
   ) as unknown as Schema.Schema<DownloadJsonPackageProjectsLocationsIntegrationsVersionsRequest>;
 
@@ -11236,7 +11248,7 @@ export const UnpublishProjectsLocationsIntegrationsVersionsRequest =
       GoogleCloudIntegrationsV1alphaUnpublishIntegrationVersionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:unpublish", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:unpublish", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UnpublishProjectsLocationsIntegrationsVersionsRequest>;
 
@@ -11273,7 +11285,7 @@ export const TestProjectsLocationsIntegrationsVersionsRequest =
       GoogleCloudIntegrationsV1alphaTestIntegrationsRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:test", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:test", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TestProjectsLocationsIntegrationsVersionsRequest>;
 
@@ -11313,7 +11325,7 @@ export const CreateProjectsLocationsIntegrationsVersionsTestCasesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/testCases", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/testCases", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsIntegrationsVersionsTestCasesRequest>;
 
@@ -11346,7 +11358,7 @@ export const GetProjectsLocationsIntegrationsVersionsTestCasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIntegrationsVersionsTestCasesRequest>;
 
@@ -11387,7 +11399,7 @@ export const PatchProjectsLocationsIntegrationsVersionsTestCasesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsIntegrationsVersionsTestCasesRequest>;
 
@@ -11420,7 +11432,7 @@ export const DeleteProjectsLocationsIntegrationsVersionsTestCasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsIntegrationsVersionsTestCasesRequest>;
 
@@ -11468,7 +11480,7 @@ export const ListProjectsLocationsIntegrationsVersionsTestCasesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/testCases" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/testCases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIntegrationsVersionsTestCasesRequest>;
 
@@ -11512,7 +11524,7 @@ export const ExecuteTestProjectsLocationsIntegrationsVersionsTestCasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{testCaseName}:executeTest",
+      path: "v1/{+testCaseName}:executeTest",
       hasBody: true,
     }),
     svc,
@@ -11554,7 +11566,7 @@ export const UploadProjectsLocationsIntegrationsVersionsTestCasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/testCases:upload",
+      path: "v1/{+parent}/testCases:upload",
       hasBody: true,
     }),
     svc,
@@ -11592,7 +11604,7 @@ export const DownloadProjectsLocationsIntegrationsVersionsTestCasesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     fileFormat: Schema.optional(Schema.String).pipe(T.HttpQuery("fileFormat")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:download" }),
+    T.Http({ method: "GET", path: "v1/{+name}:download" }),
     svc,
   ) as unknown as Schema.Schema<DownloadProjectsLocationsIntegrationsVersionsTestCasesRequest>;
 
@@ -11632,7 +11644,7 @@ export const TakeoverEditLockProjectsLocationsIntegrationsVersionsTestCasesReque
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:takeoverEditLock",
+      path: "v1/{+name}:takeoverEditLock",
       hasBody: true,
     }),
     svc,
@@ -11675,7 +11687,7 @@ export const ExecuteProjectsLocationsIntegrationsVersionsTestCasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/testCases:execute",
+      path: "v1/{+parent}/testCases:execute",
       hasBody: true,
     }),
     svc,
@@ -11798,7 +11810,7 @@ export const ListProjectsLocationsIntegrationsExecutionsRequest =
       T.HttpQuery("snapshotMetadataWithoutParams"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/executions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/executions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIntegrationsExecutionsRequest>;
 
@@ -11834,7 +11846,7 @@ export const GetProjectsLocationsIntegrationsExecutionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsIntegrationsExecutionsRequest>;
 
@@ -11871,7 +11883,7 @@ export const CancelProjectsLocationsIntegrationsExecutionsRequest =
       GoogleCloudIntegrationsV1alphaCancelExecutionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsIntegrationsExecutionsRequest>;
 
@@ -11903,7 +11915,7 @@ export const DownloadProjectsLocationsIntegrationsExecutionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:download" }),
+    T.Http({ method: "GET", path: "v1/{+name}:download" }),
     svc,
   ) as unknown as Schema.Schema<DownloadProjectsLocationsIntegrationsExecutionsRequest>;
 
@@ -11941,7 +11953,7 @@ export const ReplayProjectsLocationsIntegrationsExecutionsRequest =
       GoogleCloudIntegrationsV1alphaReplayExecutionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:replay", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:replay", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReplayProjectsLocationsIntegrationsExecutionsRequest>;
 
@@ -11978,7 +11990,7 @@ export const ResolveProjectsLocationsIntegrationsExecutionsSuspensionsRequest =
       GoogleCloudIntegrationsV1alphaResolveSuspensionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:resolve", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:resolve", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResolveProjectsLocationsIntegrationsExecutionsSuspensionsRequest>;
 
@@ -12023,7 +12035,7 @@ export const ListProjectsLocationsIntegrationsExecutionsSuspensionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/suspensions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/suspensions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsIntegrationsExecutionsSuspensionsRequest>;
 
@@ -12065,7 +12077,7 @@ export const LiftProjectsLocationsIntegrationsExecutionsSuspensionsRequest =
       GoogleCloudIntegrationsV1alphaLiftSuspensionRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:lift", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:lift", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<LiftProjectsLocationsIntegrationsExecutionsSuspensionsRequest>;
 
@@ -12105,7 +12117,7 @@ export const CreateProjectsLocationsSfdcInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/sfdcInstances",
+      path: "v1/{+parent}/sfdcInstances",
       hasBody: true,
     }),
     svc,
@@ -12147,7 +12159,7 @@ export const PatchProjectsLocationsSfdcInstancesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSfdcInstancesRequest>;
 
@@ -12179,7 +12191,7 @@ export const DeleteProjectsLocationsSfdcInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSfdcInstancesRequest>;
 
@@ -12210,7 +12222,7 @@ export const GetProjectsLocationsSfdcInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSfdcInstancesRequest>;
 
@@ -12254,7 +12266,7 @@ export const ListProjectsLocationsSfdcInstancesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sfdcInstances" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sfdcInstances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSfdcInstancesRequest>;
 
@@ -12295,7 +12307,11 @@ export const CreateProjectsLocationsSfdcInstancesSfdcChannelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/sfdcChannels", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/sfdcChannels",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSfdcInstancesSfdcChannelsRequest>;
 
@@ -12336,7 +12352,7 @@ export const PatchProjectsLocationsSfdcInstancesSfdcChannelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSfdcInstancesSfdcChannelsRequest>;
 
@@ -12369,7 +12385,7 @@ export const DeleteProjectsLocationsSfdcInstancesSfdcChannelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSfdcInstancesSfdcChannelsRequest>;
 
@@ -12402,7 +12418,7 @@ export const GetProjectsLocationsSfdcInstancesSfdcChannelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSfdcInstancesSfdcChannelsRequest>;
 
@@ -12446,7 +12462,7 @@ export const ListProjectsLocationsSfdcInstancesSfdcChannelsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sfdcChannels" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sfdcChannels" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSfdcInstancesSfdcChannelsRequest>;
 
@@ -12497,7 +12513,7 @@ export const ListProjectsLocationsTemplatesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/templates" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/templates" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTemplatesRequest>;
 
@@ -12533,7 +12549,7 @@ export const GetProjectsLocationsTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTemplatesRequest>;
 
@@ -12570,7 +12586,7 @@ export const CreateProjectsLocationsTemplatesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/templates", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/templates", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTemplatesRequest>;
 
@@ -12610,7 +12626,7 @@ export const PatchProjectsLocationsTemplatesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTemplatesRequest>;
 
@@ -12642,7 +12658,7 @@ export const DeleteProjectsLocationsTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTemplatesRequest>;
 
@@ -12696,7 +12712,7 @@ export const SearchProjectsLocationsTemplatesRequest =
       Schema.Boolean,
     ).pipe(T.HttpQuery("enableNaturalLanguageQueryUnderstanding")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/templates:search" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/templates:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsLocationsTemplatesRequest>;
 
@@ -12737,7 +12753,7 @@ export const UseProjectsLocationsTemplatesRequest =
       GoogleCloudIntegrationsV1alphaUseTemplateRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:use", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:use", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UseProjectsLocationsTemplatesRequest>;
 
@@ -12774,7 +12790,7 @@ export const ImportProjectsLocationsTemplatesRequest =
       GoogleCloudIntegrationsV1alphaImportTemplateRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:import", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:import", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsLocationsTemplatesRequest>;
 
@@ -12811,7 +12827,7 @@ export const ShareProjectsLocationsTemplatesRequest =
       GoogleCloudIntegrationsV1alphaShareTemplateRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:share", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:share", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ShareProjectsLocationsTemplatesRequest>;
 
@@ -12847,7 +12863,7 @@ export const UnshareProjectsLocationsTemplatesRequest =
       GoogleCloudIntegrationsV1alphaUnshareTemplateRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:unshare", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:unshare", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UnshareProjectsLocationsTemplatesRequest>;
 
@@ -12885,7 +12901,7 @@ export const UploadProjectsLocationsTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/templates:upload",
+      path: "v1/{+parent}/templates:upload",
       hasBody: true,
     }),
     svc,
@@ -12922,7 +12938,7 @@ export const DownloadProjectsLocationsTemplatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     fileFormat: Schema.optional(Schema.String).pipe(T.HttpQuery("fileFormat")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:download" }),
+    T.Http({ method: "GET", path: "v1/{+name}:download" }),
     svc,
   ) as unknown as Schema.Schema<DownloadProjectsLocationsTemplatesRequest>;
 

--- a/packages/gcp/src/services/jobs-v3.ts
+++ b/packages/gcp/src/services/jobs-v3.ts
@@ -1336,7 +1336,7 @@ export const CompleteProjectsRequest =
     query: Schema.optional(Schema.String).pipe(T.HttpQuery("query")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}:complete" }),
+    T.Http({ method: "GET", path: "v3/{+name}:complete" }),
     svc,
   ) as unknown as Schema.Schema<CompleteProjectsRequest>;
 
@@ -1370,7 +1370,7 @@ export const CreateProjectsJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/jobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/jobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsJobsRequest>;
 
@@ -1400,7 +1400,7 @@ export const DeleteProjectsJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsJobsRequest>;
 
@@ -1433,7 +1433,7 @@ export const PatchProjectsJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsJobsRequest>;
 
@@ -1468,7 +1468,7 @@ export const SearchForAlertProjectsJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}/jobs:searchForAlert",
+      path: "v3/{+parent}/jobs:searchForAlert",
       hasBody: true,
     }),
     svc,
@@ -1506,7 +1506,7 @@ export const BatchDeleteProjectsJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}/jobs:batchDelete",
+      path: "v3/{+parent}/jobs:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -1557,7 +1557,7 @@ export const ListProjectsJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/jobs" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/jobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsJobsRequest>;
 
@@ -1593,7 +1593,7 @@ export const GetProjectsJobsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     name: Schema.String.pipe(T.HttpPath("name")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "v3/{name}" }),
+  T.Http({ method: "GET", path: "v3/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetProjectsJobsRequest>;
 
@@ -1626,7 +1626,7 @@ export const SearchProjectsJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(SearchJobsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/jobs:search", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/jobs:search", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsJobsRequest>;
 
@@ -1660,7 +1660,7 @@ export const PatchProjectsCompaniesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateCompanyRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsCompaniesRequest>;
 
@@ -1694,7 +1694,7 @@ export const CreateProjectsCompaniesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateCompanyRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/companies", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/companies", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsCompaniesRequest>;
 
@@ -1725,7 +1725,7 @@ export const DeleteProjectsCompaniesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsCompaniesRequest>;
 
@@ -1767,7 +1767,7 @@ export const ListProjectsCompaniesRequest =
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/companies" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/companies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsCompaniesRequest>;
 
@@ -1802,7 +1802,7 @@ export const GetProjectsCompaniesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsCompaniesRequest>;
 
@@ -1835,7 +1835,11 @@ export const CreateProjectsClientEventsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateClientEventRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/clientEvents", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v3/{+parent}/clientEvents",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsClientEventsRequest>;
 

--- a/packages/gcp/src/services/jobs-v3p1beta1.ts
+++ b/packages/gcp/src/services/jobs-v3p1beta1.ts
@@ -1429,7 +1429,7 @@ export const CompleteProjectsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3p1beta1/{name}:complete" }),
+    T.Http({ method: "GET", path: "v3p1beta1/{+name}:complete" }),
     svc,
   ) as unknown as Schema.Schema<CompleteProjectsRequest>;
 
@@ -1460,7 +1460,7 @@ export const DeleteProjectsCompaniesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3p1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3p1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsCompaniesRequest>;
 
@@ -1496,7 +1496,7 @@ export const CreateProjectsCompaniesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3p1beta1/{parent}/companies",
+      path: "v3p1beta1/{+parent}/companies",
       hasBody: true,
     }),
     svc,
@@ -1529,7 +1529,7 @@ export const GetProjectsCompaniesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3p1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3p1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsCompaniesRequest>;
 
@@ -1570,7 +1570,7 @@ export const ListProjectsCompaniesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3p1beta1/{parent}/companies" }),
+    T.Http({ method: "GET", path: "v3p1beta1/{+parent}/companies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsCompaniesRequest>;
 
@@ -1608,7 +1608,7 @@ export const PatchProjectsCompaniesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateCompanyRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3p1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3p1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsCompaniesRequest>;
 
@@ -1644,7 +1644,7 @@ export const CreateProjectsClientEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3p1beta1/{parent}/clientEvents",
+      path: "v3p1beta1/{+parent}/clientEvents",
       hasBody: true,
     }),
     svc,
@@ -1682,7 +1682,7 @@ export const BatchDeleteProjectsJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3p1beta1/{parent}/jobs:batchDelete",
+      path: "v3p1beta1/{+parent}/jobs:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -1720,7 +1720,7 @@ export const SearchForAlertProjectsJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3p1beta1/{parent}/jobs:searchForAlert",
+      path: "v3p1beta1/{+parent}/jobs:searchForAlert",
       hasBody: true,
     }),
     svc,
@@ -1754,7 +1754,7 @@ export const GetProjectsJobsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     name: Schema.String.pipe(T.HttpPath("name")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "v3p1beta1/{name}" }),
+  T.Http({ method: "GET", path: "v3p1beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetProjectsJobsRequest>;
 
@@ -1787,7 +1787,7 @@ export const PatchProjectsJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3p1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3p1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsJobsRequest>;
 
@@ -1820,7 +1820,7 @@ export const CreateProjectsJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3p1beta1/{parent}/jobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v3p1beta1/{+parent}/jobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsJobsRequest>;
 
@@ -1855,7 +1855,7 @@ export const SearchProjectsJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3p1beta1/{parent}/jobs:search",
+      path: "v3p1beta1/{+parent}/jobs:search",
       hasBody: true,
     }),
     svc,
@@ -1888,7 +1888,7 @@ export const DeleteProjectsJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3p1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3p1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsJobsRequest>;
 
@@ -1936,7 +1936,7 @@ export const ListProjectsJobsRequest =
     jobView: Schema.optional(Schema.String).pipe(T.HttpQuery("jobView")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3p1beta1/{parent}/jobs" }),
+    T.Http({ method: "GET", path: "v3p1beta1/{+parent}/jobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsJobsRequest>;
 
@@ -1971,7 +1971,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3p1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3p1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 

--- a/packages/gcp/src/services/jobs-v4.ts
+++ b/packages/gcp/src/services/jobs-v4.ts
@@ -1307,7 +1307,7 @@ export const CompleteQueryProjectsTenantsRequest =
     ),
     tenant: Schema.String.pipe(T.HttpPath("tenant")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/{tenant}:completeQuery" }),
+    T.Http({ method: "GET", path: "v4/{+tenant}:completeQuery" }),
     svc,
   ) as unknown as Schema.Schema<CompleteQueryProjectsTenantsRequest>;
 
@@ -1338,7 +1338,7 @@ export const DeleteProjectsTenantsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v4/{name}" }),
+    T.Http({ method: "DELETE", path: "v4/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsTenantsRequest>;
 
@@ -1374,7 +1374,7 @@ export const ListProjectsTenantsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/{parent}/tenants" }),
+    T.Http({ method: "GET", path: "v4/{+parent}/tenants" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTenantsRequest>;
 
@@ -1412,7 +1412,7 @@ export const CreateProjectsTenantsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Tenant).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v4/{parent}/tenants", hasBody: true }),
+    T.Http({ method: "POST", path: "v4/{+parent}/tenants", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsTenantsRequest>;
 
@@ -1442,7 +1442,7 @@ export const GetProjectsTenantsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/{name}" }),
+    T.Http({ method: "GET", path: "v4/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsTenantsRequest>;
 
@@ -1478,7 +1478,7 @@ export const PatchProjectsTenantsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Tenant).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v4/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v4/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsTenantsRequest>;
 
@@ -1508,7 +1508,7 @@ export const DeleteProjectsTenantsJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v4/{name}" }),
+    T.Http({ method: "DELETE", path: "v4/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsTenantsJobsRequest>;
 
@@ -1545,7 +1545,7 @@ export const PatchProjectsTenantsJobsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Job).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v4/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v4/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsTenantsJobsRequest>;
 
@@ -1580,7 +1580,7 @@ export const BatchUpdateProjectsTenantsJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/{parent}/jobs:batchUpdate",
+      path: "v4/{+parent}/jobs:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -1631,7 +1631,7 @@ export const ListProjectsTenantsJobsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/{parent}/jobs" }),
+    T.Http({ method: "GET", path: "v4/{+parent}/jobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTenantsJobsRequest>;
 
@@ -1671,7 +1671,7 @@ export const SearchForAlertProjectsTenantsJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/{parent}/jobs:searchForAlert",
+      path: "v4/{+parent}/jobs:searchForAlert",
       hasBody: true,
     }),
     svc,
@@ -1709,7 +1709,7 @@ export const BatchCreateProjectsTenantsJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/{parent}/jobs:batchCreate",
+      path: "v4/{+parent}/jobs:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -1745,7 +1745,7 @@ export const CreateProjectsTenantsJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Job).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v4/{parent}/jobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v4/{+parent}/jobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsTenantsJobsRequest>;
 
@@ -1781,7 +1781,7 @@ export const BatchDeleteProjectsTenantsJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v4/{parent}/jobs:batchDelete",
+      path: "v4/{+parent}/jobs:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -1817,7 +1817,7 @@ export const SearchProjectsTenantsJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(SearchJobsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v4/{parent}/jobs:search", hasBody: true }),
+    T.Http({ method: "POST", path: "v4/{+parent}/jobs:search", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsTenantsJobsRequest>;
 
@@ -1848,7 +1848,7 @@ export const GetProjectsTenantsJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/{name}" }),
+    T.Http({ method: "GET", path: "v4/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsTenantsJobsRequest>;
 
@@ -1878,7 +1878,7 @@ export const DeleteProjectsTenantsCompaniesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v4/{name}" }),
+    T.Http({ method: "DELETE", path: "v4/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsTenantsCompaniesRequest>;
 
@@ -1909,7 +1909,7 @@ export const GetProjectsTenantsCompaniesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/{name}" }),
+    T.Http({ method: "GET", path: "v4/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsTenantsCompaniesRequest>;
 
@@ -1946,7 +1946,7 @@ export const PatchProjectsTenantsCompaniesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Company).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v4/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v4/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsTenantsCompaniesRequest>;
 
@@ -1980,7 +1980,7 @@ export const CreateProjectsTenantsCompaniesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Company).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v4/{parent}/companies", hasBody: true }),
+    T.Http({ method: "POST", path: "v4/{+parent}/companies", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsTenantsCompaniesRequest>;
 
@@ -2022,7 +2022,7 @@ export const ListProjectsTenantsCompaniesRequest =
       T.HttpQuery("requireOpenJobs"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/{parent}/companies" }),
+    T.Http({ method: "GET", path: "v4/{+parent}/companies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTenantsCompaniesRequest>;
 
@@ -2060,7 +2060,11 @@ export const CreateProjectsTenantsClientEventsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(ClientEvent).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v4/{parent}/clientEvents", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v4/{+parent}/clientEvents",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsTenantsClientEventsRequest>;
 
@@ -2091,7 +2095,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v4/{name}" }),
+    T.Http({ method: "GET", path: "v4/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 

--- a/packages/gcp/src/services/keep-v1.ts
+++ b/packages/gcp/src/services/keep-v1.ts
@@ -308,7 +308,7 @@ export interface GetNotesRequest {
 export const GetNotesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetNotesRequest>;
 
@@ -337,7 +337,7 @@ export interface DeleteNotesRequest {
 export const DeleteNotesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v1/{name}" }),
+  T.Http({ method: "DELETE", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteNotesRequest>;
 
@@ -372,7 +372,7 @@ export const BatchDeleteNotesPermissionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/permissions:batchDelete",
+      path: "v1/{+parent}/permissions:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -410,7 +410,7 @@ export const BatchCreateNotesPermissionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/permissions:batchCreate",
+      path: "v1/{+parent}/permissions:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -446,7 +446,7 @@ export const DownloadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   mimeType: Schema.optional(Schema.String).pipe(T.HttpQuery("mimeType")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DownloadMediaRequest>;
 

--- a/packages/gcp/src/services/kmsinventory-v1.ts
+++ b/packages/gcp/src/services/kmsinventory-v1.ts
@@ -488,7 +488,7 @@ export const SearchProjectsProtectedResourcesRequest =
       T.HttpQuery("resourceTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{scope}/protectedResources:search" }),
+    T.Http({ method: "GET", path: "v1/{+scope}/protectedResources:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsProtectedResourcesRequest>;
 
@@ -530,7 +530,7 @@ export const ListProjectsCryptoKeysRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/cryptoKeys" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/cryptoKeys" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsCryptoKeysRequest>;
 
@@ -574,7 +574,7 @@ export const GetProtectedResourcesSummaryProjectsLocationsKeyRingsCryptoKeysRequ
       T.HttpQuery("fallbackScope"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/protectedResourcesSummary" }),
+    T.Http({ method: "GET", path: "v1/{+name}/protectedResourcesSummary" }),
     svc,
   ) as unknown as Schema.Schema<GetProtectedResourcesSummaryProjectsLocationsKeyRingsCryptoKeysRequest>;
 
@@ -622,7 +622,7 @@ export const SearchOrganizationsProtectedResourcesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{scope}/protectedResources:search" }),
+    T.Http({ method: "GET", path: "v1/{+scope}/protectedResources:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchOrganizationsProtectedResourcesRequest>;
 

--- a/packages/gcp/src/services/libraryagent-v1.ts
+++ b/packages/gcp/src/services/libraryagent-v1.ts
@@ -130,7 +130,7 @@ export interface GetShelvesRequest {
 export const GetShelvesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetShelvesRequest>;
 
@@ -162,7 +162,7 @@ export const GetShelvesBooksRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     name: Schema.String.pipe(T.HttpPath("name")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetShelvesBooksRequest>;
 
@@ -199,7 +199,7 @@ export const ListShelvesBooksRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/books" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/books" }),
     svc,
   ) as unknown as Schema.Schema<ListShelvesBooksRequest>;
 
@@ -235,7 +235,7 @@ export const BorrowShelvesBooksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:borrow", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:borrow", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<BorrowShelvesBooksRequest>;
 
@@ -266,7 +266,7 @@ export const ReturnShelvesBooksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:return", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:return", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReturnShelvesBooksRequest>;
 

--- a/packages/gcp/src/services/logging-v2.ts
+++ b/packages/gcp/src/services/logging-v2.ts
@@ -1931,7 +1931,7 @@ export const DeleteExclusionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteExclusionsRequest>;
 
@@ -1964,7 +1964,7 @@ export const CreateExclusionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(LogExclusion).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/exclusions", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/exclusions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateExclusionsRequest>;
 
@@ -2000,7 +2000,7 @@ export const ListExclusionsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   parent: Schema.String.pipe(T.HttpPath("parent")),
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{parent}/exclusions" }),
+  T.Http({ method: "GET", path: "v2/{+parent}/exclusions" }),
   svc,
 ) as unknown as Schema.Schema<ListExclusionsRequest>;
 
@@ -2034,7 +2034,7 @@ export interface GetExclusionsRequest {
 export const GetExclusionsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{name}" }),
+  T.Http({ method: "GET", path: "v2/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetExclusionsRequest>;
 
@@ -2071,7 +2071,7 @@ export const PatchExclusionsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     body: Schema.optional(LogExclusion).pipe(T.HttpBody()),
   },
 ).pipe(
-  T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchExclusionsRequest>;
 
@@ -2101,7 +2101,7 @@ export const GetSettingsProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/settings" }),
+    T.Http({ method: "GET", path: "v2/{+name}/settings" }),
     svc,
   ) as unknown as Schema.Schema<GetSettingsProjectsRequest>;
 
@@ -2131,7 +2131,7 @@ export const GetCmekSettingsProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/cmekSettings" }),
+    T.Http({ method: "GET", path: "v2/{+name}/cmekSettings" }),
     svc,
   ) as unknown as Schema.Schema<GetCmekSettingsProjectsRequest>;
 
@@ -2176,7 +2176,7 @@ export const ListProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2211,7 +2211,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2248,7 +2248,7 @@ export const PatchProjectsLocationsSavedQueriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SavedQuery).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSavedQueriesRequest>;
 
@@ -2279,7 +2279,7 @@ export const GetProjectsLocationsSavedQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSavedQueriesRequest>;
 
@@ -2319,7 +2319,7 @@ export const ListProjectsLocationsSavedQueriesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/savedQueries" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/savedQueries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSavedQueriesRequest>;
 
@@ -2363,7 +2363,11 @@ export const CreateProjectsLocationsSavedQueriesRequest =
     ),
     body: Schema.optional(SavedQuery).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/savedQueries", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+parent}/savedQueries",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSavedQueriesRequest>;
 
@@ -2394,7 +2398,7 @@ export const DeleteProjectsLocationsSavedQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSavedQueriesRequest>;
 
@@ -2425,7 +2429,7 @@ export const DeleteProjectsLocationsLogScopesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsLogScopesRequest>;
 
@@ -2462,7 +2466,7 @@ export const CreateProjectsLocationsLogScopesRequest =
     logScopeId: Schema.optional(Schema.String).pipe(T.HttpQuery("logScopeId")),
     body: Schema.optional(LogScope).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/logScopes", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/logScopes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsLogScopesRequest>;
 
@@ -2499,7 +2503,7 @@ export const ListProjectsLocationsLogScopesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/logScopes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/logScopes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsLogScopesRequest>;
 
@@ -2534,7 +2538,7 @@ export const GetProjectsLocationsLogScopesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsLogScopesRequest>;
 
@@ -2571,7 +2575,7 @@ export const PatchProjectsLocationsLogScopesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(LogScope).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsLogScopesRequest>;
 
@@ -2611,7 +2615,7 @@ export const ListProjectsLocationsRecentQueriesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/recentQueries" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/recentQueries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRecentQueriesRequest>;
 
@@ -2653,7 +2657,7 @@ export const PatchProjectsLocationsBucketsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(LogBucket).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBucketsRequest>;
 
@@ -2684,7 +2688,7 @@ export const GetProjectsLocationsBucketsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBucketsRequest>;
 
@@ -2723,7 +2727,7 @@ export const CreateAsyncProjectsLocationsBucketsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/buckets:createAsync",
+      path: "v2/{+parent}/buckets:createAsync",
       hasBody: true,
     }),
     svc,
@@ -2762,7 +2766,7 @@ export const ListProjectsLocationsBucketsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/buckets" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/buckets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBucketsRequest>;
 
@@ -2803,7 +2807,7 @@ export const UpdateAsyncProjectsLocationsBucketsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LogBucket).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:updateAsync", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:updateAsync", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAsyncProjectsLocationsBucketsRequest>;
 
@@ -2840,7 +2844,7 @@ export const CreateProjectsLocationsBucketsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(LogBucket).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/buckets", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/buckets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBucketsRequest>;
 
@@ -2871,7 +2875,7 @@ export const DeleteProjectsLocationsBucketsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBucketsRequest>;
 
@@ -2905,7 +2909,7 @@ export const UndeleteProjectsLocationsBucketsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndeleteBucketRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsLocationsBucketsRequest>;
 
@@ -2942,7 +2946,7 @@ export const ListProjectsLocationsBucketsViewsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/views" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/views" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBucketsViewsRequest>;
 
@@ -2982,7 +2986,7 @@ export const SetIamPolicyProjectsLocationsBucketsViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3020,7 +3024,7 @@ export const TestIamPermissionsProjectsLocationsBucketsViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3055,7 +3059,7 @@ export const GetProjectsLocationsBucketsViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBucketsViewsRequest>;
 
@@ -3091,7 +3095,7 @@ export const GetIamPolicyProjectsLocationsBucketsViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:getIamPolicy",
+      path: "v2/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3130,7 +3134,7 @@ export const PatchProjectsLocationsBucketsViewsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(LogView).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBucketsViewsRequest>;
 
@@ -3161,7 +3165,7 @@ export const DeleteProjectsLocationsBucketsViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBucketsViewsRequest>;
 
@@ -3198,7 +3202,7 @@ export const CreateProjectsLocationsBucketsViewsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(LogView).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/views", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/views", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBucketsViewsRequest>;
 
@@ -3240,7 +3244,7 @@ export const ListProjectsLocationsBucketsViewsLogsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/logs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/logs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBucketsViewsLogsRequest>;
 
@@ -3281,7 +3285,7 @@ export const CreateProjectsLocationsBucketsLinksRequest =
     linkId: Schema.optional(Schema.String).pipe(T.HttpQuery("linkId")),
     body: Schema.optional(Link).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/links", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/links", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBucketsLinksRequest>;
 
@@ -3312,7 +3316,7 @@ export const DeleteProjectsLocationsBucketsLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBucketsLinksRequest>;
 
@@ -3343,7 +3347,7 @@ export const GetProjectsLocationsBucketsLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBucketsLinksRequest>;
 
@@ -3380,7 +3384,7 @@ export const ListProjectsLocationsBucketsLinksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/links" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/links" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBucketsLinksRequest>;
 
@@ -3415,7 +3419,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -3460,7 +3464,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -3498,7 +3502,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -3529,7 +3533,7 @@ export const DeleteProjectsLogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     logName: Schema.String.pipe(T.HttpPath("logName")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{logName}" }),
+    T.Http({ method: "DELETE", path: "v2/{+logName}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLogsRequest>;
 
@@ -3570,7 +3574,7 @@ export const ListProjectsLogsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/logs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/logs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLogsRequest>;
 
@@ -3611,7 +3615,7 @@ export const ListProjectsMetricsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/metrics" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/metrics" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsMetricsRequest>;
 
@@ -3649,7 +3653,7 @@ export const UpdateProjectsMetricsRequest =
     metricName: Schema.String.pipe(T.HttpPath("metricName")),
     body: Schema.optional(LogMetric).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v2/{metricName}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v2/{+metricName}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsMetricsRequest>;
 
@@ -3680,7 +3684,7 @@ export const GetProjectsMetricsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     metricName: Schema.String.pipe(T.HttpPath("metricName")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{metricName}" }),
+    T.Http({ method: "GET", path: "v2/{+metricName}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsMetricsRequest>;
 
@@ -3710,7 +3714,7 @@ export const DeleteProjectsMetricsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     metricName: Schema.String.pipe(T.HttpPath("metricName")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{metricName}" }),
+    T.Http({ method: "DELETE", path: "v2/{+metricName}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsMetricsRequest>;
 
@@ -3743,7 +3747,7 @@ export const CreateProjectsMetricsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(LogMetric).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/metrics", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/metrics", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsMetricsRequest>;
 
@@ -3774,7 +3778,7 @@ export const DeleteProjectsExclusionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsExclusionsRequest>;
 
@@ -3808,7 +3812,7 @@ export const CreateProjectsExclusionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(LogExclusion).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/exclusions", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/exclusions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsExclusionsRequest>;
 
@@ -3845,7 +3849,7 @@ export const PatchProjectsExclusionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LogExclusion).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsExclusionsRequest>;
 
@@ -3882,7 +3886,7 @@ export const ListProjectsExclusionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/exclusions" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/exclusions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsExclusionsRequest>;
 
@@ -3917,7 +3921,7 @@ export const GetProjectsExclusionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsExclusionsRequest>;
 
@@ -3948,7 +3952,7 @@ export const DeleteProjectsSinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     sinkName: Schema.String.pipe(T.HttpPath("sinkName")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{sinkName}" }),
+    T.Http({ method: "DELETE", path: "v2/{+sinkName}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsSinksRequest>;
 
@@ -3991,7 +3995,7 @@ export const CreateProjectsSinksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(LogSink).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/sinks", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/sinks", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsSinksRequest>;
 
@@ -4030,7 +4034,7 @@ export const ListProjectsSinksRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/sinks" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/sinks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSinksRequest>;
 
@@ -4081,7 +4085,7 @@ export const UpdateProjectsSinksRequest =
     ),
     body: Schema.optional(LogSink).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v2/{sinkName}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v2/{+sinkName}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsSinksRequest>;
 
@@ -4111,7 +4115,7 @@ export const GetProjectsSinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     sinkName: Schema.String.pipe(T.HttpPath("sinkName")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{sinkName}" }),
+    T.Http({ method: "GET", path: "v2/{+sinkName}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSinksRequest>;
 
@@ -4157,7 +4161,7 @@ export const PatchProjectsSinksRequest =
     ),
     body: Schema.optional(LogSink).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{sinkName}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+sinkName}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsSinksRequest>;
 
@@ -4306,7 +4310,7 @@ export const GetCmekSettingsBillingAccountsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/cmekSettings" }),
+    T.Http({ method: "GET", path: "v2/{+name}/cmekSettings" }),
     svc,
   ) as unknown as Schema.Schema<GetCmekSettingsBillingAccountsRequest>;
 
@@ -4337,7 +4341,7 @@ export const GetSettingsBillingAccountsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/settings" }),
+    T.Http({ method: "GET", path: "v2/{+name}/settings" }),
     svc,
   ) as unknown as Schema.Schema<GetSettingsBillingAccountsRequest>;
 
@@ -4368,7 +4372,7 @@ export const GetBillingAccountsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsLocationsRequest>;
 
@@ -4413,7 +4417,7 @@ export const ListBillingAccountsLocationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsLocationsRequest>;
 
@@ -4454,7 +4458,7 @@ export const ListBillingAccountsLocationsBucketsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/buckets" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/buckets" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsLocationsBucketsRequest>;
 
@@ -4489,7 +4493,7 @@ export const GetBillingAccountsLocationsBucketsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsLocationsBucketsRequest>;
 
@@ -4528,7 +4532,7 @@ export const CreateAsyncBillingAccountsLocationsBucketsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/buckets:createAsync",
+      path: "v2/{+parent}/buckets:createAsync",
       hasBody: true,
     }),
     svc,
@@ -4567,7 +4571,7 @@ export const PatchBillingAccountsLocationsBucketsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(LogBucket).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchBillingAccountsLocationsBucketsRequest>;
 
@@ -4598,7 +4602,7 @@ export const DeleteBillingAccountsLocationsBucketsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteBillingAccountsLocationsBucketsRequest>;
 
@@ -4632,7 +4636,7 @@ export const UndeleteBillingAccountsLocationsBucketsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndeleteBucketRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteBillingAccountsLocationsBucketsRequest>;
 
@@ -4669,7 +4673,7 @@ export const UpdateAsyncBillingAccountsLocationsBucketsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(LogBucket).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:updateAsync", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:updateAsync", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAsyncBillingAccountsLocationsBucketsRequest>;
 
@@ -4706,7 +4710,7 @@ export const CreateBillingAccountsLocationsBucketsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(LogBucket).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/buckets", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/buckets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateBillingAccountsLocationsBucketsRequest>;
 
@@ -4743,7 +4747,7 @@ export const PatchBillingAccountsLocationsBucketsViewsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(LogView).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchBillingAccountsLocationsBucketsViewsRequest>;
 
@@ -4774,7 +4778,7 @@ export const GetBillingAccountsLocationsBucketsViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsLocationsBucketsViewsRequest>;
 
@@ -4811,7 +4815,7 @@ export const ListBillingAccountsLocationsBucketsViewsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/views" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/views" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsLocationsBucketsViewsRequest>;
 
@@ -4853,7 +4857,7 @@ export const CreateBillingAccountsLocationsBucketsViewsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(LogView).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/views", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/views", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateBillingAccountsLocationsBucketsViewsRequest>;
 
@@ -4884,7 +4888,7 @@ export const DeleteBillingAccountsLocationsBucketsViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteBillingAccountsLocationsBucketsViewsRequest>;
 
@@ -4926,7 +4930,7 @@ export const ListBillingAccountsLocationsBucketsViewsLogsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/logs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/logs" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsLocationsBucketsViewsLogsRequest>;
 
@@ -4962,7 +4966,7 @@ export const GetBillingAccountsLocationsBucketsLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsLocationsBucketsLinksRequest>;
 
@@ -4999,7 +5003,7 @@ export const ListBillingAccountsLocationsBucketsLinksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/links" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/links" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsLocationsBucketsLinksRequest>;
 
@@ -5041,7 +5045,7 @@ export const CreateBillingAccountsLocationsBucketsLinksRequest =
     linkId: Schema.optional(Schema.String).pipe(T.HttpQuery("linkId")),
     body: Schema.optional(Link).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/links", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/links", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateBillingAccountsLocationsBucketsLinksRequest>;
 
@@ -5072,7 +5076,7 @@ export const DeleteBillingAccountsLocationsBucketsLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteBillingAccountsLocationsBucketsLinksRequest>;
 
@@ -5106,7 +5110,7 @@ export const CancelBillingAccountsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelBillingAccountsLocationsOperationsRequest>;
 
@@ -5137,7 +5141,7 @@ export const GetBillingAccountsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsLocationsOperationsRequest>;
 
@@ -5182,7 +5186,7 @@ export const ListBillingAccountsLocationsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsLocationsOperationsRequest>;
 
@@ -5227,7 +5231,7 @@ export const ListBillingAccountsLocationsRecentQueriesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/recentQueries" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/recentQueries" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsLocationsRecentQueriesRequest>;
 
@@ -5263,7 +5267,7 @@ export const DeleteBillingAccountsLocationsSavedQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteBillingAccountsLocationsSavedQueriesRequest>;
 
@@ -5302,7 +5306,11 @@ export const CreateBillingAccountsLocationsSavedQueriesRequest =
     ),
     body: Schema.optional(SavedQuery).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/savedQueries", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+parent}/savedQueries",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateBillingAccountsLocationsSavedQueriesRequest>;
 
@@ -5342,7 +5350,7 @@ export const ListBillingAccountsLocationsSavedQueriesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/savedQueries" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/savedQueries" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsLocationsSavedQueriesRequest>;
 
@@ -5378,7 +5386,7 @@ export const GetBillingAccountsLocationsSavedQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsLocationsSavedQueriesRequest>;
 
@@ -5415,7 +5423,7 @@ export const PatchBillingAccountsLocationsSavedQueriesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SavedQuery).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchBillingAccountsLocationsSavedQueriesRequest>;
 
@@ -5446,7 +5454,7 @@ export const DeleteBillingAccountsSinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     sinkName: Schema.String.pipe(T.HttpPath("sinkName")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{sinkName}" }),
+    T.Http({ method: "DELETE", path: "v2/{+sinkName}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteBillingAccountsSinksRequest>;
 
@@ -5490,7 +5498,7 @@ export const CreateBillingAccountsSinksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(LogSink).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/sinks", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/sinks", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateBillingAccountsSinksRequest>;
 
@@ -5530,7 +5538,7 @@ export const ListBillingAccountsSinksRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/sinks" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/sinks" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsSinksRequest>;
 
@@ -5581,7 +5589,7 @@ export const UpdateBillingAccountsSinksRequest =
     ),
     body: Schema.optional(LogSink).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v2/{sinkName}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v2/{+sinkName}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateBillingAccountsSinksRequest>;
 
@@ -5612,7 +5620,7 @@ export const GetBillingAccountsSinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     sinkName: Schema.String.pipe(T.HttpPath("sinkName")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{sinkName}" }),
+    T.Http({ method: "GET", path: "v2/{+sinkName}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsSinksRequest>;
 
@@ -5659,7 +5667,7 @@ export const PatchBillingAccountsSinksRequest =
     ),
     body: Schema.optional(LogSink).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{sinkName}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+sinkName}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchBillingAccountsSinksRequest>;
 
@@ -5693,7 +5701,7 @@ export const CreateBillingAccountsExclusionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(LogExclusion).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/exclusions", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/exclusions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateBillingAccountsExclusionsRequest>;
 
@@ -5724,7 +5732,7 @@ export const DeleteBillingAccountsExclusionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteBillingAccountsExclusionsRequest>;
 
@@ -5761,7 +5769,7 @@ export const PatchBillingAccountsExclusionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LogExclusion).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchBillingAccountsExclusionsRequest>;
 
@@ -5792,7 +5800,7 @@ export const GetBillingAccountsExclusionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsExclusionsRequest>;
 
@@ -5829,7 +5837,7 @@ export const ListBillingAccountsExclusionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/exclusions" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/exclusions" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsExclusionsRequest>;
 
@@ -5864,7 +5872,7 @@ export const DeleteBillingAccountsLogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     logName: Schema.String.pipe(T.HttpPath("logName")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{logName}" }),
+    T.Http({ method: "DELETE", path: "v2/{+logName}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteBillingAccountsLogsRequest>;
 
@@ -5906,7 +5914,7 @@ export const ListBillingAccountsLogsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/logs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/logs" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsLogsRequest>;
 
@@ -5940,7 +5948,7 @@ export interface GetSinksRequest {
 export const GetSinksRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   sinkName: Schema.String.pipe(T.HttpPath("sinkName")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{sinkName}" }),
+  T.Http({ method: "GET", path: "v2/{+sinkName}" }),
   svc,
 ) as unknown as Schema.Schema<GetSinksRequest>;
 
@@ -5978,7 +5986,7 @@ export const ListSinksRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{parent}/sinks" }),
+  T.Http({ method: "GET", path: "v2/{+parent}/sinks" }),
   svc,
 ) as unknown as Schema.Schema<ListSinksRequest>;
 
@@ -6028,7 +6036,7 @@ export const UpdateSinksRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   ),
   body: Schema.optional(LogSink).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PUT", path: "v2/{sinkName}", hasBody: true }),
+  T.Http({ method: "PUT", path: "v2/{+sinkName}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<UpdateSinksRequest>;
 
@@ -6070,7 +6078,7 @@ export const CreateSinksRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   ),
   body: Schema.optional(LogSink).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v2/{parent}/sinks", hasBody: true }),
+  T.Http({ method: "POST", path: "v2/{+parent}/sinks", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<CreateSinksRequest>;
 
@@ -6099,7 +6107,7 @@ export interface DeleteSinksRequest {
 export const DeleteSinksRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   sinkName: Schema.String.pipe(T.HttpPath("sinkName")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v2/{sinkName}" }),
+  T.Http({ method: "DELETE", path: "v2/{+sinkName}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteSinksRequest>;
 
@@ -6129,7 +6137,7 @@ export const GetCmekSettingsV2Request =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/cmekSettings" }),
+    T.Http({ method: "GET", path: "v2/{+name}/cmekSettings" }),
     svc,
   ) as unknown as Schema.Schema<GetCmekSettingsV2Request>;
 
@@ -6159,7 +6167,7 @@ export interface GetSettingsV2Request {
 export const GetSettingsV2Request = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{name}/settings" }),
+  T.Http({ method: "GET", path: "v2/{+name}/settings" }),
   svc,
 ) as unknown as Schema.Schema<GetSettingsV2Request>;
 
@@ -6195,7 +6203,7 @@ export const UpdateCmekSettingsV2Request =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CmekSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}/cmekSettings", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}/cmekSettings", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateCmekSettingsV2Request>;
 
@@ -6232,7 +6240,7 @@ export const UpdateSettingsV2Request =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Settings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}/settings", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}/settings", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSettingsV2Request>;
 
@@ -6268,7 +6276,7 @@ export const UpdateSettingsFoldersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Settings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}/settings", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}/settings", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSettingsFoldersRequest>;
 
@@ -6299,7 +6307,7 @@ export const GetCmekSettingsFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/cmekSettings" }),
+    T.Http({ method: "GET", path: "v2/{+name}/cmekSettings" }),
     svc,
   ) as unknown as Schema.Schema<GetCmekSettingsFoldersRequest>;
 
@@ -6330,7 +6338,7 @@ export const GetSettingsFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/settings" }),
+    T.Http({ method: "GET", path: "v2/{+name}/settings" }),
     svc,
   ) as unknown as Schema.Schema<GetSettingsFoldersRequest>;
 
@@ -6360,7 +6368,7 @@ export const DeleteFoldersExclusionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersExclusionsRequest>;
 
@@ -6394,7 +6402,7 @@ export const CreateFoldersExclusionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(LogExclusion).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/exclusions", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/exclusions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateFoldersExclusionsRequest>;
 
@@ -6431,7 +6439,7 @@ export const PatchFoldersExclusionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LogExclusion).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersExclusionsRequest>;
 
@@ -6468,7 +6476,7 @@ export const ListFoldersExclusionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/exclusions" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/exclusions" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersExclusionsRequest>;
 
@@ -6503,7 +6511,7 @@ export const GetFoldersExclusionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersExclusionsRequest>;
 
@@ -6534,7 +6542,7 @@ export const DeleteFoldersLogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     logName: Schema.String.pipe(T.HttpPath("logName")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{logName}" }),
+    T.Http({ method: "DELETE", path: "v2/{+logName}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersLogsRequest>;
 
@@ -6576,7 +6584,7 @@ export const ListFoldersLogsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "v2/{parent}/logs" }),
+  T.Http({ method: "GET", path: "v2/{+parent}/logs" }),
   svc,
 ) as unknown as Schema.Schema<ListFoldersLogsRequest>;
 
@@ -6611,7 +6619,7 @@ export const DeleteFoldersSinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     sinkName: Schema.String.pipe(T.HttpPath("sinkName")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{sinkName}" }),
+    T.Http({ method: "DELETE", path: "v2/{+sinkName}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersSinksRequest>;
 
@@ -6654,7 +6662,7 @@ export const CreateFoldersSinksRequest =
     ),
     body: Schema.optional(LogSink).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/sinks", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/sinks", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateFoldersSinksRequest>;
 
@@ -6700,7 +6708,7 @@ export const PatchFoldersSinksRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LogSink).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{sinkName}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+sinkName}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersSinksRequest>;
 
@@ -6739,7 +6747,7 @@ export const ListFoldersSinksRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/sinks" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/sinks" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersSinksRequest>;
 
@@ -6790,7 +6798,7 @@ export const UpdateFoldersSinksRequest =
     ),
     body: Schema.optional(LogSink).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v2/{sinkName}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v2/{+sinkName}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateFoldersSinksRequest>;
 
@@ -6821,7 +6829,7 @@ export const GetFoldersSinksRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     sinkName: Schema.String.pipe(T.HttpPath("sinkName")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "v2/{sinkName}" }),
+  T.Http({ method: "GET", path: "v2/{+sinkName}" }),
   svc,
 ) as unknown as Schema.Schema<GetFoldersSinksRequest>;
 
@@ -6865,7 +6873,7 @@ export const ListFoldersLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsRequest>;
 
@@ -6900,7 +6908,7 @@ export const GetFoldersLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsRequest>;
 
@@ -6930,7 +6938,7 @@ export const GetFoldersLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsOperationsRequest>;
 
@@ -6975,7 +6983,7 @@ export const ListFoldersLocationsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsOperationsRequest>;
 
@@ -7013,7 +7021,7 @@ export const CancelFoldersLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelFoldersLocationsOperationsRequest>;
 
@@ -7050,7 +7058,7 @@ export const PatchFoldersLocationsBucketsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LogBucket).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersLocationsBucketsRequest>;
 
@@ -7087,7 +7095,7 @@ export const ListFoldersLocationsBucketsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/buckets" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/buckets" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsBucketsRequest>;
 
@@ -7122,7 +7130,7 @@ export const GetFoldersLocationsBucketsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsBucketsRequest>;
 
@@ -7161,7 +7169,7 @@ export const CreateAsyncFoldersLocationsBucketsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/buckets:createAsync",
+      path: "v2/{+parent}/buckets:createAsync",
       hasBody: true,
     }),
     svc,
@@ -7194,7 +7202,7 @@ export const DeleteFoldersLocationsBucketsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersLocationsBucketsRequest>;
 
@@ -7228,7 +7236,7 @@ export const UndeleteFoldersLocationsBucketsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndeleteBucketRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteFoldersLocationsBucketsRequest>;
 
@@ -7265,7 +7273,7 @@ export const UpdateAsyncFoldersLocationsBucketsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LogBucket).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:updateAsync", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:updateAsync", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAsyncFoldersLocationsBucketsRequest>;
 
@@ -7302,7 +7310,7 @@ export const CreateFoldersLocationsBucketsRequest =
     bucketId: Schema.optional(Schema.String).pipe(T.HttpQuery("bucketId")),
     body: Schema.optional(LogBucket).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/buckets", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/buckets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateFoldersLocationsBucketsRequest>;
 
@@ -7338,7 +7346,7 @@ export const GetIamPolicyFoldersLocationsBucketsViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:getIamPolicy",
+      path: "v2/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -7377,7 +7385,7 @@ export const PatchFoldersLocationsBucketsViewsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(LogView).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersLocationsBucketsViewsRequest>;
 
@@ -7414,7 +7422,7 @@ export const ListFoldersLocationsBucketsViewsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/views" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/views" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsBucketsViewsRequest>;
 
@@ -7454,7 +7462,7 @@ export const SetIamPolicyFoldersLocationsBucketsViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -7492,7 +7500,7 @@ export const TestIamPermissionsFoldersLocationsBucketsViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -7526,7 +7534,7 @@ export const GetFoldersLocationsBucketsViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsBucketsViewsRequest>;
 
@@ -7557,7 +7565,7 @@ export const DeleteFoldersLocationsBucketsViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersLocationsBucketsViewsRequest>;
 
@@ -7594,7 +7602,7 @@ export const CreateFoldersLocationsBucketsViewsRequest =
     viewId: Schema.optional(Schema.String).pipe(T.HttpQuery("viewId")),
     body: Schema.optional(LogView).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/views", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/views", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateFoldersLocationsBucketsViewsRequest>;
 
@@ -7636,7 +7644,7 @@ export const ListFoldersLocationsBucketsViewsLogsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/logs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/logs" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsBucketsViewsLogsRequest>;
 
@@ -7677,7 +7685,7 @@ export const ListFoldersLocationsBucketsLinksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/links" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/links" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsBucketsLinksRequest>;
 
@@ -7712,7 +7720,7 @@ export const GetFoldersLocationsBucketsLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsBucketsLinksRequest>;
 
@@ -7743,7 +7751,7 @@ export const DeleteFoldersLocationsBucketsLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersLocationsBucketsLinksRequest>;
 
@@ -7780,7 +7788,7 @@ export const CreateFoldersLocationsBucketsLinksRequest =
     linkId: Schema.optional(Schema.String).pipe(T.HttpQuery("linkId")),
     body: Schema.optional(Link).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/links", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/links", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateFoldersLocationsBucketsLinksRequest>;
 
@@ -7817,7 +7825,7 @@ export const PatchFoldersLocationsSavedQueriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SavedQuery).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersLocationsSavedQueriesRequest>;
 
@@ -7848,7 +7856,7 @@ export const GetFoldersLocationsSavedQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsSavedQueriesRequest>;
 
@@ -7888,7 +7896,7 @@ export const ListFoldersLocationsSavedQueriesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/savedQueries" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/savedQueries" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsSavedQueriesRequest>;
 
@@ -7931,7 +7939,11 @@ export const CreateFoldersLocationsSavedQueriesRequest =
     ),
     body: Schema.optional(SavedQuery).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/savedQueries", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+parent}/savedQueries",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateFoldersLocationsSavedQueriesRequest>;
 
@@ -7962,7 +7974,7 @@ export const DeleteFoldersLocationsSavedQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersLocationsSavedQueriesRequest>;
 
@@ -7993,7 +8005,7 @@ export const DeleteFoldersLocationsLogScopesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersLocationsLogScopesRequest>;
 
@@ -8030,7 +8042,7 @@ export const CreateFoldersLocationsLogScopesRequest =
     logScopeId: Schema.optional(Schema.String).pipe(T.HttpQuery("logScopeId")),
     body: Schema.optional(LogScope).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/logScopes", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/logScopes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateFoldersLocationsLogScopesRequest>;
 
@@ -8067,7 +8079,7 @@ export const PatchFoldersLocationsLogScopesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LogScope).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersLocationsLogScopesRequest>;
 
@@ -8104,7 +8116,7 @@ export const ListFoldersLocationsLogScopesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/logScopes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/logScopes" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsLogScopesRequest>;
 
@@ -8139,7 +8151,7 @@ export const GetFoldersLocationsLogScopesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsLogScopesRequest>;
 
@@ -8179,7 +8191,7 @@ export const ListFoldersLocationsRecentQueriesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/recentQueries" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/recentQueries" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsRecentQueriesRequest>;
 
@@ -8214,7 +8226,7 @@ export interface GetLocationsRequest {
 export const GetLocationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{name}" }),
+  T.Http({ method: "GET", path: "v2/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetLocationsRequest>;
 
@@ -8257,7 +8269,7 @@ export const ListLocationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{name}/locations" }),
+  T.Http({ method: "GET", path: "v2/{+name}/locations" }),
   svc,
 ) as unknown as Schema.Schema<ListLocationsRequest>;
 
@@ -8295,7 +8307,7 @@ export const CancelLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelLocationsOperationsRequest>;
 
@@ -8340,7 +8352,7 @@ export const ListLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListLocationsOperationsRequest>;
 
@@ -8375,7 +8387,7 @@ export const GetLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLocationsOperationsRequest>;
 
@@ -8412,7 +8424,7 @@ export const ListLocationsBucketsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/buckets" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/buckets" }),
     svc,
   ) as unknown as Schema.Schema<ListLocationsBucketsRequest>;
 
@@ -8447,7 +8459,7 @@ export const GetLocationsBucketsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLocationsBucketsRequest>;
 
@@ -8486,7 +8498,7 @@ export const CreateAsyncLocationsBucketsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/buckets:createAsync",
+      path: "v2/{+parent}/buckets:createAsync",
       hasBody: true,
     }),
     svc,
@@ -8525,7 +8537,7 @@ export const PatchLocationsBucketsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LogBucket).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchLocationsBucketsRequest>;
 
@@ -8556,7 +8568,7 @@ export const DeleteLocationsBucketsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteLocationsBucketsRequest>;
 
@@ -8589,7 +8601,7 @@ export const UndeleteLocationsBucketsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndeleteBucketRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteLocationsBucketsRequest>;
 
@@ -8626,7 +8638,7 @@ export const UpdateAsyncLocationsBucketsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LogBucket).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:updateAsync", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:updateAsync", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAsyncLocationsBucketsRequest>;
 
@@ -8663,7 +8675,7 @@ export const CreateLocationsBucketsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(LogBucket).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/buckets", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/buckets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateLocationsBucketsRequest>;
 
@@ -8699,7 +8711,7 @@ export const GetIamPolicyLocationsBucketsViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:getIamPolicy",
+      path: "v2/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -8738,7 +8750,7 @@ export const PatchLocationsBucketsViewsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LogView).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchLocationsBucketsViewsRequest>;
 
@@ -8774,7 +8786,7 @@ export const SetIamPolicyLocationsBucketsViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -8812,7 +8824,7 @@ export const TestIamPermissionsLocationsBucketsViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -8846,7 +8858,7 @@ export const GetLocationsBucketsViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLocationsBucketsViewsRequest>;
 
@@ -8883,7 +8895,7 @@ export const ListLocationsBucketsViewsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/views" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/views" }),
     svc,
   ) as unknown as Schema.Schema<ListLocationsBucketsViewsRequest>;
 
@@ -8924,7 +8936,7 @@ export const CreateLocationsBucketsViewsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(LogView).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/views", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/views", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateLocationsBucketsViewsRequest>;
 
@@ -8955,7 +8967,7 @@ export const DeleteLocationsBucketsViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteLocationsBucketsViewsRequest>;
 
@@ -8992,7 +9004,7 @@ export const CreateLocationsBucketsLinksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Link).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/links", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/links", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateLocationsBucketsLinksRequest>;
 
@@ -9023,7 +9035,7 @@ export const DeleteLocationsBucketsLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteLocationsBucketsLinksRequest>;
 
@@ -9054,7 +9066,7 @@ export const GetLocationsBucketsLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLocationsBucketsLinksRequest>;
 
@@ -9091,7 +9103,7 @@ export const ListLocationsBucketsLinksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/links" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/links" }),
     svc,
   ) as unknown as Schema.Schema<ListLocationsBucketsLinksRequest>;
 
@@ -9164,7 +9176,7 @@ export interface DeleteLogsRequest {
 export const DeleteLogsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   logName: Schema.String.pipe(T.HttpPath("logName")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v2/{logName}" }),
+  T.Http({ method: "DELETE", path: "v2/{+logName}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteLogsRequest>;
 
@@ -9204,7 +9216,7 @@ export const ListLogsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   parent: Schema.String.pipe(T.HttpPath("parent")),
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{parent}/logs" }),
+  T.Http({ method: "GET", path: "v2/{+parent}/logs" }),
   svc,
 ) as unknown as Schema.Schema<ListLogsRequest>;
 
@@ -9244,7 +9256,7 @@ export const UpdateSettingsOrganizationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Settings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}/settings", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}/settings", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSettingsOrganizationsRequest>;
 
@@ -9281,7 +9293,7 @@ export const UpdateCmekSettingsOrganizationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CmekSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}/cmekSettings", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}/cmekSettings", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateCmekSettingsOrganizationsRequest>;
 
@@ -9312,7 +9324,7 @@ export const GetSettingsOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/settings" }),
+    T.Http({ method: "GET", path: "v2/{+name}/settings" }),
     svc,
   ) as unknown as Schema.Schema<GetSettingsOrganizationsRequest>;
 
@@ -9343,7 +9355,7 @@ export const GetCmekSettingsOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/cmekSettings" }),
+    T.Http({ method: "GET", path: "v2/{+name}/cmekSettings" }),
     svc,
   ) as unknown as Schema.Schema<GetCmekSettingsOrganizationsRequest>;
 
@@ -9374,7 +9386,7 @@ export const GetOrganizationsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsRequest>;
 
@@ -9419,7 +9431,7 @@ export const ListOrganizationsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsRequest>;
 
@@ -9457,7 +9469,7 @@ export const CancelOrganizationsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOrganizationsLocationsOperationsRequest>;
 
@@ -9502,7 +9514,7 @@ export const ListOrganizationsLocationsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsOperationsRequest>;
 
@@ -9538,7 +9550,7 @@ export const GetOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsOperationsRequest>;
 
@@ -9577,7 +9589,11 @@ export const CreateOrganizationsLocationsSavedQueriesRequest =
     ),
     body: Schema.optional(SavedQuery).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/savedQueries", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2/{+parent}/savedQueries",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsLocationsSavedQueriesRequest>;
 
@@ -9608,7 +9624,7 @@ export const DeleteOrganizationsLocationsSavedQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsSavedQueriesRequest>;
 
@@ -9645,7 +9661,7 @@ export const PatchOrganizationsLocationsSavedQueriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SavedQuery).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsSavedQueriesRequest>;
 
@@ -9676,7 +9692,7 @@ export const GetOrganizationsLocationsSavedQueriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsSavedQueriesRequest>;
 
@@ -9716,7 +9732,7 @@ export const ListOrganizationsLocationsSavedQueriesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/savedQueries" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/savedQueries" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsSavedQueriesRequest>;
 
@@ -9752,7 +9768,7 @@ export const DeleteOrganizationsLocationsLogScopesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsLogScopesRequest>;
 
@@ -9789,7 +9805,7 @@ export const CreateOrganizationsLocationsLogScopesRequest =
     logScopeId: Schema.optional(Schema.String).pipe(T.HttpQuery("logScopeId")),
     body: Schema.optional(LogScope).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/logScopes", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/logScopes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsLocationsLogScopesRequest>;
 
@@ -9826,7 +9842,7 @@ export const PatchOrganizationsLocationsLogScopesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(LogScope).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsLogScopesRequest>;
 
@@ -9863,7 +9879,7 @@ export const ListOrganizationsLocationsLogScopesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/logScopes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/logScopes" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsLogScopesRequest>;
 
@@ -9898,7 +9914,7 @@ export const GetOrganizationsLocationsLogScopesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsLogScopesRequest>;
 
@@ -9938,7 +9954,7 @@ export const ListOrganizationsLocationsRecentQueriesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/recentQueries" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/recentQueries" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsRecentQueriesRequest>;
 
@@ -9974,7 +9990,7 @@ export const GetOrganizationsLocationsBucketsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsBucketsRequest>;
 
@@ -10013,7 +10029,7 @@ export const CreateAsyncOrganizationsLocationsBucketsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/buckets:createAsync",
+      path: "v2/{+parent}/buckets:createAsync",
       hasBody: true,
     }),
     svc,
@@ -10052,7 +10068,7 @@ export const ListOrganizationsLocationsBucketsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/buckets" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/buckets" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsBucketsRequest>;
 
@@ -10093,7 +10109,7 @@ export const PatchOrganizationsLocationsBucketsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LogBucket).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsBucketsRequest>;
 
@@ -10130,7 +10146,7 @@ export const UpdateAsyncOrganizationsLocationsBucketsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(LogBucket).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:updateAsync", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:updateAsync", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAsyncOrganizationsLocationsBucketsRequest>;
 
@@ -10167,7 +10183,7 @@ export const CreateOrganizationsLocationsBucketsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(LogBucket).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/buckets", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/buckets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsLocationsBucketsRequest>;
 
@@ -10198,7 +10214,7 @@ export const DeleteOrganizationsLocationsBucketsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsBucketsRequest>;
 
@@ -10232,7 +10248,7 @@ export const UndeleteOrganizationsLocationsBucketsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndeleteBucketRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteOrganizationsLocationsBucketsRequest>;
 
@@ -10268,7 +10284,7 @@ export const GetIamPolicyOrganizationsLocationsBucketsViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:getIamPolicy",
+      path: "v2/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -10307,7 +10323,7 @@ export const PatchOrganizationsLocationsBucketsViewsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LogView).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsBucketsViewsRequest>;
 
@@ -10344,7 +10360,7 @@ export const ListOrganizationsLocationsBucketsViewsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/views" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/views" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsBucketsViewsRequest>;
 
@@ -10384,7 +10400,7 @@ export const SetIamPolicyOrganizationsLocationsBucketsViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -10422,7 +10438,7 @@ export const TestIamPermissionsOrganizationsLocationsBucketsViewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -10457,7 +10473,7 @@ export const GetOrganizationsLocationsBucketsViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsBucketsViewsRequest>;
 
@@ -10488,7 +10504,7 @@ export const DeleteOrganizationsLocationsBucketsViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsBucketsViewsRequest>;
 
@@ -10525,7 +10541,7 @@ export const CreateOrganizationsLocationsBucketsViewsRequest =
     viewId: Schema.optional(Schema.String).pipe(T.HttpQuery("viewId")),
     body: Schema.optional(LogView).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/views", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/views", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsLocationsBucketsViewsRequest>;
 
@@ -10567,7 +10583,7 @@ export const ListOrganizationsLocationsBucketsViewsLogsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/logs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/logs" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsBucketsViewsLogsRequest>;
 
@@ -10609,7 +10625,7 @@ export const CreateOrganizationsLocationsBucketsLinksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Link).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/links", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/links", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsLocationsBucketsLinksRequest>;
 
@@ -10640,7 +10656,7 @@ export const DeleteOrganizationsLocationsBucketsLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsBucketsLinksRequest>;
 
@@ -10671,7 +10687,7 @@ export const GetOrganizationsLocationsBucketsLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsBucketsLinksRequest>;
 
@@ -10708,7 +10724,7 @@ export const ListOrganizationsLocationsBucketsLinksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/links" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/links" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsBucketsLinksRequest>;
 
@@ -10749,7 +10765,7 @@ export const ListOrganizationsExclusionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/exclusions" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/exclusions" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsExclusionsRequest>;
 
@@ -10784,7 +10800,7 @@ export const GetOrganizationsExclusionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsExclusionsRequest>;
 
@@ -10821,7 +10837,7 @@ export const PatchOrganizationsExclusionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LogExclusion).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsExclusionsRequest>;
 
@@ -10852,7 +10868,7 @@ export const DeleteOrganizationsExclusionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsExclusionsRequest>;
 
@@ -10886,7 +10902,7 @@ export const CreateOrganizationsExclusionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(LogExclusion).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/exclusions", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/exclusions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsExclusionsRequest>;
 
@@ -10917,7 +10933,7 @@ export const DeleteOrganizationsLogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     logName: Schema.String.pipe(T.HttpPath("logName")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{logName}" }),
+    T.Http({ method: "DELETE", path: "v2/{+logName}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLogsRequest>;
 
@@ -10959,7 +10975,7 @@ export const ListOrganizationsLogsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/logs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/logs" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLogsRequest>;
 
@@ -11010,7 +11026,7 @@ export const PatchOrganizationsSinksRequest =
     ),
     body: Schema.optional(LogSink).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{sinkName}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+sinkName}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsSinksRequest>;
 
@@ -11050,7 +11066,7 @@ export const ListOrganizationsSinksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/sinks" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/sinks" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSinksRequest>;
 
@@ -11101,7 +11117,7 @@ export const UpdateOrganizationsSinksRequest =
     ),
     body: Schema.optional(LogSink).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v2/{sinkName}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v2/{+sinkName}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationsSinksRequest>;
 
@@ -11132,7 +11148,7 @@ export const GetOrganizationsSinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     sinkName: Schema.String.pipe(T.HttpPath("sinkName")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{sinkName}" }),
+    T.Http({ method: "GET", path: "v2/{+sinkName}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsSinksRequest>;
 
@@ -11163,7 +11179,7 @@ export const DeleteOrganizationsSinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     sinkName: Schema.String.pipe(T.HttpPath("sinkName")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{sinkName}" }),
+    T.Http({ method: "DELETE", path: "v2/{+sinkName}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsSinksRequest>;
 
@@ -11207,7 +11223,7 @@ export const CreateOrganizationsSinksRequest =
     ),
     body: Schema.optional(LogSink).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/sinks", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/sinks", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsSinksRequest>;
 

--- a/packages/gcp/src/services/looker-v1.ts
+++ b/packages/gcp/src/services/looker-v1.ts
@@ -728,7 +728,7 @@ export const ListProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -763,7 +763,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -797,7 +797,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -842,7 +842,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -877,7 +877,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -908,7 +908,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -945,7 +945,7 @@ export const CreateProjectsLocationsInstancesRequest =
     instanceId: Schema.optional(Schema.String).pipe(T.HttpQuery("instanceId")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/instances", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/instances", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsInstancesRequest>;
 
@@ -979,7 +979,7 @@ export const DeleteProjectsLocationsInstancesRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesRequest>;
 
@@ -1013,7 +1013,7 @@ export const RestartProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestartInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:restart", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:restart", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestartProjectsLocationsInstancesRequest>;
 
@@ -1047,7 +1047,7 @@ export const RestoreProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestoreInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsInstancesRequest>;
 
@@ -1078,7 +1078,7 @@ export const GetProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesRequest>;
 
@@ -1112,7 +1112,7 @@ export const ExportProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsInstancesRequest>;
 
@@ -1146,7 +1146,7 @@ export const ImportProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ImportInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:import", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:import", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsLocationsInstancesRequest>;
 
@@ -1183,7 +1183,7 @@ export const ListProjectsLocationsInstancesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesRequest>;
 
@@ -1224,7 +1224,7 @@ export const PatchProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInstancesRequest>;
 
@@ -1264,7 +1264,7 @@ export const ListProjectsLocationsInstancesBackupsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesBackupsRequest>;
 
@@ -1300,7 +1300,7 @@ export const GetProjectsLocationsInstancesBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesBackupsRequest>;
 
@@ -1333,7 +1333,7 @@ export const CreateProjectsLocationsInstancesBackupsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(InstanceBackup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/backups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/backups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsInstancesBackupsRequest>;
 
@@ -1364,7 +1364,7 @@ export const DeleteProjectsLocationsInstancesBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesBackupsRequest>;
 

--- a/packages/gcp/src/services/managedidentities-v1.ts
+++ b/packages/gcp/src/services/managedidentities-v1.ts
@@ -1237,7 +1237,7 @@ export const ListProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1272,7 +1272,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1303,7 +1303,7 @@ export const GetProjectsLocationsGlobalPeeringsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalPeeringsRequest>;
 
@@ -1340,7 +1340,7 @@ export const PatchProjectsLocationsGlobalPeeringsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Peering).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlobalPeeringsRequest>;
 
@@ -1376,7 +1376,7 @@ export const SetIamPolicyProjectsLocationsGlobalPeeringsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1415,7 +1415,7 @@ export const CreateProjectsLocationsGlobalPeeringsRequest =
     peeringId: Schema.optional(Schema.String).pipe(T.HttpQuery("peeringId")),
     body: Schema.optional(Peering).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/peerings", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/peerings", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGlobalPeeringsRequest>;
 
@@ -1451,7 +1451,7 @@ export const TestIamPermissionsProjectsLocationsGlobalPeeringsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1498,7 +1498,7 @@ export const ListProjectsLocationsGlobalPeeringsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/peerings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/peerings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalPeeringsRequest>;
 
@@ -1533,7 +1533,7 @@ export const DeleteProjectsLocationsGlobalPeeringsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalPeeringsRequest>;
 
@@ -1569,7 +1569,7 @@ export const GetIamPolicyProjectsLocationsGlobalPeeringsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGlobalPeeringsRequest>;
 
@@ -1600,7 +1600,7 @@ export const GetProjectsLocationsGlobalOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalOperationsRequest>;
 
@@ -1645,7 +1645,7 @@ export const ListProjectsLocationsGlobalOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalOperationsRequest>;
 
@@ -1681,7 +1681,7 @@ export const DeleteProjectsLocationsGlobalOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalOperationsRequest>;
 
@@ -1715,7 +1715,7 @@ export const CancelProjectsLocationsGlobalOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsGlobalOperationsRequest>;
 
@@ -1758,7 +1758,7 @@ export const ListProjectsLocationsGlobalDomainsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/domains" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/domains" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalDomainsRequest>;
 
@@ -1796,7 +1796,7 @@ export const RestoreProjectsLocationsGlobalDomainsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestoreDomainRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsGlobalDomainsRequest>;
 
@@ -1832,7 +1832,7 @@ export const DomainJoinMachineProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{domain}:domainJoinMachine",
+      path: "v1/{+domain}:domainJoinMachine",
       hasBody: true,
     }),
     svc,
@@ -1872,7 +1872,7 @@ export const CheckMigrationPermissionProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{domain}:checkMigrationPermission",
+      path: "v1/{+domain}:checkMigrationPermission",
       hasBody: true,
     }),
     svc,
@@ -1910,7 +1910,7 @@ export const ValidateTrustProjectsLocationsGlobalDomainsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ValidateTrustRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:validateTrust", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:validateTrust", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ValidateTrustProjectsLocationsGlobalDomainsRequest>;
 
@@ -1941,7 +1941,7 @@ export const GetProjectsLocationsGlobalDomainsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalDomainsRequest>;
 
@@ -1975,7 +1975,7 @@ export const DetachTrustProjectsLocationsGlobalDomainsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DetachTrustRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:detachTrust", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:detachTrust", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DetachTrustProjectsLocationsGlobalDomainsRequest>;
 
@@ -2006,7 +2006,7 @@ export const DeleteProjectsLocationsGlobalDomainsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalDomainsRequest>;
 
@@ -2042,7 +2042,7 @@ export const GetIamPolicyProjectsLocationsGlobalDomainsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGlobalDomainsRequest>;
 
@@ -2078,7 +2078,7 @@ export const ReconfigureTrustProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:reconfigureTrust",
+      path: "v1/{+name}:reconfigureTrust",
       hasBody: true,
     }),
     svc,
@@ -2117,7 +2117,7 @@ export const CreateProjectsLocationsGlobalDomainsRequest =
     domainName: Schema.optional(Schema.String).pipe(T.HttpQuery("domainName")),
     body: Schema.optional(Domain).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/domains", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/domains", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGlobalDomainsRequest>;
 
@@ -2153,7 +2153,7 @@ export const DisableMigrationProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{domain}:disableMigration",
+      path: "v1/{+domain}:disableMigration",
       hasBody: true,
     }),
     svc,
@@ -2191,7 +2191,7 @@ export const SetIamPolicyProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2230,7 +2230,11 @@ export const UpdateLdapssettingsProjectsLocationsGlobalDomainsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LDAPSSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}/ldapssettings", hasBody: true }),
+    T.Http({
+      method: "PATCH",
+      path: "v1/{+name}/ldapssettings",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<UpdateLdapssettingsProjectsLocationsGlobalDomainsRequest>;
 
@@ -2263,7 +2267,7 @@ export const GetLdapssettingsProjectsLocationsGlobalDomainsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/ldapssettings" }),
+    T.Http({ method: "GET", path: "v1/{+name}/ldapssettings" }),
     svc,
   ) as unknown as Schema.Schema<GetLdapssettingsProjectsLocationsGlobalDomainsRequest>;
 
@@ -2298,7 +2302,7 @@ export const AttachTrustProjectsLocationsGlobalDomainsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AttachTrustRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:attachTrust", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:attachTrust", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AttachTrustProjectsLocationsGlobalDomainsRequest>;
 
@@ -2332,7 +2336,11 @@ export const ExtendSchemaProjectsLocationsGlobalDomainsRequest =
     domain: Schema.String.pipe(T.HttpPath("domain")),
     body: Schema.optional(ExtendSchemaRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{domain}:extendSchema", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+domain}:extendSchema",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<ExtendSchemaProjectsLocationsGlobalDomainsRequest>;
 
@@ -2369,7 +2377,7 @@ export const PatchProjectsLocationsGlobalDomainsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Domain).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlobalDomainsRequest>;
 
@@ -2405,7 +2413,7 @@ export const EnableMigrationProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{domain}:enableMigration",
+      path: "v1/{+domain}:enableMigration",
       hasBody: true,
     }),
     svc,
@@ -2443,7 +2451,7 @@ export const TestIamPermissionsProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2483,7 +2491,7 @@ export const ResetAdminPasswordProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:resetAdminPassword",
+      path: "v1/{+name}:resetAdminPassword",
       hasBody: true,
     }),
     svc,
@@ -2530,7 +2538,7 @@ export const ListProjectsLocationsGlobalDomainsBackupsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalDomainsBackupsRequest>;
 
@@ -2566,7 +2574,7 @@ export const DeleteProjectsLocationsGlobalDomainsBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalDomainsBackupsRequest>;
 
@@ -2602,7 +2610,7 @@ export const GetIamPolicyProjectsLocationsGlobalDomainsBackupsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGlobalDomainsBackupsRequest>;
 
@@ -2639,7 +2647,7 @@ export const TestIamPermissionsProjectsLocationsGlobalDomainsBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2680,7 +2688,7 @@ export const CreateProjectsLocationsGlobalDomainsBackupsRequest =
     backupId: Schema.optional(Schema.String).pipe(T.HttpQuery("backupId")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/backups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/backups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGlobalDomainsBackupsRequest>;
 
@@ -2711,7 +2719,7 @@ export const GetProjectsLocationsGlobalDomainsBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalDomainsBackupsRequest>;
 
@@ -2748,7 +2756,7 @@ export const PatchProjectsLocationsGlobalDomainsBackupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlobalDomainsBackupsRequest>;
 
@@ -2784,7 +2792,7 @@ export const SetIamPolicyProjectsLocationsGlobalDomainsBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2830,7 +2838,7 @@ export const ListProjectsLocationsGlobalDomainsSqlIntegrationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sqlIntegrations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sqlIntegrations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalDomainsSqlIntegrationsRequest>;
 
@@ -2867,7 +2875,7 @@ export const GetProjectsLocationsGlobalDomainsSqlIntegrationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalDomainsSqlIntegrationsRequest>;
 

--- a/packages/gcp/src/services/managedidentities-v1alpha1.ts
+++ b/packages/gcp/src/services/managedidentities-v1alpha1.ts
@@ -1245,7 +1245,7 @@ export const ListProjectsLocationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1280,7 +1280,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1311,7 +1311,7 @@ export const GetProjectsLocationsGlobalOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalOperationsRequest>;
 
@@ -1356,7 +1356,7 @@ export const ListProjectsLocationsGlobalOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalOperationsRequest>;
 
@@ -1392,7 +1392,7 @@ export const DeleteProjectsLocationsGlobalOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalOperationsRequest>;
 
@@ -1426,7 +1426,7 @@ export const CancelProjectsLocationsGlobalOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsGlobalOperationsRequest>;
 
@@ -1457,7 +1457,7 @@ export const GetLdapssettingsProjectsLocationsGlobalDomainsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/ldapssettings" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/ldapssettings" }),
     svc,
   ) as unknown as Schema.Schema<GetLdapssettingsProjectsLocationsGlobalDomainsRequest>;
 
@@ -1494,7 +1494,7 @@ export const TestIamPermissionsProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:testIamPermissions",
+      path: "v1alpha1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1534,7 +1534,7 @@ export const ValidateTrustProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{name}:validateTrust",
+      path: "v1alpha1/{+name}:validateTrust",
       hasBody: true,
     }),
     svc,
@@ -1572,7 +1572,7 @@ export const SetIamPolicyProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:setIamPolicy",
+      path: "v1alpha1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1610,7 +1610,7 @@ export const DisableMigrationProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{domain}:disableMigration",
+      path: "v1alpha1/{+domain}:disableMigration",
       hasBody: true,
     }),
     svc,
@@ -1643,7 +1643,7 @@ export const GetProjectsLocationsGlobalDomainsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalDomainsRequest>;
 
@@ -1686,7 +1686,7 @@ export const ListProjectsLocationsGlobalDomainsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/domains" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/domains" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalDomainsRequest>;
 
@@ -1724,7 +1724,7 @@ export const RestoreProjectsLocationsGlobalDomainsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestoreDomainRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsGlobalDomainsRequest>;
 
@@ -1760,7 +1760,7 @@ export const AttachTrustProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{name}:attachTrust",
+      path: "v1alpha1/{+name}:attachTrust",
       hasBody: true,
     }),
     svc,
@@ -1798,7 +1798,7 @@ export const DetachTrustProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{name}:detachTrust",
+      path: "v1alpha1/{+name}:detachTrust",
       hasBody: true,
     }),
     svc,
@@ -1836,7 +1836,7 @@ export const EnableMigrationProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{domain}:enableMigration",
+      path: "v1alpha1/{+domain}:enableMigration",
       hasBody: true,
     }),
     svc,
@@ -1877,7 +1877,7 @@ export const CreateProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/domains",
+      path: "v1alpha1/{+parent}/domains",
       hasBody: true,
     }),
     svc,
@@ -1918,7 +1918,7 @@ export const UpdateLdapssettingsProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1alpha1/{name}/ldapssettings",
+      path: "v1alpha1/{+name}/ldapssettings",
       hasBody: true,
     }),
     svc,
@@ -1958,7 +1958,7 @@ export const DomainJoinMachineProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{domain}:domainJoinMachine",
+      path: "v1alpha1/{+domain}:domainJoinMachine",
       hasBody: true,
     }),
     svc,
@@ -1998,7 +1998,7 @@ export const ReconfigureTrustProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{name}:reconfigureTrust",
+      path: "v1alpha1/{+name}:reconfigureTrust",
       hasBody: true,
     }),
     svc,
@@ -2036,7 +2036,7 @@ export const GetIamPolicyProjectsLocationsGlobalDomainsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGlobalDomainsRequest>;
 
@@ -2072,7 +2072,7 @@ export const ResetAdminPasswordProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{name}:resetAdminPassword",
+      path: "v1alpha1/{+name}:resetAdminPassword",
       hasBody: true,
     }),
     svc,
@@ -2112,7 +2112,7 @@ export const CheckMigrationPermissionProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{domain}:checkMigrationPermission",
+      path: "v1alpha1/{+domain}:checkMigrationPermission",
       hasBody: true,
     }),
     svc,
@@ -2153,7 +2153,7 @@ export const PatchProjectsLocationsGlobalDomainsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Domain).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlobalDomainsRequest>;
 
@@ -2189,7 +2189,7 @@ export const ExtendSchemaProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{domain}:extendSchema",
+      path: "v1alpha1/{+domain}:extendSchema",
       hasBody: true,
     }),
     svc,
@@ -2222,7 +2222,7 @@ export const DeleteProjectsLocationsGlobalDomainsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalDomainsRequest>;
 
@@ -2253,7 +2253,7 @@ export const GetProjectsLocationsGlobalDomainsSqlIntegrationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalDomainsSqlIntegrationsRequest>;
 
@@ -2298,7 +2298,7 @@ export const ListProjectsLocationsGlobalDomainsSqlIntegrationsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/sqlIntegrations" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/sqlIntegrations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalDomainsSqlIntegrationsRequest>;
 
@@ -2347,7 +2347,7 @@ export const ListProjectsLocationsGlobalDomainsBackupsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalDomainsBackupsRequest>;
 
@@ -2383,7 +2383,7 @@ export const GetProjectsLocationsGlobalDomainsBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalDomainsBackupsRequest>;
 
@@ -2419,7 +2419,7 @@ export const GetIamPolicyProjectsLocationsGlobalDomainsBackupsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGlobalDomainsBackupsRequest>;
 
@@ -2456,7 +2456,7 @@ export const TestIamPermissionsProjectsLocationsGlobalDomainsBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:testIamPermissions",
+      path: "v1alpha1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2496,7 +2496,7 @@ export const SetIamPolicyProjectsLocationsGlobalDomainsBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:setIamPolicy",
+      path: "v1alpha1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2536,7 +2536,7 @@ export const PatchProjectsLocationsGlobalDomainsBackupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlobalDomainsBackupsRequest>;
 
@@ -2575,7 +2575,7 @@ export const CreateProjectsLocationsGlobalDomainsBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/backups",
+      path: "v1alpha1/{+parent}/backups",
       hasBody: true,
     }),
     svc,
@@ -2608,7 +2608,7 @@ export const DeleteProjectsLocationsGlobalDomainsBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalDomainsBackupsRequest>;
 
@@ -2651,7 +2651,7 @@ export const ListProjectsLocationsGlobalPeeringsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/peerings" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/peerings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalPeeringsRequest>;
 
@@ -2686,7 +2686,7 @@ export const GetProjectsLocationsGlobalPeeringsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalPeeringsRequest>;
 
@@ -2722,7 +2722,7 @@ export const GetIamPolicyProjectsLocationsGlobalPeeringsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGlobalPeeringsRequest>;
 
@@ -2758,7 +2758,7 @@ export const TestIamPermissionsProjectsLocationsGlobalPeeringsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:testIamPermissions",
+      path: "v1alpha1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2798,7 +2798,7 @@ export const SetIamPolicyProjectsLocationsGlobalPeeringsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:setIamPolicy",
+      path: "v1alpha1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2837,7 +2837,7 @@ export const PatchProjectsLocationsGlobalPeeringsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Peering).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlobalPeeringsRequest>;
 
@@ -2876,7 +2876,7 @@ export const CreateProjectsLocationsGlobalPeeringsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/peerings",
+      path: "v1alpha1/{+parent}/peerings",
       hasBody: true,
     }),
     svc,
@@ -2909,7 +2909,7 @@ export const DeleteProjectsLocationsGlobalPeeringsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalPeeringsRequest>;
 

--- a/packages/gcp/src/services/managedidentities-v1beta1.ts
+++ b/packages/gcp/src/services/managedidentities-v1beta1.ts
@@ -1248,7 +1248,7 @@ export const ListProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1283,7 +1283,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1328,7 +1328,7 @@ export const ListProjectsLocationsGlobalOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalOperationsRequest>;
 
@@ -1364,7 +1364,7 @@ export const GetProjectsLocationsGlobalOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalOperationsRequest>;
 
@@ -1395,7 +1395,7 @@ export const DeleteProjectsLocationsGlobalOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalOperationsRequest>;
 
@@ -1429,7 +1429,7 @@ export const CancelProjectsLocationsGlobalOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsGlobalOperationsRequest>;
 
@@ -1465,7 +1465,7 @@ export const DetachTrustProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:detachTrust",
+      path: "v1beta1/{+name}:detachTrust",
       hasBody: true,
     }),
     svc,
@@ -1501,7 +1501,7 @@ export const RestoreProjectsLocationsGlobalDomainsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestoreDomainRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsGlobalDomainsRequest>;
 
@@ -1537,7 +1537,7 @@ export const SetIamPolicyProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1576,7 +1576,11 @@ export const CreateProjectsLocationsGlobalDomainsRequest =
     domainName: Schema.optional(Schema.String).pipe(T.HttpQuery("domainName")),
     body: Schema.optional(Domain).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/domains", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/domains",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGlobalDomainsRequest>;
 
@@ -1607,7 +1611,7 @@ export const GetProjectsLocationsGlobalDomainsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalDomainsRequest>;
 
@@ -1643,7 +1647,7 @@ export const TestIamPermissionsProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1683,7 +1687,7 @@ export const CheckMigrationPermissionProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{domain}:checkMigrationPermission",
+      path: "v1beta1/{+domain}:checkMigrationPermission",
       hasBody: true,
     }),
     svc,
@@ -1723,7 +1727,7 @@ export const ExtendSchemaProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{domain}:extendSchema",
+      path: "v1beta1/{+domain}:extendSchema",
       hasBody: true,
     }),
     svc,
@@ -1761,7 +1765,7 @@ export const ValidateTrustProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:validateTrust",
+      path: "v1beta1/{+name}:validateTrust",
       hasBody: true,
     }),
     svc,
@@ -1794,7 +1798,7 @@ export const DeleteProjectsLocationsGlobalDomainsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalDomainsRequest>;
 
@@ -1833,7 +1837,7 @@ export const UpdateLdapssettingsProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1beta1/{name}/ldapssettings",
+      path: "v1beta1/{+name}/ldapssettings",
       hasBody: true,
     }),
     svc,
@@ -1868,7 +1872,7 @@ export const GetLdapssettingsProjectsLocationsGlobalDomainsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/ldapssettings" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/ldapssettings" }),
     svc,
   ) as unknown as Schema.Schema<GetLdapssettingsProjectsLocationsGlobalDomainsRequest>;
 
@@ -1905,7 +1909,7 @@ export const DomainJoinMachineProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{domain}:domainJoinMachine",
+      path: "v1beta1/{+domain}:domainJoinMachine",
       hasBody: true,
     }),
     svc,
@@ -1945,7 +1949,7 @@ export const GetIamPolicyProjectsLocationsGlobalDomainsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGlobalDomainsRequest>;
 
@@ -1981,7 +1985,7 @@ export const ResetAdminPasswordProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:resetAdminPassword",
+      path: "v1beta1/{+name}:resetAdminPassword",
       hasBody: true,
     }),
     svc,
@@ -2021,7 +2025,7 @@ export const DisableMigrationProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{domain}:disableMigration",
+      path: "v1beta1/{+domain}:disableMigration",
       hasBody: true,
     }),
     svc,
@@ -2060,7 +2064,7 @@ export const PatchProjectsLocationsGlobalDomainsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Domain).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlobalDomainsRequest>;
 
@@ -2096,7 +2100,7 @@ export const AttachTrustProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:attachTrust",
+      path: "v1beta1/{+name}:attachTrust",
       hasBody: true,
     }),
     svc,
@@ -2134,7 +2138,7 @@ export const EnableMigrationProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{domain}:enableMigration",
+      path: "v1beta1/{+domain}:enableMigration",
       hasBody: true,
     }),
     svc,
@@ -2179,7 +2183,7 @@ export const ListProjectsLocationsGlobalDomainsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/domains" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/domains" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalDomainsRequest>;
 
@@ -2219,7 +2223,7 @@ export const ReconfigureTrustProjectsLocationsGlobalDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:reconfigureTrust",
+      path: "v1beta1/{+name}:reconfigureTrust",
       hasBody: true,
     }),
     svc,
@@ -2264,7 +2268,7 @@ export const ListProjectsLocationsGlobalDomainsSqlIntegrationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/sqlIntegrations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/sqlIntegrations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalDomainsSqlIntegrationsRequest>;
 
@@ -2301,7 +2305,7 @@ export const GetProjectsLocationsGlobalDomainsSqlIntegrationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalDomainsSqlIntegrationsRequest>;
 
@@ -2339,7 +2343,7 @@ export const GetIamPolicyProjectsLocationsGlobalDomainsBackupsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGlobalDomainsBackupsRequest>;
 
@@ -2371,7 +2375,7 @@ export const GetProjectsLocationsGlobalDomainsBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalDomainsBackupsRequest>;
 
@@ -2407,7 +2411,7 @@ export const TestIamPermissionsProjectsLocationsGlobalDomainsBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2448,7 +2452,11 @@ export const CreateProjectsLocationsGlobalDomainsBackupsRequest =
     backupId: Schema.optional(Schema.String).pipe(T.HttpQuery("backupId")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/backups", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/backups",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGlobalDomainsBackupsRequest>;
 
@@ -2485,7 +2493,7 @@ export const PatchProjectsLocationsGlobalDomainsBackupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlobalDomainsBackupsRequest>;
 
@@ -2521,7 +2529,7 @@ export const SetIamPolicyProjectsLocationsGlobalDomainsBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2567,7 +2575,7 @@ export const ListProjectsLocationsGlobalDomainsBackupsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalDomainsBackupsRequest>;
 
@@ -2603,7 +2611,7 @@ export const DeleteProjectsLocationsGlobalDomainsBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalDomainsBackupsRequest>;
 
@@ -2646,7 +2654,7 @@ export const ListProjectsLocationsGlobalPeeringsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/peerings" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/peerings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalPeeringsRequest>;
 
@@ -2681,7 +2689,7 @@ export const DeleteProjectsLocationsGlobalPeeringsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalPeeringsRequest>;
 
@@ -2720,7 +2728,7 @@ export const CreateProjectsLocationsGlobalPeeringsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/peerings",
+      path: "v1beta1/{+parent}/peerings",
       hasBody: true,
     }),
     svc,
@@ -2759,7 +2767,7 @@ export const PatchProjectsLocationsGlobalPeeringsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Peering).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlobalPeeringsRequest>;
 
@@ -2795,7 +2803,7 @@ export const SetIamPolicyProjectsLocationsGlobalPeeringsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2833,7 +2841,7 @@ export const GetIamPolicyProjectsLocationsGlobalPeeringsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGlobalPeeringsRequest>;
 
@@ -2864,7 +2872,7 @@ export const GetProjectsLocationsGlobalPeeringsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalPeeringsRequest>;
 
@@ -2900,7 +2908,7 @@ export const TestIamPermissionsProjectsLocationsGlobalPeeringsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/managedkafka-v1.ts
+++ b/packages/gcp/src/services/managedkafka-v1.ts
@@ -1009,7 +1009,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1044,7 +1044,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1089,7 +1089,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1124,7 +1124,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1155,7 +1155,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1189,7 +1189,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1232,7 +1232,7 @@ export const ListProjectsLocationsClustersRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/clusters" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/clusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersRequest>;
 
@@ -1274,7 +1274,7 @@ export const GetProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersRequest>;
 
@@ -1314,7 +1314,7 @@ export const CreateProjectsLocationsClustersRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Cluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/clusters", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/clusters", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsClustersRequest>;
 
@@ -1354,7 +1354,7 @@ export const PatchProjectsLocationsClustersRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Cluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsClustersRequest>;
 
@@ -1388,7 +1388,7 @@ export const DeleteProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersRequest>;
 
@@ -1425,7 +1425,7 @@ export const ListProjectsLocationsClustersTopicsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/topics" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/topics" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersTopicsRequest>;
 
@@ -1460,7 +1460,7 @@ export const GetProjectsLocationsClustersTopicsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersTopicsRequest>;
 
@@ -1497,7 +1497,7 @@ export const CreateProjectsLocationsClustersTopicsRequest =
     topicId: Schema.optional(Schema.String).pipe(T.HttpQuery("topicId")),
     body: Schema.optional(Topic).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/topics", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/topics", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsClustersTopicsRequest>;
 
@@ -1534,7 +1534,7 @@ export const PatchProjectsLocationsClustersTopicsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Topic).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsClustersTopicsRequest>;
 
@@ -1565,7 +1565,7 @@ export const DeleteProjectsLocationsClustersTopicsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersTopicsRequest>;
 
@@ -1612,7 +1612,7 @@ export const ListProjectsLocationsClustersConsumerGroupsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/consumerGroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/consumerGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersConsumerGroupsRequest>;
 
@@ -1648,7 +1648,7 @@ export const GetProjectsLocationsClustersConsumerGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersConsumerGroupsRequest>;
 
@@ -1685,7 +1685,7 @@ export const PatchProjectsLocationsClustersConsumerGroupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ConsumerGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsClustersConsumerGroupsRequest>;
 
@@ -1717,7 +1717,7 @@ export const DeleteProjectsLocationsClustersConsumerGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersConsumerGroupsRequest>;
 
@@ -1754,7 +1754,7 @@ export const ListProjectsLocationsClustersAclsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/acls" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/acls" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersAclsRequest>;
 
@@ -1789,7 +1789,7 @@ export const GetProjectsLocationsClustersAclsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersAclsRequest>;
 
@@ -1826,7 +1826,7 @@ export const CreateProjectsLocationsClustersAclsRequest =
     aclId: Schema.optional(Schema.String).pipe(T.HttpQuery("aclId")),
     body: Schema.optional(Acl).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/acls", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/acls", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsClustersAclsRequest>;
 
@@ -1863,7 +1863,7 @@ export const PatchProjectsLocationsClustersAclsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Acl).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsClustersAclsRequest>;
 
@@ -1894,7 +1894,7 @@ export const DeleteProjectsLocationsClustersAclsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersAclsRequest>;
 
@@ -1928,7 +1928,7 @@ export const AddAclEntryProjectsLocationsClustersAclsRequest =
     acl: Schema.String.pipe(T.HttpPath("acl")),
     body: Schema.optional(AclEntry).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{acl}:addAclEntry", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+acl}:addAclEntry", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AddAclEntryProjectsLocationsClustersAclsRequest>;
 
@@ -1963,7 +1963,7 @@ export const RemoveAclEntryProjectsLocationsClustersAclsRequest =
     acl: Schema.String.pipe(T.HttpPath("acl")),
     body: Schema.optional(AclEntry).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{acl}:removeAclEntry", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+acl}:removeAclEntry", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RemoveAclEntryProjectsLocationsClustersAclsRequest>;
 
@@ -2007,7 +2007,7 @@ export const ListProjectsLocationsConnectClustersRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/connectClusters" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/connectClusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectClustersRequest>;
 
@@ -2043,7 +2043,7 @@ export const GetProjectsLocationsConnectClustersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectClustersRequest>;
 
@@ -2087,7 +2087,7 @@ export const CreateProjectsLocationsConnectClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/connectClusters",
+      path: "v1/{+parent}/connectClusters",
       hasBody: true,
     }),
     svc,
@@ -2129,7 +2129,7 @@ export const PatchProjectsLocationsConnectClustersRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(ConnectCluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectClustersRequest>;
 
@@ -2163,7 +2163,7 @@ export const DeleteProjectsLocationsConnectClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectClustersRequest>;
 
@@ -2200,7 +2200,7 @@ export const ListProjectsLocationsConnectClustersConnectorsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/connectors" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/connectors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectClustersConnectorsRequest>;
 
@@ -2236,7 +2236,7 @@ export const GetProjectsLocationsConnectClustersConnectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectClustersConnectorsRequest>;
 
@@ -2275,7 +2275,7 @@ export const CreateProjectsLocationsConnectClustersConnectorsRequest =
     ),
     body: Schema.optional(Connector).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/connectors", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/connectors", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsConnectClustersConnectorsRequest>;
 
@@ -2314,7 +2314,7 @@ export const PatchProjectsLocationsConnectClustersConnectorsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Connector).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectClustersConnectorsRequest>;
 
@@ -2346,7 +2346,7 @@ export const DeleteProjectsLocationsConnectClustersConnectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectClustersConnectorsRequest>;
 
@@ -2381,7 +2381,7 @@ export const PauseProjectsLocationsConnectClustersConnectorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PauseConnectorRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsLocationsConnectClustersConnectorsRequest>;
 
@@ -2417,7 +2417,7 @@ export const ResumeProjectsLocationsConnectClustersConnectorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResumeConnectorRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsConnectClustersConnectorsRequest>;
 
@@ -2453,7 +2453,7 @@ export const RestartProjectsLocationsConnectClustersConnectorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestartConnectorRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:restart", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:restart", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestartProjectsLocationsConnectClustersConnectorsRequest>;
 
@@ -2489,7 +2489,7 @@ export const StopProjectsLocationsConnectClustersConnectorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopConnectorRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsConnectClustersConnectorsRequest>;
 
@@ -2521,7 +2521,7 @@ export const GetProjectsLocationsSchemaRegistriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchemaRegistriesRequest>;
 
@@ -2559,7 +2559,7 @@ export const ListProjectsLocationsSchemaRegistriesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/schemaRegistries" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/schemaRegistries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchemaRegistriesRequest>;
 
@@ -2596,7 +2596,7 @@ export const CreateProjectsLocationsSchemaRegistriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/schemaRegistries",
+      path: "v1/{+parent}/schemaRegistries",
       hasBody: true,
     }),
     svc,
@@ -2629,7 +2629,7 @@ export const DeleteProjectsLocationsSchemaRegistriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSchemaRegistriesRequest>;
 
@@ -2660,7 +2660,7 @@ export const GetProjectsLocationsSchemaRegistriesContextsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchemaRegistriesContextsRequest>;
 
@@ -2691,7 +2691,7 @@ export const ListProjectsLocationsSchemaRegistriesContextsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/contexts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/contexts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchemaRegistriesContextsRequest>;
 
@@ -2725,7 +2725,7 @@ export const GetProjectsLocationsSchemaRegistriesContextsSchemasRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     subject: Schema.optional(Schema.String).pipe(T.HttpQuery("subject")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchemaRegistriesContextsSchemasRequest>;
 
@@ -2761,7 +2761,7 @@ export const GetSchemaProjectsLocationsSchemaRegistriesContextsSchemasRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     subject: Schema.optional(Schema.String).pipe(T.HttpQuery("subject")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/schema" }),
+    T.Http({ method: "GET", path: "v1/{+name}/schema" }),
     svc,
   ) as unknown as Schema.Schema<GetSchemaProjectsLocationsSchemaRegistriesContextsSchemasRequest>;
 
@@ -2800,7 +2800,7 @@ export const ListProjectsLocationsSchemaRegistriesContextsSchemasVersionsRequest
     subject: Schema.optional(Schema.String).pipe(T.HttpQuery("subject")),
     deleted: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("deleted")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchemaRegistriesContextsSchemasVersionsRequest>;
 
@@ -2833,7 +2833,7 @@ export const ListProjectsLocationsSchemaRegistriesContextsSchemasTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/schemas/types" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/schemas/types" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchemaRegistriesContextsSchemasTypesRequest>;
 
@@ -2872,7 +2872,7 @@ export const ListProjectsLocationsSchemaRegistriesContextsSchemasSubjectsRequest
     subject: Schema.optional(Schema.String).pipe(T.HttpQuery("subject")),
     deleted: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("deleted")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/subjects" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/subjects" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchemaRegistriesContextsSchemasSubjectsRequest>;
 
@@ -2913,7 +2913,7 @@ export const ListProjectsLocationsSchemaRegistriesContextsSubjectsRequest =
     ),
     deleted: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("deleted")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/subjects" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/subjects" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchemaRegistriesContextsSubjectsRequest>;
 
@@ -2949,7 +2949,7 @@ export const DeleteProjectsLocationsSchemaRegistriesContextsSubjectsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     permanent: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("permanent")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSchemaRegistriesContextsSubjectsRequest>;
 
@@ -2985,7 +2985,7 @@ export const LookupVersionProjectsLocationsSchemaRegistriesContextsSubjectsReque
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(LookupVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<LookupVersionProjectsLocationsSchemaRegistriesContextsSubjectsRequest>;
 
@@ -3022,7 +3022,7 @@ export const GetProjectsLocationsSchemaRegistriesContextsSubjectsVersionsRequest
     name: Schema.String.pipe(T.HttpPath("name")),
     deleted: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("deleted")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchemaRegistriesContextsSubjectsVersionsRequest>;
 
@@ -3058,7 +3058,7 @@ export const GetSchemaProjectsLocationsSchemaRegistriesContextsSubjectsVersionsR
     name: Schema.String.pipe(T.HttpPath("name")),
     deleted: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("deleted")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/schema" }),
+    T.Http({ method: "GET", path: "v1/{+name}/schema" }),
     svc,
   ) as unknown as Schema.Schema<GetSchemaProjectsLocationsSchemaRegistriesContextsSubjectsVersionsRequest>;
 
@@ -3096,7 +3096,7 @@ export const ListProjectsLocationsSchemaRegistriesContextsSubjectsVersionsReques
     parent: Schema.String.pipe(T.HttpPath("parent")),
     deleted: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("deleted")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchemaRegistriesContextsSubjectsVersionsRequest>;
 
@@ -3132,7 +3132,7 @@ export const CreateProjectsLocationsSchemaRegistriesContextsSubjectsVersionsRequ
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/versions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/versions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSchemaRegistriesContextsSubjectsVersionsRequest>;
 
@@ -3169,7 +3169,7 @@ export const DeleteProjectsLocationsSchemaRegistriesContextsSubjectsVersionsRequ
     name: Schema.String.pipe(T.HttpPath("name")),
     permanent: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("permanent")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSchemaRegistriesContextsSubjectsVersionsRequest>;
 
@@ -3203,7 +3203,7 @@ export const ListProjectsLocationsSchemaRegistriesContextsSubjectsVersionsRefere
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/referencedby" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/referencedby" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchemaRegistriesContextsSubjectsVersionsReferencedbyRequest>;
 
@@ -3241,7 +3241,7 @@ export const CheckCompatibilityProjectsLocationsSchemaRegistriesContextsCompatib
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CheckCompatibilityRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CheckCompatibilityProjectsLocationsSchemaRegistriesContextsCompatibilityRequest>;
 
@@ -3281,7 +3281,7 @@ export const GetProjectsLocationsSchemaRegistriesContextsConfigRequest =
       T.HttpQuery("defaultToGlobal"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchemaRegistriesContextsConfigRequest>;
 
@@ -3317,7 +3317,7 @@ export const UpdateProjectsLocationsSchemaRegistriesContextsConfigRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateSchemaConfigRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsSchemaRegistriesContextsConfigRequest>;
 
@@ -3350,7 +3350,7 @@ export const DeleteProjectsLocationsSchemaRegistriesContextsConfigRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSchemaRegistriesContextsConfigRequest>;
 
@@ -3383,7 +3383,7 @@ export const GetProjectsLocationsSchemaRegistriesContextsModeRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchemaRegistriesContextsModeRequest>;
 
@@ -3419,7 +3419,7 @@ export const UpdateProjectsLocationsSchemaRegistriesContextsModeRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateSchemaModeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsSchemaRegistriesContextsModeRequest>;
 
@@ -3452,7 +3452,7 @@ export const DeleteProjectsLocationsSchemaRegistriesContextsModeRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSchemaRegistriesContextsModeRequest>;
 
@@ -3488,7 +3488,7 @@ export const GetProjectsLocationsSchemaRegistriesSchemasRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     subject: Schema.optional(Schema.String).pipe(T.HttpQuery("subject")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchemaRegistriesSchemasRequest>;
 
@@ -3523,7 +3523,7 @@ export const GetSchemaProjectsLocationsSchemaRegistriesSchemasRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     subject: Schema.optional(Schema.String).pipe(T.HttpQuery("subject")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/schema" }),
+    T.Http({ method: "GET", path: "v1/{+name}/schema" }),
     svc,
   ) as unknown as Schema.Schema<GetSchemaProjectsLocationsSchemaRegistriesSchemasRequest>;
 
@@ -3562,7 +3562,7 @@ export const ListProjectsLocationsSchemaRegistriesSchemasVersionsRequest =
     subject: Schema.optional(Schema.String).pipe(T.HttpQuery("subject")),
     deleted: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("deleted")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchemaRegistriesSchemasVersionsRequest>;
 
@@ -3595,7 +3595,7 @@ export const ListProjectsLocationsSchemaRegistriesSchemasTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/schemas/types" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/schemas/types" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchemaRegistriesSchemasTypesRequest>;
 
@@ -3634,7 +3634,7 @@ export const ListProjectsLocationsSchemaRegistriesSchemasSubjectsRequest =
     subject: Schema.optional(Schema.String).pipe(T.HttpQuery("subject")),
     deleted: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("deleted")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/subjects" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/subjects" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchemaRegistriesSchemasSubjectsRequest>;
 
@@ -3675,7 +3675,7 @@ export const ListProjectsLocationsSchemaRegistriesSubjectsRequest =
     ),
     deleted: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("deleted")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/subjects" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/subjects" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchemaRegistriesSubjectsRequest>;
 
@@ -3709,7 +3709,7 @@ export const DeleteProjectsLocationsSchemaRegistriesSubjectsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     permanent: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("permanent")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSchemaRegistriesSubjectsRequest>;
 
@@ -3744,7 +3744,7 @@ export const LookupVersionProjectsLocationsSchemaRegistriesSubjectsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(LookupVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<LookupVersionProjectsLocationsSchemaRegistriesSubjectsRequest>;
 
@@ -3780,7 +3780,7 @@ export const GetProjectsLocationsSchemaRegistriesSubjectsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     deleted: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("deleted")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchemaRegistriesSubjectsVersionsRequest>;
 
@@ -3816,7 +3816,7 @@ export const GetSchemaProjectsLocationsSchemaRegistriesSubjectsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     deleted: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("deleted")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/schema" }),
+    T.Http({ method: "GET", path: "v1/{+name}/schema" }),
     svc,
   ) as unknown as Schema.Schema<GetSchemaProjectsLocationsSchemaRegistriesSubjectsVersionsRequest>;
 
@@ -3852,7 +3852,7 @@ export const ListProjectsLocationsSchemaRegistriesSubjectsVersionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     deleted: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("deleted")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchemaRegistriesSubjectsVersionsRequest>;
 
@@ -3888,7 +3888,7 @@ export const CreateProjectsLocationsSchemaRegistriesSubjectsVersionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/versions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/versions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSchemaRegistriesSubjectsVersionsRequest>;
 
@@ -3924,7 +3924,7 @@ export const DeleteProjectsLocationsSchemaRegistriesSubjectsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     permanent: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("permanent")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSchemaRegistriesSubjectsVersionsRequest>;
 
@@ -3957,7 +3957,7 @@ export const ListProjectsLocationsSchemaRegistriesSubjectsVersionsReferencedbyRe
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/referencedby" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/referencedby" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchemaRegistriesSubjectsVersionsReferencedbyRequest>;
 
@@ -3995,7 +3995,7 @@ export const CheckCompatibilityProjectsLocationsSchemaRegistriesCompatibilityReq
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CheckCompatibilityRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CheckCompatibilityProjectsLocationsSchemaRegistriesCompatibilityRequest>;
 
@@ -4035,7 +4035,7 @@ export const GetProjectsLocationsSchemaRegistriesConfigRequest =
       T.HttpQuery("defaultToGlobal"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchemaRegistriesConfigRequest>;
 
@@ -4069,7 +4069,7 @@ export const UpdateProjectsLocationsSchemaRegistriesConfigRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateSchemaConfigRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsSchemaRegistriesConfigRequest>;
 
@@ -4101,7 +4101,7 @@ export const DeleteProjectsLocationsSchemaRegistriesConfigRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSchemaRegistriesConfigRequest>;
 
@@ -4133,7 +4133,7 @@ export const GetProjectsLocationsSchemaRegistriesModeRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchemaRegistriesModeRequest>;
 
@@ -4167,7 +4167,7 @@ export const UpdateProjectsLocationsSchemaRegistriesModeRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateSchemaModeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsLocationsSchemaRegistriesModeRequest>;
 
@@ -4198,7 +4198,7 @@ export const DeleteProjectsLocationsSchemaRegistriesModeRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSchemaRegistriesModeRequest>;
 

--- a/packages/gcp/src/services/manufacturers-v1.ts
+++ b/packages/gcp/src/services/manufacturers-v1.ts
@@ -694,7 +694,7 @@ export const GetAccountsProductsRequest =
     ),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/products/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/products/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsProductsRequest>;
 
@@ -727,7 +727,7 @@ export const DeleteAccountsProductsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{parent}/products/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+parent}/products/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsProductsRequest>;
 
@@ -773,7 +773,7 @@ export const ListAccountsProductsRequest =
       T.HttpQuery("include"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/products" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/products" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsProductsRequest>;
 
@@ -816,7 +816,7 @@ export const UpdateAccountsProductsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "v1/{parent}/products/{name}",
+      path: "v1/{+parent}/products/{+name}",
       hasBody: true,
     }),
     svc,
@@ -854,7 +854,7 @@ export const ListAccountsLanguagesProductCertificationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/productCertifications" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/productCertifications" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsLanguagesProductCertificationsRequest>;
 
@@ -896,7 +896,7 @@ export const PatchAccountsLanguagesProductCertificationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ProductCertification).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsLanguagesProductCertificationsRequest>;
 
@@ -928,7 +928,7 @@ export const GetAccountsLanguagesProductCertificationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsLanguagesProductCertificationsRequest>;
 
@@ -960,7 +960,7 @@ export const DeleteAccountsLanguagesProductCertificationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsLanguagesProductCertificationsRequest>;
 

--- a/packages/gcp/src/services/marketingplatformadmin-v1alpha.ts
+++ b/packages/gcp/src/services/marketingplatformadmin-v1alpha.ts
@@ -268,7 +268,7 @@ export const GetOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsRequest>;
 
@@ -342,7 +342,7 @@ export const ReportPropertyUsageOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{organization}:reportPropertyUsage",
+      path: "v1alpha/{+organization}:reportPropertyUsage",
       hasBody: true,
     }),
     svc,
@@ -383,7 +383,7 @@ export const FindSalesPartnerManagedClientsOrganizationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{organization}:findSalesPartnerManagedClients",
+      path: "v1alpha/{+organization}:findSalesPartnerManagedClients",
       hasBody: true,
     }),
     svc,
@@ -417,7 +417,7 @@ export const DeleteOrganizationsAnalyticsAccountLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsAnalyticsAccountLinksRequest>;
 
@@ -454,7 +454,7 @@ export const ListOrganizationsAnalyticsAccountLinksRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/analyticsAccountLinks" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/analyticsAccountLinks" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsAnalyticsAccountLinksRequest>;
 
@@ -495,7 +495,7 @@ export const CreateOrganizationsAnalyticsAccountLinksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/analyticsAccountLinks",
+      path: "v1alpha/{+parent}/analyticsAccountLinks",
       hasBody: true,
     }),
     svc,
@@ -536,7 +536,7 @@ export const SetPropertyServiceLevelOrganizationsAnalyticsAccountLinksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{analyticsAccountLink}:setPropertyServiceLevel",
+      path: "v1alpha/{+analyticsAccountLink}:setPropertyServiceLevel",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/meet-v2.ts
+++ b/packages/gcp/src/services/meet-v2.ts
@@ -581,7 +581,7 @@ export interface GetSpacesRequest {
 export const GetSpacesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v2/{name}" }),
+  T.Http({ method: "GET", path: "v2/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetSpacesRequest>;
 
@@ -616,7 +616,7 @@ export const EndActiveConferenceSpacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:endActiveConference",
+      path: "v2/{+name}:endActiveConference",
       hasBody: true,
     }),
     svc,
@@ -654,7 +654,7 @@ export const PatchSpacesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(Space).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchSpacesRequest>;
 
@@ -684,7 +684,7 @@ export const GetConferenceRecordsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConferenceRecordsRequest>;
 
@@ -756,7 +756,7 @@ export const GetConferenceRecordsRecordingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConferenceRecordsRecordingsRequest>;
 
@@ -793,7 +793,7 @@ export const ListConferenceRecordsRecordingsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/recordings" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/recordings" }),
     svc,
   ) as unknown as Schema.Schema<ListConferenceRecordsRecordingsRequest>;
 
@@ -828,7 +828,7 @@ export const GetConferenceRecordsParticipantsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConferenceRecordsParticipantsRequest>;
 
@@ -868,7 +868,7 @@ export const ListConferenceRecordsParticipantsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/participants" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/participants" }),
     svc,
   ) as unknown as Schema.Schema<ListConferenceRecordsParticipantsRequest>;
 
@@ -904,7 +904,7 @@ export const GetConferenceRecordsParticipantsParticipantSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConferenceRecordsParticipantsParticipantSessionsRequest>;
 
@@ -946,7 +946,7 @@ export const ListConferenceRecordsParticipantsParticipantSessionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/participantSessions" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/participantSessions" }),
     svc,
   ) as unknown as Schema.Schema<ListConferenceRecordsParticipantsParticipantSessionsRequest>;
 
@@ -983,7 +983,7 @@ export const GetConferenceRecordsTranscriptsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConferenceRecordsTranscriptsRequest>;
 
@@ -1020,7 +1020,7 @@ export const ListConferenceRecordsTranscriptsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/transcripts" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/transcripts" }),
     svc,
   ) as unknown as Schema.Schema<ListConferenceRecordsTranscriptsRequest>;
 
@@ -1055,7 +1055,7 @@ export const GetConferenceRecordsTranscriptsEntriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConferenceRecordsTranscriptsEntriesRequest>;
 
@@ -1092,7 +1092,7 @@ export const ListConferenceRecordsTranscriptsEntriesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/entries" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/entries" }),
     svc,
   ) as unknown as Schema.Schema<ListConferenceRecordsTranscriptsEntriesRequest>;
 
@@ -1128,7 +1128,7 @@ export const GetConferenceRecordsSmartNotesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConferenceRecordsSmartNotesRequest>;
 
@@ -1165,7 +1165,7 @@ export const ListConferenceRecordsSmartNotesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/smartNotes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/smartNotes" }),
     svc,
   ) as unknown as Schema.Schema<ListConferenceRecordsSmartNotesRequest>;
 

--- a/packages/gcp/src/services/memcache-v1.ts
+++ b/packages/gcp/src/services/memcache-v1.ts
@@ -1007,7 +1007,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1042,7 +1042,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1087,7 +1087,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1122,7 +1122,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1153,7 +1153,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1187,7 +1187,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1230,7 +1230,7 @@ export const ListProjectsLocationsInstancesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesRequest>;
 
@@ -1265,7 +1265,7 @@ export const GetProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesRequest>;
 
@@ -1302,7 +1302,7 @@ export const CreateProjectsLocationsInstancesRequest =
     instanceId: Schema.optional(Schema.String).pipe(T.HttpQuery("instanceId")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/instances", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/instances", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsInstancesRequest>;
 
@@ -1339,7 +1339,7 @@ export const PatchProjectsLocationsInstancesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInstancesRequest>;
 
@@ -1375,7 +1375,7 @@ export const UpdateParametersProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1/{name}:updateParameters",
+      path: "v1/{+name}:updateParameters",
       hasBody: true,
     }),
     svc,
@@ -1408,7 +1408,7 @@ export const DeleteProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesRequest>;
 
@@ -1444,7 +1444,7 @@ export const ApplyParametersProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:applyParameters",
+      path: "v1/{+name}:applyParameters",
       hasBody: true,
     }),
     svc,
@@ -1482,7 +1482,7 @@ export const RescheduleMaintenanceProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{instance}:rescheduleMaintenance",
+      path: "v1/{+instance}:rescheduleMaintenance",
       hasBody: true,
     }),
     svc,
@@ -1521,7 +1521,7 @@ export const UpgradeProjectsLocationsInstancesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:upgrade", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:upgrade", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpgradeProjectsLocationsInstancesRequest>;
 
@@ -1555,7 +1555,7 @@ export const SetTagsProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetTagsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setTags", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setTags", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetTagsProjectsLocationsInstancesRequest>;
 
@@ -1586,7 +1586,7 @@ export const GetTagsProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getTags" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getTags" }),
     svc,
   ) as unknown as Schema.Schema<GetTagsProjectsLocationsInstancesRequest>;
 

--- a/packages/gcp/src/services/memcache-v1beta2.ts
+++ b/packages/gcp/src/services/memcache-v1beta2.ts
@@ -1030,7 +1030,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1065,7 +1065,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1110,7 +1110,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1145,7 +1145,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1176,7 +1176,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta2/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1210,7 +1210,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta2/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta2/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1253,7 +1253,7 @@ export const ListProjectsLocationsInstancesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1beta2/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesRequest>;
 
@@ -1288,7 +1288,7 @@ export const GetProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesRequest>;
 
@@ -1327,7 +1327,7 @@ export const CreateProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{parent}/instances",
+      path: "v1beta2/{+parent}/instances",
       hasBody: true,
     }),
     svc,
@@ -1366,7 +1366,7 @@ export const PatchProjectsLocationsInstancesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInstancesRequest>;
 
@@ -1402,7 +1402,7 @@ export const UpdateParametersProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1beta2/{name}:updateParameters",
+      path: "v1beta2/{+name}:updateParameters",
       hasBody: true,
     }),
     svc,
@@ -1435,7 +1435,7 @@ export const DeleteProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta2/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesRequest>;
 
@@ -1471,7 +1471,7 @@ export const ApplyParametersProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{name}:applyParameters",
+      path: "v1beta2/{+name}:applyParameters",
       hasBody: true,
     }),
     svc,
@@ -1509,7 +1509,7 @@ export const ApplySoftwareUpdateProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{instance}:applySoftwareUpdate",
+      path: "v1beta2/{+instance}:applySoftwareUpdate",
       hasBody: true,
     }),
     svc,
@@ -1547,7 +1547,7 @@ export const RescheduleMaintenanceProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{instance}:rescheduleMaintenance",
+      path: "v1beta2/{+instance}:rescheduleMaintenance",
       hasBody: true,
     }),
     svc,
@@ -1586,7 +1586,7 @@ export const UpgradeProjectsLocationsInstancesRequest =
       GoogleCloudMemcacheV1beta2UpgradeInstanceRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta2/{name}:upgrade", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta2/{+name}:upgrade", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpgradeProjectsLocationsInstancesRequest>;
 

--- a/packages/gcp/src/services/merchantapi-accounts_v1.ts
+++ b/packages/gcp/src/services/merchantapi-accounts_v1.ts
@@ -2281,7 +2281,7 @@ export const DeleteAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "accounts/v1/{name}" }),
+  T.Http({ method: "DELETE", path: "accounts/v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteAccountsRequest>;
 
@@ -2316,7 +2316,7 @@ export const CreateTestAccountAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{parent}:createTestAccount",
+      path: "accounts/v1/{+parent}:createTestAccount",
       hasBody: true,
     }),
     svc,
@@ -2354,7 +2354,7 @@ export const PatchAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(Account).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "accounts/v1/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "accounts/v1/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchAccountsRequest>;
 
@@ -2430,7 +2430,7 @@ export const ListSubaccountsAccountsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{provider}:listSubaccounts" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+provider}:listSubaccounts" }),
     svc,
   ) as unknown as Schema.Schema<ListSubaccountsAccountsRequest>;
 
@@ -2499,7 +2499,7 @@ export interface GetAccountsRequest {
 export const GetAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+  T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetAccountsRequest>;
 
@@ -2529,7 +2529,7 @@ export const GetShippingSettingsAccountsShippingSettingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetShippingSettingsAccountsShippingSettingsRequest>;
 
@@ -2566,7 +2566,7 @@ export const InsertAccountsShippingSettingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{parent}/shippingSettings:insert",
+      path: "accounts/v1/{+parent}/shippingSettings:insert",
       hasBody: true,
     }),
     svc,
@@ -2605,7 +2605,7 @@ export const UpdateEmailPreferencesAccountsEmailPreferencesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(EmailPreferences).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateEmailPreferencesAccountsEmailPreferencesRequest>;
 
@@ -2637,7 +2637,7 @@ export const GetEmailPreferencesAccountsEmailPreferencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEmailPreferencesAccountsEmailPreferencesRequest>;
 
@@ -2683,7 +2683,7 @@ export const ListAccountsIssuesRequest =
       T.HttpQuery("languageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{parent}/issues" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+parent}/issues" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsIssuesRequest>;
 
@@ -2724,7 +2724,7 @@ export const ListAccountsUsersRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{parent}/users" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+parent}/users" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsUsersRequest>;
 
@@ -2759,7 +2759,7 @@ export const GetAccountsUsersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsUsersRequest>;
 
@@ -2797,7 +2797,7 @@ export const CreateAccountsUsersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{parent}/users",
+      path: "accounts/v1/{+parent}/users",
       hasBody: true,
     }),
     svc,
@@ -2829,7 +2829,7 @@ export const DeleteAccountsUsersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "accounts/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsUsersRequest>;
 
@@ -2865,7 +2865,7 @@ export const PatchAccountsUsersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(User).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsUsersRequest>;
 
@@ -2900,7 +2900,7 @@ export const VerifySelfAccountsUsersMeRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "accounts/v1/{account}/users/me:verifySelf",
+      path: "accounts/v1/{+account}/users/me:verifySelf",
       hasBody: true,
     }),
     svc,
@@ -2933,7 +2933,7 @@ export const GetAccountsOnlineReturnPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsOnlineReturnPoliciesRequest>;
 
@@ -2969,7 +2969,7 @@ export const CreateAccountsOnlineReturnPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{parent}/onlineReturnPolicies",
+      path: "accounts/v1/{+parent}/onlineReturnPolicies",
       hasBody: true,
     }),
     svc,
@@ -3010,7 +3010,7 @@ export const ListAccountsOnlineReturnPoliciesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "accounts/v1/{parent}/onlineReturnPolicies",
+      path: "accounts/v1/{+parent}/onlineReturnPolicies",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsOnlineReturnPoliciesRequest>;
@@ -3047,7 +3047,7 @@ export const DeleteAccountsOnlineReturnPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "accounts/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsOnlineReturnPoliciesRequest>;
 
@@ -3078,7 +3078,7 @@ export const GetAccountsRelationshipsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsRelationshipsRequest>;
 
@@ -3115,7 +3115,7 @@ export const PatchAccountsRelationshipsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AccountRelationship).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsRelationshipsRequest>;
 
@@ -3152,7 +3152,7 @@ export const ListAccountsRelationshipsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{parent}/relationships" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+parent}/relationships" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsRelationshipsRequest>;
 
@@ -3194,7 +3194,7 @@ export const UpdateBusinessInfoAccountsBusinessInfoRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(BusinessInfo).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateBusinessInfoAccountsBusinessInfoRequest>;
 
@@ -3225,7 +3225,7 @@ export const GetBusinessInfoAccountsBusinessInfoRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBusinessInfoAccountsBusinessInfoRequest>;
 
@@ -3256,7 +3256,7 @@ export const GetAutofeedSettingsAccountsAutofeedSettingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAutofeedSettingsAccountsAutofeedSettingsRequest>;
 
@@ -3294,7 +3294,7 @@ export const UpdateAutofeedSettingsAccountsAutofeedSettingsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AutofeedSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAutofeedSettingsAccountsAutofeedSettingsRequest>;
 
@@ -3333,7 +3333,7 @@ export const RequestInventoryVerificationAccountsOmnichannelSettingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{name}:requestInventoryVerification",
+      path: "accounts/v1/{+name}:requestInventoryVerification",
       hasBody: true,
     }),
     svc,
@@ -3374,7 +3374,7 @@ export const PatchAccountsOmnichannelSettingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(OmnichannelSetting).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsOmnichannelSettingsRequest>;
 
@@ -3411,7 +3411,10 @@ export const ListAccountsOmnichannelSettingsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{parent}/omnichannelSettings" }),
+    T.Http({
+      method: "GET",
+      path: "accounts/v1/{+parent}/omnichannelSettings",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsOmnichannelSettingsRequest>;
 
@@ -3447,7 +3450,7 @@ export const GetAccountsOmnichannelSettingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsOmnichannelSettingsRequest>;
 
@@ -3483,7 +3486,7 @@ export const CreateAccountsOmnichannelSettingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{parent}/omnichannelSettings",
+      path: "accounts/v1/{+parent}/omnichannelSettings",
       hasBody: true,
     }),
     svc,
@@ -3522,7 +3525,7 @@ export const FindAccountsOmnichannelSettingsLfpProvidersRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{parent}/lfpProviders:find" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+parent}/lfpProviders:find" }),
     svc,
   ) as unknown as Schema.Schema<FindAccountsOmnichannelSettingsLfpProvidersRequest>;
 
@@ -3563,7 +3566,7 @@ export const LinkLfpProviderAccountsOmnichannelSettingsLfpProvidersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{name}:linkLfpProvider",
+      path: "accounts/v1/{+name}:linkLfpProvider",
       hasBody: true,
     }),
     svc,
@@ -3603,7 +3606,7 @@ export const EnableAccountsProgramsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{name}:enable",
+      path: "accounts/v1/{+name}:enable",
       hasBody: true,
     }),
     svc,
@@ -3642,7 +3645,7 @@ export const ListAccountsProgramsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{parent}/programs" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+parent}/programs" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsProgramsRequest>;
 
@@ -3677,7 +3680,7 @@ export const GetAccountsProgramsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsProgramsRequest>;
 
@@ -3712,7 +3715,7 @@ export const DisableAccountsProgramsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{name}:disable",
+      path: "accounts/v1/{+name}:disable",
       hasBody: true,
     }),
     svc,
@@ -3745,7 +3748,7 @@ export const GetCheckoutSettingsAccountsProgramsCheckoutSettingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCheckoutSettingsAccountsProgramsCheckoutSettingsRequest>;
 
@@ -3783,7 +3786,7 @@ export const CreateAccountsProgramsCheckoutSettingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{parent}/checkoutSettings",
+      path: "accounts/v1/{+parent}/checkoutSettings",
       hasBody: true,
     }),
     svc,
@@ -3822,7 +3825,7 @@ export const UpdateCheckoutSettingsAccountsProgramsCheckoutSettingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(CheckoutSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateCheckoutSettingsAccountsProgramsCheckoutSettingsRequest>;
 
@@ -3855,7 +3858,7 @@ export const DeleteCheckoutSettingsAccountsProgramsCheckoutSettingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "accounts/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteCheckoutSettingsAccountsProgramsCheckoutSettingsRequest>;
 
@@ -3888,7 +3891,7 @@ export const GetDeveloperRegistrationAccountsDeveloperRegistrationRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDeveloperRegistrationAccountsDeveloperRegistrationRequest>;
 
@@ -3926,7 +3929,7 @@ export const RegisterGcpAccountsDeveloperRegistrationRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{name}:registerGcp",
+      path: "accounts/v1/{+name}:registerGcp",
       hasBody: true,
     }),
     svc,
@@ -3996,7 +3999,7 @@ export const UnregisterGcpAccountsDeveloperRegistrationRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{name}:unregisterGcp",
+      path: "accounts/v1/{+name}:unregisterGcp",
       hasBody: true,
     }),
     svc,
@@ -4031,7 +4034,7 @@ export const RetrieveForApplicationAccountsTermsOfServiceAgreementStatesRequest 
   }).pipe(
     T.Http({
       method: "GET",
-      path: "accounts/v1/{parent}/termsOfServiceAgreementStates:retrieveForApplication",
+      path: "accounts/v1/{+parent}/termsOfServiceAgreementStates:retrieveForApplication",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveForApplicationAccountsTermsOfServiceAgreementStatesRequest>;
@@ -4065,7 +4068,7 @@ export const GetAccountsTermsOfServiceAgreementStatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsTermsOfServiceAgreementStatesRequest>;
 
@@ -4100,7 +4103,11 @@ export const ClaimAccountsHomepageRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ClaimHomepageRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "accounts/v1/{name}:claim", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "accounts/v1/{+name}:claim",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<ClaimAccountsHomepageRequest>;
 
@@ -4136,7 +4143,7 @@ export const UnclaimAccountsHomepageRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{name}:unclaim",
+      path: "accounts/v1/{+name}:unclaim",
       hasBody: true,
     }),
     svc,
@@ -4169,7 +4176,7 @@ export const GetHomepageAccountsHomepageRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetHomepageAccountsHomepageRequest>;
 
@@ -4206,7 +4213,7 @@ export const UpdateHomepageAccountsHomepageRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Homepage).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateHomepageAccountsHomepageRequest>;
 
@@ -4237,7 +4244,7 @@ export const GetAutomaticImprovementsAccountsAutomaticImprovementsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAutomaticImprovementsAccountsAutomaticImprovementsRequest>;
 
@@ -4276,7 +4283,7 @@ export const UpdateAutomaticImprovementsAccountsAutomaticImprovementsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AutomaticImprovements).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAutomaticImprovementsAccountsAutomaticImprovementsRequest>;
 
@@ -4315,7 +4322,7 @@ export const ListAccountsGbpAccountsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{parent}/gbpAccounts" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+parent}/gbpAccounts" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsGbpAccountsRequest>;
 
@@ -4355,7 +4362,7 @@ export const LinkGbpAccountAccountsGbpAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{parent}/gbpAccounts:linkGbpAccount",
+      path: "accounts/v1/{+parent}/gbpAccounts:linkGbpAccount",
       hasBody: true,
     }),
     svc,
@@ -4394,7 +4401,7 @@ export const PatchAccountsRegionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Region).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsRegionsRequest>;
 
@@ -4424,7 +4431,7 @@ export const DeleteAccountsRegionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "accounts/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsRegionsRequest>;
 
@@ -4454,7 +4461,7 @@ export const GetAccountsRegionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsRegionsRequest>;
 
@@ -4492,7 +4499,7 @@ export const CreateAccountsRegionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{parent}/regions",
+      path: "accounts/v1/{+parent}/regions",
       hasBody: true,
     }),
     svc,
@@ -4529,7 +4536,7 @@ export const BatchUpdateAccountsRegionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{parent}/regions:batchUpdate",
+      path: "accounts/v1/{+parent}/regions:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -4567,7 +4574,7 @@ export const BatchDeleteAccountsRegionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{parent}/regions:batchDelete",
+      path: "accounts/v1/{+parent}/regions:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -4605,7 +4612,7 @@ export const BatchCreateAccountsRegionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{parent}/regions:batchCreate",
+      path: "accounts/v1/{+parent}/regions:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -4644,7 +4651,7 @@ export const ListAccountsRegionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{parent}/regions" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+parent}/regions" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsRegionsRequest>;
 
@@ -4679,7 +4686,7 @@ export const GetBusinessIdentityAccountsBusinessIdentityRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBusinessIdentityAccountsBusinessIdentityRequest>;
 
@@ -4717,7 +4724,7 @@ export const UpdateBusinessIdentityAccountsBusinessIdentityRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(BusinessIdentity).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateBusinessIdentityAccountsBusinessIdentityRequest>;
 
@@ -4754,7 +4761,7 @@ export const RejectAccountsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{name}:reject",
+      path: "accounts/v1/{+name}:reject",
       hasBody: true,
     }),
     svc,
@@ -4791,7 +4798,7 @@ export const ApproveAccountsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{name}:approve",
+      path: "accounts/v1/{+name}:approve",
       hasBody: true,
     }),
     svc,
@@ -4824,7 +4831,7 @@ export const GetAccountsServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsServicesRequest>;
 
@@ -4860,7 +4867,7 @@ export const ProposeAccountsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{parent}/services:propose",
+      path: "accounts/v1/{+parent}/services:propose",
       hasBody: true,
     }),
     svc,
@@ -4899,7 +4906,7 @@ export const ListAccountsServicesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{parent}/services" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+parent}/services" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsServicesRequest>;
 
@@ -4934,7 +4941,7 @@ export const GetTermsOfServiceRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTermsOfServiceRequest>;
 
@@ -5013,7 +5020,7 @@ export const AcceptTermsOfServiceRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1/{name}:accept",
+      path: "accounts/v1/{+name}:accept",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/merchantapi-accounts_v1beta.ts
+++ b/packages/gcp/src/services/merchantapi-accounts_v1beta.ts
@@ -2219,7 +2219,7 @@ export const AcceptTermsOfServiceRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{name}:accept",
+      path: "accounts/v1beta/{+name}:accept",
       hasBody: true,
     }),
     svc,
@@ -2292,7 +2292,7 @@ export const GetTermsOfServiceRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTermsOfServiceRequest>;
 
@@ -2322,7 +2322,7 @@ export interface GetAccountsRequest {
 export const GetAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+  T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetAccountsRequest>;
 
@@ -2357,7 +2357,7 @@ export const PatchAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(Account).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "accounts/v1beta/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "accounts/v1beta/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchAccountsRequest>;
 
@@ -2395,7 +2395,7 @@ export const ListSubaccountsAccountsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "accounts/v1beta/{provider}:listSubaccounts",
+      path: "accounts/v1beta/{+provider}:listSubaccounts",
     }),
     svc,
   ) as unknown as Schema.Schema<ListSubaccountsAccountsRequest>;
@@ -2471,7 +2471,7 @@ export const CreateTestAccountAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{parent}:createTestAccount",
+      path: "accounts/v1beta/{+parent}:createTestAccount",
       hasBody: true,
     }),
     svc,
@@ -2546,7 +2546,7 @@ export const DeleteAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "accounts/v1beta/{name}" }),
+  T.Http({ method: "DELETE", path: "accounts/v1beta/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteAccountsRequest>;
 
@@ -2576,7 +2576,7 @@ export const GetAccountsUsersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsUsersRequest>;
 
@@ -2612,7 +2612,7 @@ export const PatchAccountsUsersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(User).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsUsersRequest>;
 
@@ -2650,7 +2650,7 @@ export const CreateAccountsUsersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{parent}/users",
+      path: "accounts/v1beta/{+parent}/users",
       hasBody: true,
     }),
     svc,
@@ -2682,7 +2682,7 @@ export const DeleteAccountsUsersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsUsersRequest>;
 
@@ -2718,7 +2718,7 @@ export const ListAccountsUsersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{parent}/users" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+parent}/users" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsUsersRequest>;
 
@@ -2758,7 +2758,7 @@ export const VerifySelfAccountsUsersMeRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "accounts/v1beta/{account}/users/me:verifySelf",
+      path: "accounts/v1beta/{+account}/users/me:verifySelf",
       hasBody: true,
     }),
     svc,
@@ -2796,7 +2796,7 @@ export const DisableAccountsProgramsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{name}:disable",
+      path: "accounts/v1beta/{+name}:disable",
       hasBody: true,
     }),
     svc,
@@ -2835,7 +2835,7 @@ export const ListAccountsProgramsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{parent}/programs" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+parent}/programs" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsProgramsRequest>;
 
@@ -2870,7 +2870,7 @@ export const GetAccountsProgramsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsProgramsRequest>;
 
@@ -2905,7 +2905,7 @@ export const EnableAccountsProgramsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{name}:enable",
+      path: "accounts/v1beta/{+name}:enable",
       hasBody: true,
     }),
     svc,
@@ -2943,7 +2943,7 @@ export const CreateAccountsProgramsCheckoutSettingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{parent}/checkoutSettings",
+      path: "accounts/v1beta/{+parent}/checkoutSettings",
       hasBody: true,
     }),
     svc,
@@ -2982,7 +2982,7 @@ export const UpdateCheckoutSettingsAccountsProgramsCheckoutSettingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(CheckoutSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateCheckoutSettingsAccountsProgramsCheckoutSettingsRequest>;
 
@@ -3015,7 +3015,7 @@ export const DeleteCheckoutSettingsAccountsProgramsCheckoutSettingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteCheckoutSettingsAccountsProgramsCheckoutSettingsRequest>;
 
@@ -3048,7 +3048,7 @@ export const GetCheckoutSettingsAccountsProgramsCheckoutSettingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCheckoutSettingsAccountsProgramsCheckoutSettingsRequest>;
 
@@ -3117,7 +3117,7 @@ export const RegisterGcpAccountsDeveloperRegistrationRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{name}:registerGcp",
+      path: "accounts/v1beta/{+name}:registerGcp",
       hasBody: true,
     }),
     svc,
@@ -3151,7 +3151,7 @@ export const GetDeveloperRegistrationAccountsDeveloperRegistrationRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDeveloperRegistrationAccountsDeveloperRegistrationRequest>;
 
@@ -3189,7 +3189,7 @@ export const UnregisterGcpAccountsDeveloperRegistrationRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{name}:unregisterGcp",
+      path: "accounts/v1beta/{+name}:unregisterGcp",
       hasBody: true,
     }),
     svc,
@@ -3228,7 +3228,7 @@ export const ListAccountsGbpAccountsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{parent}/gbpAccounts" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+parent}/gbpAccounts" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsGbpAccountsRequest>;
 
@@ -3268,7 +3268,7 @@ export const LinkGbpAccountAccountsGbpAccountsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{parent}/gbpAccounts:linkGbpAccount",
+      path: "accounts/v1beta/{+parent}/gbpAccounts:linkGbpAccount",
       hasBody: true,
     }),
     svc,
@@ -3301,7 +3301,7 @@ export const GetEmailPreferencesAccountsEmailPreferencesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEmailPreferencesAccountsEmailPreferencesRequest>;
 
@@ -3339,7 +3339,7 @@ export const UpdateEmailPreferencesAccountsEmailPreferencesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(EmailPreferences).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateEmailPreferencesAccountsEmailPreferencesRequest>;
 
@@ -3385,7 +3385,7 @@ export const ListAccountsIssuesRequest =
     timeZone: Schema.optional(Schema.String).pipe(T.HttpQuery("timeZone")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{parent}/issues" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+parent}/issues" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsIssuesRequest>;
 
@@ -3426,7 +3426,7 @@ export const ListAccountsRelationshipsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{parent}/relationships" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+parent}/relationships" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsRelationshipsRequest>;
 
@@ -3462,7 +3462,7 @@ export const GetAccountsRelationshipsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsRelationshipsRequest>;
 
@@ -3499,7 +3499,7 @@ export const PatchAccountsRelationshipsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AccountRelationship).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsRelationshipsRequest>;
 
@@ -3530,7 +3530,7 @@ export const GetBusinessIdentityAccountsBusinessIdentityRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBusinessIdentityAccountsBusinessIdentityRequest>;
 
@@ -3568,7 +3568,7 @@ export const UpdateBusinessIdentityAccountsBusinessIdentityRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(BusinessIdentity).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateBusinessIdentityAccountsBusinessIdentityRequest>;
 
@@ -3605,7 +3605,7 @@ export const InsertAccountsShippingSettingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{parent}/shippingSettings:insert",
+      path: "accounts/v1beta/{+parent}/shippingSettings:insert",
       hasBody: true,
     }),
     svc,
@@ -3638,7 +3638,7 @@ export const GetShippingSettingsAccountsShippingSettingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetShippingSettingsAccountsShippingSettingsRequest>;
 
@@ -3672,7 +3672,7 @@ export const RetrieveForApplicationAccountsTermsOfServiceAgreementStatesRequest 
   }).pipe(
     T.Http({
       method: "GET",
-      path: "accounts/v1beta/{parent}/termsOfServiceAgreementStates:retrieveForApplication",
+      path: "accounts/v1beta/{+parent}/termsOfServiceAgreementStates:retrieveForApplication",
     }),
     svc,
   ) as unknown as Schema.Schema<RetrieveForApplicationAccountsTermsOfServiceAgreementStatesRequest>;
@@ -3706,7 +3706,7 @@ export const GetAccountsTermsOfServiceAgreementStatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsTermsOfServiceAgreementStatesRequest>;
 
@@ -3744,7 +3744,7 @@ export const UpdateAutofeedSettingsAccountsAutofeedSettingsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AutofeedSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAutofeedSettingsAccountsAutofeedSettingsRequest>;
 
@@ -3776,7 +3776,7 @@ export const GetAutofeedSettingsAccountsAutofeedSettingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAutofeedSettingsAccountsAutofeedSettingsRequest>;
 
@@ -3808,7 +3808,7 @@ export const GetBusinessInfoAccountsBusinessInfoRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBusinessInfoAccountsBusinessInfoRequest>;
 
@@ -3845,7 +3845,7 @@ export const UpdateBusinessInfoAccountsBusinessInfoRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(BusinessInfo).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateBusinessInfoAccountsBusinessInfoRequest>;
 
@@ -3882,7 +3882,7 @@ export const ListAccountsServicesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{parent}/services" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+parent}/services" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsServicesRequest>;
 
@@ -3922,7 +3922,7 @@ export const ApproveAccountsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{name}:approve",
+      path: "accounts/v1beta/{+name}:approve",
       hasBody: true,
     }),
     svc,
@@ -3960,7 +3960,7 @@ export const ProposeAccountsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{parent}/services:propose",
+      path: "accounts/v1beta/{+parent}/services:propose",
       hasBody: true,
     }),
     svc,
@@ -3998,7 +3998,7 @@ export const RejectAccountsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{name}:reject",
+      path: "accounts/v1beta/{+name}:reject",
       hasBody: true,
     }),
     svc,
@@ -4030,7 +4030,7 @@ export const GetAccountsServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsServicesRequest>;
 
@@ -4069,7 +4069,7 @@ export const CreateAccountsRegionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{parent}/regions",
+      path: "accounts/v1beta/{+parent}/regions",
       hasBody: true,
     }),
     svc,
@@ -4101,7 +4101,7 @@ export const GetAccountsRegionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsRegionsRequest>;
 
@@ -4137,7 +4137,7 @@ export const PatchAccountsRegionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Region).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsRegionsRequest>;
 
@@ -4173,7 +4173,7 @@ export const ListAccountsRegionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{parent}/regions" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+parent}/regions" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsRegionsRequest>;
 
@@ -4208,7 +4208,7 @@ export const DeleteAccountsRegionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsRegionsRequest>;
 
@@ -4243,7 +4243,7 @@ export const CreateAccountsOnlineReturnPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{parent}/onlineReturnPolicies",
+      path: "accounts/v1beta/{+parent}/onlineReturnPolicies",
       hasBody: true,
     }),
     svc,
@@ -4276,7 +4276,7 @@ export const GetAccountsOnlineReturnPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsOnlineReturnPoliciesRequest>;
 
@@ -4313,7 +4313,7 @@ export const PatchAccountsOnlineReturnPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(OnlineReturnPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsOnlineReturnPoliciesRequest>;
 
@@ -4352,7 +4352,7 @@ export const ListAccountsOnlineReturnPoliciesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "accounts/v1beta/{parent}/onlineReturnPolicies",
+      path: "accounts/v1beta/{+parent}/onlineReturnPolicies",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsOnlineReturnPoliciesRequest>;
@@ -4389,7 +4389,7 @@ export const DeleteAccountsOnlineReturnPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsOnlineReturnPoliciesRequest>;
 
@@ -4425,7 +4425,7 @@ export const UnclaimAccountsHomepageRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{name}:unclaim",
+      path: "accounts/v1beta/{+name}:unclaim",
       hasBody: true,
     }),
     svc,
@@ -4458,7 +4458,7 @@ export const GetHomepageAccountsHomepageRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetHomepageAccountsHomepageRequest>;
 
@@ -4494,7 +4494,7 @@ export const ClaimAccountsHomepageRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{name}:claim",
+      path: "accounts/v1beta/{+name}:claim",
       hasBody: true,
     }),
     svc,
@@ -4533,7 +4533,7 @@ export const UpdateHomepageAccountsHomepageRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Homepage).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateHomepageAccountsHomepageRequest>;
 
@@ -4572,7 +4572,7 @@ export const ListAccountsOmnichannelSettingsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "accounts/v1beta/{parent}/omnichannelSettings",
+      path: "accounts/v1beta/{+parent}/omnichannelSettings",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsOmnichannelSettingsRequest>;
@@ -4614,7 +4614,7 @@ export const CreateAccountsOmnichannelSettingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{parent}/omnichannelSettings",
+      path: "accounts/v1beta/{+parent}/omnichannelSettings",
       hasBody: true,
     }),
     svc,
@@ -4647,7 +4647,7 @@ export const GetAccountsOmnichannelSettingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsOmnichannelSettingsRequest>;
 
@@ -4684,7 +4684,7 @@ export const PatchAccountsOmnichannelSettingsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(OmnichannelSetting).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsOmnichannelSettingsRequest>;
 
@@ -4722,7 +4722,7 @@ export const RequestInventoryVerificationAccountsOmnichannelSettingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{name}:requestInventoryVerification",
+      path: "accounts/v1beta/{+name}:requestInventoryVerification",
       hasBody: true,
     }),
     svc,
@@ -4765,7 +4765,7 @@ export const FindAccountsOmnichannelSettingsLfpProvidersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "accounts/v1beta/{parent}/lfpProviders:find",
+      path: "accounts/v1beta/{+parent}/lfpProviders:find",
     }),
     svc,
   ) as unknown as Schema.Schema<FindAccountsOmnichannelSettingsLfpProvidersRequest>;
@@ -4807,7 +4807,7 @@ export const LinkLfpProviderAccountsOmnichannelSettingsLfpProvidersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "accounts/v1beta/{name}:linkLfpProvider",
+      path: "accounts/v1beta/{+name}:linkLfpProvider",
       hasBody: true,
     }),
     svc,
@@ -4848,7 +4848,7 @@ export const UpdateAutomaticImprovementsAccountsAutomaticImprovementsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AutomaticImprovements).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "accounts/v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "accounts/v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAutomaticImprovementsAccountsAutomaticImprovementsRequest>;
 
@@ -4881,7 +4881,7 @@ export const GetAutomaticImprovementsAccountsAutomaticImprovementsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "accounts/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "accounts/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAutomaticImprovementsAccountsAutomaticImprovementsRequest>;
 

--- a/packages/gcp/src/services/merchantapi-conversions_v1.ts
+++ b/packages/gcp/src/services/merchantapi-conversions_v1.ts
@@ -242,7 +242,7 @@ export const CreateAccountsConversionSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "conversions/v1/{parent}/conversionSources",
+      path: "conversions/v1/{+parent}/conversionSources",
       hasBody: true,
     }),
     svc,
@@ -281,7 +281,7 @@ export const PatchAccountsConversionSourcesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ConversionSource).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "conversions/v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "conversions/v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsConversionSourcesRequest>;
 
@@ -312,7 +312,7 @@ export const GetAccountsConversionSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "conversions/v1/{name}" }),
+    T.Http({ method: "GET", path: "conversions/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsConversionSourcesRequest>;
 
@@ -356,7 +356,7 @@ export const ListAccountsConversionSourcesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "conversions/v1/{parent}/conversionSources",
+      path: "conversions/v1/{+parent}/conversionSources",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsConversionSourcesRequest>;
@@ -398,7 +398,7 @@ export const UndeleteAccountsConversionSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "conversions/v1/{name}:undelete",
+      path: "conversions/v1/{+name}:undelete",
       hasBody: true,
     }),
     svc,
@@ -431,7 +431,7 @@ export const DeleteAccountsConversionSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "conversions/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "conversions/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsConversionSourcesRequest>;
 

--- a/packages/gcp/src/services/merchantapi-conversions_v1beta.ts
+++ b/packages/gcp/src/services/merchantapi-conversions_v1beta.ts
@@ -242,7 +242,7 @@ export const CreateAccountsConversionSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "conversions/v1beta/{parent}/conversionSources",
+      path: "conversions/v1beta/{+parent}/conversionSources",
       hasBody: true,
     }),
     svc,
@@ -275,7 +275,7 @@ export const DeleteAccountsConversionSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "conversions/v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "conversions/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsConversionSourcesRequest>;
 
@@ -306,7 +306,7 @@ export const GetAccountsConversionSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "conversions/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "conversions/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsConversionSourcesRequest>;
 
@@ -342,7 +342,7 @@ export const UndeleteAccountsConversionSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "conversions/v1beta/{name}:undelete",
+      path: "conversions/v1beta/{+name}:undelete",
       hasBody: true,
     }),
     svc,
@@ -388,7 +388,7 @@ export const ListAccountsConversionSourcesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "conversions/v1beta/{parent}/conversionSources",
+      path: "conversions/v1beta/{+parent}/conversionSources",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsConversionSourcesRequest>;
@@ -433,7 +433,7 @@ export const PatchAccountsConversionSourcesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "conversions/v1beta/{name}",
+      path: "conversions/v1beta/{+name}",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/merchantapi-datasources_v1.ts
+++ b/packages/gcp/src/services/merchantapi-datasources_v1.ts
@@ -475,7 +475,7 @@ export const CreateAccountsDataSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "datasources/v1/{parent}/dataSources",
+      path: "datasources/v1/{+parent}/dataSources",
       hasBody: true,
     }),
     svc,
@@ -513,7 +513,7 @@ export const FetchAccountsDataSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "datasources/v1/{name}:fetch",
+      path: "datasources/v1/{+name}:fetch",
       hasBody: true,
     }),
     svc,
@@ -546,7 +546,7 @@ export const GetAccountsDataSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "datasources/v1/{name}" }),
+    T.Http({ method: "GET", path: "datasources/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsDataSourcesRequest>;
 
@@ -583,7 +583,7 @@ export const PatchAccountsDataSourcesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(DataSource).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "datasources/v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "datasources/v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsDataSourcesRequest>;
 
@@ -614,7 +614,7 @@ export const DeleteAccountsDataSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "datasources/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "datasources/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsDataSourcesRequest>;
 
@@ -651,7 +651,7 @@ export const ListAccountsDataSourcesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "datasources/v1/{parent}/dataSources" }),
+    T.Http({ method: "GET", path: "datasources/v1/{+parent}/dataSources" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsDataSourcesRequest>;
 
@@ -686,7 +686,7 @@ export const GetAccountsDataSourcesFileUploadsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "datasources/v1/{name}" }),
+    T.Http({ method: "GET", path: "datasources/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsDataSourcesFileUploadsRequest>;
 

--- a/packages/gcp/src/services/merchantapi-datasources_v1beta.ts
+++ b/packages/gcp/src/services/merchantapi-datasources_v1beta.ts
@@ -483,7 +483,7 @@ export const PatchAccountsDataSourcesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "datasources/v1beta/{name}",
+      path: "datasources/v1beta/{+name}",
       hasBody: true,
     }),
     svc,
@@ -521,7 +521,7 @@ export const FetchAccountsDataSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "datasources/v1beta/{name}:fetch",
+      path: "datasources/v1beta/{+name}:fetch",
       hasBody: true,
     }),
     svc,
@@ -559,7 +559,7 @@ export const CreateAccountsDataSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "datasources/v1beta/{parent}/dataSources",
+      path: "datasources/v1beta/{+parent}/dataSources",
       hasBody: true,
     }),
     svc,
@@ -592,7 +592,7 @@ export const GetAccountsDataSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "datasources/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "datasources/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsDataSourcesRequest>;
 
@@ -629,7 +629,7 @@ export const ListAccountsDataSourcesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "datasources/v1beta/{parent}/dataSources" }),
+    T.Http({ method: "GET", path: "datasources/v1beta/{+parent}/dataSources" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsDataSourcesRequest>;
 
@@ -664,7 +664,7 @@ export const DeleteAccountsDataSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "datasources/v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "datasources/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsDataSourcesRequest>;
 
@@ -695,7 +695,7 @@ export const GetAccountsDataSourcesFileUploadsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "datasources/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "datasources/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsDataSourcesFileUploadsRequest>;
 

--- a/packages/gcp/src/services/merchantapi-inventories_v1.ts
+++ b/packages/gcp/src/services/merchantapi-inventories_v1.ts
@@ -323,7 +323,10 @@ export const ListAccountsProductsLocalInventoriesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "inventories/v1/{parent}/localInventories" }),
+    T.Http({
+      method: "GET",
+      path: "inventories/v1/{+parent}/localInventories",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsProductsLocalInventoriesRequest>;
 
@@ -359,7 +362,7 @@ export const DeleteAccountsProductsLocalInventoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "inventories/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "inventories/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsProductsLocalInventoriesRequest>;
 
@@ -395,7 +398,7 @@ export const InsertAccountsProductsLocalInventoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "inventories/v1/{parent}/localInventories:insert",
+      path: "inventories/v1/{+parent}/localInventories:insert",
       hasBody: true,
     }),
     svc,
@@ -433,7 +436,7 @@ export const InsertAccountsProductsRegionalInventoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "inventories/v1/{parent}/regionalInventories:insert",
+      path: "inventories/v1/{+parent}/regionalInventories:insert",
       hasBody: true,
     }),
     svc,
@@ -475,7 +478,7 @@ export const ListAccountsProductsRegionalInventoriesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "inventories/v1/{parent}/regionalInventories",
+      path: "inventories/v1/{+parent}/regionalInventories",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsProductsRegionalInventoriesRequest>;
@@ -512,7 +515,7 @@ export const DeleteAccountsProductsRegionalInventoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "inventories/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "inventories/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsProductsRegionalInventoriesRequest>;
 

--- a/packages/gcp/src/services/merchantapi-inventories_v1beta.ts
+++ b/packages/gcp/src/services/merchantapi-inventories_v1beta.ts
@@ -267,7 +267,7 @@ export const InsertAccountsProductsLocalInventoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "inventories/v1beta/{parent}/localInventories:insert",
+      path: "inventories/v1beta/{+parent}/localInventories:insert",
       hasBody: true,
     }),
     svc,
@@ -308,7 +308,7 @@ export const ListAccountsProductsLocalInventoriesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "inventories/v1beta/{parent}/localInventories",
+      path: "inventories/v1beta/{+parent}/localInventories",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsProductsLocalInventoriesRequest>;
@@ -345,7 +345,7 @@ export const DeleteAccountsProductsLocalInventoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "inventories/v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "inventories/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsProductsLocalInventoriesRequest>;
 
@@ -381,7 +381,7 @@ export const InsertAccountsProductsRegionalInventoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "inventories/v1beta/{parent}/regionalInventories:insert",
+      path: "inventories/v1beta/{+parent}/regionalInventories:insert",
       hasBody: true,
     }),
     svc,
@@ -423,7 +423,7 @@ export const ListAccountsProductsRegionalInventoriesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "inventories/v1beta/{parent}/regionalInventories",
+      path: "inventories/v1beta/{+parent}/regionalInventories",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsProductsRegionalInventoriesRequest>;
@@ -460,7 +460,7 @@ export const DeleteAccountsProductsRegionalInventoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "inventories/v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "inventories/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsProductsRegionalInventoriesRequest>;
 

--- a/packages/gcp/src/services/merchantapi-issueresolution_v1.ts
+++ b/packages/gcp/src/services/merchantapi-issueresolution_v1.ts
@@ -686,7 +686,7 @@ export const ListAccountsAggregateProductStatusesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "issueresolution/v1/{parent}/aggregateProductStatuses",
+      path: "issueresolution/v1/{+parent}/aggregateProductStatuses",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAggregateProductStatusesRequest>;
@@ -736,7 +736,7 @@ export const RenderaccountissuesIssueresolutionRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "issueresolution/v1/{name}:renderaccountissues",
+      path: "issueresolution/v1/{+name}:renderaccountissues",
       hasBody: true,
     }),
     svc,
@@ -780,7 +780,7 @@ export const TriggeractionIssueresolutionRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "issueresolution/v1/{name}:triggeraction",
+      path: "issueresolution/v1/{+name}:triggeraction",
       hasBody: true,
     }),
     svc,
@@ -826,7 +826,7 @@ export const RenderproductissuesIssueresolutionRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "issueresolution/v1/{name}:renderproductissues",
+      path: "issueresolution/v1/{+name}:renderproductissues",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/merchantapi-issueresolution_v1beta.ts
+++ b/packages/gcp/src/services/merchantapi-issueresolution_v1beta.ts
@@ -686,7 +686,7 @@ export const ListAccountsAggregateProductStatusesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "issueresolution/v1beta/{parent}/aggregateProductStatuses",
+      path: "issueresolution/v1beta/{+parent}/aggregateProductStatuses",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAggregateProductStatusesRequest>;
@@ -736,7 +736,7 @@ export const RenderaccountissuesIssueresolutionRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "issueresolution/v1beta/{name}:renderaccountissues",
+      path: "issueresolution/v1beta/{+name}:renderaccountissues",
       hasBody: true,
     }),
     svc,
@@ -783,7 +783,7 @@ export const RenderproductissuesIssueresolutionRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "issueresolution/v1beta/{name}:renderproductissues",
+      path: "issueresolution/v1beta/{+name}:renderproductissues",
       hasBody: true,
     }),
     svc,
@@ -827,7 +827,7 @@ export const TriggeractionIssueresolutionRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "issueresolution/v1beta/{name}:triggeraction",
+      path: "issueresolution/v1beta/{+name}:triggeraction",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/merchantapi-lfp_v1.ts
+++ b/packages/gcp/src/services/merchantapi-lfp_v1.ts
@@ -381,7 +381,7 @@ export const InsertAccountsLfpInventoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "lfp/v1/{parent}/lfpInventories:insert",
+      path: "lfp/v1/{+parent}/lfpInventories:insert",
       hasBody: true,
     }),
     svc,
@@ -414,7 +414,7 @@ export const GetAccountsLfpMerchantStatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "lfp/v1/{name}" }),
+    T.Http({ method: "GET", path: "lfp/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsLfpMerchantStatesRequest>;
 
@@ -445,7 +445,7 @@ export const GetAccountsLfpStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "lfp/v1/{name}" }),
+    T.Http({ method: "GET", path: "lfp/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsLfpStoresRequest>;
 
@@ -487,7 +487,7 @@ export const ListAccountsLfpStoresRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "lfp/v1/{parent}/lfpStores" }),
+    T.Http({ method: "GET", path: "lfp/v1/{+parent}/lfpStores" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsLfpStoresRequest>;
 
@@ -527,7 +527,7 @@ export const InsertAccountsLfpStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "lfp/v1/{parent}/lfpStores:insert",
+      path: "lfp/v1/{+parent}/lfpStores:insert",
       hasBody: true,
     }),
     svc,
@@ -560,7 +560,7 @@ export const DeleteAccountsLfpStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "lfp/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "lfp/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsLfpStoresRequest>;
 
@@ -596,7 +596,7 @@ export const InsertAccountsLfpSalesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "lfp/v1/{parent}/lfpSales:insert",
+      path: "lfp/v1/{+parent}/lfpSales:insert",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/merchantapi-lfp_v1beta.ts
+++ b/packages/gcp/src/services/merchantapi-lfp_v1beta.ts
@@ -376,7 +376,7 @@ export const DeleteAccountsLfpStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "lfp/v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "lfp/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsLfpStoresRequest>;
 
@@ -407,7 +407,7 @@ export const GetAccountsLfpStoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "lfp/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "lfp/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsLfpStoresRequest>;
 
@@ -443,7 +443,7 @@ export const InsertAccountsLfpStoresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "lfp/v1beta/{parent}/lfpStores:insert",
+      path: "lfp/v1beta/{+parent}/lfpStores:insert",
       hasBody: true,
     }),
     svc,
@@ -487,7 +487,7 @@ export const ListAccountsLfpStoresRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "lfp/v1beta/{parent}/lfpStores" }),
+    T.Http({ method: "GET", path: "lfp/v1beta/{+parent}/lfpStores" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsLfpStoresRequest>;
 
@@ -522,7 +522,7 @@ export const GetAccountsLfpMerchantStatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "lfp/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "lfp/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsLfpMerchantStatesRequest>;
 
@@ -558,7 +558,7 @@ export const InsertAccountsLfpSalesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "lfp/v1beta/{parent}/lfpSales:insert",
+      path: "lfp/v1beta/{+parent}/lfpSales:insert",
       hasBody: true,
     }),
     svc,
@@ -596,7 +596,7 @@ export const InsertAccountsLfpInventoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "lfp/v1beta/{parent}/lfpInventories:insert",
+      path: "lfp/v1beta/{+parent}/lfpInventories:insert",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/merchantapi-notifications_v1.ts
+++ b/packages/gcp/src/services/merchantapi-notifications_v1.ts
@@ -159,7 +159,7 @@ export const CreateAccountsNotificationsubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "notifications/v1/{parent}/notificationsubscriptions",
+      path: "notifications/v1/{+parent}/notificationsubscriptions",
       hasBody: true,
     }),
     svc,
@@ -193,7 +193,7 @@ export const GetAccountsNotificationsubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "notifications/v1/{name}" }),
+    T.Http({ method: "GET", path: "notifications/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsNotificationsubscriptionsRequest>;
 
@@ -225,7 +225,7 @@ export const DeleteAccountsNotificationsubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "notifications/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "notifications/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsNotificationsubscriptionsRequest>;
 
@@ -264,7 +264,7 @@ export const ListAccountsNotificationsubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "notifications/v1/{parent}/notificationsubscriptions",
+      path: "notifications/v1/{+parent}/notificationsubscriptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsNotificationsubscriptionsRequest>;
@@ -307,7 +307,11 @@ export const PatchAccountsNotificationsubscriptionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(NotificationSubscription).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "notifications/v1/{name}", hasBody: true }),
+    T.Http({
+      method: "PATCH",
+      path: "notifications/v1/{+name}",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsNotificationsubscriptionsRequest>;
 

--- a/packages/gcp/src/services/merchantapi-notifications_v1beta.ts
+++ b/packages/gcp/src/services/merchantapi-notifications_v1beta.ts
@@ -154,7 +154,7 @@ export const GetAccountsNotificationsubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "notifications/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "notifications/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsNotificationsubscriptionsRequest>;
 
@@ -194,7 +194,7 @@ export const PatchAccountsNotificationsubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "notifications/v1beta/{name}",
+      path: "notifications/v1beta/{+name}",
       hasBody: true,
     }),
     svc,
@@ -228,7 +228,7 @@ export const DeleteAccountsNotificationsubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "notifications/v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "notifications/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsNotificationsubscriptionsRequest>;
 
@@ -267,7 +267,7 @@ export const ListAccountsNotificationsubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "notifications/v1beta/{parent}/notificationsubscriptions",
+      path: "notifications/v1beta/{+parent}/notificationsubscriptions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsNotificationsubscriptionsRequest>;
@@ -309,7 +309,7 @@ export const CreateAccountsNotificationsubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "notifications/v1beta/{parent}/notificationsubscriptions",
+      path: "notifications/v1beta/{+parent}/notificationsubscriptions",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/merchantapi-ordertracking_v1.ts
+++ b/packages/gcp/src/services/merchantapi-ordertracking_v1.ts
@@ -299,7 +299,7 @@ export const CreateAccountsOrderTrackingSignalsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "ordertracking/v1/{parent}/orderTrackingSignals",
+      path: "ordertracking/v1/{+parent}/orderTrackingSignals",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/merchantapi-ordertracking_v1beta.ts
+++ b/packages/gcp/src/services/merchantapi-ordertracking_v1beta.ts
@@ -302,7 +302,7 @@ export const CreateAccountsOrderTrackingSignalsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "ordertracking/v1beta/{parent}/orderTrackingSignals",
+      path: "ordertracking/v1beta/{+parent}/orderTrackingSignals",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/merchantapi-products_v1.ts
+++ b/packages/gcp/src/services/merchantapi-products_v1.ts
@@ -1337,7 +1337,7 @@ export const DeleteAccountsProductInputsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     dataSource: Schema.optional(Schema.String).pipe(T.HttpQuery("dataSource")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "products/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "products/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsProductInputsRequest>;
 
@@ -1376,7 +1376,7 @@ export const InsertAccountsProductInputsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "products/v1/{parent}/productInputs:insert",
+      path: "products/v1/{+parent}/productInputs:insert",
       hasBody: true,
     }),
     svc,
@@ -1418,7 +1418,7 @@ export const PatchAccountsProductInputsRequest =
     dataSource: Schema.optional(Schema.String).pipe(T.HttpQuery("dataSource")),
     body: Schema.optional(ProductInput).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "products/v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "products/v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsProductInputsRequest>;
 
@@ -1449,7 +1449,7 @@ export const GetAccountsProductsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "products/v1/{name}" }),
+    T.Http({ method: "GET", path: "products/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsProductsRequest>;
 
@@ -1485,7 +1485,7 @@ export const ListAccountsProductsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "products/v1/{parent}/products" }),
+    T.Http({ method: "GET", path: "products/v1/{+parent}/products" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsProductsRequest>;
 

--- a/packages/gcp/src/services/merchantapi-products_v1beta.ts
+++ b/packages/gcp/src/services/merchantapi-products_v1beta.ts
@@ -1029,7 +1029,7 @@ export const DeleteAccountsProductInputsRequest =
     dataSource: Schema.optional(Schema.String).pipe(T.HttpQuery("dataSource")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "products/v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "products/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsProductInputsRequest>;
 
@@ -1069,7 +1069,7 @@ export const PatchAccountsProductInputsRequest =
     dataSource: Schema.optional(Schema.String).pipe(T.HttpQuery("dataSource")),
     body: Schema.optional(ProductInput).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "products/v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "products/v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsProductInputsRequest>;
 
@@ -1108,7 +1108,7 @@ export const InsertAccountsProductInputsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "products/v1beta/{parent}/productInputs:insert",
+      path: "products/v1beta/{+parent}/productInputs:insert",
       hasBody: true,
     }),
     svc,
@@ -1141,7 +1141,7 @@ export const GetAccountsProductsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "products/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "products/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsProductsRequest>;
 
@@ -1177,7 +1177,7 @@ export const ListAccountsProductsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "products/v1beta/{parent}/products" }),
+    T.Http({ method: "GET", path: "products/v1beta/{+parent}/products" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsProductsRequest>;
 

--- a/packages/gcp/src/services/merchantapi-promotions_v1.ts
+++ b/packages/gcp/src/services/merchantapi-promotions_v1.ts
@@ -527,7 +527,7 @@ export const InsertAccountsPromotionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "promotions/v1/{parent}/promotions:insert",
+      path: "promotions/v1/{+parent}/promotions:insert",
       hasBody: true,
     }),
     svc,
@@ -566,7 +566,7 @@ export const ListAccountsPromotionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "promotions/v1/{parent}/promotions" }),
+    T.Http({ method: "GET", path: "promotions/v1/{+parent}/promotions" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsPromotionsRequest>;
 
@@ -601,7 +601,7 @@ export const GetAccountsPromotionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "promotions/v1/{name}" }),
+    T.Http({ method: "GET", path: "promotions/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsPromotionsRequest>;
 

--- a/packages/gcp/src/services/merchantapi-promotions_v1beta.ts
+++ b/packages/gcp/src/services/merchantapi-promotions_v1beta.ts
@@ -522,7 +522,7 @@ export const GetAccountsPromotionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "promotions/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "promotions/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsPromotionsRequest>;
 
@@ -558,7 +558,7 @@ export const InsertAccountsPromotionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "promotions/v1beta/{parent}/promotions:insert",
+      path: "promotions/v1beta/{+parent}/promotions:insert",
       hasBody: true,
     }),
     svc,
@@ -597,7 +597,7 @@ export const ListAccountsPromotionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "promotions/v1beta/{parent}/promotions" }),
+    T.Http({ method: "GET", path: "promotions/v1beta/{+parent}/promotions" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsPromotionsRequest>;
 

--- a/packages/gcp/src/services/merchantapi-quota_v1.ts
+++ b/packages/gcp/src/services/merchantapi-quota_v1.ts
@@ -203,7 +203,7 @@ export const ListAccountsQuotasRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "quota/v1/{parent}/quotas" }),
+    T.Http({ method: "GET", path: "quota/v1/{+parent}/quotas" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsQuotasRequest>;
 
@@ -238,7 +238,7 @@ export const GetAccountsLimitsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "quota/v1/{name}" }),
+    T.Http({ method: "GET", path: "quota/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsLimitsRequest>;
 
@@ -278,7 +278,7 @@ export const ListAccountsLimitsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "quota/v1/{parent}/limits" }),
+    T.Http({ method: "GET", path: "quota/v1/{+parent}/limits" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsLimitsRequest>;
 

--- a/packages/gcp/src/services/merchantapi-quota_v1beta.ts
+++ b/packages/gcp/src/services/merchantapi-quota_v1beta.ts
@@ -166,7 +166,7 @@ export const ListAccountsQuotasRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "quota/v1beta/{parent}/quotas" }),
+    T.Http({ method: "GET", path: "quota/v1beta/{+parent}/quotas" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsQuotasRequest>;
 

--- a/packages/gcp/src/services/merchantapi-reports_v1.ts
+++ b/packages/gcp/src/services/merchantapi-reports_v1.ts
@@ -995,7 +995,7 @@ export const SearchAccountsReportsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "reports/v1/{parent}/reports:search",
+      path: "reports/v1/{+parent}/reports:search",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/merchantapi-reports_v1beta.ts
+++ b/packages/gcp/src/services/merchantapi-reports_v1beta.ts
@@ -995,7 +995,7 @@ export const SearchAccountsReportsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "reports/v1beta/{parent}/reports:search",
+      path: "reports/v1beta/{+parent}/reports:search",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/merchantapi-reviews_v1beta.ts
+++ b/packages/gcp/src/services/merchantapi-reviews_v1beta.ts
@@ -598,7 +598,7 @@ export const GetAccountsMerchantReviewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "reviews/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "reviews/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsMerchantReviewsRequest>;
 
@@ -629,7 +629,7 @@ export const DeleteAccountsMerchantReviewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "reviews/v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "reviews/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsMerchantReviewsRequest>;
 
@@ -666,7 +666,7 @@ export const ListAccountsMerchantReviewsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "reviews/v1beta/{parent}/merchantReviews" }),
+    T.Http({ method: "GET", path: "reviews/v1beta/{+parent}/merchantReviews" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsMerchantReviewsRequest>;
 
@@ -709,7 +709,7 @@ export const InsertAccountsMerchantReviewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "reviews/v1beta/{parent}/merchantReviews:insert",
+      path: "reviews/v1beta/{+parent}/merchantReviews:insert",
       hasBody: true,
     }),
     svc,
@@ -750,7 +750,7 @@ export const InsertAccountsProductReviewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "reviews/v1beta/{parent}/productReviews:insert",
+      path: "reviews/v1beta/{+parent}/productReviews:insert",
       hasBody: true,
     }),
     svc,
@@ -789,7 +789,7 @@ export const ListAccountsProductReviewsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "reviews/v1beta/{parent}/productReviews" }),
+    T.Http({ method: "GET", path: "reviews/v1beta/{+parent}/productReviews" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsProductReviewsRequest>;
 
@@ -824,7 +824,7 @@ export const GetAccountsProductReviewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "reviews/v1beta/{name}" }),
+    T.Http({ method: "GET", path: "reviews/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsProductReviewsRequest>;
 
@@ -855,7 +855,7 @@ export const DeleteAccountsProductReviewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "reviews/v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "reviews/v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsProductReviewsRequest>;
 

--- a/packages/gcp/src/services/metastore-v1.ts
+++ b/packages/gcp/src/services/metastore-v1.ts
@@ -1277,7 +1277,7 @@ export const ListProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1312,7 +1312,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1343,7 +1343,7 @@ export const GetProjectsLocationsFederationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFederationsRequest>;
 
@@ -1386,7 +1386,7 @@ export const ListProjectsLocationsFederationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/federations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/federations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFederationsRequest>;
 
@@ -1430,7 +1430,7 @@ export const PatchProjectsLocationsFederationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Federation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFederationsRequest>;
 
@@ -1466,7 +1466,7 @@ export const TestIamPermissionsProjectsLocationsFederationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1511,7 +1511,7 @@ export const CreateProjectsLocationsFederationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Federation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/federations", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/federations", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsFederationsRequest>;
 
@@ -1545,7 +1545,7 @@ export const DeleteProjectsLocationsFederationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFederationsRequest>;
 
@@ -1581,7 +1581,7 @@ export const SetIamPolicyProjectsLocationsFederationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1619,7 +1619,7 @@ export const GetIamPolicyProjectsLocationsFederationsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsFederationsRequest>;
 
@@ -1650,7 +1650,7 @@ export const GetProjectsLocationsServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesRequest>;
 
@@ -1686,7 +1686,7 @@ export const CancelMigrationProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{service}:cancelMigration",
+      path: "v1/{+service}:cancelMigration",
       hasBody: true,
     }),
     svc,
@@ -1728,7 +1728,7 @@ export const CreateProjectsLocationsServicesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/services", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/services", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsServicesRequest>;
 
@@ -1764,7 +1764,7 @@ export const GetIamPolicyProjectsLocationsServicesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsServicesRequest>;
 
@@ -1800,7 +1800,7 @@ export const CompleteMigrationProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{service}:completeMigration",
+      path: "v1/{+service}:completeMigration",
       hasBody: true,
     }),
     svc,
@@ -1838,7 +1838,7 @@ export const TestIamPermissionsProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1877,7 +1877,7 @@ export const QueryMetadataProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{service}:queryMetadata",
+      path: "v1/{+service}:queryMetadata",
       hasBody: true,
     }),
     svc,
@@ -1922,7 +1922,7 @@ export const ListProjectsLocationsServicesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/services" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/services" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesRequest>;
 
@@ -1966,7 +1966,7 @@ export const PatchProjectsLocationsServicesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServicesRequest>;
 
@@ -2004,7 +2004,7 @@ export const AlterLocationProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{service}:alterLocation",
+      path: "v1/{+service}:alterLocation",
       hasBody: true,
     }),
     svc,
@@ -2040,7 +2040,7 @@ export const RestoreProjectsLocationsServicesRequest =
     service: Schema.String.pipe(T.HttpPath("service")),
     body: Schema.optional(RestoreServiceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{service}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+service}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsServicesRequest>;
 
@@ -2076,7 +2076,7 @@ export const SetIamPolicyProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2114,7 +2114,7 @@ export const StartMigrationProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{service}:startMigration",
+      path: "v1/{+service}:startMigration",
       hasBody: true,
     }),
     svc,
@@ -2152,7 +2152,7 @@ export const MoveTableToDatabaseProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{service}:moveTableToDatabase",
+      path: "v1/{+service}:moveTableToDatabase",
       hasBody: true,
     }),
     svc,
@@ -2188,7 +2188,7 @@ export const DeleteProjectsLocationsServicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesRequest>;
 
@@ -2224,7 +2224,7 @@ export const ExportMetadataProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{service}:exportMetadata",
+      path: "v1/{+service}:exportMetadata",
       hasBody: true,
     }),
     svc,
@@ -2262,7 +2262,7 @@ export const AlterTablePropertiesProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{service}:alterTableProperties",
+      path: "v1/{+service}:alterTableProperties",
       hasBody: true,
     }),
     svc,
@@ -2300,7 +2300,7 @@ export const SetIamPolicyProjectsLocationsServicesDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2338,7 +2338,7 @@ export const GetIamPolicyProjectsLocationsServicesDatabasesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsServicesDatabasesRequest>;
 
@@ -2374,7 +2374,7 @@ export const SetIamPolicyProjectsLocationsServicesDatabasesTablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2414,7 +2414,7 @@ export const GetIamPolicyProjectsLocationsServicesDatabasesTablesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsServicesDatabasesTablesRequest>;
 
@@ -2459,7 +2459,7 @@ export const ListProjectsLocationsServicesMetadataImportsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/metadataImports" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/metadataImports" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesMetadataImportsRequest>;
 
@@ -2504,7 +2504,7 @@ export const PatchProjectsLocationsServicesMetadataImportsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MetadataImport).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServicesMetadataImportsRequest>;
 
@@ -2535,7 +2535,7 @@ export const GetProjectsLocationsServicesMetadataImportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesMetadataImportsRequest>;
 
@@ -2580,7 +2580,7 @@ export const CreateProjectsLocationsServicesMetadataImportsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/metadataImports",
+      path: "v1/{+parent}/metadataImports",
       hasBody: true,
     }),
     svc,
@@ -2618,7 +2618,7 @@ export const GetIamPolicyProjectsLocationsServicesBackupsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsServicesBackupsRequest>;
 
@@ -2658,7 +2658,7 @@ export const CreateProjectsLocationsServicesBackupsRequest =
     backupId: Schema.optional(Schema.String).pipe(T.HttpQuery("backupId")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/backups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/backups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsServicesBackupsRequest>;
 
@@ -2692,7 +2692,7 @@ export const DeleteProjectsLocationsServicesBackupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesBackupsRequest>;
 
@@ -2728,7 +2728,7 @@ export const SetIamPolicyProjectsLocationsServicesBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2761,7 +2761,7 @@ export const GetProjectsLocationsServicesBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesBackupsRequest>;
 
@@ -2804,7 +2804,7 @@ export const ListProjectsLocationsServicesBackupsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesBackupsRequest>;
 
@@ -2842,7 +2842,7 @@ export const DeleteProjectsLocationsServicesMigrationExecutionsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesMigrationExecutionsRequest>;
 
@@ -2875,7 +2875,7 @@ export const GetProjectsLocationsServicesMigrationExecutionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesMigrationExecutionsRequest>;
 
@@ -2920,7 +2920,7 @@ export const ListProjectsLocationsServicesMigrationExecutionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/migrationExecutions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/migrationExecutions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesMigrationExecutionsRequest>;
 
@@ -2957,7 +2957,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2991,7 +2991,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -3036,7 +3036,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -3071,7 +3071,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/metastore-v1alpha.ts
+++ b/packages/gcp/src/services/metastore-v1alpha.ts
@@ -1371,7 +1371,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1416,7 +1416,7 @@ export const ListProjectsLocationsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1451,7 +1451,7 @@ export const GetProjectsLocationsFederationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFederationsRequest>;
 
@@ -1491,7 +1491,7 @@ export const PatchProjectsLocationsFederationsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Federation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFederationsRequest>;
 
@@ -1527,7 +1527,7 @@ export const SetIamPolicyProjectsLocationsFederationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1565,7 +1565,7 @@ export const GetIamPolicyProjectsLocationsFederationsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsFederationsRequest>;
 
@@ -1601,7 +1601,7 @@ export const TestIamPermissionsProjectsLocationsFederationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:testIamPermissions",
+      path: "v1alpha/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1647,7 +1647,7 @@ export const ListProjectsLocationsFederationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/federations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/federations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFederationsRequest>;
 
@@ -1695,7 +1695,7 @@ export const CreateProjectsLocationsFederationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/federations",
+      path: "v1alpha/{+parent}/federations",
       hasBody: true,
     }),
     svc,
@@ -1731,7 +1731,7 @@ export const DeleteProjectsLocationsFederationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFederationsRequest>;
 
@@ -1776,7 +1776,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1811,7 +1811,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1842,7 +1842,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1876,7 +1876,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1912,7 +1912,7 @@ export const ExportMetadataProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{service}:exportMetadata",
+      path: "v1alpha/{+service}:exportMetadata",
       hasBody: true,
     }),
     svc,
@@ -1950,7 +1950,7 @@ export const AlterTablePropertiesProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{service}:alterTableProperties",
+      path: "v1alpha/{+service}:alterTableProperties",
       hasBody: true,
     }),
     svc,
@@ -1986,7 +1986,7 @@ export const DeleteProjectsLocationsServicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesRequest>;
 
@@ -2022,7 +2022,7 @@ export const CancelMigrationProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{service}:cancelMigration",
+      path: "v1alpha/{+service}:cancelMigration",
       hasBody: true,
     }),
     svc,
@@ -2055,7 +2055,7 @@ export const GetProjectsLocationsServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesRequest>;
 
@@ -2091,7 +2091,7 @@ export const SetIamPolicyProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2129,7 +2129,7 @@ export const StartMigrationProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{service}:startMigration",
+      path: "v1alpha/{+service}:startMigration",
       hasBody: true,
     }),
     svc,
@@ -2167,7 +2167,7 @@ export const TestIamPermissionsProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:testIamPermissions",
+      path: "v1alpha/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2206,7 +2206,7 @@ export const GetIamPolicyProjectsLocationsServicesRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsServicesRequest>;
 
@@ -2248,7 +2248,7 @@ export const CreateProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/services",
+      path: "v1alpha/{+parent}/services",
       hasBody: true,
     }),
     svc,
@@ -2290,7 +2290,7 @@ export const PatchProjectsLocationsServicesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServicesRequest>;
 
@@ -2326,7 +2326,7 @@ export const MoveTableToDatabaseProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{service}:moveTableToDatabase",
+      path: "v1alpha/{+service}:moveTableToDatabase",
       hasBody: true,
     }),
     svc,
@@ -2364,7 +2364,7 @@ export const RestoreProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{service}:restore",
+      path: "v1alpha/{+service}:restore",
       hasBody: true,
     }),
     svc,
@@ -2409,7 +2409,7 @@ export const ListProjectsLocationsServicesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/services" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/services" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesRequest>;
 
@@ -2451,7 +2451,7 @@ export const AlterLocationProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{service}:alterLocation",
+      path: "v1alpha/{+service}:alterLocation",
       hasBody: true,
     }),
     svc,
@@ -2489,7 +2489,7 @@ export const QueryMetadataProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{service}:queryMetadata",
+      path: "v1alpha/{+service}:queryMetadata",
       hasBody: true,
     }),
     svc,
@@ -2527,7 +2527,7 @@ export const CompleteMigrationProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{service}:completeMigration",
+      path: "v1alpha/{+service}:completeMigration",
       hasBody: true,
     }),
     svc,
@@ -2565,7 +2565,7 @@ export const RemoveIamPolicyProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:removeIamPolicy",
+      path: "v1alpha/{+resource}:removeIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2611,7 +2611,7 @@ export const ListProjectsLocationsServicesMetadataImportsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/metadataImports" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/metadataImports" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesMetadataImportsRequest>;
 
@@ -2660,7 +2660,7 @@ export const CreateProjectsLocationsServicesMetadataImportsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/metadataImports",
+      path: "v1alpha/{+parent}/metadataImports",
       hasBody: true,
     }),
     svc,
@@ -2693,7 +2693,7 @@ export const GetProjectsLocationsServicesMetadataImportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesMetadataImportsRequest>;
 
@@ -2734,7 +2734,7 @@ export const PatchProjectsLocationsServicesMetadataImportsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(MetadataImport).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServicesMetadataImportsRequest>;
 
@@ -2770,7 +2770,7 @@ export const TestIamPermissionsProjectsLocationsServicesBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:testIamPermissions",
+      path: "v1alpha/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2810,7 +2810,7 @@ export const GetIamPolicyProjectsLocationsServicesBackupsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsServicesBackupsRequest>;
 
@@ -2853,7 +2853,7 @@ export const ListProjectsLocationsServicesBackupsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesBackupsRequest>;
 
@@ -2897,7 +2897,11 @@ export const CreateProjectsLocationsServicesBackupsRequest =
     backupId: Schema.optional(Schema.String).pipe(T.HttpQuery("backupId")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{parent}/backups", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1alpha/{+parent}/backups",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsServicesBackupsRequest>;
 
@@ -2931,7 +2935,7 @@ export const DeleteProjectsLocationsServicesBackupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesBackupsRequest>;
 
@@ -2962,7 +2966,7 @@ export const GetProjectsLocationsServicesBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesBackupsRequest>;
 
@@ -2998,7 +3002,7 @@ export const SetIamPolicyProjectsLocationsServicesBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3031,7 +3035,7 @@ export const GetProjectsLocationsServicesMigrationExecutionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesMigrationExecutionsRequest>;
 
@@ -3076,7 +3080,7 @@ export const ListProjectsLocationsServicesMigrationExecutionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/migrationExecutions" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/migrationExecutions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesMigrationExecutionsRequest>;
 
@@ -3116,7 +3120,7 @@ export const DeleteProjectsLocationsServicesMigrationExecutionsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesMigrationExecutionsRequest>;
 
@@ -3154,7 +3158,7 @@ export const GetIamPolicyProjectsLocationsServicesDatabasesRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsServicesDatabasesRequest>;
 
@@ -3190,7 +3194,7 @@ export const TestIamPermissionsProjectsLocationsServicesDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:testIamPermissions",
+      path: "v1alpha/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3230,7 +3234,7 @@ export const SetIamPolicyProjectsLocationsServicesDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3268,7 +3272,7 @@ export const SetIamPolicyProjectsLocationsServicesDatabasesTablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:setIamPolicy",
+      path: "v1alpha/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3308,7 +3312,7 @@ export const TestIamPermissionsProjectsLocationsServicesDatabasesTablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{resource}:testIamPermissions",
+      path: "v1alpha/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3348,7 +3352,7 @@ export const GetIamPolicyProjectsLocationsServicesDatabasesTablesRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsServicesDatabasesTablesRequest>;
 

--- a/packages/gcp/src/services/metastore-v1beta.ts
+++ b/packages/gcp/src/services/metastore-v1beta.ts
@@ -1385,7 +1385,7 @@ export const ListProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1420,7 +1420,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1463,7 +1463,7 @@ export const ListProjectsLocationsFederationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/federations" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/federations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFederationsRequest>;
 
@@ -1511,7 +1511,7 @@ export const CreateProjectsLocationsFederationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/federations",
+      path: "v1beta/{+parent}/federations",
       hasBody: true,
     }),
     svc,
@@ -1547,7 +1547,7 @@ export const DeleteProjectsLocationsFederationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFederationsRequest>;
 
@@ -1583,7 +1583,7 @@ export const TestIamPermissionsProjectsLocationsFederationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:testIamPermissions",
+      path: "v1beta/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1622,7 +1622,7 @@ export const SetIamPolicyProjectsLocationsFederationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:setIamPolicy",
+      path: "v1beta/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1655,7 +1655,7 @@ export const GetProjectsLocationsFederationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFederationsRequest>;
 
@@ -1695,7 +1695,7 @@ export const PatchProjectsLocationsFederationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Federation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFederationsRequest>;
 
@@ -1731,7 +1731,7 @@ export const GetIamPolicyProjectsLocationsFederationsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsFederationsRequest>;
 
@@ -1776,7 +1776,7 @@ export const ListProjectsLocationsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1811,7 +1811,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1842,7 +1842,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1876,7 +1876,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1912,7 +1912,7 @@ export const AlterTablePropertiesProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{service}:alterTableProperties",
+      path: "v1beta/{+service}:alterTableProperties",
       hasBody: true,
     }),
     svc,
@@ -1950,7 +1950,7 @@ export const GetIamPolicyProjectsLocationsServicesRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsServicesRequest>;
 
@@ -1981,7 +1981,7 @@ export const GetProjectsLocationsServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesRequest>;
 
@@ -2017,7 +2017,7 @@ export const StartMigrationProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{service}:startMigration",
+      path: "v1beta/{+service}:startMigration",
       hasBody: true,
     }),
     svc,
@@ -2055,7 +2055,7 @@ export const CancelMigrationProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{service}:cancelMigration",
+      path: "v1beta/{+service}:cancelMigration",
       hasBody: true,
     }),
     svc,
@@ -2100,7 +2100,7 @@ export const ListProjectsLocationsServicesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/services" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/services" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesRequest>;
 
@@ -2144,7 +2144,11 @@ export const CreateProjectsLocationsServicesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/services", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+parent}/services",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsServicesRequest>;
 
@@ -2178,7 +2182,7 @@ export const DeleteProjectsLocationsServicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesRequest>;
 
@@ -2214,7 +2218,7 @@ export const SetIamPolicyProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:setIamPolicy",
+      path: "v1beta/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2252,7 +2256,7 @@ export const TestIamPermissionsProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:testIamPermissions",
+      path: "v1beta/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2289,7 +2293,11 @@ export const RestoreProjectsLocationsServicesRequest =
     service: Schema.String.pipe(T.HttpPath("service")),
     body: Schema.optional(RestoreServiceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{service}:restore", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+service}:restore",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsServicesRequest>;
 
@@ -2325,7 +2333,7 @@ export const ExportMetadataProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{service}:exportMetadata",
+      path: "v1beta/{+service}:exportMetadata",
       hasBody: true,
     }),
     svc,
@@ -2363,7 +2371,7 @@ export const MoveTableToDatabaseProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{service}:moveTableToDatabase",
+      path: "v1beta/{+service}:moveTableToDatabase",
       hasBody: true,
     }),
     svc,
@@ -2405,7 +2413,7 @@ export const PatchProjectsLocationsServicesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServicesRequest>;
 
@@ -2441,7 +2449,7 @@ export const RemoveIamPolicyProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:removeIamPolicy",
+      path: "v1beta/{+resource}:removeIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2480,7 +2488,7 @@ export const CompleteMigrationProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{service}:completeMigration",
+      path: "v1beta/{+service}:completeMigration",
       hasBody: true,
     }),
     svc,
@@ -2518,7 +2526,7 @@ export const QueryMetadataProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{service}:queryMetadata",
+      path: "v1beta/{+service}:queryMetadata",
       hasBody: true,
     }),
     svc,
@@ -2558,7 +2566,7 @@ export const AlterLocationProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{service}:alterLocation",
+      path: "v1beta/{+service}:alterLocation",
       hasBody: true,
     }),
     svc,
@@ -2603,7 +2611,7 @@ export const ListProjectsLocationsServicesMetadataImportsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/metadataImports" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/metadataImports" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesMetadataImportsRequest>;
 
@@ -2639,7 +2647,7 @@ export const GetProjectsLocationsServicesMetadataImportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesMetadataImportsRequest>;
 
@@ -2684,7 +2692,7 @@ export const CreateProjectsLocationsServicesMetadataImportsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/metadataImports",
+      path: "v1beta/{+parent}/metadataImports",
       hasBody: true,
     }),
     svc,
@@ -2726,7 +2734,7 @@ export const PatchProjectsLocationsServicesMetadataImportsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(MetadataImport).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServicesMetadataImportsRequest>;
 
@@ -2757,7 +2765,7 @@ export const GetProjectsLocationsServicesMigrationExecutionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesMigrationExecutionsRequest>;
 
@@ -2802,7 +2810,7 @@ export const ListProjectsLocationsServicesMigrationExecutionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/migrationExecutions" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/migrationExecutions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesMigrationExecutionsRequest>;
 
@@ -2842,7 +2850,7 @@ export const DeleteProjectsLocationsServicesMigrationExecutionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesMigrationExecutionsRequest>;
 
@@ -2880,7 +2888,7 @@ export const GetIamPolicyProjectsLocationsServicesDatabasesRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsServicesDatabasesRequest>;
 
@@ -2916,7 +2924,7 @@ export const TestIamPermissionsProjectsLocationsServicesDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:testIamPermissions",
+      path: "v1beta/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2956,7 +2964,7 @@ export const SetIamPolicyProjectsLocationsServicesDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:setIamPolicy",
+      path: "v1beta/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2994,7 +3002,7 @@ export const SetIamPolicyProjectsLocationsServicesDatabasesTablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:setIamPolicy",
+      path: "v1beta/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3034,7 +3042,7 @@ export const TestIamPermissionsProjectsLocationsServicesDatabasesTablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:testIamPermissions",
+      path: "v1beta/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3074,7 +3082,7 @@ export const GetIamPolicyProjectsLocationsServicesDatabasesTablesRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsServicesDatabasesTablesRequest>;
 
@@ -3112,7 +3120,7 @@ export const SetIamPolicyProjectsLocationsServicesBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:setIamPolicy",
+      path: "v1beta/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3145,7 +3153,7 @@ export const GetProjectsLocationsServicesBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesBackupsRequest>;
 
@@ -3181,7 +3189,7 @@ export const GetIamPolicyProjectsLocationsServicesBackupsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsServicesBackupsRequest>;
 
@@ -3224,7 +3232,7 @@ export const ListProjectsLocationsServicesBackupsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesBackupsRequest>;
 
@@ -3268,7 +3276,7 @@ export const CreateProjectsLocationsServicesBackupsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/backups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/backups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsServicesBackupsRequest>;
 
@@ -3302,7 +3310,7 @@ export const DeleteProjectsLocationsServicesBackupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesBackupsRequest>;
 
@@ -3338,7 +3346,7 @@ export const TestIamPermissionsProjectsLocationsServicesBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:testIamPermissions",
+      path: "v1beta/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/migrationcenter-v1.ts
+++ b/packages/gcp/src/services/migrationcenter-v1.ts
@@ -3522,7 +3522,7 @@ export const GetSettingsProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSettingsProjectsLocationsRequest>;
 
@@ -3562,7 +3562,7 @@ export const UpdateSettingsProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Settings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSettingsProjectsLocationsRequest>;
 
@@ -3593,7 +3593,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -3638,7 +3638,7 @@ export const ListProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -3685,7 +3685,7 @@ export const ListProjectsLocationsDiscoveryClientsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/discoveryClients" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/discoveryClients" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDiscoveryClientsRequest>;
 
@@ -3721,7 +3721,7 @@ export const GetProjectsLocationsDiscoveryClientsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDiscoveryClientsRequest>;
 
@@ -3757,7 +3757,7 @@ export const SendHeartbeatProjectsLocationsDiscoveryClientsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:sendHeartbeat", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:sendHeartbeat", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SendHeartbeatProjectsLocationsDiscoveryClientsRequest>;
 
@@ -3791,7 +3791,7 @@ export const DeleteProjectsLocationsDiscoveryClientsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDiscoveryClientsRequest>;
 
@@ -3831,7 +3831,7 @@ export const PatchProjectsLocationsDiscoveryClientsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DiscoveryClient).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDiscoveryClientsRequest>;
 
@@ -3875,7 +3875,7 @@ export const CreateProjectsLocationsDiscoveryClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/discoveryClients",
+      path: "v1/{+parent}/discoveryClients",
       hasBody: true,
     }),
     svc,
@@ -3908,7 +3908,7 @@ export const GetProjectsLocationsReportConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReportConfigsRequest>;
 
@@ -3952,7 +3952,7 @@ export const CreateProjectsLocationsReportConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/reportConfigs",
+      path: "v1/{+parent}/reportConfigs",
       hasBody: true,
     }),
     svc,
@@ -3997,7 +3997,7 @@ export const ListProjectsLocationsReportConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/reportConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/reportConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReportConfigsRequest>;
 
@@ -4039,7 +4039,7 @@ export const DeleteProjectsLocationsReportConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReportConfigsRequest>;
 
@@ -4090,7 +4090,7 @@ export const ListProjectsLocationsReportConfigsReportsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/reports" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/reports" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReportConfigsReportsRequest>;
 
@@ -4129,7 +4129,7 @@ export const DeleteProjectsLocationsReportConfigsReportsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReportConfigsReportsRequest>;
 
@@ -4169,7 +4169,7 @@ export const CreateProjectsLocationsReportConfigsReportsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Report).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/reports", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/reports", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsReportConfigsReportsRequest>;
 
@@ -4208,7 +4208,7 @@ export const GetProjectsLocationsReportConfigsReportsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReportConfigsReportsRequest>;
 
@@ -4239,7 +4239,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -4284,7 +4284,7 @@ export const ListProjectsLocationsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -4319,7 +4319,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -4353,7 +4353,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -4393,7 +4393,7 @@ export const PatchProjectsLocationsSourcesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Source).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSourcesRequest>;
 
@@ -4433,7 +4433,7 @@ export const CreateProjectsLocationsSourcesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Source).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/sources", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/sources", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSourcesRequest>;
 
@@ -4467,7 +4467,7 @@ export const DeleteProjectsLocationsSourcesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSourcesRequest>;
 
@@ -4498,7 +4498,7 @@ export const GetProjectsLocationsSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesRequest>;
 
@@ -4541,7 +4541,7 @@ export const ListProjectsLocationsSourcesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sources" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesRequest>;
 
@@ -4583,7 +4583,7 @@ export const GetProjectsLocationsSourcesErrorFramesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesErrorFramesRequest>;
 
@@ -4627,7 +4627,7 @@ export const ListProjectsLocationsSourcesErrorFramesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/errorFrames" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/errorFrames" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesErrorFramesRequest>;
 
@@ -4669,7 +4669,7 @@ export const ListProjectsLocationsAssetsExportJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/assetsExportJobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/assetsExportJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAssetsExportJobsRequest>;
 
@@ -4705,7 +4705,7 @@ export const GetProjectsLocationsAssetsExportJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAssetsExportJobsRequest>;
 
@@ -4739,7 +4739,7 @@ export const RunProjectsLocationsAssetsExportJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RunAssetsExportJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsAssetsExportJobsRequest>;
 
@@ -4770,7 +4770,7 @@ export const DeleteProjectsLocationsAssetsExportJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAssetsExportJobsRequest>;
 
@@ -4814,7 +4814,7 @@ export const CreateProjectsLocationsAssetsExportJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/assetsExportJobs",
+      path: "v1/{+parent}/assetsExportJobs",
       hasBody: true,
     }),
     svc,
@@ -4850,7 +4850,7 @@ export const RemoveAssetsProjectsLocationsGroupsRequest =
     group: Schema.String.pipe(T.HttpPath("group")),
     body: Schema.optional(RemoveAssetsFromGroupRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{group}:removeAssets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+group}:removeAssets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RemoveAssetsProjectsLocationsGroupsRequest>;
 
@@ -4893,7 +4893,7 @@ export const ListProjectsLocationsGroupsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/groups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/groups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGroupsRequest>;
 
@@ -4931,7 +4931,7 @@ export const AddAssetsProjectsLocationsGroupsRequest =
     group: Schema.String.pipe(T.HttpPath("group")),
     body: Schema.optional(AddAssetsToGroupRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{group}:addAssets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+group}:addAssets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AddAssetsProjectsLocationsGroupsRequest>;
 
@@ -4962,7 +4962,7 @@ export const GetProjectsLocationsGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGroupsRequest>;
 
@@ -4996,7 +4996,7 @@ export const DeleteProjectsLocationsGroupsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGroupsRequest>;
 
@@ -5036,7 +5036,7 @@ export const PatchProjectsLocationsGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Group).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGroupsRequest>;
 
@@ -5076,7 +5076,7 @@ export const CreateProjectsLocationsGroupsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Group).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/groups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/groups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGroupsRequest>;
 
@@ -5114,7 +5114,7 @@ export const GetProjectsLocationsImportJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsImportJobsRequest>;
 
@@ -5148,7 +5148,7 @@ export const RunProjectsLocationsImportJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RunImportJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsImportJobsRequest>;
 
@@ -5198,7 +5198,7 @@ export const ListProjectsLocationsImportJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/importJobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/importJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsImportJobsRequest>;
 
@@ -5236,7 +5236,7 @@ export const ValidateProjectsLocationsImportJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ValidateImportJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:validate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:validate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ValidateProjectsLocationsImportJobsRequest>;
 
@@ -5278,7 +5278,7 @@ export const CreateProjectsLocationsImportJobsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(ImportJob).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/importJobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/importJobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsImportJobsRequest>;
 
@@ -5318,7 +5318,7 @@ export const PatchProjectsLocationsImportJobsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(ImportJob).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsImportJobsRequest>;
 
@@ -5355,7 +5355,7 @@ export const DeleteProjectsLocationsImportJobsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsImportJobsRequest>;
 
@@ -5386,7 +5386,7 @@ export const GetProjectsLocationsImportJobsImportDataFilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsImportJobsImportDataFilesRequest>;
 
@@ -5431,7 +5431,7 @@ export const CreateProjectsLocationsImportJobsImportDataFilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/importDataFiles",
+      path: "v1/{+parent}/importDataFiles",
       hasBody: true,
     }),
     svc,
@@ -5478,7 +5478,7 @@ export const ListProjectsLocationsImportJobsImportDataFilesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/importDataFiles" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/importDataFiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsImportJobsImportDataFilesRequest>;
 
@@ -5517,7 +5517,7 @@ export const DeleteProjectsLocationsImportJobsImportDataFilesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsImportJobsImportDataFilesRequest>;
 
@@ -5562,7 +5562,7 @@ export const ListProjectsLocationsRelationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/relations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/relations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRelationsRequest>;
 
@@ -5597,7 +5597,7 @@ export const GetProjectsLocationsRelationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRelationsRequest>;
 
@@ -5636,7 +5636,7 @@ export const ReportAssetFramesProjectsLocationsAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/assets:reportAssetFrames",
+      path: "v1/{+parent}/assets:reportAssetFrames",
       hasBody: true,
     }),
     svc,
@@ -5673,7 +5673,7 @@ export const DeleteProjectsLocationsAssetsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAssetsRequest>;
 
@@ -5709,7 +5709,7 @@ export const AggregateValuesProjectsLocationsAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/assets:aggregateValues",
+      path: "v1/{+parent}/assets:aggregateValues",
       hasBody: true,
     }),
     svc,
@@ -5752,7 +5752,7 @@ export const PatchProjectsLocationsAssetsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Asset).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAssetsRequest>;
 
@@ -5788,7 +5788,7 @@ export const BatchUpdateProjectsLocationsAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/assets:batchUpdate",
+      path: "v1/{+parent}/assets:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -5847,7 +5847,7 @@ export const ListProjectsLocationsAssetsRequest =
     showHidden: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("showHidden")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/assets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/assets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAssetsRequest>;
 
@@ -5892,7 +5892,7 @@ export const GetProjectsLocationsAssetsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAssetsRequest>;
 
@@ -5928,7 +5928,7 @@ export const BatchDeleteProjectsLocationsAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/assets:batchDelete",
+      path: "v1/{+parent}/assets:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -5974,7 +5974,7 @@ export const CreateProjectsLocationsPreferenceSetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/preferenceSets",
+      path: "v1/{+parent}/preferenceSets",
       hasBody: true,
     }),
     svc,
@@ -6016,7 +6016,7 @@ export const PatchProjectsLocationsPreferenceSetsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PreferenceSet).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPreferenceSetsRequest>;
 
@@ -6050,7 +6050,7 @@ export const DeleteProjectsLocationsPreferenceSetsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPreferenceSetsRequest>;
 
@@ -6081,7 +6081,7 @@ export const GetProjectsLocationsPreferenceSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPreferenceSetsRequest>;
 
@@ -6121,7 +6121,7 @@ export const ListProjectsLocationsPreferenceSetsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/preferenceSets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/preferenceSets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPreferenceSetsRequest>;
 

--- a/packages/gcp/src/services/migrationcenter-v1alpha1.ts
+++ b/packages/gcp/src/services/migrationcenter-v1alpha1.ts
@@ -5020,7 +5020,7 @@ export const UpdateSettingsProjectsLocationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Settings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSettingsProjectsLocationsRequest>;
 
@@ -5051,7 +5051,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -5082,7 +5082,7 @@ export const GetSettingsProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSettingsProjectsLocationsRequest>;
 
@@ -5127,7 +5127,7 @@ export const ListProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -5174,7 +5174,7 @@ export const CreateProjectsLocationsPreferenceSetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/preferenceSets",
+      path: "v1alpha1/{+parent}/preferenceSets",
       hasBody: true,
     }),
     svc,
@@ -5216,7 +5216,7 @@ export const PatchProjectsLocationsPreferenceSetsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(PreferenceSet).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPreferenceSetsRequest>;
 
@@ -5256,7 +5256,7 @@ export const ListProjectsLocationsPreferenceSetsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/preferenceSets" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/preferenceSets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPreferenceSetsRequest>;
 
@@ -5292,7 +5292,7 @@ export const GetProjectsLocationsPreferenceSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPreferenceSetsRequest>;
 
@@ -5326,7 +5326,7 @@ export const DeleteProjectsLocationsPreferenceSetsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPreferenceSetsRequest>;
 
@@ -5357,7 +5357,7 @@ export const GetProjectsLocationsRelationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRelationsRequest>;
 
@@ -5400,7 +5400,7 @@ export const ListProjectsLocationsRelationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/relations" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/relations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRelationsRequest>;
 
@@ -5438,7 +5438,7 @@ export const RunProjectsLocationsImportJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RunImportJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsImportJobsRequest>;
 
@@ -5482,7 +5482,7 @@ export const CreateProjectsLocationsImportJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/importJobs",
+      path: "v1alpha1/{+parent}/importJobs",
       hasBody: true,
     }),
     svc,
@@ -5524,7 +5524,7 @@ export const PatchProjectsLocationsImportJobsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ImportJob).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsImportJobsRequest>;
 
@@ -5558,7 +5558,11 @@ export const ValidateProjectsLocationsImportJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ValidateImportJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:validate", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1alpha1/{+name}:validate",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<ValidateProjectsLocationsImportJobsRequest>;
 
@@ -5608,7 +5612,7 @@ export const ListProjectsLocationsImportJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/importJobs" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/importJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsImportJobsRequest>;
 
@@ -5650,7 +5654,7 @@ export const GetProjectsLocationsImportJobsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsImportJobsRequest>;
 
@@ -5687,7 +5691,7 @@ export const DeleteProjectsLocationsImportJobsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsImportJobsRequest>;
 
@@ -5718,7 +5722,7 @@ export const GetProjectsLocationsImportJobsImportDataFilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsImportJobsImportDataFilesRequest>;
 
@@ -5763,7 +5767,7 @@ export const CreateProjectsLocationsImportJobsImportDataFilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/importDataFiles",
+      path: "v1alpha1/{+parent}/importDataFiles",
       hasBody: true,
     }),
     svc,
@@ -5801,7 +5805,7 @@ export const DeleteProjectsLocationsImportJobsImportDataFilesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsImportJobsImportDataFilesRequest>;
 
@@ -5846,7 +5850,7 @@ export const ListProjectsLocationsImportJobsImportDataFilesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/importDataFiles" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/importDataFiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsImportJobsImportDataFilesRequest>;
 
@@ -5890,7 +5894,7 @@ export const ReportAssetFramesProjectsLocationsAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/assets:reportAssetFrames",
+      path: "v1alpha1/{+parent}/assets:reportAssetFrames",
       hasBody: true,
     }),
     svc,
@@ -5933,7 +5937,7 @@ export const PatchProjectsLocationsAssetsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Asset).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAssetsRequest>;
 
@@ -5987,7 +5991,7 @@ export const ListProjectsLocationsAssetsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     showHidden: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("showHidden")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/assets" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/assets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAssetsRequest>;
 
@@ -6027,7 +6031,7 @@ export const BatchDeleteProjectsLocationsAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/assets:batchDelete",
+      path: "v1alpha1/{+parent}/assets:batchDelete",
       hasBody: true,
     }),
     svc,
@@ -6065,7 +6069,7 @@ export const AggregateValuesProjectsLocationsAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/assets:aggregateValues",
+      path: "v1alpha1/{+parent}/assets:aggregateValues",
       hasBody: true,
     }),
     svc,
@@ -6107,7 +6111,7 @@ export const GetProjectsLocationsAssetsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAssetsRequest>;
 
@@ -6143,7 +6147,7 @@ export const BatchUpdateProjectsLocationsAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/assets:batchUpdate",
+      path: "v1alpha1/{+parent}/assets:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -6180,7 +6184,7 @@ export const DeleteProjectsLocationsAssetsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAssetsRequest>;
 
@@ -6214,7 +6218,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -6245,7 +6249,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -6276,7 +6280,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -6321,7 +6325,7 @@ export const ListProjectsLocationsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -6361,7 +6365,7 @@ export const AddAssetsProjectsLocationsGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{group}:addAssets",
+      path: "v1alpha1/{+group}:addAssets",
       hasBody: true,
     }),
     svc,
@@ -6394,7 +6398,7 @@ export const GetProjectsLocationsGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGroupsRequest>;
 
@@ -6428,7 +6432,7 @@ export const DeleteProjectsLocationsGroupsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGroupsRequest>;
 
@@ -6471,7 +6475,7 @@ export const ListProjectsLocationsGroupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/groups" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/groups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGroupsRequest>;
 
@@ -6515,7 +6519,11 @@ export const CreateProjectsLocationsGroupsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Group).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{parent}/groups", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1alpha1/{+parent}/groups",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGroupsRequest>;
 
@@ -6555,7 +6563,7 @@ export const PatchProjectsLocationsGroupsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Group).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGroupsRequest>;
 
@@ -6591,7 +6599,7 @@ export const RemoveAssetsProjectsLocationsGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{group}:removeAssets",
+      path: "v1alpha1/{+group}:removeAssets",
       hasBody: true,
     }),
     svc,
@@ -6637,7 +6645,7 @@ export const CreateProjectsLocationsReportConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/reportConfigs",
+      path: "v1alpha1/{+parent}/reportConfigs",
       hasBody: true,
     }),
     svc,
@@ -6670,7 +6678,7 @@ export const GetProjectsLocationsReportConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReportConfigsRequest>;
 
@@ -6707,7 +6715,7 @@ export const DeleteProjectsLocationsReportConfigsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReportConfigsRequest>;
 
@@ -6750,7 +6758,7 @@ export const ListProjectsLocationsReportConfigsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/reportConfigs" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/reportConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReportConfigsRequest>;
 
@@ -6806,7 +6814,7 @@ export const ListProjectsLocationsReportConfigsReportsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/reports" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/reports" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReportConfigsReportsRequest>;
 
@@ -6853,7 +6861,7 @@ export const CreateProjectsLocationsReportConfigsReportsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/reports",
+      path: "v1alpha1/{+parent}/reports",
       hasBody: true,
     }),
     svc,
@@ -6894,7 +6902,7 @@ export const GetProjectsLocationsReportConfigsReportsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReportConfigsReportsRequest>;
 
@@ -6928,7 +6936,7 @@ export const DeleteProjectsLocationsReportConfigsReportsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReportConfigsReportsRequest>;
 
@@ -6959,7 +6967,7 @@ export const GetProjectsLocationsReportConfigsReportsReportExportJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReportConfigsReportsReportExportJobsRequest>;
 
@@ -6995,7 +7003,7 @@ export const DeleteProjectsLocationsReportConfigsReportsReportExportJobsRequest 
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReportConfigsReportsReportExportJobsRequest>;
 
@@ -7034,7 +7042,7 @@ export const ListProjectsLocationsReportConfigsReportsReportExportJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/reportExportJobs" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/reportExportJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReportConfigsReportsReportExportJobsRequest>;
 
@@ -7084,7 +7092,7 @@ export const CreateProjectsLocationsReportConfigsReportsReportExportJobsRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/reportExportJobs",
+      path: "v1alpha1/{+parent}/reportExportJobs",
       hasBody: true,
     }),
     svc,
@@ -7122,7 +7130,7 @@ export const RunProjectsLocationsReportConfigsReportsReportExportJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RunReportExportJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsReportConfigsReportsReportExportJobsRequest>;
 
@@ -7155,7 +7163,7 @@ export const GetProjectsLocationsAssetsExportJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAssetsExportJobsRequest>;
 
@@ -7186,7 +7194,7 @@ export const DeleteProjectsLocationsAssetsExportJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAssetsExportJobsRequest>;
 
@@ -7223,7 +7231,7 @@ export const ListProjectsLocationsAssetsExportJobsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/assetsExportJobs" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/assetsExportJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAssetsExportJobsRequest>;
 
@@ -7262,7 +7270,7 @@ export const RunProjectsLocationsAssetsExportJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RunAssetsExportJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsAssetsExportJobsRequest>;
 
@@ -7306,7 +7314,7 @@ export const CreateProjectsLocationsAssetsExportJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/assetsExportJobs",
+      path: "v1alpha1/{+parent}/assetsExportJobs",
       hasBody: true,
     }),
     svc,
@@ -7350,7 +7358,7 @@ export const CreateProjectsLocationsSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/sources",
+      path: "v1alpha1/{+parent}/sources",
       hasBody: true,
     }),
     svc,
@@ -7392,7 +7400,7 @@ export const PatchProjectsLocationsSourcesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Source).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSourcesRequest>;
 
@@ -7435,7 +7443,7 @@ export const ListProjectsLocationsSourcesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/sources" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/sources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesRequest>;
 
@@ -7470,7 +7478,7 @@ export const GetProjectsLocationsSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesRequest>;
 
@@ -7504,7 +7512,7 @@ export const DeleteProjectsLocationsSourcesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSourcesRequest>;
 
@@ -7548,7 +7556,7 @@ export const ListProjectsLocationsSourcesErrorFramesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/errorFrames" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/errorFrames" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesErrorFramesRequest>;
 
@@ -7591,7 +7599,7 @@ export const GetProjectsLocationsSourcesErrorFramesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesErrorFramesRequest>;
 
@@ -7629,7 +7637,7 @@ export const SendHeartbeatProjectsLocationsDiscoveryClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{name}:sendHeartbeat",
+      path: "v1alpha1/{+name}:sendHeartbeat",
       hasBody: true,
     }),
     svc,
@@ -7675,7 +7683,7 @@ export const CreateProjectsLocationsDiscoveryClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/discoveryClients",
+      path: "v1alpha1/{+parent}/discoveryClients",
       hasBody: true,
     }),
     svc,
@@ -7717,7 +7725,7 @@ export const PatchProjectsLocationsDiscoveryClientsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(DiscoveryClient).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDiscoveryClientsRequest>;
 
@@ -7760,7 +7768,7 @@ export const ListProjectsLocationsDiscoveryClientsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/discoveryClients" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/discoveryClients" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDiscoveryClientsRequest>;
 
@@ -7796,7 +7804,7 @@ export const GetProjectsLocationsDiscoveryClientsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDiscoveryClientsRequest>;
 
@@ -7830,7 +7838,7 @@ export const DeleteProjectsLocationsDiscoveryClientsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDiscoveryClientsRequest>;
 

--- a/packages/gcp/src/services/ml-v1.ts
+++ b/packages/gcp/src/services/ml-v1.ts
@@ -1771,7 +1771,7 @@ export const ExplainProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     body: Schema.optional(GoogleCloudMlV1__ExplainRequest).pipe(T.HttpBody()),
   },
 ).pipe(
-  T.Http({ method: "POST", path: "v1/{name}:explain", hasBody: true }),
+  T.Http({ method: "POST", path: "v1/{+name}:explain", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<ExplainProjectsRequest>;
 
@@ -1802,7 +1802,7 @@ export const GetConfigProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getConfig" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getConfig" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigProjectsRequest>;
 
@@ -1837,7 +1837,7 @@ export const PredictProjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     body: Schema.optional(GoogleCloudMlV1__PredictRequest).pipe(T.HttpBody()),
   },
 ).pipe(
-  T.Http({ method: "POST", path: "v1/{name}:predict", hasBody: true }),
+  T.Http({ method: "POST", path: "v1/{+name}:predict", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PredictProjectsRequest>;
 
@@ -1877,7 +1877,7 @@ export const ListProjectsJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/jobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/jobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsJobsRequest>;
 
@@ -1913,7 +1913,7 @@ export const GetProjectsJobsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     name: Schema.String.pipe(T.HttpPath("name")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetProjectsJobsRequest>;
 
@@ -1951,7 +1951,7 @@ export const TestIamPermissionsProjectsJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1991,7 +1991,7 @@ export const PatchProjectsJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudMlV1__Job).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsJobsRequest>;
 
@@ -2027,7 +2027,7 @@ export const GetIamPolicyProjectsJobsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsJobsRequest>;
 
@@ -2063,7 +2063,7 @@ export const SetIamPolicyProjectsJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2099,7 +2099,7 @@ export const CreateProjectsJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudMlV1__Job).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/jobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/jobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsJobsRequest>;
 
@@ -2133,7 +2133,7 @@ export const CancelProjectsJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudMlV1__CancelJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsJobsRequest>;
 
@@ -2164,7 +2164,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 
@@ -2195,7 +2195,7 @@ export const CancelProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsOperationsRequest>;
 
@@ -2240,7 +2240,7 @@ export const ListProjectsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsOperationsRequest>;
 
@@ -2279,7 +2279,7 @@ export const CreateProjectsModelsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudMlV1__Model).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/models", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/models", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsModelsRequest>;
 
@@ -2317,7 +2317,7 @@ export const TestIamPermissionsProjectsModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2356,7 +2356,7 @@ export const SetIamPolicyProjectsModelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2398,7 +2398,7 @@ export const ListProjectsModelsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/models" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/models" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsModelsRequest>;
 
@@ -2438,7 +2438,7 @@ export const GetIamPolicyProjectsModelsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsModelsRequest>;
 
@@ -2469,7 +2469,7 @@ export const DeleteProjectsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsModelsRequest>;
 
@@ -2500,7 +2500,7 @@ export const GetProjectsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsModelsRequest>;
 
@@ -2537,7 +2537,7 @@ export const PatchProjectsModelsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudMlV1__Model).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsModelsRequest>;
 
@@ -2574,7 +2574,7 @@ export const PatchProjectsModelsVersionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudMlV1__Version).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsModelsVersionsRequest>;
 
@@ -2605,7 +2605,7 @@ export const GetProjectsModelsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsModelsVersionsRequest>;
 
@@ -2639,7 +2639,7 @@ export const CreateProjectsModelsVersionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudMlV1__Version).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/versions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/versions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsModelsVersionsRequest>;
 
@@ -2670,7 +2670,7 @@ export const DeleteProjectsModelsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsModelsVersionsRequest>;
 
@@ -2710,7 +2710,7 @@ export const ListProjectsModelsVersionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsModelsVersionsRequest>;
 
@@ -2751,7 +2751,7 @@ export const SetDefaultProjectsModelsVersionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setDefault", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setDefault", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetDefaultProjectsModelsVersionsRequest>;
 
@@ -2788,7 +2788,7 @@ export const ListProjectsLocationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2824,7 +2824,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2855,7 +2855,7 @@ export const DeleteProjectsLocationsStudiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsStudiesRequest>;
 
@@ -2886,7 +2886,7 @@ export const ListProjectsLocationsStudiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/studies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/studies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsStudiesRequest>;
 
@@ -2918,7 +2918,7 @@ export const GetProjectsLocationsStudiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsStudiesRequest>;
 
@@ -2955,7 +2955,7 @@ export const CreateProjectsLocationsStudiesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudMlV1__Study).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/studies", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/studies", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsStudiesRequest>;
 
@@ -2986,7 +2986,7 @@ export const ListProjectsLocationsStudiesTrialsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/trials" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/trials" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsStudiesTrialsRequest>;
 
@@ -3018,7 +3018,7 @@ export const DeleteProjectsLocationsStudiesTrialsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsStudiesTrialsRequest>;
 
@@ -3057,7 +3057,7 @@ export const SuggestProjectsLocationsStudiesTrialsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/trials:suggest",
+      path: "v1/{+parent}/trials:suggest",
       hasBody: true,
     }),
     svc,
@@ -3096,7 +3096,11 @@ export const AddMeasurementProjectsLocationsStudiesTrialsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:addMeasurement", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+name}:addMeasurement",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<AddMeasurementProjectsLocationsStudiesTrialsRequest>;
 
@@ -3133,7 +3137,7 @@ export const CompleteProjectsLocationsStudiesTrialsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:complete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:complete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CompleteProjectsLocationsStudiesTrialsRequest>;
 
@@ -3172,7 +3176,7 @@ export const ListOptimalTrialsProjectsLocationsStudiesTrialsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/trials:listOptimalTrials",
+      path: "v1/{+parent}/trials:listOptimalTrials",
       hasBody: true,
     }),
     svc,
@@ -3207,7 +3211,7 @@ export const GetProjectsLocationsStudiesTrialsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsStudiesTrialsRequest>;
 
@@ -3245,7 +3249,7 @@ export const CheckEarlyStoppingStateProjectsLocationsStudiesTrialsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:checkEarlyStoppingState",
+      path: "v1/{+name}:checkEarlyStoppingState",
       hasBody: true,
     }),
     svc,
@@ -3283,7 +3287,7 @@ export const StopProjectsLocationsStudiesTrialsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudMlV1__StopTrialRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsStudiesTrialsRequest>;
 
@@ -3317,7 +3321,7 @@ export const CreateProjectsLocationsStudiesTrialsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudMlV1__Trial).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/trials", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/trials", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsStudiesTrialsRequest>;
 
@@ -3349,7 +3353,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -3381,7 +3385,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/monitoring-v1.ts
+++ b/packages/gcp/src/services/monitoring-v1.ts
@@ -1490,7 +1490,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -1520,7 +1520,7 @@ export const GetLocationsGlobalMetricsScopesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLocationsGlobalMetricsScopesRequest>;
 
@@ -1593,7 +1593,7 @@ export const CreateLocationsGlobalMetricsScopesProjectsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(MonitoredProject).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/projects", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/projects", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateLocationsGlobalMetricsScopesProjectsRequest>;
 
@@ -1624,7 +1624,7 @@ export const DeleteLocationsGlobalMetricsScopesProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteLocationsGlobalMetricsScopesProjectsRequest>;
 
@@ -1661,7 +1661,7 @@ export const ListProjectsDashboardsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dashboards" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dashboards" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDashboardsRequest>;
 
@@ -1696,7 +1696,7 @@ export const GetProjectsDashboardsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDashboardsRequest>;
 
@@ -1735,7 +1735,7 @@ export const PatchProjectsDashboardsRequest =
     ),
     body: Schema.optional(Dashboard).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsDashboardsRequest>;
 
@@ -1774,7 +1774,7 @@ export const CreateProjectsDashboardsRequest =
     ),
     body: Schema.optional(Dashboard).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/dashboards", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/dashboards", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsDashboardsRequest>;
 
@@ -1805,7 +1805,7 @@ export const DeleteProjectsDashboardsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsDashboardsRequest>;
 
@@ -1844,7 +1844,7 @@ export const LabelsProjectsLocationPrometheusApiV1Request =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}/location/{location}/prometheus/api/v1/labels",
+      path: "v1/{+name}/location/{location}/prometheus/api/v1/labels",
       hasBody: true,
     }),
     svc,
@@ -1885,7 +1885,7 @@ export const Query_rangeProjectsLocationPrometheusApiV1Request =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}/location/{location}/prometheus/api/v1/query_range",
+      path: "v1/{+name}/location/{location}/prometheus/api/v1/query_range",
       hasBody: true,
     }),
     svc,
@@ -1926,7 +1926,7 @@ export const Query_exemplarsProjectsLocationPrometheusApiV1Request =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}/location/{location}/prometheus/api/v1/query_exemplars",
+      path: "v1/{+name}/location/{location}/prometheus/api/v1/query_exemplars",
       hasBody: true,
     }),
     svc,
@@ -1967,7 +1967,7 @@ export const QueryProjectsLocationPrometheusApiV1Request =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}/location/{location}/prometheus/api/v1/query",
+      path: "v1/{+name}/location/{location}/prometheus/api/v1/query",
       hasBody: true,
     }),
     svc,
@@ -2008,7 +2008,7 @@ export const SeriesProjectsLocationPrometheusApiV1Request =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}/location/{location}/prometheus/api/v1/series",
+      path: "v1/{+name}/location/{location}/prometheus/api/v1/series",
       hasBody: true,
     }),
     svc,
@@ -2052,7 +2052,7 @@ export const ListProjectsLocationPrometheusApiV1MetadataRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{name}/location/{location}/prometheus/api/v1/metadata",
+      path: "v1/{+name}/location/{location}/prometheus/api/v1/metadata",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationPrometheusApiV1MetadataRequest>;
@@ -2101,7 +2101,7 @@ export const ValuesProjectsLocationPrometheusApiV1LabelRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{name}/location/{location}/prometheus/api/v1/label/{label}/values",
+      path: "v1/{+name}/location/{location}/prometheus/api/v1/label/{label}/values",
     }),
     svc,
   ) as unknown as Schema.Schema<ValuesProjectsLocationPrometheusApiV1LabelRequest>;

--- a/packages/gcp/src/services/monitoring-v3.ts
+++ b/packages/gcp/src/services/monitoring-v3.ts
@@ -2508,7 +2508,7 @@ export const GetProjectsMetricDescriptorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsMetricDescriptorsRequest>;
 
@@ -2539,7 +2539,7 @@ export const DeleteProjectsMetricDescriptorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsMetricDescriptorsRequest>;
 
@@ -2582,7 +2582,7 @@ export const ListProjectsMetricDescriptorsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     activeOnly: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("activeOnly")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}/metricDescriptors" }),
+    T.Http({ method: "GET", path: "v3/{+name}/metricDescriptors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsMetricDescriptorsRequest>;
 
@@ -2623,7 +2623,7 @@ export const CreateProjectsMetricDescriptorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{name}/metricDescriptors",
+      path: "v3/{+name}/metricDescriptors",
       hasBody: true,
     }),
     svc,
@@ -2661,7 +2661,7 @@ export const CreateServiceProjectsTimeSeriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{name}/timeSeries:createService",
+      path: "v3/{+name}/timeSeries:createService",
       hasBody: true,
     }),
     svc,
@@ -2699,7 +2699,7 @@ export const QueryProjectsTimeSeriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{name}/timeSeries:query",
+      path: "v3/{+name}/timeSeries:query",
       hasBody: true,
     }),
     svc,
@@ -2867,7 +2867,7 @@ export const ListProjectsTimeSeriesRequest =
       T.HttpQuery("aggregation.crossSeriesReducer"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}/timeSeries" }),
+    T.Http({ method: "GET", path: "v3/{+name}/timeSeries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTimeSeriesRequest>;
 
@@ -2905,7 +2905,7 @@ export const CreateProjectsTimeSeriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CreateTimeSeriesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}/timeSeries", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}/timeSeries", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsTimeSeriesRequest>;
 
@@ -2945,7 +2945,7 @@ export const ListProjectsMonitoredResourceDescriptorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}/monitoredResourceDescriptors" }),
+    T.Http({ method: "GET", path: "v3/{+name}/monitoredResourceDescriptors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsMonitoredResourceDescriptorsRequest>;
 
@@ -2981,7 +2981,7 @@ export const GetProjectsMonitoredResourceDescriptorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsMonitoredResourceDescriptorsRequest>;
 
@@ -3016,7 +3016,7 @@ export const CreateProjectsSnoozesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Snooze).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/snoozes", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/snoozes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsSnoozesRequest>;
 
@@ -3055,7 +3055,7 @@ export const ListProjectsSnoozesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/snoozes" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/snoozes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSnoozesRequest>;
 
@@ -3096,7 +3096,7 @@ export const PatchProjectsSnoozesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Snooze).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsSnoozesRequest>;
 
@@ -3126,7 +3126,7 @@ export const GetProjectsSnoozesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSnoozesRequest>;
 
@@ -3161,7 +3161,7 @@ export const CreateProjectsUptimeCheckConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}/uptimeCheckConfigs",
+      path: "v3/{+parent}/uptimeCheckConfigs",
       hasBody: true,
     }),
     svc,
@@ -3200,7 +3200,7 @@ export const PatchProjectsUptimeCheckConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(UptimeCheckConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsUptimeCheckConfigsRequest>;
 
@@ -3240,7 +3240,7 @@ export const ListProjectsUptimeCheckConfigsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/uptimeCheckConfigs" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/uptimeCheckConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsUptimeCheckConfigsRequest>;
 
@@ -3276,7 +3276,7 @@ export const DeleteProjectsUptimeCheckConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsUptimeCheckConfigsRequest>;
 
@@ -3307,7 +3307,7 @@ export const GetProjectsUptimeCheckConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsUptimeCheckConfigsRequest>;
 
@@ -3359,7 +3359,7 @@ export const ListProjectsGroupsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}/groups" }),
+    T.Http({ method: "GET", path: "v3/{+name}/groups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsGroupsRequest>;
 
@@ -3394,7 +3394,7 @@ export const GetProjectsGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsGroupsRequest>;
 
@@ -3427,7 +3427,7 @@ export const DeleteProjectsGroupsRequest =
     recursive: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("recursive")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsGroupsRequest>;
 
@@ -3465,7 +3465,7 @@ export const CreateProjectsGroupsRequest =
     ),
     body: Schema.optional(Group).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}/groups", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}/groups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsGroupsRequest>;
 
@@ -3503,7 +3503,7 @@ export const UpdateProjectsGroupsRequest =
     ),
     body: Schema.optional(Group).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsGroupsRequest>;
 
@@ -3552,7 +3552,7 @@ export const ListProjectsGroupsMembersRequest =
       T.HttpQuery("interval.endTime"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}/members" }),
+    T.Http({ method: "GET", path: "v3/{+name}/members" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsGroupsMembersRequest>;
 
@@ -3593,7 +3593,10 @@ export const ListProjectsNotificationChannelDescriptorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}/notificationChannelDescriptors" }),
+    T.Http({
+      method: "GET",
+      path: "v3/{+name}/notificationChannelDescriptors",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsNotificationChannelDescriptorsRequest>;
 
@@ -3629,7 +3632,7 @@ export const GetProjectsNotificationChannelDescriptorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsNotificationChannelDescriptorsRequest>;
 
@@ -3673,7 +3676,7 @@ export const ListProjectsAlertsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/alerts" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/alerts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAlertsRequest>;
 
@@ -3708,7 +3711,7 @@ export const GetProjectsAlertsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAlertsRequest>;
 
@@ -3741,7 +3744,7 @@ export const DeleteProjectsNotificationChannelsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsNotificationChannelsRequest>;
 
@@ -3772,7 +3775,7 @@ export const GetProjectsNotificationChannelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsNotificationChannelsRequest>;
 
@@ -3810,7 +3813,7 @@ export const SendVerificationCodeProjectsNotificationChannelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{name}:sendVerificationCode",
+      path: "v3/{+name}:sendVerificationCode",
       hasBody: true,
     }),
     svc,
@@ -3856,7 +3859,7 @@ export const ListProjectsNotificationChannelsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}/notificationChannels" }),
+    T.Http({ method: "GET", path: "v3/{+name}/notificationChannels" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsNotificationChannelsRequest>;
 
@@ -3895,7 +3898,7 @@ export const VerifyProjectsNotificationChannelsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(VerifyNotificationChannelRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:verify", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:verify", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<VerifyProjectsNotificationChannelsRequest>;
 
@@ -3933,7 +3936,7 @@ export const GetVerificationCodeProjectsNotificationChannelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{name}:getVerificationCode",
+      path: "v3/{+name}:getVerificationCode",
       hasBody: true,
     }),
     svc,
@@ -3973,7 +3976,7 @@ export const CreateProjectsNotificationChannelsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{name}/notificationChannels",
+      path: "v3/{+name}/notificationChannels",
       hasBody: true,
     }),
     svc,
@@ -4012,7 +4015,7 @@ export const PatchProjectsNotificationChannelsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(NotificationChannel).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsNotificationChannelsRequest>;
 
@@ -4048,7 +4051,7 @@ export const CreateProjectsCollectdTimeSeriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{name}/collectdTimeSeries",
+      path: "v3/{+name}/collectdTimeSeries",
       hasBody: true,
     }),
     svc,
@@ -4082,7 +4085,7 @@ export const DeleteProjectsAlertPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAlertPoliciesRequest>;
 
@@ -4113,7 +4116,7 @@ export const GetProjectsAlertPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAlertPoliciesRequest>;
 
@@ -4156,7 +4159,7 @@ export const ListProjectsAlertPoliciesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}/alertPolicies" }),
+    T.Http({ method: "GET", path: "v3/{+name}/alertPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAlertPoliciesRequest>;
 
@@ -4194,7 +4197,7 @@ export const CreateProjectsAlertPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AlertPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}/alertPolicies", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}/alertPolicies", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsAlertPoliciesRequest>;
 
@@ -4231,7 +4234,7 @@ export const PatchProjectsAlertPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AlertPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAlertPoliciesRequest>;
 
@@ -4397,7 +4400,7 @@ export const ListOrganizationsTimeSeriesRequest =
       Schema.Array(Schema.String),
     ).pipe(T.HttpQuery("aggregation.groupByFields")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}/timeSeries" }),
+    T.Http({ method: "GET", path: "v3/{+name}/timeSeries" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsTimeSeriesRequest>;
 
@@ -4567,7 +4570,7 @@ export const ListFoldersTimeSeriesRequest =
       Schema.Array(Schema.String),
     ).pipe(T.HttpQuery("aggregation.groupByFields")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}/timeSeries" }),
+    T.Http({ method: "GET", path: "v3/{+name}/timeSeries" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersTimeSeriesRequest>;
 
@@ -4607,7 +4610,7 @@ export const CreateServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   parent: Schema.String.pipe(T.HttpPath("parent")),
   body: Schema.optional(Service).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v3/{parent}/services", hasBody: true }),
+  T.Http({ method: "POST", path: "v3/{+parent}/services", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<CreateServicesRequest>;
 
@@ -4642,7 +4645,7 @@ export const PatchServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(Service).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchServicesRequest>;
 
@@ -4680,7 +4683,7 @@ export const ListServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
 }).pipe(
-  T.Http({ method: "GET", path: "v3/{parent}/services" }),
+  T.Http({ method: "GET", path: "v3/{+parent}/services" }),
   svc,
 ) as unknown as Schema.Schema<ListServicesRequest>;
 
@@ -4714,7 +4717,7 @@ export interface DeleteServicesRequest {
 export const DeleteServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v3/{name}" }),
+  T.Http({ method: "DELETE", path: "v3/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteServicesRequest>;
 
@@ -4743,7 +4746,7 @@ export interface GetServicesRequest {
 export const GetServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v3/{name}" }),
+  T.Http({ method: "GET", path: "v3/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetServicesRequest>;
 
@@ -4773,7 +4776,7 @@ export const DeleteServicesServiceLevelObjectivesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteServicesServiceLevelObjectivesRequest>;
 
@@ -4807,7 +4810,7 @@ export const GetServicesServiceLevelObjectivesRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetServicesServiceLevelObjectivesRequest>;
 
@@ -4850,7 +4853,7 @@ export const ListServicesServiceLevelObjectivesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/serviceLevelObjectives" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/serviceLevelObjectives" }),
     svc,
   ) as unknown as Schema.Schema<ListServicesServiceLevelObjectivesRequest>;
 
@@ -4896,7 +4899,7 @@ export const CreateServicesServiceLevelObjectivesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}/serviceLevelObjectives",
+      path: "v3/{+parent}/serviceLevelObjectives",
       hasBody: true,
     }),
     svc,
@@ -4936,7 +4939,7 @@ export const PatchServicesServiceLevelObjectivesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ServiceLevelObjective).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchServicesServiceLevelObjectivesRequest>;
 

--- a/packages/gcp/src/services/mybusinessaccountmanagement-v1.ts
+++ b/packages/gcp/src/services/mybusinessaccountmanagement-v1.ts
@@ -292,7 +292,7 @@ export interface GetAccountsRequest {
 export const GetAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetAccountsRequest>;
 
@@ -361,7 +361,7 @@ export const PatchAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(Account).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchAccountsRequest>;
 
@@ -439,7 +439,7 @@ export const AcceptAccountsInvitationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AcceptInvitationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:accept", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:accept", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AcceptAccountsInvitationsRequest>;
 
@@ -473,7 +473,7 @@ export const ListAccountsInvitationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/invitations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/invitations" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsInvitationsRequest>;
 
@@ -507,7 +507,7 @@ export const DeclineAccountsInvitationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DeclineInvitationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:decline", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:decline", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeclineAccountsInvitationsRequest>;
 
@@ -538,7 +538,7 @@ export const DeleteAccountsAdminsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsAdminsRequest>;
 
@@ -571,7 +571,7 @@ export const CreateAccountsAdminsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Admin).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/admins", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/admins", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateAccountsAdminsRequest>;
 
@@ -607,7 +607,7 @@ export const PatchAccountsAdminsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Admin).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAccountsAdminsRequest>;
 
@@ -637,7 +637,7 @@ export const ListAccountsAdminsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/admins" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/admins" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsAdminsRequest>;
 
@@ -671,7 +671,7 @@ export const TransferLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(TransferLocationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:transfer", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:transfer", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TransferLocationsRequest>;
 
@@ -701,7 +701,7 @@ export const DeleteLocationsAdminsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteLocationsAdminsRequest>;
 
@@ -734,7 +734,7 @@ export const CreateLocationsAdminsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Admin).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/admins", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/admins", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateLocationsAdminsRequest>;
 
@@ -770,7 +770,7 @@ export const PatchLocationsAdminsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Admin).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchLocationsAdminsRequest>;
 
@@ -800,7 +800,7 @@ export const ListLocationsAdminsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/admins" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/admins" }),
     svc,
   ) as unknown as Schema.Schema<ListLocationsAdminsRequest>;
 

--- a/packages/gcp/src/services/mybusinessbusinessinformation-v1.ts
+++ b/packages/gcp/src/services/mybusinessbusinessinformation-v1.ts
@@ -844,7 +844,7 @@ export const GetLocationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetLocationsRequest>;
 
@@ -877,7 +877,7 @@ export const GetGoogleUpdatedLocationsRequest =
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getGoogleUpdated" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getGoogleUpdated" }),
     svc,
   ) as unknown as Schema.Schema<GetGoogleUpdatedLocationsRequest>;
 
@@ -916,7 +916,7 @@ export const UpdateAttributesLocationsRequest =
     ),
     body: Schema.optional(Attributes).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAttributesLocationsRequest>;
 
@@ -947,7 +947,7 @@ export const GetAttributesLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAttributesLocationsRequest>;
 
@@ -979,7 +979,7 @@ export const DeleteLocationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     name: Schema.String.pipe(T.HttpPath("name")),
   },
 ).pipe(
-  T.Http({ method: "DELETE", path: "v1/{name}" }),
+  T.Http({ method: "DELETE", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteLocationsRequest>;
 
@@ -1019,7 +1019,7 @@ export const PatchLocationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(Location).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchLocationsRequest>;
 
@@ -1049,7 +1049,7 @@ export const GetGoogleUpdatedLocationsAttributesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getGoogleUpdated" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getGoogleUpdated" }),
     svc,
   ) as unknown as Schema.Schema<GetGoogleUpdatedLocationsAttributesRequest>;
 
@@ -1095,7 +1095,7 @@ export const ListAccountsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsLocationsRequest>;
 
@@ -1141,7 +1141,7 @@ export const CreateAccountsLocationsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Location).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/locations", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/locations", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateAccountsLocationsRequest>;
 
@@ -1266,7 +1266,7 @@ export interface GetChainsRequest {
 export const GetChainsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetChainsRequest>;
 

--- a/packages/gcp/src/services/mybusinesslodging-v1.ts
+++ b/packages/gcp/src/services/mybusinesslodging-v1.ts
@@ -3470,7 +3470,7 @@ export const GetLodgingLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLodgingLocationsRequest>;
 
@@ -3506,7 +3506,7 @@ export const UpdateLodgingLocationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Lodging).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateLodgingLocationsRequest>;
 
@@ -3540,7 +3540,7 @@ export const GetGoogleUpdatedLocationsLodgingRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getGoogleUpdated" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getGoogleUpdated" }),
     svc,
   ) as unknown as Schema.Schema<GetGoogleUpdatedLocationsLodgingRequest>;
 

--- a/packages/gcp/src/services/mybusinessnotifications-v1.ts
+++ b/packages/gcp/src/services/mybusinessnotifications-v1.ts
@@ -64,7 +64,7 @@ export const GetNotificationSettingAccountsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNotificationSettingAccountsRequest>;
 
@@ -101,7 +101,7 @@ export const UpdateNotificationSettingAccountsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(NotificationSetting).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateNotificationSettingAccountsRequest>;
 

--- a/packages/gcp/src/services/mybusinessplaceactions-v1.ts
+++ b/packages/gcp/src/services/mybusinessplaceactions-v1.ts
@@ -192,7 +192,7 @@ export const ListLocationsPlaceActionLinksRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/placeActionLinks" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/placeActionLinks" }),
     svc,
   ) as unknown as Schema.Schema<ListLocationsPlaceActionLinksRequest>;
 
@@ -233,7 +233,7 @@ export const CreateLocationsPlaceActionLinksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/placeActionLinks",
+      path: "v1/{+parent}/placeActionLinks",
       hasBody: true,
     }),
     svc,
@@ -272,7 +272,7 @@ export const PatchLocationsPlaceActionLinksRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PlaceActionLink).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchLocationsPlaceActionLinksRequest>;
 
@@ -303,7 +303,7 @@ export const GetLocationsPlaceActionLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLocationsPlaceActionLinksRequest>;
 
@@ -334,7 +334,7 @@ export const DeleteLocationsPlaceActionLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteLocationsPlaceActionLinksRequest>;
 

--- a/packages/gcp/src/services/mybusinessqanda-v1.ts
+++ b/packages/gcp/src/services/mybusinessqanda-v1.ts
@@ -171,7 +171,7 @@ export const ListLocationsQuestionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}" }),
+    T.Http({ method: "GET", path: "v1/{+parent}" }),
     svc,
   ) as unknown as Schema.Schema<ListLocationsQuestionsRequest>;
 
@@ -209,7 +209,7 @@ export const CreateLocationsQuestionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Question).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateLocationsQuestionsRequest>;
 
@@ -246,7 +246,7 @@ export const PatchLocationsQuestionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Question).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchLocationsQuestionsRequest>;
 
@@ -277,7 +277,7 @@ export const DeleteLocationsQuestionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteLocationsQuestionsRequest>;
 
@@ -317,7 +317,7 @@ export const ListLocationsQuestionsAnswersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/answers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/answers" }),
     svc,
   ) as unknown as Schema.Schema<ListLocationsQuestionsAnswersRequest>;
 
@@ -357,7 +357,7 @@ export const UpsertLocationsQuestionsAnswersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/answers:upsert",
+      path: "v1/{+parent}/answers:upsert",
       hasBody: true,
     }),
     svc,
@@ -390,7 +390,7 @@ export const DeleteLocationsQuestionsAnswersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}/answers:delete" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}/answers:delete" }),
     svc,
   ) as unknown as Schema.Schema<DeleteLocationsQuestionsAnswersRequest>;
 

--- a/packages/gcp/src/services/mybusinessverifications-v1.ts
+++ b/packages/gcp/src/services/mybusinessverifications-v1.ts
@@ -393,7 +393,7 @@ export const GetVoiceOfMerchantStateLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/VoiceOfMerchantState" }),
+    T.Http({ method: "GET", path: "v1/{+name}/VoiceOfMerchantState" }),
     svc,
   ) as unknown as Schema.Schema<GetVoiceOfMerchantStateLocationsRequest>;
 
@@ -429,7 +429,7 @@ export const FetchVerificationOptionsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{location}:fetchVerificationOptions",
+      path: "v1/{+location}:fetchVerificationOptions",
       hasBody: true,
     }),
     svc,
@@ -467,7 +467,7 @@ export const VerifyLocationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     body: Schema.optional(VerifyLocationRequest).pipe(T.HttpBody()),
   },
 ).pipe(
-  T.Http({ method: "POST", path: "v1/{name}:verify", hasBody: true }),
+  T.Http({ method: "POST", path: "v1/{+name}:verify", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<VerifyLocationsRequest>;
 
@@ -501,7 +501,7 @@ export const CompleteLocationsVerificationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CompleteVerificationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:complete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:complete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CompleteLocationsVerificationsRequest>;
 
@@ -539,7 +539,7 @@ export const ListLocationsVerificationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/verifications" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/verifications" }),
     svc,
   ) as unknown as Schema.Schema<ListLocationsVerificationsRequest>;
 

--- a/packages/gcp/src/services/netapp-v1.ts
+++ b/packages/gcp/src/services/netapp-v1.ts
@@ -1918,7 +1918,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1953,7 +1953,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1998,7 +1998,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2033,7 +2033,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2064,7 +2064,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2098,7 +2098,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2141,7 +2141,7 @@ export const ListProjectsLocationsStoragePoolsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/storagePools" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/storagePools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsStoragePoolsRequest>;
 
@@ -2185,7 +2185,11 @@ export const CreateProjectsLocationsStoragePoolsRequest =
     ),
     body: Schema.optional(StoragePool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/storagePools", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/storagePools",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsStoragePoolsRequest>;
 
@@ -2216,7 +2220,7 @@ export const GetProjectsLocationsStoragePoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsStoragePoolsRequest>;
 
@@ -2253,7 +2257,7 @@ export const PatchProjectsLocationsStoragePoolsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(StoragePool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsStoragePoolsRequest>;
 
@@ -2284,7 +2288,7 @@ export const DeleteProjectsLocationsStoragePoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsStoragePoolsRequest>;
 
@@ -2320,7 +2324,7 @@ export const ValidateDirectoryServiceProjectsLocationsStoragePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:validateDirectoryService",
+      path: "v1/{+name}:validateDirectoryService",
       hasBody: true,
     }),
     svc,
@@ -2358,7 +2362,7 @@ export const SwitchProjectsLocationsStoragePoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SwitchActiveReplicaZoneRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:switch", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:switch", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SwitchProjectsLocationsStoragePoolsRequest>;
 
@@ -2392,7 +2396,7 @@ export const ExecuteOntapPostProjectsLocationsStoragePoolsOntapRequest =
     ontapPath: Schema.String.pipe(T.HttpPath("ontapPath")),
     body: Schema.optional(ExecuteOntapPostRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{ontapPath}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+ontapPath}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteOntapPostProjectsLocationsStoragePoolsOntapRequest>;
 
@@ -2425,7 +2429,7 @@ export const ExecuteOntapGetProjectsLocationsStoragePoolsOntapRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     ontapPath: Schema.String.pipe(T.HttpPath("ontapPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{ontapPath}" }),
+    T.Http({ method: "GET", path: "v1/{+ontapPath}" }),
     svc,
   ) as unknown as Schema.Schema<ExecuteOntapGetProjectsLocationsStoragePoolsOntapRequest>;
 
@@ -2458,7 +2462,7 @@ export const ExecuteOntapDeleteProjectsLocationsStoragePoolsOntapRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     ontapPath: Schema.String.pipe(T.HttpPath("ontapPath")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{ontapPath}" }),
+    T.Http({ method: "DELETE", path: "v1/{+ontapPath}" }),
     svc,
   ) as unknown as Schema.Schema<ExecuteOntapDeleteProjectsLocationsStoragePoolsOntapRequest>;
 
@@ -2494,7 +2498,7 @@ export const ExecuteOntapPatchProjectsLocationsStoragePoolsOntapRequest =
     ontapPath: Schema.String.pipe(T.HttpPath("ontapPath")),
     body: Schema.optional(ExecuteOntapPatchRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{ontapPath}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+ontapPath}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteOntapPatchProjectsLocationsStoragePoolsOntapRequest>;
 
@@ -2539,7 +2543,7 @@ export const ListProjectsLocationsVolumesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/volumes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/volumes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVolumesRequest>;
 
@@ -2574,7 +2578,7 @@ export const GetProjectsLocationsVolumesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVolumesRequest>;
 
@@ -2611,7 +2615,7 @@ export const CreateProjectsLocationsVolumesRequest =
     volumeId: Schema.optional(Schema.String).pipe(T.HttpQuery("volumeId")),
     body: Schema.optional(Volume).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/volumes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/volumes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsVolumesRequest>;
 
@@ -2648,7 +2652,7 @@ export const PatchProjectsLocationsVolumesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Volume).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsVolumesRequest>;
 
@@ -2682,7 +2686,7 @@ export const DeleteProjectsLocationsVolumesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsVolumesRequest>;
 
@@ -2716,7 +2720,7 @@ export const RevertProjectsLocationsVolumesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RevertVolumeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:revert", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:revert", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RevertProjectsLocationsVolumesRequest>;
 
@@ -2752,7 +2756,7 @@ export const EstablishPeeringProjectsLocationsVolumesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:establishPeering",
+      path: "v1/{+name}:establishPeering",
       hasBody: true,
     }),
     svc,
@@ -2788,7 +2792,7 @@ export const RestoreProjectsLocationsVolumesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestoreBackupFilesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsVolumesRequest>;
 
@@ -2831,7 +2835,7 @@ export const ListProjectsLocationsVolumesSnapshotsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/snapshots" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/snapshots" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVolumesSnapshotsRequest>;
 
@@ -2867,7 +2871,7 @@ export const GetProjectsLocationsVolumesSnapshotsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVolumesSnapshotsRequest>;
 
@@ -2904,7 +2908,7 @@ export const CreateProjectsLocationsVolumesSnapshotsRequest =
     snapshotId: Schema.optional(Schema.String).pipe(T.HttpQuery("snapshotId")),
     body: Schema.optional(Snapshot).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/snapshots", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/snapshots", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsVolumesSnapshotsRequest>;
 
@@ -2935,7 +2939,7 @@ export const DeleteProjectsLocationsVolumesSnapshotsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsVolumesSnapshotsRequest>;
 
@@ -2972,7 +2976,7 @@ export const PatchProjectsLocationsVolumesSnapshotsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Snapshot).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsVolumesSnapshotsRequest>;
 
@@ -3015,7 +3019,7 @@ export const ListProjectsLocationsVolumesReplicationsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/replications" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/replications" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVolumesReplicationsRequest>;
 
@@ -3051,7 +3055,7 @@ export const GetProjectsLocationsVolumesReplicationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVolumesReplicationsRequest>;
 
@@ -3090,7 +3094,11 @@ export const CreateProjectsLocationsVolumesReplicationsRequest =
     ),
     body: Schema.optional(Replication).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/replications", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/replications",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsVolumesReplicationsRequest>;
 
@@ -3121,7 +3129,7 @@ export const DeleteProjectsLocationsVolumesReplicationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsVolumesReplicationsRequest>;
 
@@ -3158,7 +3166,7 @@ export const PatchProjectsLocationsVolumesReplicationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Replication).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsVolumesReplicationsRequest>;
 
@@ -3192,7 +3200,7 @@ export const StopProjectsLocationsVolumesReplicationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopReplicationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsVolumesReplicationsRequest>;
 
@@ -3226,7 +3234,7 @@ export const ResumeProjectsLocationsVolumesReplicationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResumeReplicationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsVolumesReplicationsRequest>;
 
@@ -3264,7 +3272,7 @@ export const ReverseDirectionProjectsLocationsVolumesReplicationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:reverseDirection",
+      path: "v1/{+name}:reverseDirection",
       hasBody: true,
     }),
     svc,
@@ -3304,7 +3312,7 @@ export const EstablishPeeringProjectsLocationsVolumesReplicationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:establishPeering",
+      path: "v1/{+name}:establishPeering",
       hasBody: true,
     }),
     svc,
@@ -3342,7 +3350,7 @@ export const SyncProjectsLocationsVolumesReplicationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SyncReplicationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:sync", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:sync", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SyncProjectsLocationsVolumesReplicationsRequest>;
 
@@ -3385,7 +3393,7 @@ export const ListProjectsLocationsVolumesQuotaRulesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/quotaRules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/quotaRules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVolumesQuotaRulesRequest>;
 
@@ -3421,7 +3429,7 @@ export const GetProjectsLocationsVolumesQuotaRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVolumesQuotaRulesRequest>;
 
@@ -3460,7 +3468,7 @@ export const CreateProjectsLocationsVolumesQuotaRulesRequest =
     ),
     body: Schema.optional(QuotaRule).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/quotaRules", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/quotaRules", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsVolumesQuotaRulesRequest>;
 
@@ -3497,7 +3505,7 @@ export const PatchProjectsLocationsVolumesQuotaRulesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(QuotaRule).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsVolumesQuotaRulesRequest>;
 
@@ -3528,7 +3536,7 @@ export const DeleteProjectsLocationsVolumesQuotaRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsVolumesQuotaRulesRequest>;
 
@@ -3571,7 +3579,7 @@ export const ListProjectsLocationsActiveDirectoriesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/activeDirectories" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/activeDirectories" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsActiveDirectoriesRequest>;
 
@@ -3607,7 +3615,7 @@ export const GetProjectsLocationsActiveDirectoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsActiveDirectoriesRequest>;
 
@@ -3648,7 +3656,7 @@ export const CreateProjectsLocationsActiveDirectoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/activeDirectories",
+      path: "v1/{+parent}/activeDirectories",
       hasBody: true,
     }),
     svc,
@@ -3687,7 +3695,7 @@ export const PatchProjectsLocationsActiveDirectoriesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ActiveDirectory).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsActiveDirectoriesRequest>;
 
@@ -3718,7 +3726,7 @@ export const DeleteProjectsLocationsActiveDirectoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsActiveDirectoriesRequest>;
 
@@ -3761,7 +3769,7 @@ export const ListProjectsLocationsKmsConfigsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/kmsConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/kmsConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsKmsConfigsRequest>;
 
@@ -3804,7 +3812,7 @@ export const CreateProjectsLocationsKmsConfigsRequest =
     ),
     body: Schema.optional(KmsConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/kmsConfigs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/kmsConfigs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsKmsConfigsRequest>;
 
@@ -3835,7 +3843,7 @@ export const GetProjectsLocationsKmsConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsKmsConfigsRequest>;
 
@@ -3872,7 +3880,7 @@ export const PatchProjectsLocationsKmsConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(KmsConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsKmsConfigsRequest>;
 
@@ -3906,7 +3914,7 @@ export const EncryptProjectsLocationsKmsConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EncryptVolumesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:encrypt", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:encrypt", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EncryptProjectsLocationsKmsConfigsRequest>;
 
@@ -3940,7 +3948,7 @@ export const VerifyProjectsLocationsKmsConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(VerifyKmsConfigRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:verify", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:verify", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<VerifyProjectsLocationsKmsConfigsRequest>;
 
@@ -3971,7 +3979,7 @@ export const DeleteProjectsLocationsKmsConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsKmsConfigsRequest>;
 
@@ -4010,7 +4018,11 @@ export const CreateProjectsLocationsBackupVaultsRequest =
     ),
     body: Schema.optional(BackupVault).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/backupVaults", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/backupVaults",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackupVaultsRequest>;
 
@@ -4041,7 +4053,7 @@ export const GetProjectsLocationsBackupVaultsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupVaultsRequest>;
 
@@ -4084,7 +4096,7 @@ export const ListProjectsLocationsBackupVaultsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backupVaults" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backupVaults" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupVaultsRequest>;
 
@@ -4126,7 +4138,7 @@ export const PatchProjectsLocationsBackupVaultsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(BackupVault).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupVaultsRequest>;
 
@@ -4157,7 +4169,7 @@ export const DeleteProjectsLocationsBackupVaultsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupVaultsRequest>;
 
@@ -4194,7 +4206,7 @@ export const CreateProjectsLocationsBackupVaultsBackupsRequest =
     backupId: Schema.optional(Schema.String).pipe(T.HttpQuery("backupId")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/backups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/backups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackupVaultsBackupsRequest>;
 
@@ -4225,7 +4237,7 @@ export const GetProjectsLocationsBackupVaultsBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupVaultsBackupsRequest>;
 
@@ -4268,7 +4280,7 @@ export const ListProjectsLocationsBackupVaultsBackupsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupVaultsBackupsRequest>;
 
@@ -4304,7 +4316,7 @@ export const DeleteProjectsLocationsBackupVaultsBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupVaultsBackupsRequest>;
 
@@ -4341,7 +4353,7 @@ export const PatchProjectsLocationsBackupVaultsBackupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupVaultsBackupsRequest>;
 
@@ -4382,7 +4394,7 @@ export const CreateProjectsLocationsBackupPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/backupPolicies",
+      path: "v1/{+parent}/backupPolicies",
       hasBody: true,
     }),
     svc,
@@ -4415,7 +4427,7 @@ export const GetProjectsLocationsBackupPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupPoliciesRequest>;
 
@@ -4458,7 +4470,7 @@ export const ListProjectsLocationsBackupPoliciesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backupPolicies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backupPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupPoliciesRequest>;
 
@@ -4500,7 +4512,7 @@ export const PatchProjectsLocationsBackupPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(BackupPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupPoliciesRequest>;
 
@@ -4531,7 +4543,7 @@ export const DeleteProjectsLocationsBackupPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupPoliciesRequest>;
 
@@ -4574,7 +4586,7 @@ export const ListProjectsLocationsHostGroupsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/hostGroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/hostGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsHostGroupsRequest>;
 
@@ -4609,7 +4621,7 @@ export const GetProjectsLocationsHostGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsHostGroupsRequest>;
 
@@ -4648,7 +4660,7 @@ export const CreateProjectsLocationsHostGroupsRequest =
     ),
     body: Schema.optional(HostGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/hostGroups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/hostGroups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsHostGroupsRequest>;
 
@@ -4685,7 +4697,7 @@ export const PatchProjectsLocationsHostGroupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(HostGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsHostGroupsRequest>;
 
@@ -4716,7 +4728,7 @@ export const DeleteProjectsLocationsHostGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsHostGroupsRequest>;
 

--- a/packages/gcp/src/services/netapp-v1beta1.ts
+++ b/packages/gcp/src/services/netapp-v1beta1.ts
@@ -1928,7 +1928,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1963,7 +1963,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2008,7 +2008,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2043,7 +2043,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2074,7 +2074,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2108,7 +2108,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2151,7 +2151,7 @@ export const ListProjectsLocationsStoragePoolsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/storagePools" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/storagePools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsStoragePoolsRequest>;
 
@@ -2197,7 +2197,7 @@ export const CreateProjectsLocationsStoragePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/storagePools",
+      path: "v1beta1/{+parent}/storagePools",
       hasBody: true,
     }),
     svc,
@@ -2230,7 +2230,7 @@ export const GetProjectsLocationsStoragePoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsStoragePoolsRequest>;
 
@@ -2267,7 +2267,7 @@ export const PatchProjectsLocationsStoragePoolsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(StoragePool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsStoragePoolsRequest>;
 
@@ -2298,7 +2298,7 @@ export const DeleteProjectsLocationsStoragePoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsStoragePoolsRequest>;
 
@@ -2334,7 +2334,7 @@ export const ValidateDirectoryServiceProjectsLocationsStoragePoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:validateDirectoryService",
+      path: "v1beta1/{+name}:validateDirectoryService",
       hasBody: true,
     }),
     svc,
@@ -2372,7 +2372,7 @@ export const SwitchProjectsLocationsStoragePoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SwitchActiveReplicaZoneRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:switch", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:switch", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SwitchProjectsLocationsStoragePoolsRequest>;
 
@@ -2406,7 +2406,7 @@ export const ExecuteOntapPostProjectsLocationsStoragePoolsOntapRequest =
     ontapPath: Schema.String.pipe(T.HttpPath("ontapPath")),
     body: Schema.optional(ExecuteOntapPostRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{ontapPath}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+ontapPath}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteOntapPostProjectsLocationsStoragePoolsOntapRequest>;
 
@@ -2439,7 +2439,7 @@ export const ExecuteOntapGetProjectsLocationsStoragePoolsOntapRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     ontapPath: Schema.String.pipe(T.HttpPath("ontapPath")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{ontapPath}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+ontapPath}" }),
     svc,
   ) as unknown as Schema.Schema<ExecuteOntapGetProjectsLocationsStoragePoolsOntapRequest>;
 
@@ -2472,7 +2472,7 @@ export const ExecuteOntapDeleteProjectsLocationsStoragePoolsOntapRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     ontapPath: Schema.String.pipe(T.HttpPath("ontapPath")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{ontapPath}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+ontapPath}" }),
     svc,
   ) as unknown as Schema.Schema<ExecuteOntapDeleteProjectsLocationsStoragePoolsOntapRequest>;
 
@@ -2508,7 +2508,7 @@ export const ExecuteOntapPatchProjectsLocationsStoragePoolsOntapRequest =
     ontapPath: Schema.String.pipe(T.HttpPath("ontapPath")),
     body: Schema.optional(ExecuteOntapPatchRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{ontapPath}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+ontapPath}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteOntapPatchProjectsLocationsStoragePoolsOntapRequest>;
 
@@ -2553,7 +2553,7 @@ export const ListProjectsLocationsVolumesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/volumes" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/volumes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVolumesRequest>;
 
@@ -2588,7 +2588,7 @@ export const GetProjectsLocationsVolumesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVolumesRequest>;
 
@@ -2625,7 +2625,11 @@ export const CreateProjectsLocationsVolumesRequest =
     volumeId: Schema.optional(Schema.String).pipe(T.HttpQuery("volumeId")),
     body: Schema.optional(Volume).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/volumes", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/volumes",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsVolumesRequest>;
 
@@ -2662,7 +2666,7 @@ export const PatchProjectsLocationsVolumesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Volume).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsVolumesRequest>;
 
@@ -2696,7 +2700,7 @@ export const DeleteProjectsLocationsVolumesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsVolumesRequest>;
 
@@ -2730,7 +2734,7 @@ export const RevertProjectsLocationsVolumesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RevertVolumeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:revert", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:revert", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RevertProjectsLocationsVolumesRequest>;
 
@@ -2766,7 +2770,7 @@ export const EstablishPeeringProjectsLocationsVolumesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:establishPeering",
+      path: "v1beta1/{+name}:establishPeering",
       hasBody: true,
     }),
     svc,
@@ -2802,7 +2806,7 @@ export const RestoreProjectsLocationsVolumesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestoreBackupFilesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsVolumesRequest>;
 
@@ -2845,7 +2849,7 @@ export const ListProjectsLocationsVolumesSnapshotsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/snapshots" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/snapshots" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVolumesSnapshotsRequest>;
 
@@ -2881,7 +2885,7 @@ export const GetProjectsLocationsVolumesSnapshotsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVolumesSnapshotsRequest>;
 
@@ -2920,7 +2924,7 @@ export const CreateProjectsLocationsVolumesSnapshotsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/snapshots",
+      path: "v1beta1/{+parent}/snapshots",
       hasBody: true,
     }),
     svc,
@@ -2953,7 +2957,7 @@ export const DeleteProjectsLocationsVolumesSnapshotsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsVolumesSnapshotsRequest>;
 
@@ -2990,7 +2994,7 @@ export const PatchProjectsLocationsVolumesSnapshotsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Snapshot).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsVolumesSnapshotsRequest>;
 
@@ -3033,7 +3037,7 @@ export const ListProjectsLocationsVolumesReplicationsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/replications" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/replications" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVolumesReplicationsRequest>;
 
@@ -3069,7 +3073,7 @@ export const GetProjectsLocationsVolumesReplicationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVolumesReplicationsRequest>;
 
@@ -3110,7 +3114,7 @@ export const CreateProjectsLocationsVolumesReplicationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/replications",
+      path: "v1beta1/{+parent}/replications",
       hasBody: true,
     }),
     svc,
@@ -3143,7 +3147,7 @@ export const DeleteProjectsLocationsVolumesReplicationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsVolumesReplicationsRequest>;
 
@@ -3180,7 +3184,7 @@ export const PatchProjectsLocationsVolumesReplicationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Replication).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsVolumesReplicationsRequest>;
 
@@ -3214,7 +3218,7 @@ export const StopProjectsLocationsVolumesReplicationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopReplicationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsVolumesReplicationsRequest>;
 
@@ -3248,7 +3252,7 @@ export const ResumeProjectsLocationsVolumesReplicationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResumeReplicationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsVolumesReplicationsRequest>;
 
@@ -3286,7 +3290,7 @@ export const ReverseDirectionProjectsLocationsVolumesReplicationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:reverseDirection",
+      path: "v1beta1/{+name}:reverseDirection",
       hasBody: true,
     }),
     svc,
@@ -3326,7 +3330,7 @@ export const EstablishPeeringProjectsLocationsVolumesReplicationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:establishPeering",
+      path: "v1beta1/{+name}:establishPeering",
       hasBody: true,
     }),
     svc,
@@ -3364,7 +3368,7 @@ export const SyncProjectsLocationsVolumesReplicationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SyncReplicationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:sync", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:sync", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SyncProjectsLocationsVolumesReplicationsRequest>;
 
@@ -3407,7 +3411,7 @@ export const ListProjectsLocationsVolumesQuotaRulesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/quotaRules" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/quotaRules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVolumesQuotaRulesRequest>;
 
@@ -3443,7 +3447,7 @@ export const GetProjectsLocationsVolumesQuotaRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVolumesQuotaRulesRequest>;
 
@@ -3484,7 +3488,7 @@ export const CreateProjectsLocationsVolumesQuotaRulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/quotaRules",
+      path: "v1beta1/{+parent}/quotaRules",
       hasBody: true,
     }),
     svc,
@@ -3523,7 +3527,7 @@ export const PatchProjectsLocationsVolumesQuotaRulesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(QuotaRule).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsVolumesQuotaRulesRequest>;
 
@@ -3554,7 +3558,7 @@ export const DeleteProjectsLocationsVolumesQuotaRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsVolumesQuotaRulesRequest>;
 
@@ -3597,7 +3601,7 @@ export const ListProjectsLocationsActiveDirectoriesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/activeDirectories" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/activeDirectories" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsActiveDirectoriesRequest>;
 
@@ -3633,7 +3637,7 @@ export const GetProjectsLocationsActiveDirectoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsActiveDirectoriesRequest>;
 
@@ -3674,7 +3678,7 @@ export const CreateProjectsLocationsActiveDirectoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/activeDirectories",
+      path: "v1beta1/{+parent}/activeDirectories",
       hasBody: true,
     }),
     svc,
@@ -3713,7 +3717,7 @@ export const PatchProjectsLocationsActiveDirectoriesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ActiveDirectory).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsActiveDirectoriesRequest>;
 
@@ -3744,7 +3748,7 @@ export const DeleteProjectsLocationsActiveDirectoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsActiveDirectoriesRequest>;
 
@@ -3787,7 +3791,7 @@ export const ListProjectsLocationsKmsConfigsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/kmsConfigs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/kmsConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsKmsConfigsRequest>;
 
@@ -3832,7 +3836,7 @@ export const CreateProjectsLocationsKmsConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/kmsConfigs",
+      path: "v1beta1/{+parent}/kmsConfigs",
       hasBody: true,
     }),
     svc,
@@ -3865,7 +3869,7 @@ export const GetProjectsLocationsKmsConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsKmsConfigsRequest>;
 
@@ -3902,7 +3906,7 @@ export const PatchProjectsLocationsKmsConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(KmsConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsKmsConfigsRequest>;
 
@@ -3936,7 +3940,7 @@ export const EncryptProjectsLocationsKmsConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EncryptVolumesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:encrypt", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:encrypt", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EncryptProjectsLocationsKmsConfigsRequest>;
 
@@ -3970,7 +3974,7 @@ export const VerifyProjectsLocationsKmsConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(VerifyKmsConfigRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:verify", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:verify", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<VerifyProjectsLocationsKmsConfigsRequest>;
 
@@ -4001,7 +4005,7 @@ export const DeleteProjectsLocationsKmsConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsKmsConfigsRequest>;
 
@@ -4042,7 +4046,7 @@ export const CreateProjectsLocationsBackupVaultsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/backupVaults",
+      path: "v1beta1/{+parent}/backupVaults",
       hasBody: true,
     }),
     svc,
@@ -4075,7 +4079,7 @@ export const GetProjectsLocationsBackupVaultsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupVaultsRequest>;
 
@@ -4118,7 +4122,7 @@ export const ListProjectsLocationsBackupVaultsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/backupVaults" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/backupVaults" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupVaultsRequest>;
 
@@ -4160,7 +4164,7 @@ export const PatchProjectsLocationsBackupVaultsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(BackupVault).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupVaultsRequest>;
 
@@ -4191,7 +4195,7 @@ export const DeleteProjectsLocationsBackupVaultsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupVaultsRequest>;
 
@@ -4228,7 +4232,11 @@ export const CreateProjectsLocationsBackupVaultsBackupsRequest =
     backupId: Schema.optional(Schema.String).pipe(T.HttpQuery("backupId")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/backups", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/backups",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBackupVaultsBackupsRequest>;
 
@@ -4259,7 +4267,7 @@ export const GetProjectsLocationsBackupVaultsBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupVaultsBackupsRequest>;
 
@@ -4302,7 +4310,7 @@ export const ListProjectsLocationsBackupVaultsBackupsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupVaultsBackupsRequest>;
 
@@ -4338,7 +4346,7 @@ export const DeleteProjectsLocationsBackupVaultsBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupVaultsBackupsRequest>;
 
@@ -4375,7 +4383,7 @@ export const PatchProjectsLocationsBackupVaultsBackupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupVaultsBackupsRequest>;
 
@@ -4416,7 +4424,7 @@ export const CreateProjectsLocationsBackupPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/backupPolicies",
+      path: "v1beta1/{+parent}/backupPolicies",
       hasBody: true,
     }),
     svc,
@@ -4449,7 +4457,7 @@ export const GetProjectsLocationsBackupPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupPoliciesRequest>;
 
@@ -4492,7 +4500,7 @@ export const ListProjectsLocationsBackupPoliciesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/backupPolicies" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/backupPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupPoliciesRequest>;
 
@@ -4534,7 +4542,7 @@ export const PatchProjectsLocationsBackupPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(BackupPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackupPoliciesRequest>;
 
@@ -4565,7 +4573,7 @@ export const DeleteProjectsLocationsBackupPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupPoliciesRequest>;
 
@@ -4608,7 +4616,7 @@ export const ListProjectsLocationsHostGroupsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/hostGroups" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/hostGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsHostGroupsRequest>;
 
@@ -4643,7 +4651,7 @@ export const GetProjectsLocationsHostGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsHostGroupsRequest>;
 
@@ -4684,7 +4692,7 @@ export const CreateProjectsLocationsHostGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/hostGroups",
+      path: "v1beta1/{+parent}/hostGroups",
       hasBody: true,
     }),
     svc,
@@ -4723,7 +4731,7 @@ export const PatchProjectsLocationsHostGroupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(HostGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsHostGroupsRequest>;
 
@@ -4754,7 +4762,7 @@ export const DeleteProjectsLocationsHostGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsHostGroupsRequest>;
 

--- a/packages/gcp/src/services/networkconnectivity-v1.ts
+++ b/packages/gcp/src/services/networkconnectivity-v1.ts
@@ -2516,7 +2516,7 @@ export const CheckConsumerConfigProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{location}:checkConsumerConfig",
+      path: "v1/{+location}:checkConsumerConfig",
       hasBody: true,
     }),
     svc,
@@ -2564,7 +2564,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2599,7 +2599,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2644,7 +2644,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2680,7 +2680,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2711,7 +2711,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2747,7 +2747,7 @@ export const CancelProjectsLocationsOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2790,7 +2790,7 @@ export const ListProjectsLocationsServiceConnectionMapsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/serviceConnectionMaps" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/serviceConnectionMaps" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServiceConnectionMapsRequest>;
 
@@ -2826,7 +2826,7 @@ export const GetProjectsLocationsServiceConnectionMapsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServiceConnectionMapsRequest>;
 
@@ -2871,7 +2871,7 @@ export const CreateProjectsLocationsServiceConnectionMapsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/serviceConnectionMaps",
+      path: "v1/{+parent}/serviceConnectionMaps",
       hasBody: true,
     }),
     svc,
@@ -2914,7 +2914,7 @@ export const PatchProjectsLocationsServiceConnectionMapsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(ServiceConnectionMap).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServiceConnectionMapsRequest>;
 
@@ -2952,7 +2952,7 @@ export const DeleteProjectsLocationsServiceConnectionMapsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServiceConnectionMapsRequest>;
 
@@ -2996,7 +2996,7 @@ export const ListProjectsLocationsServiceConnectionPoliciesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/serviceConnectionPolicies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/serviceConnectionPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServiceConnectionPoliciesRequest>;
 
@@ -3032,7 +3032,7 @@ export const GetProjectsLocationsServiceConnectionPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServiceConnectionPoliciesRequest>;
 
@@ -3106,7 +3106,7 @@ export const CreateProjectsLocationsServiceConnectionPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/serviceConnectionPolicies",
+      path: "v1/{+parent}/serviceConnectionPolicies",
       hasBody: true,
     }),
     svc,
@@ -3150,7 +3150,7 @@ export const PatchProjectsLocationsServiceConnectionPoliciesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(ServiceConnectionPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServiceConnectionPoliciesRequest>;
 
@@ -3189,7 +3189,7 @@ export const DeleteProjectsLocationsServiceConnectionPoliciesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServiceConnectionPoliciesRequest>;
 
@@ -3234,7 +3234,7 @@ export const ListProjectsLocationsServiceClassesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/serviceClasses" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/serviceClasses" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServiceClassesRequest>;
 
@@ -3270,7 +3270,7 @@ export const GetProjectsLocationsServiceClassesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServiceClassesRequest>;
 
@@ -3310,7 +3310,7 @@ export const PatchProjectsLocationsServiceClassesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(ServiceClass).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServiceClassesRequest>;
 
@@ -3348,7 +3348,7 @@ export const DeleteProjectsLocationsServiceClassesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServiceClassesRequest>;
 
@@ -3380,7 +3380,7 @@ export const GetProjectsLocationsServiceConnectionTokensRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServiceConnectionTokensRequest>;
 
@@ -3424,7 +3424,7 @@ export const ListProjectsLocationsServiceConnectionTokensRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/serviceConnectionTokens" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/serviceConnectionTokens" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServiceConnectionTokensRequest>;
 
@@ -3473,7 +3473,7 @@ export const CreateProjectsLocationsServiceConnectionTokensRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/serviceConnectionTokens",
+      path: "v1/{+parent}/serviceConnectionTokens",
       hasBody: true,
     }),
     svc,
@@ -3513,7 +3513,7 @@ export const DeleteProjectsLocationsServiceConnectionTokensRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServiceConnectionTokensRequest>;
 
@@ -3557,7 +3557,7 @@ export const ListProjectsLocationsAutomatedDnsRecordsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/automatedDnsRecords" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/automatedDnsRecords" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAutomatedDnsRecordsRequest>;
 
@@ -3593,7 +3593,7 @@ export const GetProjectsLocationsAutomatedDnsRecordsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAutomatedDnsRecordsRequest>;
 
@@ -3645,7 +3645,7 @@ export const CreateProjectsLocationsAutomatedDnsRecordsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/automatedDnsRecords",
+      path: "v1/{+parent}/automatedDnsRecords",
       hasBody: true,
     }),
     svc,
@@ -3692,7 +3692,7 @@ export const DeleteProjectsLocationsAutomatedDnsRecordsRequest =
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
     deleteMode: Schema.optional(Schema.String).pipe(T.HttpQuery("deleteMode")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAutomatedDnsRecordsRequest>;
 
@@ -3743,7 +3743,7 @@ export const ListProjectsLocationsMulticloudDataTransferConfigsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/multicloudDataTransferConfigs",
+      path: "v1/{+parent}/multicloudDataTransferConfigs",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMulticloudDataTransferConfigsRequest>;
@@ -3781,7 +3781,7 @@ export const GetProjectsLocationsMulticloudDataTransferConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMulticloudDataTransferConfigsRequest>;
 
@@ -3827,7 +3827,7 @@ export const CreateProjectsLocationsMulticloudDataTransferConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/multicloudDataTransferConfigs",
+      path: "v1/{+parent}/multicloudDataTransferConfigs",
       hasBody: true,
     }),
     svc,
@@ -3871,7 +3871,7 @@ export const PatchProjectsLocationsMulticloudDataTransferConfigsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(MulticloudDataTransferConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMulticloudDataTransferConfigsRequest>;
 
@@ -3910,7 +3910,7 @@ export const DeleteProjectsLocationsMulticloudDataTransferConfigsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMulticloudDataTransferConfigsRequest>;
 
@@ -3960,7 +3960,7 @@ export const ListProjectsLocationsMulticloudDataTransferConfigsDestinationsReque
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/destinations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/destinations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMulticloudDataTransferConfigsDestinationsRequest>;
 
@@ -3998,7 +3998,7 @@ export const GetProjectsLocationsMulticloudDataTransferConfigsDestinationsReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMulticloudDataTransferConfigsDestinationsRequest>;
 
@@ -4042,7 +4042,11 @@ export const CreateProjectsLocationsMulticloudDataTransferConfigsDestinationsReq
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Destination).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/destinations", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/destinations",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsMulticloudDataTransferConfigsDestinationsRequest>;
 
@@ -4086,7 +4090,7 @@ export const PatchProjectsLocationsMulticloudDataTransferConfigsDestinationsRequ
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Destination).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMulticloudDataTransferConfigsDestinationsRequest>;
 
@@ -4126,7 +4130,7 @@ export const DeleteProjectsLocationsMulticloudDataTransferConfigsDestinationsReq
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMulticloudDataTransferConfigsDestinationsRequest>;
 
@@ -4161,7 +4165,7 @@ export const GetProjectsLocationsMulticloudDataTransferSupportedServicesRequest 
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMulticloudDataTransferSupportedServicesRequest>;
 
@@ -4202,7 +4206,7 @@ export const ListProjectsLocationsMulticloudDataTransferSupportedServicesRequest
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/multicloudDataTransferSupportedServices",
+      path: "v1/{+parent}/multicloudDataTransferSupportedServices",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMulticloudDataTransferSupportedServicesRequest>;
@@ -4252,7 +4256,7 @@ export const ListProjectsLocationsGlobalHubsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/hubs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/hubs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalHubsRequest>;
 
@@ -4287,7 +4291,7 @@ export const GetProjectsLocationsGlobalHubsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalHubsRequest>;
 
@@ -4327,7 +4331,7 @@ export const CreateProjectsLocationsGlobalHubsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Hub).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/hubs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/hubs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGlobalHubsRequest>;
 
@@ -4368,7 +4372,7 @@ export const PatchProjectsLocationsGlobalHubsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Hub).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlobalHubsRequest>;
 
@@ -4403,7 +4407,7 @@ export const DeleteProjectsLocationsGlobalHubsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalHubsRequest>;
 
@@ -4455,7 +4459,7 @@ export const ListSpokesProjectsLocationsGlobalHubsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:listSpokes" }),
+    T.Http({ method: "GET", path: "v1/{+name}:listSpokes" }),
     svc,
   ) as unknown as Schema.Schema<ListSpokesProjectsLocationsGlobalHubsRequest>;
 
@@ -4506,7 +4510,7 @@ export const QueryStatusProjectsLocationsGlobalHubsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     groupBy: Schema.optional(Schema.String).pipe(T.HttpQuery("groupBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:queryStatus" }),
+    T.Http({ method: "GET", path: "v1/{+name}:queryStatus" }),
     svc,
   ) as unknown as Schema.Schema<QueryStatusProjectsLocationsGlobalHubsRequest>;
 
@@ -4545,7 +4549,7 @@ export const RejectSpokeProjectsLocationsGlobalHubsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RejectHubSpokeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:rejectSpoke", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:rejectSpoke", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RejectSpokeProjectsLocationsGlobalHubsRequest>;
 
@@ -4580,7 +4584,7 @@ export const AcceptSpokeProjectsLocationsGlobalHubsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AcceptHubSpokeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:acceptSpoke", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:acceptSpoke", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AcceptSpokeProjectsLocationsGlobalHubsRequest>;
 
@@ -4617,7 +4621,7 @@ export const AcceptSpokeUpdateProjectsLocationsGlobalHubsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:acceptSpokeUpdate",
+      path: "v1/{+name}:acceptSpokeUpdate",
       hasBody: true,
     }),
     svc,
@@ -4656,7 +4660,7 @@ export const RejectSpokeUpdateProjectsLocationsGlobalHubsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:rejectSpokeUpdate",
+      path: "v1/{+name}:rejectSpokeUpdate",
       hasBody: true,
     }),
     svc,
@@ -4695,7 +4699,7 @@ export const SetIamPolicyProjectsLocationsGlobalHubsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4733,7 +4737,7 @@ export const GetIamPolicyProjectsLocationsGlobalHubsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGlobalHubsRequest>;
 
@@ -4769,7 +4773,7 @@ export const TestIamPermissionsProjectsLocationsGlobalHubsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4803,7 +4807,7 @@ export const GetProjectsLocationsGlobalHubsRouteTablesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalHubsRouteTablesRequest>;
 
@@ -4846,7 +4850,7 @@ export const ListProjectsLocationsGlobalHubsRouteTablesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/routeTables" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/routeTables" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalHubsRouteTablesRequest>;
 
@@ -4882,7 +4886,7 @@ export const GetProjectsLocationsGlobalHubsRouteTablesRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalHubsRouteTablesRoutesRequest>;
 
@@ -4926,7 +4930,7 @@ export const ListProjectsLocationsGlobalHubsRouteTablesRoutesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/routes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/routes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalHubsRouteTablesRoutesRequest>;
 
@@ -4963,7 +4967,7 @@ export const GetProjectsLocationsGlobalHubsGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalHubsGroupsRequest>;
 
@@ -5006,7 +5010,7 @@ export const ListProjectsLocationsGlobalHubsGroupsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/groups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/groups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalHubsGroupsRequest>;
 
@@ -5050,7 +5054,7 @@ export const PatchProjectsLocationsGlobalHubsGroupsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Group).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlobalHubsGroupsRequest>;
 
@@ -5087,7 +5091,7 @@ export const SetIamPolicyProjectsLocationsGlobalHubsGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5125,7 +5129,7 @@ export const GetIamPolicyProjectsLocationsGlobalHubsGroupsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGlobalHubsGroupsRequest>;
 
@@ -5161,7 +5165,7 @@ export const TestIamPermissionsProjectsLocationsGlobalHubsGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5208,7 +5212,7 @@ export const ListProjectsLocationsGlobalPolicyBasedRoutesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/policyBasedRoutes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/policyBasedRoutes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalPolicyBasedRoutesRequest>;
 
@@ -5244,7 +5248,7 @@ export const GetProjectsLocationsGlobalPolicyBasedRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalPolicyBasedRoutesRequest>;
 
@@ -5289,7 +5293,7 @@ export const CreateProjectsLocationsGlobalPolicyBasedRoutesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/policyBasedRoutes",
+      path: "v1/{+parent}/policyBasedRoutes",
       hasBody: true,
     }),
     svc,
@@ -5326,7 +5330,7 @@ export const DeleteProjectsLocationsGlobalPolicyBasedRoutesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalPolicyBasedRoutesRequest>;
 
@@ -5363,7 +5367,7 @@ export const SetIamPolicyProjectsLocationsGlobalPolicyBasedRoutesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5403,7 +5407,7 @@ export const GetIamPolicyProjectsLocationsGlobalPolicyBasedRoutesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGlobalPolicyBasedRoutesRequest>;
 
@@ -5441,7 +5445,7 @@ export const TestIamPermissionsProjectsLocationsGlobalPolicyBasedRoutesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5488,7 +5492,7 @@ export const ListProjectsLocationsSpokesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/spokes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/spokes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSpokesRequest>;
 
@@ -5523,7 +5527,7 @@ export const GetProjectsLocationsSpokesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSpokesRequest>;
 
@@ -5563,7 +5567,7 @@ export const CreateProjectsLocationsSpokesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Spoke).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/spokes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/spokes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSpokesRequest>;
 
@@ -5603,7 +5607,7 @@ export const PatchProjectsLocationsSpokesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Spoke).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSpokesRequest>;
 
@@ -5637,7 +5641,7 @@ export const DeleteProjectsLocationsSpokesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSpokesRequest>;
 
@@ -5673,7 +5677,7 @@ export const SetIamPolicyProjectsLocationsSpokesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5711,7 +5715,7 @@ export const GetIamPolicyProjectsLocationsSpokesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsSpokesRequest>;
 
@@ -5747,7 +5751,7 @@ export const TestIamPermissionsProjectsLocationsSpokesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5793,7 +5797,7 @@ export const ListProjectsLocationsInternalRangesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/internalRanges" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/internalRanges" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInternalRangesRequest>;
 
@@ -5829,7 +5833,7 @@ export const GetProjectsLocationsInternalRangesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInternalRangesRequest>;
 
@@ -5873,7 +5877,7 @@ export const CreateProjectsLocationsInternalRangesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/internalRanges",
+      path: "v1/{+parent}/internalRanges",
       hasBody: true,
     }),
     svc,
@@ -5916,7 +5920,7 @@ export const PatchProjectsLocationsInternalRangesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(InternalRange).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInternalRangesRequest>;
 
@@ -5951,7 +5955,7 @@ export const DeleteProjectsLocationsInternalRangesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInternalRangesRequest>;
 
@@ -5988,7 +5992,7 @@ export const SetIamPolicyProjectsLocationsInternalRangesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -6026,7 +6030,7 @@ export const GetIamPolicyProjectsLocationsInternalRangesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsInternalRangesRequest>;
 
@@ -6062,7 +6066,7 @@ export const TestIamPermissionsProjectsLocationsInternalRangesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -6109,7 +6113,7 @@ export const ListProjectsLocationsRegionalEndpointsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/regionalEndpoints" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/regionalEndpoints" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRegionalEndpointsRequest>;
 
@@ -6145,7 +6149,7 @@ export const GetProjectsLocationsRegionalEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRegionalEndpointsRequest>;
 
@@ -6189,7 +6193,7 @@ export const CreateProjectsLocationsRegionalEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/regionalEndpoints",
+      path: "v1/{+parent}/regionalEndpoints",
       hasBody: true,
     }),
     svc,
@@ -6226,7 +6230,7 @@ export const DeleteProjectsLocationsRegionalEndpointsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRegionalEndpointsRequest>;
 
@@ -6270,7 +6274,7 @@ export const ListProjectsLocationsRemoteTransportProfilesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/remoteTransportProfiles" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/remoteTransportProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRemoteTransportProfilesRequest>;
 
@@ -6306,7 +6310,7 @@ export const GetProjectsLocationsRemoteTransportProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRemoteTransportProfilesRequest>;
 
@@ -6350,7 +6354,7 @@ export const ListProjectsLocationsTransportsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/transports" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/transports" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTransportsRequest>;
 
@@ -6385,7 +6389,7 @@ export const GetProjectsLocationsTransportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTransportsRequest>;
 
@@ -6427,7 +6431,7 @@ export const CreateProjectsLocationsTransportsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Transport).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/transports", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/transports", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTransportsRequest>;
 
@@ -6468,7 +6472,7 @@ export const PatchProjectsLocationsTransportsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Transport).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTransportsRequest>;
 
@@ -6503,7 +6507,7 @@ export const DeleteProjectsLocationsTransportsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTransportsRequest>;
 

--- a/packages/gcp/src/services/networkconnectivity-v1alpha1.ts
+++ b/packages/gcp/src/services/networkconnectivity-v1alpha1.ts
@@ -537,7 +537,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -572,7 +572,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -617,7 +617,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -653,7 +653,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -684,7 +684,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -720,7 +720,7 @@ export const CancelProjectsLocationsOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -763,7 +763,7 @@ export const ListProjectsLocationsGlobalHubsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/hubs" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/hubs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalHubsRequest>;
 
@@ -798,7 +798,7 @@ export const GetProjectsLocationsGlobalHubsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalHubsRequest>;
 
@@ -838,7 +838,7 @@ export const CreateProjectsLocationsGlobalHubsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Hub).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{parent}/hubs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+parent}/hubs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGlobalHubsRequest>;
 
@@ -879,7 +879,7 @@ export const PatchProjectsLocationsGlobalHubsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Hub).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlobalHubsRequest>;
 
@@ -914,7 +914,7 @@ export const DeleteProjectsLocationsGlobalHubsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalHubsRequest>;
 
@@ -951,7 +951,7 @@ export const SetIamPolicyProjectsLocationsGlobalHubsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:setIamPolicy",
+      path: "v1alpha1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -989,7 +989,7 @@ export const GetIamPolicyProjectsLocationsGlobalHubsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGlobalHubsRequest>;
 
@@ -1025,7 +1025,7 @@ export const TestIamPermissionsProjectsLocationsGlobalHubsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:testIamPermissions",
+      path: "v1alpha1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1071,7 +1071,7 @@ export const ListProjectsLocationsSpokesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/spokes" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/spokes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSpokesRequest>;
 
@@ -1106,7 +1106,7 @@ export const GetProjectsLocationsSpokesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSpokesRequest>;
 
@@ -1146,7 +1146,11 @@ export const CreateProjectsLocationsSpokesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Spoke).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{parent}/spokes", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1alpha1/{+parent}/spokes",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSpokesRequest>;
 
@@ -1186,7 +1190,7 @@ export const PatchProjectsLocationsSpokesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Spoke).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSpokesRequest>;
 
@@ -1220,7 +1224,7 @@ export const DeleteProjectsLocationsSpokesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSpokesRequest>;
 
@@ -1256,7 +1260,7 @@ export const SetIamPolicyProjectsLocationsSpokesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:setIamPolicy",
+      path: "v1alpha1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1294,7 +1298,7 @@ export const GetIamPolicyProjectsLocationsSpokesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsSpokesRequest>;
 
@@ -1330,7 +1334,7 @@ export const TestIamPermissionsProjectsLocationsSpokesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:testIamPermissions",
+      path: "v1alpha1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1376,7 +1380,7 @@ export const ListProjectsLocationsInternalRangesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/internalRanges" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/internalRanges" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInternalRangesRequest>;
 
@@ -1412,7 +1416,7 @@ export const GetProjectsLocationsInternalRangesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInternalRangesRequest>;
 
@@ -1456,7 +1460,7 @@ export const CreateProjectsLocationsInternalRangesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/internalRanges",
+      path: "v1alpha1/{+parent}/internalRanges",
       hasBody: true,
     }),
     svc,
@@ -1499,7 +1503,7 @@ export const PatchProjectsLocationsInternalRangesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(InternalRange).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInternalRangesRequest>;
 
@@ -1534,7 +1538,7 @@ export const DeleteProjectsLocationsInternalRangesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInternalRangesRequest>;
 
@@ -1571,7 +1575,7 @@ export const SetIamPolicyProjectsLocationsInternalRangesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:setIamPolicy",
+      path: "v1alpha1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1609,7 +1613,7 @@ export const GetIamPolicyProjectsLocationsInternalRangesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsInternalRangesRequest>;
 
@@ -1645,7 +1649,7 @@ export const TestIamPermissionsProjectsLocationsInternalRangesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{resource}:testIamPermissions",
+      path: "v1alpha1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/networkmanagement-v1.ts
+++ b/packages/gcp/src/services/networkmanagement-v1.ts
@@ -2206,7 +2206,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2241,7 +2241,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2286,7 +2286,7 @@ export const ListProjectsLocationsGlobalOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalOperationsRequest>;
 
@@ -2322,7 +2322,7 @@ export const GetProjectsLocationsGlobalOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalOperationsRequest>;
 
@@ -2353,7 +2353,7 @@ export const DeleteProjectsLocationsGlobalOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalOperationsRequest>;
 
@@ -2387,7 +2387,7 @@ export const CancelProjectsLocationsGlobalOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsGlobalOperationsRequest>;
 
@@ -2430,7 +2430,7 @@ export const ListProjectsLocationsGlobalConnectivityTestsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/connectivityTests" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/connectivityTests" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalConnectivityTestsRequest>;
 
@@ -2466,7 +2466,7 @@ export const GetProjectsLocationsGlobalConnectivityTestsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalConnectivityTestsRequest>;
 
@@ -2506,7 +2506,7 @@ export const CreateProjectsLocationsGlobalConnectivityTestsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/connectivityTests",
+      path: "v1/{+parent}/connectivityTests",
       hasBody: true,
     }),
     svc,
@@ -2545,7 +2545,7 @@ export const PatchProjectsLocationsGlobalConnectivityTestsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ConnectivityTest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlobalConnectivityTestsRequest>;
 
@@ -2579,7 +2579,7 @@ export const RerunProjectsLocationsGlobalConnectivityTestsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RerunConnectivityTestRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:rerun", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:rerun", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RerunProjectsLocationsGlobalConnectivityTestsRequest>;
 
@@ -2610,7 +2610,7 @@ export const DeleteProjectsLocationsGlobalConnectivityTestsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalConnectivityTestsRequest>;
 
@@ -2646,7 +2646,7 @@ export const SetIamPolicyProjectsLocationsGlobalConnectivityTestsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2686,7 +2686,7 @@ export const GetIamPolicyProjectsLocationsGlobalConnectivityTestsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGlobalConnectivityTestsRequest>;
 
@@ -2724,7 +2724,7 @@ export const TestIamPermissionsProjectsLocationsGlobalConnectivityTestsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2771,7 +2771,7 @@ export const ListProjectsLocationsVpcFlowLogsConfigsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/vpcFlowLogsConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/vpcFlowLogsConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVpcFlowLogsConfigsRequest>;
 
@@ -2807,7 +2807,7 @@ export const GetProjectsLocationsVpcFlowLogsConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVpcFlowLogsConfigsRequest>;
 
@@ -2848,7 +2848,7 @@ export const CreateProjectsLocationsVpcFlowLogsConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/vpcFlowLogsConfigs",
+      path: "v1/{+parent}/vpcFlowLogsConfigs",
       hasBody: true,
     }),
     svc,
@@ -2887,7 +2887,7 @@ export const PatchProjectsLocationsVpcFlowLogsConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(VpcFlowLogsConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsVpcFlowLogsConfigsRequest>;
 
@@ -2918,7 +2918,7 @@ export const DeleteProjectsLocationsVpcFlowLogsConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsVpcFlowLogsConfigsRequest>;
 
@@ -2960,7 +2960,7 @@ export const QueryOrgVpcFlowLogsConfigsProjectsLocationsVpcFlowLogsConfigsReques
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/vpcFlowLogsConfigs:queryOrgVpcFlowLogsConfigs",
+      path: "v1/{+parent}/vpcFlowLogsConfigs:queryOrgVpcFlowLogsConfigs",
     }),
     svc,
   ) as unknown as Schema.Schema<QueryOrgVpcFlowLogsConfigsProjectsLocationsVpcFlowLogsConfigsRequest>;
@@ -3012,7 +3012,7 @@ export const ShowEffectiveFlowLogsConfigsProjectsLocationsVpcFlowLogsConfigsRequ
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/vpcFlowLogsConfigs:showEffectiveFlowLogsConfigs",
+      path: "v1/{+parent}/vpcFlowLogsConfigs:showEffectiveFlowLogsConfigs",
     }),
     svc,
   ) as unknown as Schema.Schema<ShowEffectiveFlowLogsConfigsProjectsLocationsVpcFlowLogsConfigsRequest>;
@@ -3065,7 +3065,7 @@ export const ListOrganizationsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsRequest>;
 
@@ -3100,7 +3100,7 @@ export const GetOrganizationsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsRequest>;
 
@@ -3145,7 +3145,7 @@ export const ListOrganizationsLocationsGlobalOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsGlobalOperationsRequest>;
 
@@ -3181,7 +3181,7 @@ export const GetOrganizationsLocationsGlobalOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsGlobalOperationsRequest>;
 
@@ -3212,7 +3212,7 @@ export const DeleteOrganizationsLocationsGlobalOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsGlobalOperationsRequest>;
 
@@ -3246,7 +3246,7 @@ export const CancelOrganizationsLocationsGlobalOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOrganizationsLocationsGlobalOperationsRequest>;
 
@@ -3289,7 +3289,7 @@ export const ListOrganizationsLocationsVpcFlowLogsConfigsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/vpcFlowLogsConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/vpcFlowLogsConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsVpcFlowLogsConfigsRequest>;
 
@@ -3325,7 +3325,7 @@ export const GetOrganizationsLocationsVpcFlowLogsConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsVpcFlowLogsConfigsRequest>;
 
@@ -3367,7 +3367,7 @@ export const CreateOrganizationsLocationsVpcFlowLogsConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/vpcFlowLogsConfigs",
+      path: "v1/{+parent}/vpcFlowLogsConfigs",
       hasBody: true,
     }),
     svc,
@@ -3406,7 +3406,7 @@ export const PatchOrganizationsLocationsVpcFlowLogsConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(VpcFlowLogsConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsVpcFlowLogsConfigsRequest>;
 
@@ -3437,7 +3437,7 @@ export const DeleteOrganizationsLocationsVpcFlowLogsConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsVpcFlowLogsConfigsRequest>;
 

--- a/packages/gcp/src/services/networkmanagement-v1beta1.ts
+++ b/packages/gcp/src/services/networkmanagement-v1beta1.ts
@@ -2206,7 +2206,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2241,7 +2241,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2286,7 +2286,7 @@ export const ListProjectsLocationsGlobalOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalOperationsRequest>;
 
@@ -2322,7 +2322,7 @@ export const GetProjectsLocationsGlobalOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalOperationsRequest>;
 
@@ -2353,7 +2353,7 @@ export const DeleteProjectsLocationsGlobalOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalOperationsRequest>;
 
@@ -2387,7 +2387,7 @@ export const CancelProjectsLocationsGlobalOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsGlobalOperationsRequest>;
 
@@ -2430,7 +2430,7 @@ export const ListProjectsLocationsGlobalConnectivityTestsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/connectivityTests" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/connectivityTests" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalConnectivityTestsRequest>;
 
@@ -2466,7 +2466,7 @@ export const GetProjectsLocationsGlobalConnectivityTestsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalConnectivityTestsRequest>;
 
@@ -2506,7 +2506,7 @@ export const CreateProjectsLocationsGlobalConnectivityTestsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/connectivityTests",
+      path: "v1beta1/{+parent}/connectivityTests",
       hasBody: true,
     }),
     svc,
@@ -2545,7 +2545,7 @@ export const PatchProjectsLocationsGlobalConnectivityTestsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ConnectivityTest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlobalConnectivityTestsRequest>;
 
@@ -2579,7 +2579,7 @@ export const RerunProjectsLocationsGlobalConnectivityTestsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RerunConnectivityTestRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:rerun", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:rerun", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RerunProjectsLocationsGlobalConnectivityTestsRequest>;
 
@@ -2610,7 +2610,7 @@ export const DeleteProjectsLocationsGlobalConnectivityTestsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalConnectivityTestsRequest>;
 
@@ -2646,7 +2646,7 @@ export const SetIamPolicyProjectsLocationsGlobalConnectivityTestsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2686,7 +2686,7 @@ export const GetIamPolicyProjectsLocationsGlobalConnectivityTestsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsGlobalConnectivityTestsRequest>;
 
@@ -2724,7 +2724,7 @@ export const TestIamPermissionsProjectsLocationsGlobalConnectivityTestsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2771,7 +2771,7 @@ export const ListProjectsLocationsVpcFlowLogsConfigsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/vpcFlowLogsConfigs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/vpcFlowLogsConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVpcFlowLogsConfigsRequest>;
 
@@ -2807,7 +2807,7 @@ export const GetProjectsLocationsVpcFlowLogsConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVpcFlowLogsConfigsRequest>;
 
@@ -2848,7 +2848,7 @@ export const CreateProjectsLocationsVpcFlowLogsConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/vpcFlowLogsConfigs",
+      path: "v1beta1/{+parent}/vpcFlowLogsConfigs",
       hasBody: true,
     }),
     svc,
@@ -2887,7 +2887,7 @@ export const PatchProjectsLocationsVpcFlowLogsConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(VpcFlowLogsConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsVpcFlowLogsConfigsRequest>;
 
@@ -2918,7 +2918,7 @@ export const DeleteProjectsLocationsVpcFlowLogsConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsVpcFlowLogsConfigsRequest>;
 
@@ -2960,7 +2960,7 @@ export const QueryOrgVpcFlowLogsConfigsProjectsLocationsVpcFlowLogsConfigsReques
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/vpcFlowLogsConfigs:queryOrgVpcFlowLogsConfigs",
+      path: "v1beta1/{+parent}/vpcFlowLogsConfigs:queryOrgVpcFlowLogsConfigs",
     }),
     svc,
   ) as unknown as Schema.Schema<QueryOrgVpcFlowLogsConfigsProjectsLocationsVpcFlowLogsConfigsRequest>;
@@ -3012,7 +3012,7 @@ export const ShowEffectiveFlowLogsConfigsProjectsLocationsVpcFlowLogsConfigsRequ
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/vpcFlowLogsConfigs:showEffectiveFlowLogsConfigs",
+      path: "v1beta1/{+parent}/vpcFlowLogsConfigs:showEffectiveFlowLogsConfigs",
     }),
     svc,
   ) as unknown as Schema.Schema<ShowEffectiveFlowLogsConfigsProjectsLocationsVpcFlowLogsConfigsRequest>;
@@ -3065,7 +3065,7 @@ export const ListOrganizationsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsRequest>;
 
@@ -3100,7 +3100,7 @@ export const GetOrganizationsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsRequest>;
 
@@ -3145,7 +3145,7 @@ export const ListOrganizationsLocationsGlobalOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsGlobalOperationsRequest>;
 
@@ -3181,7 +3181,7 @@ export const GetOrganizationsLocationsGlobalOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsGlobalOperationsRequest>;
 
@@ -3212,7 +3212,7 @@ export const DeleteOrganizationsLocationsGlobalOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsGlobalOperationsRequest>;
 
@@ -3246,7 +3246,7 @@ export const CancelOrganizationsLocationsGlobalOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOrganizationsLocationsGlobalOperationsRequest>;
 
@@ -3289,7 +3289,7 @@ export const ListOrganizationsLocationsVpcFlowLogsConfigsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/vpcFlowLogsConfigs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/vpcFlowLogsConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsVpcFlowLogsConfigsRequest>;
 
@@ -3325,7 +3325,7 @@ export const GetOrganizationsLocationsVpcFlowLogsConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsVpcFlowLogsConfigsRequest>;
 
@@ -3367,7 +3367,7 @@ export const CreateOrganizationsLocationsVpcFlowLogsConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/vpcFlowLogsConfigs",
+      path: "v1beta1/{+parent}/vpcFlowLogsConfigs",
       hasBody: true,
     }),
     svc,
@@ -3406,7 +3406,7 @@ export const PatchOrganizationsLocationsVpcFlowLogsConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(VpcFlowLogsConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsVpcFlowLogsConfigsRequest>;
 
@@ -3437,7 +3437,7 @@ export const DeleteOrganizationsLocationsVpcFlowLogsConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsVpcFlowLogsConfigsRequest>;
 

--- a/packages/gcp/src/services/networksecurity-v1.ts
+++ b/packages/gcp/src/services/networksecurity-v1.ts
@@ -2397,7 +2397,7 @@ export const ListProjectsLocationsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2432,7 +2432,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2463,7 +2463,7 @@ export const GetProjectsLocationsInterceptDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInterceptDeploymentsRequest>;
 
@@ -2504,7 +2504,7 @@ export const PatchProjectsLocationsInterceptDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(InterceptDeployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInterceptDeploymentsRequest>;
 
@@ -2547,7 +2547,7 @@ export const ListProjectsLocationsInterceptDeploymentsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/interceptDeployments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/interceptDeployments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInterceptDeploymentsRequest>;
 
@@ -2596,7 +2596,7 @@ export const CreateProjectsLocationsInterceptDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/interceptDeployments",
+      path: "v1/{+parent}/interceptDeployments",
       hasBody: true,
     }),
     svc,
@@ -2632,7 +2632,7 @@ export const DeleteProjectsLocationsInterceptDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInterceptDeploymentsRequest>;
 
@@ -2666,7 +2666,7 @@ export const DeleteProjectsLocationsMirroringDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMirroringDeploymentsRequest>;
 
@@ -2710,7 +2710,7 @@ export const CreateProjectsLocationsMirroringDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/mirroringDeployments",
+      path: "v1/{+parent}/mirroringDeployments",
       hasBody: true,
     }),
     svc,
@@ -2752,7 +2752,7 @@ export const PatchProjectsLocationsMirroringDeploymentsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(MirroringDeployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMirroringDeploymentsRequest>;
 
@@ -2795,7 +2795,7 @@ export const ListProjectsLocationsMirroringDeploymentsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/mirroringDeployments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/mirroringDeployments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMirroringDeploymentsRequest>;
 
@@ -2831,7 +2831,7 @@ export const GetProjectsLocationsMirroringDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMirroringDeploymentsRequest>;
 
@@ -2872,7 +2872,7 @@ export const PatchProjectsLocationsFirewallEndpointAssociationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(FirewallEndpointAssociation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFirewallEndpointAssociationsRequest>;
 
@@ -2917,7 +2917,10 @@ export const ListProjectsLocationsFirewallEndpointAssociationsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/firewallEndpointAssociations" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+parent}/firewallEndpointAssociations",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFirewallEndpointAssociationsRequest>;
 
@@ -2954,7 +2957,7 @@ export const GetProjectsLocationsFirewallEndpointAssociationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFirewallEndpointAssociationsRequest>;
 
@@ -2990,7 +2993,7 @@ export const DeleteProjectsLocationsFirewallEndpointAssociationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFirewallEndpointAssociationsRequest>;
 
@@ -3036,7 +3039,7 @@ export const CreateProjectsLocationsFirewallEndpointAssociationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/firewallEndpointAssociations",
+      path: "v1/{+parent}/firewallEndpointAssociations",
       hasBody: true,
     }),
     svc,
@@ -3071,7 +3074,7 @@ export const GetProjectsLocationsGatewaySecurityPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGatewaySecurityPoliciesRequest>;
 
@@ -3109,7 +3112,7 @@ export const PatchProjectsLocationsGatewaySecurityPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GatewaySecurityPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGatewaySecurityPoliciesRequest>;
 
@@ -3146,7 +3149,7 @@ export const ListProjectsLocationsGatewaySecurityPoliciesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/gatewaySecurityPolicies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/gatewaySecurityPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGatewaySecurityPoliciesRequest>;
 
@@ -3192,7 +3195,7 @@ export const CreateProjectsLocationsGatewaySecurityPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/gatewaySecurityPolicies",
+      path: "v1/{+parent}/gatewaySecurityPolicies",
       hasBody: true,
     }),
     svc,
@@ -3225,7 +3228,7 @@ export const DeleteProjectsLocationsGatewaySecurityPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGatewaySecurityPoliciesRequest>;
 
@@ -3256,7 +3259,7 @@ export const DeleteProjectsLocationsGatewaySecurityPoliciesRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGatewaySecurityPoliciesRulesRequest>;
 
@@ -3297,7 +3300,7 @@ export const CreateProjectsLocationsGatewaySecurityPoliciesRulesRequest =
     ),
     body: Schema.optional(GatewaySecurityPolicyRule).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/rules", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/rules", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGatewaySecurityPoliciesRulesRequest>;
 
@@ -3336,7 +3339,7 @@ export const PatchProjectsLocationsGatewaySecurityPoliciesRulesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GatewaySecurityPolicyRule).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGatewaySecurityPoliciesRulesRequest>;
 
@@ -3375,7 +3378,7 @@ export const ListProjectsLocationsGatewaySecurityPoliciesRulesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/rules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/rules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGatewaySecurityPoliciesRulesRequest>;
 
@@ -3412,7 +3415,7 @@ export const GetProjectsLocationsGatewaySecurityPoliciesRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGatewaySecurityPoliciesRulesRequest>;
 
@@ -3448,7 +3451,7 @@ export const DeleteProjectsLocationsTlsInspectionPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTlsInspectionPoliciesRequest>;
 
@@ -3489,7 +3492,7 @@ export const CreateProjectsLocationsTlsInspectionPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/tlsInspectionPolicies",
+      path: "v1/{+parent}/tlsInspectionPolicies",
       hasBody: true,
     }),
     svc,
@@ -3528,7 +3531,7 @@ export const ListProjectsLocationsTlsInspectionPoliciesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/tlsInspectionPolicies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/tlsInspectionPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTlsInspectionPoliciesRequest>;
 
@@ -3570,7 +3573,7 @@ export const PatchProjectsLocationsTlsInspectionPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(TlsInspectionPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTlsInspectionPoliciesRequest>;
 
@@ -3601,7 +3604,7 @@ export const GetProjectsLocationsTlsInspectionPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTlsInspectionPoliciesRequest>;
 
@@ -3644,7 +3647,7 @@ export const ListProjectsLocationsAddressGroupsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/addressGroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/addressGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAddressGroupsRequest>;
 
@@ -3685,7 +3688,7 @@ export const CloneItemsProjectsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{addressGroup}:cloneItems",
+      path: "v1/{+addressGroup}:cloneItems",
       hasBody: true,
     }),
     svc,
@@ -3723,7 +3726,7 @@ export const AddItemsProjectsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{addressGroup}:addItems",
+      path: "v1/{+addressGroup}:addItems",
       hasBody: true,
     }),
     svc,
@@ -3761,7 +3764,7 @@ export const RemoveItemsProjectsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{addressGroup}:removeItems",
+      path: "v1/{+addressGroup}:removeItems",
       hasBody: true,
     }),
     svc,
@@ -3797,7 +3800,7 @@ export const DeleteProjectsLocationsAddressGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAddressGroupsRequest>;
 
@@ -3837,7 +3840,7 @@ export const PatchProjectsLocationsAddressGroupsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(AddressGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAddressGroupsRequest>;
 
@@ -3868,7 +3871,7 @@ export const GetProjectsLocationsAddressGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAddressGroupsRequest>;
 
@@ -3906,7 +3909,7 @@ export const TestIamPermissionsProjectsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3954,7 +3957,7 @@ export const CreateProjectsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/addressGroups",
+      path: "v1/{+parent}/addressGroups",
       hasBody: true,
     }),
     svc,
@@ -3992,7 +3995,7 @@ export const SetIamPolicyProjectsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4031,7 +4034,7 @@ export const GetIamPolicyProjectsLocationsAddressGroupsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsAddressGroupsRequest>;
 
@@ -4069,7 +4072,7 @@ export const ListReferencesProjectsLocationsAddressGroupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{addressGroup}:listReferences" }),
+    T.Http({ method: "GET", path: "v1/{+addressGroup}:listReferences" }),
     svc,
   ) as unknown as Schema.Schema<ListReferencesProjectsLocationsAddressGroupsRequest>;
 
@@ -4115,7 +4118,7 @@ export const CreateProjectsLocationsClientTlsPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/clientTlsPolicies",
+      path: "v1/{+parent}/clientTlsPolicies",
       hasBody: true,
     }),
     svc,
@@ -4153,7 +4156,7 @@ export const SetIamPolicyProjectsLocationsClientTlsPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4192,7 +4195,7 @@ export const GetIamPolicyProjectsLocationsClientTlsPoliciesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsClientTlsPoliciesRequest>;
 
@@ -4224,7 +4227,7 @@ export const DeleteProjectsLocationsClientTlsPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClientTlsPoliciesRequest>;
 
@@ -4255,7 +4258,7 @@ export const GetProjectsLocationsClientTlsPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClientTlsPoliciesRequest>;
 
@@ -4293,7 +4296,7 @@ export const TestIamPermissionsProjectsLocationsClientTlsPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4334,7 +4337,7 @@ export const PatchProjectsLocationsClientTlsPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ClientTlsPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsClientTlsPoliciesRequest>;
 
@@ -4371,7 +4374,7 @@ export const ListProjectsLocationsClientTlsPoliciesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/clientTlsPolicies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/clientTlsPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClientTlsPoliciesRequest>;
 
@@ -4407,7 +4410,7 @@ export const GetProjectsLocationsInterceptEndpointGroupAssociationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInterceptEndpointGroupAssociationsRequest>;
 
@@ -4449,7 +4452,7 @@ export const PatchProjectsLocationsInterceptEndpointGroupAssociationsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(InterceptEndpointGroupAssociation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInterceptEndpointGroupAssociationsRequest>;
 
@@ -4496,7 +4499,7 @@ export const ListProjectsLocationsInterceptEndpointGroupAssociationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/interceptEndpointGroupAssociations",
+      path: "v1/{+parent}/interceptEndpointGroupAssociations",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInterceptEndpointGroupAssociationsRequest>;
@@ -4547,7 +4550,7 @@ export const CreateProjectsLocationsInterceptEndpointGroupAssociationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/interceptEndpointGroupAssociations",
+      path: "v1/{+parent}/interceptEndpointGroupAssociations",
       hasBody: true,
     }),
     svc,
@@ -4585,7 +4588,7 @@ export const DeleteProjectsLocationsInterceptEndpointGroupAssociationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInterceptEndpointGroupAssociationsRequest>;
 
@@ -4624,7 +4627,10 @@ export const ListProjectsLocationsBackendAuthenticationConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backendAuthenticationConfigs" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+parent}/backendAuthenticationConfigs",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackendAuthenticationConfigsRequest>;
 
@@ -4667,7 +4673,7 @@ export const PatchProjectsLocationsBackendAuthenticationConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(BackendAuthenticationConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackendAuthenticationConfigsRequest>;
 
@@ -4700,7 +4706,7 @@ export const GetProjectsLocationsBackendAuthenticationConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackendAuthenticationConfigsRequest>;
 
@@ -4736,7 +4742,7 @@ export const DeleteProjectsLocationsBackendAuthenticationConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackendAuthenticationConfigsRequest>;
 
@@ -4779,7 +4785,7 @@ export const CreateProjectsLocationsBackendAuthenticationConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/backendAuthenticationConfigs",
+      path: "v1/{+parent}/backendAuthenticationConfigs",
       hasBody: true,
     }),
     svc,
@@ -4817,7 +4823,7 @@ export const DeleteProjectsLocationsMirroringEndpointGroupAssociationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMirroringEndpointGroupAssociationsRequest>;
 
@@ -4863,7 +4869,7 @@ export const CreateProjectsLocationsMirroringEndpointGroupAssociationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/mirroringEndpointGroupAssociations",
+      path: "v1/{+parent}/mirroringEndpointGroupAssociations",
       hasBody: true,
     }),
     svc,
@@ -4907,7 +4913,7 @@ export const PatchProjectsLocationsMirroringEndpointGroupAssociationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MirroringEndpointGroupAssociation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMirroringEndpointGroupAssociationsRequest>;
 
@@ -4954,7 +4960,7 @@ export const ListProjectsLocationsMirroringEndpointGroupAssociationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/mirroringEndpointGroupAssociations",
+      path: "v1/{+parent}/mirroringEndpointGroupAssociations",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMirroringEndpointGroupAssociationsRequest>;
@@ -4992,7 +4998,7 @@ export const GetProjectsLocationsMirroringEndpointGroupAssociationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMirroringEndpointGroupAssociationsRequest>;
 
@@ -5025,7 +5031,7 @@ export const DeleteProjectsLocationsAuthorizationPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAuthorizationPoliciesRequest>;
 
@@ -5066,7 +5072,7 @@ export const CreateProjectsLocationsAuthorizationPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/authorizationPolicies",
+      path: "v1/{+parent}/authorizationPolicies",
       hasBody: true,
     }),
     svc,
@@ -5104,7 +5110,7 @@ export const SetIamPolicyProjectsLocationsAuthorizationPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5144,7 +5150,7 @@ export const GetIamPolicyProjectsLocationsAuthorizationPoliciesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsAuthorizationPoliciesRequest>;
 
@@ -5183,7 +5189,7 @@ export const ListProjectsLocationsAuthorizationPoliciesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/authorizationPolicies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/authorizationPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAuthorizationPoliciesRequest>;
 
@@ -5225,7 +5231,7 @@ export const PatchProjectsLocationsAuthorizationPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AuthorizationPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAuthorizationPoliciesRequest>;
 
@@ -5256,7 +5262,7 @@ export const GetProjectsLocationsAuthorizationPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAuthorizationPoliciesRequest>;
 
@@ -5295,7 +5301,7 @@ export const TestIamPermissionsProjectsLocationsAuthorizationPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5343,7 +5349,7 @@ export const CreateProjectsLocationsAuthzPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/authzPolicies",
+      path: "v1/{+parent}/authzPolicies",
       hasBody: true,
     }),
     svc,
@@ -5381,7 +5387,7 @@ export const SetIamPolicyProjectsLocationsAuthzPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5420,7 +5426,7 @@ export const GetIamPolicyProjectsLocationsAuthzPoliciesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsAuthzPoliciesRequest>;
 
@@ -5455,7 +5461,7 @@ export const DeleteProjectsLocationsAuthzPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAuthzPoliciesRequest>;
 
@@ -5486,7 +5492,7 @@ export const GetProjectsLocationsAuthzPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAuthzPoliciesRequest>;
 
@@ -5524,7 +5530,7 @@ export const TestIamPermissionsProjectsLocationsAuthzPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5568,7 +5574,7 @@ export const PatchProjectsLocationsAuthzPoliciesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(AuthzPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAuthzPoliciesRequest>;
 
@@ -5611,7 +5617,7 @@ export const ListProjectsLocationsAuthzPoliciesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/authzPolicies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/authzPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAuthzPoliciesRequest>;
 
@@ -5660,7 +5666,7 @@ export const CreateProjectsLocationsMirroringDeploymentGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/mirroringDeploymentGroups",
+      path: "v1/{+parent}/mirroringDeploymentGroups",
       hasBody: true,
     }),
     svc,
@@ -5698,7 +5704,7 @@ export const DeleteProjectsLocationsMirroringDeploymentGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMirroringDeploymentGroupsRequest>;
 
@@ -5731,7 +5737,7 @@ export const GetProjectsLocationsMirroringDeploymentGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMirroringDeploymentGroupsRequest>;
 
@@ -5772,7 +5778,7 @@ export const PatchProjectsLocationsMirroringDeploymentGroupsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(MirroringDeploymentGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMirroringDeploymentGroupsRequest>;
 
@@ -5816,7 +5822,7 @@ export const ListProjectsLocationsMirroringDeploymentGroupsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/mirroringDeploymentGroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/mirroringDeploymentGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMirroringDeploymentGroupsRequest>;
 
@@ -5852,7 +5858,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -5886,7 +5892,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -5931,7 +5937,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -5966,7 +5972,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -5997,7 +6003,7 @@ export const GetProjectsLocationsInterceptEndpointGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInterceptEndpointGroupsRequest>;
 
@@ -6038,7 +6044,7 @@ export const PatchProjectsLocationsInterceptEndpointGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(InterceptEndpointGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInterceptEndpointGroupsRequest>;
 
@@ -6081,7 +6087,7 @@ export const ListProjectsLocationsInterceptEndpointGroupsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/interceptEndpointGroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/interceptEndpointGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInterceptEndpointGroupsRequest>;
 
@@ -6130,7 +6136,7 @@ export const CreateProjectsLocationsInterceptEndpointGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/interceptEndpointGroups",
+      path: "v1/{+parent}/interceptEndpointGroups",
       hasBody: true,
     }),
     svc,
@@ -6166,7 +6172,7 @@ export const DeleteProjectsLocationsInterceptEndpointGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInterceptEndpointGroupsRequest>;
 
@@ -6208,7 +6214,7 @@ export const ListProjectsLocationsServerTlsPoliciesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/serverTlsPolicies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/serverTlsPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServerTlsPoliciesRequest>;
 
@@ -6250,7 +6256,7 @@ export const PatchProjectsLocationsServerTlsPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ServerTlsPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServerTlsPoliciesRequest>;
 
@@ -6281,7 +6287,7 @@ export const GetProjectsLocationsServerTlsPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServerTlsPoliciesRequest>;
 
@@ -6319,7 +6325,7 @@ export const TestIamPermissionsProjectsLocationsServerTlsPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -6354,7 +6360,7 @@ export const DeleteProjectsLocationsServerTlsPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServerTlsPoliciesRequest>;
 
@@ -6395,7 +6401,7 @@ export const CreateProjectsLocationsServerTlsPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/serverTlsPolicies",
+      path: "v1/{+parent}/serverTlsPolicies",
       hasBody: true,
     }),
     svc,
@@ -6433,7 +6439,7 @@ export const SetIamPolicyProjectsLocationsServerTlsPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -6472,7 +6478,7 @@ export const GetIamPolicyProjectsLocationsServerTlsPoliciesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsServerTlsPoliciesRequest>;
 
@@ -6507,7 +6513,7 @@ export const DeleteProjectsLocationsMirroringEndpointGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMirroringEndpointGroupsRequest>;
 
@@ -6551,7 +6557,7 @@ export const CreateProjectsLocationsMirroringEndpointGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/mirroringEndpointGroups",
+      path: "v1/{+parent}/mirroringEndpointGroups",
       hasBody: true,
     }),
     svc,
@@ -6593,7 +6599,7 @@ export const PatchProjectsLocationsMirroringEndpointGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MirroringEndpointGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMirroringEndpointGroupsRequest>;
 
@@ -6636,7 +6642,7 @@ export const ListProjectsLocationsMirroringEndpointGroupsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/mirroringEndpointGroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/mirroringEndpointGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMirroringEndpointGroupsRequest>;
 
@@ -6672,7 +6678,7 @@ export const GetProjectsLocationsMirroringEndpointGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMirroringEndpointGroupsRequest>;
 
@@ -6710,7 +6716,7 @@ export const PatchProjectsLocationsUrlListsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(UrlList).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsUrlListsRequest>;
 
@@ -6747,7 +6753,7 @@ export const ListProjectsLocationsUrlListsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/urlLists" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/urlLists" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsUrlListsRequest>;
 
@@ -6782,7 +6788,7 @@ export const GetProjectsLocationsUrlListsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsUrlListsRequest>;
 
@@ -6813,7 +6819,7 @@ export const DeleteProjectsLocationsUrlListsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsUrlListsRequest>;
 
@@ -6850,7 +6856,7 @@ export const CreateProjectsLocationsUrlListsRequest =
     urlListId: Schema.optional(Schema.String).pipe(T.HttpQuery("urlListId")),
     body: Schema.optional(UrlList).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/urlLists", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/urlLists", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsUrlListsRequest>;
 
@@ -6881,7 +6887,7 @@ export const GetProjectsLocationsInterceptDeploymentGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInterceptDeploymentGroupsRequest>;
 
@@ -6925,7 +6931,7 @@ export const ListProjectsLocationsInterceptDeploymentGroupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/interceptDeploymentGroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/interceptDeploymentGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInterceptDeploymentGroupsRequest>;
 
@@ -6970,7 +6976,7 @@ export const PatchProjectsLocationsInterceptDeploymentGroupsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(InterceptDeploymentGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInterceptDeploymentGroupsRequest>;
 
@@ -7015,7 +7021,7 @@ export const CreateProjectsLocationsInterceptDeploymentGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/interceptDeploymentGroups",
+      path: "v1/{+parent}/interceptDeploymentGroups",
       hasBody: true,
     }),
     svc,
@@ -7053,7 +7059,7 @@ export const DeleteProjectsLocationsInterceptDeploymentGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInterceptDeploymentGroupsRequest>;
 
@@ -7096,7 +7102,7 @@ export const CreateProjectsLocationsDnsThreatDetectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/dnsThreatDetectors",
+      path: "v1/{+parent}/dnsThreatDetectors",
       hasBody: true,
     }),
     svc,
@@ -7130,7 +7136,7 @@ export const DeleteProjectsLocationsDnsThreatDetectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDnsThreatDetectorsRequest>;
 
@@ -7161,7 +7167,7 @@ export const GetProjectsLocationsDnsThreatDetectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDnsThreatDetectorsRequest>;
 
@@ -7198,7 +7204,7 @@ export const PatchProjectsLocationsDnsThreatDetectorsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(DnsThreatDetector).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDnsThreatDetectorsRequest>;
 
@@ -7236,7 +7242,7 @@ export const ListProjectsLocationsDnsThreatDetectorsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dnsThreatDetectors" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dnsThreatDetectors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDnsThreatDetectorsRequest>;
 
@@ -7272,7 +7278,7 @@ export const GetOrganizationsLocationsFirewallEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsFirewallEndpointsRequest>;
 
@@ -7316,7 +7322,7 @@ export const ListOrganizationsLocationsFirewallEndpointsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/firewallEndpoints" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/firewallEndpoints" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsFirewallEndpointsRequest>;
 
@@ -7361,7 +7367,7 @@ export const PatchOrganizationsLocationsFirewallEndpointsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(FirewallEndpoint).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsFirewallEndpointsRequest>;
 
@@ -7405,7 +7411,7 @@ export const CreateOrganizationsLocationsFirewallEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/firewallEndpoints",
+      path: "v1/{+parent}/firewallEndpoints",
       hasBody: true,
     }),
     svc,
@@ -7441,7 +7447,7 @@ export const DeleteOrganizationsLocationsFirewallEndpointsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsFirewallEndpointsRequest>;
 
@@ -7472,7 +7478,7 @@ export const GetOrganizationsLocationsSecurityProfileGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsSecurityProfileGroupsRequest>;
 
@@ -7510,7 +7516,7 @@ export const ListOrganizationsLocationsSecurityProfileGroupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/securityProfileGroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/securityProfileGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsSecurityProfileGroupsRequest>;
 
@@ -7553,7 +7559,7 @@ export const PatchOrganizationsLocationsSecurityProfileGroupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SecurityProfileGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsSecurityProfileGroupsRequest>;
 
@@ -7596,7 +7602,7 @@ export const CreateOrganizationsLocationsSecurityProfileGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/securityProfileGroups",
+      path: "v1/{+parent}/securityProfileGroups",
       hasBody: true,
     }),
     svc,
@@ -7634,7 +7640,7 @@ export const DeleteOrganizationsLocationsSecurityProfileGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsSecurityProfileGroupsRequest>;
 
@@ -7667,7 +7673,7 @@ export const GetOrganizationsLocationsSecurityProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsSecurityProfilesRequest>;
 
@@ -7704,7 +7710,7 @@ export const ListOrganizationsLocationsSecurityProfilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/securityProfiles" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/securityProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsSecurityProfilesRequest>;
 
@@ -7746,7 +7752,7 @@ export const PatchOrganizationsLocationsSecurityProfilesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SecurityProfile).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsSecurityProfilesRequest>;
 
@@ -7787,7 +7793,7 @@ export const CreateOrganizationsLocationsSecurityProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/securityProfiles",
+      path: "v1/{+parent}/securityProfiles",
       hasBody: true,
     }),
     svc,
@@ -7823,7 +7829,7 @@ export const DeleteOrganizationsLocationsSecurityProfilesRequest =
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsSecurityProfilesRequest>;
 
@@ -7854,7 +7860,7 @@ export const GetOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsOperationsRequest>;
 
@@ -7888,7 +7894,7 @@ export const CancelOrganizationsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOrganizationsLocationsOperationsRequest>;
 
@@ -7933,7 +7939,7 @@ export const ListOrganizationsLocationsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsOperationsRequest>;
 
@@ -7969,7 +7975,7 @@ export const DeleteOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsOperationsRequest>;
 
@@ -8005,7 +8011,7 @@ export const AddItemsOrganizationsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{addressGroup}:addItems",
+      path: "v1/{+addressGroup}:addItems",
       hasBody: true,
     }),
     svc,
@@ -8043,7 +8049,7 @@ export const RemoveItemsOrganizationsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{addressGroup}:removeItems",
+      path: "v1/{+addressGroup}:removeItems",
       hasBody: true,
     }),
     svc,
@@ -8079,7 +8085,7 @@ export const DeleteOrganizationsLocationsAddressGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsAddressGroupsRequest>;
 
@@ -8121,7 +8127,7 @@ export const ListOrganizationsLocationsAddressGroupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/addressGroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/addressGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsAddressGroupsRequest>;
 
@@ -8162,7 +8168,7 @@ export const CloneItemsOrganizationsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{addressGroup}:cloneItems",
+      path: "v1/{+addressGroup}:cloneItems",
       hasBody: true,
     }),
     svc,
@@ -8208,7 +8214,7 @@ export const CreateOrganizationsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/addressGroups",
+      path: "v1/{+parent}/addressGroups",
       hasBody: true,
     }),
     svc,
@@ -8247,7 +8253,7 @@ export const ListReferencesOrganizationsLocationsAddressGroupsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     addressGroup: Schema.String.pipe(T.HttpPath("addressGroup")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{addressGroup}:listReferences" }),
+    T.Http({ method: "GET", path: "v1/{+addressGroup}:listReferences" }),
     svc,
   ) as unknown as Schema.Schema<ListReferencesOrganizationsLocationsAddressGroupsRequest>;
 
@@ -8293,7 +8299,7 @@ export const PatchOrganizationsLocationsAddressGroupsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(AddressGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsAddressGroupsRequest>;
 
@@ -8324,7 +8330,7 @@ export const GetOrganizationsLocationsAddressGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsAddressGroupsRequest>;
 

--- a/packages/gcp/src/services/networksecurity-v1beta1.ts
+++ b/packages/gcp/src/services/networksecurity-v1beta1.ts
@@ -2558,7 +2558,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2593,7 +2593,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2631,7 +2631,7 @@ export const TestIamPermissionsProjectsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2671,7 +2671,7 @@ export const AddItemsProjectsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{addressGroup}:addItems",
+      path: "v1beta1/{+addressGroup}:addItems",
       hasBody: true,
     }),
     svc,
@@ -2709,7 +2709,7 @@ export const SetIamPolicyProjectsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2749,7 +2749,7 @@ export const ListReferencesProjectsLocationsAddressGroupsRequest =
     addressGroup: Schema.String.pipe(T.HttpPath("addressGroup")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{addressGroup}:listReferences" }),
+    T.Http({ method: "GET", path: "v1beta1/{+addressGroup}:listReferences" }),
     svc,
   ) as unknown as Schema.Schema<ListReferencesProjectsLocationsAddressGroupsRequest>;
 
@@ -2785,7 +2785,7 @@ export const GetProjectsLocationsAddressGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAddressGroupsRequest>;
 
@@ -2821,7 +2821,7 @@ export const GetIamPolicyProjectsLocationsAddressGroupsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsAddressGroupsRequest>;
 
@@ -2864,7 +2864,7 @@ export const ListProjectsLocationsAddressGroupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/addressGroups" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/addressGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAddressGroupsRequest>;
 
@@ -2905,7 +2905,7 @@ export const RemoveItemsProjectsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{addressGroup}:removeItems",
+      path: "v1beta1/{+addressGroup}:removeItems",
       hasBody: true,
     }),
     svc,
@@ -2947,7 +2947,7 @@ export const PatchProjectsLocationsAddressGroupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AddressGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAddressGroupsRequest>;
 
@@ -2991,7 +2991,7 @@ export const CreateProjectsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/addressGroups",
+      path: "v1beta1/{+parent}/addressGroups",
       hasBody: true,
     }),
     svc,
@@ -3029,7 +3029,7 @@ export const CloneItemsProjectsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{addressGroup}:cloneItems",
+      path: "v1beta1/{+addressGroup}:cloneItems",
       hasBody: true,
     }),
     svc,
@@ -3065,7 +3065,7 @@ export const DeleteProjectsLocationsAddressGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAddressGroupsRequest>;
 
@@ -3109,7 +3109,7 @@ export const CreateProjectsLocationsSacAttachmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/sacAttachments",
+      path: "v1beta1/{+parent}/sacAttachments",
       hasBody: true,
     }),
     svc,
@@ -3145,7 +3145,7 @@ export const DeleteProjectsLocationsSacAttachmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSacAttachmentsRequest>;
 
@@ -3176,7 +3176,7 @@ export const GetProjectsLocationsSacAttachmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSacAttachmentsRequest>;
 
@@ -3219,7 +3219,7 @@ export const ListProjectsLocationsSacAttachmentsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/sacAttachments" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/sacAttachments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSacAttachmentsRequest>;
 
@@ -3263,7 +3263,7 @@ export const CreateProjectsLocationsUrlListsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/urlLists",
+      path: "v1beta1/{+parent}/urlLists",
       hasBody: true,
     }),
     svc,
@@ -3296,7 +3296,7 @@ export const DeleteProjectsLocationsUrlListsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsUrlListsRequest>;
 
@@ -3333,7 +3333,7 @@ export const PatchProjectsLocationsUrlListsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UrlList).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsUrlListsRequest>;
 
@@ -3370,7 +3370,7 @@ export const ListProjectsLocationsUrlListsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/urlLists" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/urlLists" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsUrlListsRequest>;
 
@@ -3405,7 +3405,7 @@ export const GetProjectsLocationsUrlListsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsUrlListsRequest>;
 
@@ -3448,7 +3448,7 @@ export const ListProjectsLocationsMirroringDeploymentsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/mirroringDeployments" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/mirroringDeployments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMirroringDeploymentsRequest>;
 
@@ -3484,7 +3484,7 @@ export const GetProjectsLocationsMirroringDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMirroringDeploymentsRequest>;
 
@@ -3529,7 +3529,7 @@ export const CreateProjectsLocationsMirroringDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/mirroringDeployments",
+      path: "v1beta1/{+parent}/mirroringDeployments",
       hasBody: true,
     }),
     svc,
@@ -3565,7 +3565,7 @@ export const DeleteProjectsLocationsMirroringDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMirroringDeploymentsRequest>;
 
@@ -3605,7 +3605,7 @@ export const PatchProjectsLocationsMirroringDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MirroringDeployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMirroringDeploymentsRequest>;
 
@@ -3650,7 +3650,7 @@ export const ListProjectsLocationsFirewallEndpointAssociationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/firewallEndpointAssociations",
+      path: "v1beta1/{+parent}/firewallEndpointAssociations",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFirewallEndpointAssociationsRequest>;
@@ -3688,7 +3688,7 @@ export const GetProjectsLocationsFirewallEndpointAssociationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFirewallEndpointAssociationsRequest>;
 
@@ -3730,7 +3730,7 @@ export const PatchProjectsLocationsFirewallEndpointAssociationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(FirewallEndpointAssociation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFirewallEndpointAssociationsRequest>;
 
@@ -3776,7 +3776,7 @@ export const CreateProjectsLocationsFirewallEndpointAssociationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/firewallEndpointAssociations",
+      path: "v1beta1/{+parent}/firewallEndpointAssociations",
       hasBody: true,
     }),
     svc,
@@ -3814,7 +3814,7 @@ export const DeleteProjectsLocationsFirewallEndpointAssociationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFirewallEndpointAssociationsRequest>;
 
@@ -3856,7 +3856,7 @@ export const PatchProjectsLocationsInterceptDeploymentGroupsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(InterceptDeploymentGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInterceptDeploymentGroupsRequest>;
 
@@ -3901,7 +3901,7 @@ export const CreateProjectsLocationsInterceptDeploymentGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/interceptDeploymentGroups",
+      path: "v1beta1/{+parent}/interceptDeploymentGroups",
       hasBody: true,
     }),
     svc,
@@ -3939,7 +3939,7 @@ export const DeleteProjectsLocationsInterceptDeploymentGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInterceptDeploymentGroupsRequest>;
 
@@ -3972,7 +3972,7 @@ export const GetProjectsLocationsInterceptDeploymentGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInterceptDeploymentGroupsRequest>;
 
@@ -4018,7 +4018,7 @@ export const ListProjectsLocationsInterceptDeploymentGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/interceptDeploymentGroups",
+      path: "v1beta1/{+parent}/interceptDeploymentGroups",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInterceptDeploymentGroupsRequest>;
@@ -4064,7 +4064,7 @@ export const PatchProjectsLocationsInterceptDeploymentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(InterceptDeployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInterceptDeploymentsRequest>;
 
@@ -4108,7 +4108,7 @@ export const CreateProjectsLocationsInterceptDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/interceptDeployments",
+      path: "v1beta1/{+parent}/interceptDeployments",
       hasBody: true,
     }),
     svc,
@@ -4144,7 +4144,7 @@ export const DeleteProjectsLocationsInterceptDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInterceptDeploymentsRequest>;
 
@@ -4187,7 +4187,7 @@ export const ListProjectsLocationsInterceptDeploymentsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/interceptDeployments" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/interceptDeployments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInterceptDeploymentsRequest>;
 
@@ -4223,7 +4223,7 @@ export const GetProjectsLocationsInterceptDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInterceptDeploymentsRequest>;
 
@@ -4261,7 +4261,7 @@ export const PatchProjectsLocationsClientTlsPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ClientTlsPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsClientTlsPoliciesRequest>;
 
@@ -4302,7 +4302,7 @@ export const CreateProjectsLocationsClientTlsPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/clientTlsPolicies",
+      path: "v1beta1/{+parent}/clientTlsPolicies",
       hasBody: true,
     }),
     svc,
@@ -4335,7 +4335,7 @@ export const DeleteProjectsLocationsClientTlsPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClientTlsPoliciesRequest>;
 
@@ -4372,7 +4372,7 @@ export const ListProjectsLocationsClientTlsPoliciesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/clientTlsPolicies" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/clientTlsPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClientTlsPoliciesRequest>;
 
@@ -4408,7 +4408,7 @@ export const GetProjectsLocationsClientTlsPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClientTlsPoliciesRequest>;
 
@@ -4444,7 +4444,7 @@ export const GetIamPolicyProjectsLocationsClientTlsPoliciesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsClientTlsPoliciesRequest>;
 
@@ -4483,7 +4483,7 @@ export const TestIamPermissionsProjectsLocationsClientTlsPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4523,7 +4523,7 @@ export const SetIamPolicyProjectsLocationsClientTlsPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4567,7 +4567,7 @@ export const CreateProjectsLocationsDnsThreatDetectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/dnsThreatDetectors",
+      path: "v1beta1/{+parent}/dnsThreatDetectors",
       hasBody: true,
     }),
     svc,
@@ -4601,7 +4601,7 @@ export const DeleteProjectsLocationsDnsThreatDetectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDnsThreatDetectorsRequest>;
 
@@ -4638,7 +4638,7 @@ export const PatchProjectsLocationsDnsThreatDetectorsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(DnsThreatDetector).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDnsThreatDetectorsRequest>;
 
@@ -4670,7 +4670,7 @@ export const GetProjectsLocationsDnsThreatDetectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDnsThreatDetectorsRequest>;
 
@@ -4707,7 +4707,7 @@ export const ListProjectsLocationsDnsThreatDetectorsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/dnsThreatDetectors" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/dnsThreatDetectors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDnsThreatDetectorsRequest>;
 
@@ -4743,7 +4743,7 @@ export const GetProjectsLocationsInterceptEndpointGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInterceptEndpointGroupsRequest>;
 
@@ -4787,7 +4787,10 @@ export const ListProjectsLocationsInterceptEndpointGroupsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/interceptEndpointGroups" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/interceptEndpointGroups",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInterceptEndpointGroupsRequest>;
 
@@ -4836,7 +4839,7 @@ export const CreateProjectsLocationsInterceptEndpointGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/interceptEndpointGroups",
+      path: "v1beta1/{+parent}/interceptEndpointGroups",
       hasBody: true,
     }),
     svc,
@@ -4872,7 +4875,7 @@ export const DeleteProjectsLocationsInterceptEndpointGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInterceptEndpointGroupsRequest>;
 
@@ -4912,7 +4915,7 @@ export const PatchProjectsLocationsInterceptEndpointGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(InterceptEndpointGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInterceptEndpointGroupsRequest>;
 
@@ -4952,7 +4955,7 @@ export const PatchProjectsLocationsAuthzPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AuthzPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAuthzPoliciesRequest>;
 
@@ -4996,7 +4999,7 @@ export const CreateProjectsLocationsAuthzPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/authzPolicies",
+      path: "v1beta1/{+parent}/authzPolicies",
       hasBody: true,
     }),
     svc,
@@ -5032,7 +5035,7 @@ export const DeleteProjectsLocationsAuthzPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAuthzPoliciesRequest>;
 
@@ -5063,7 +5066,7 @@ export const GetProjectsLocationsAuthzPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAuthzPoliciesRequest>;
 
@@ -5099,7 +5102,7 @@ export const GetIamPolicyProjectsLocationsAuthzPoliciesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsAuthzPoliciesRequest>;
 
@@ -5138,7 +5141,7 @@ export const TestIamPermissionsProjectsLocationsAuthzPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5185,7 +5188,7 @@ export const ListProjectsLocationsAuthzPoliciesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/authzPolicies" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/authzPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAuthzPoliciesRequest>;
 
@@ -5226,7 +5229,7 @@ export const SetIamPolicyProjectsLocationsAuthzPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5274,7 +5277,7 @@ export const ListProjectsLocationsMirroringDeploymentGroupsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/mirroringDeploymentGroups",
+      path: "v1beta1/{+parent}/mirroringDeploymentGroups",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMirroringDeploymentGroupsRequest>;
@@ -5311,7 +5314,7 @@ export const GetProjectsLocationsMirroringDeploymentGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMirroringDeploymentGroupsRequest>;
 
@@ -5352,7 +5355,7 @@ export const PatchProjectsLocationsMirroringDeploymentGroupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(MirroringDeploymentGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMirroringDeploymentGroupsRequest>;
 
@@ -5397,7 +5400,7 @@ export const CreateProjectsLocationsMirroringDeploymentGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/mirroringDeploymentGroups",
+      path: "v1beta1/{+parent}/mirroringDeploymentGroups",
       hasBody: true,
     }),
     svc,
@@ -5435,7 +5438,7 @@ export const DeleteProjectsLocationsMirroringDeploymentGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMirroringDeploymentGroupsRequest>;
 
@@ -5477,7 +5480,7 @@ export const PatchProjectsLocationsMirroringEndpointGroupAssociationsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(MirroringEndpointGroupAssociation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMirroringEndpointGroupAssociationsRequest>;
 
@@ -5523,7 +5526,7 @@ export const CreateProjectsLocationsMirroringEndpointGroupAssociationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/mirroringEndpointGroupAssociations",
+      path: "v1beta1/{+parent}/mirroringEndpointGroupAssociations",
       hasBody: true,
     }),
     svc,
@@ -5561,7 +5564,7 @@ export const DeleteProjectsLocationsMirroringEndpointGroupAssociationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMirroringEndpointGroupAssociationsRequest>;
 
@@ -5594,7 +5597,7 @@ export const GetProjectsLocationsMirroringEndpointGroupAssociationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMirroringEndpointGroupAssociationsRequest>;
 
@@ -5641,7 +5644,7 @@ export const ListProjectsLocationsMirroringEndpointGroupAssociationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/mirroringEndpointGroupAssociations",
+      path: "v1beta1/{+parent}/mirroringEndpointGroupAssociations",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMirroringEndpointGroupAssociationsRequest>;
@@ -5693,7 +5696,7 @@ export const ListProjectsLocationsInterceptEndpointGroupAssociationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/interceptEndpointGroupAssociations",
+      path: "v1beta1/{+parent}/interceptEndpointGroupAssociations",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInterceptEndpointGroupAssociationsRequest>;
@@ -5731,7 +5734,7 @@ export const GetProjectsLocationsInterceptEndpointGroupAssociationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInterceptEndpointGroupAssociationsRequest>;
 
@@ -5777,7 +5780,7 @@ export const CreateProjectsLocationsInterceptEndpointGroupAssociationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/interceptEndpointGroupAssociations",
+      path: "v1beta1/{+parent}/interceptEndpointGroupAssociations",
       hasBody: true,
     }),
     svc,
@@ -5815,7 +5818,7 @@ export const DeleteProjectsLocationsInterceptEndpointGroupAssociationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInterceptEndpointGroupAssociationsRequest>;
 
@@ -5857,7 +5860,7 @@ export const PatchProjectsLocationsInterceptEndpointGroupAssociationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(InterceptEndpointGroupAssociation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInterceptEndpointGroupAssociationsRequest>;
 
@@ -5890,7 +5893,7 @@ export const GetProjectsLocationsServerTlsPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServerTlsPoliciesRequest>;
 
@@ -5926,7 +5929,7 @@ export const GetIamPolicyProjectsLocationsServerTlsPoliciesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsServerTlsPoliciesRequest>;
 
@@ -5965,7 +5968,7 @@ export const TestIamPermissionsProjectsLocationsServerTlsPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -6011,7 +6014,7 @@ export const ListProjectsLocationsServerTlsPoliciesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/serverTlsPolicies" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/serverTlsPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServerTlsPoliciesRequest>;
 
@@ -6052,7 +6055,7 @@ export const SetIamPolicyProjectsLocationsServerTlsPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -6092,7 +6095,7 @@ export const PatchProjectsLocationsServerTlsPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ServerTlsPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServerTlsPoliciesRequest>;
 
@@ -6133,7 +6136,7 @@ export const CreateProjectsLocationsServerTlsPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/serverTlsPolicies",
+      path: "v1beta1/{+parent}/serverTlsPolicies",
       hasBody: true,
     }),
     svc,
@@ -6166,7 +6169,7 @@ export const DeleteProjectsLocationsServerTlsPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServerTlsPoliciesRequest>;
 
@@ -6208,7 +6211,7 @@ export const CreateProjectsLocationsSacRealmsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/sacRealms",
+      path: "v1beta1/{+parent}/sacRealms",
       hasBody: true,
     }),
     svc,
@@ -6244,7 +6247,7 @@ export const DeleteProjectsLocationsSacRealmsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSacRealmsRequest>;
 
@@ -6287,7 +6290,7 @@ export const ListProjectsLocationsSacRealmsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/sacRealms" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/sacRealms" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSacRealmsRequest>;
 
@@ -6322,7 +6325,7 @@ export const GetProjectsLocationsSacRealmsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSacRealmsRequest>;
 
@@ -6366,7 +6369,7 @@ export const CreateProjectsLocationsMirroringEndpointGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/mirroringEndpointGroups",
+      path: "v1beta1/{+parent}/mirroringEndpointGroups",
       hasBody: true,
     }),
     svc,
@@ -6402,7 +6405,7 @@ export const DeleteProjectsLocationsMirroringEndpointGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMirroringEndpointGroupsRequest>;
 
@@ -6442,7 +6445,7 @@ export const PatchProjectsLocationsMirroringEndpointGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MirroringEndpointGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMirroringEndpointGroupsRequest>;
 
@@ -6485,7 +6488,10 @@ export const ListProjectsLocationsMirroringEndpointGroupsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/mirroringEndpointGroups" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/mirroringEndpointGroups",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMirroringEndpointGroupsRequest>;
 
@@ -6521,7 +6527,7 @@ export const GetProjectsLocationsMirroringEndpointGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMirroringEndpointGroupsRequest>;
 
@@ -6553,7 +6559,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -6598,7 +6604,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -6633,7 +6639,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -6667,7 +6673,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -6698,7 +6704,7 @@ export const GetProjectsLocationsBackendAuthenticationConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackendAuthenticationConfigsRequest>;
 
@@ -6739,7 +6745,7 @@ export const ListProjectsLocationsBackendAuthenticationConfigsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/backendAuthenticationConfigs",
+      path: "v1beta1/{+parent}/backendAuthenticationConfigs",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackendAuthenticationConfigsRequest>;
@@ -6787,7 +6793,7 @@ export const CreateProjectsLocationsBackendAuthenticationConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/backendAuthenticationConfigs",
+      path: "v1beta1/{+parent}/backendAuthenticationConfigs",
       hasBody: true,
     }),
     svc,
@@ -6825,7 +6831,7 @@ export const DeleteProjectsLocationsBackendAuthenticationConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackendAuthenticationConfigsRequest>;
 
@@ -6864,7 +6870,7 @@ export const PatchProjectsLocationsBackendAuthenticationConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(BackendAuthenticationConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBackendAuthenticationConfigsRequest>;
 
@@ -6903,7 +6909,7 @@ export const PatchProjectsLocationsTlsInspectionPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(TlsInspectionPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTlsInspectionPoliciesRequest>;
 
@@ -6944,7 +6950,7 @@ export const CreateProjectsLocationsTlsInspectionPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/tlsInspectionPolicies",
+      path: "v1beta1/{+parent}/tlsInspectionPolicies",
       hasBody: true,
     }),
     svc,
@@ -6980,7 +6986,7 @@ export const DeleteProjectsLocationsTlsInspectionPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTlsInspectionPoliciesRequest>;
 
@@ -7011,7 +7017,7 @@ export const GetProjectsLocationsTlsInspectionPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTlsInspectionPoliciesRequest>;
 
@@ -7049,7 +7055,7 @@ export const ListProjectsLocationsTlsInspectionPoliciesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/tlsInspectionPolicies" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/tlsInspectionPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTlsInspectionPoliciesRequest>;
 
@@ -7090,7 +7096,7 @@ export const SetIamPolicyProjectsLocationsAuthorizationPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -7125,7 +7131,7 @@ export const GetProjectsLocationsAuthorizationPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAuthorizationPoliciesRequest>;
 
@@ -7162,7 +7168,7 @@ export const GetIamPolicyProjectsLocationsAuthorizationPoliciesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsAuthorizationPoliciesRequest>;
 
@@ -7202,7 +7208,7 @@ export const TestIamPermissionsProjectsLocationsAuthorizationPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -7243,7 +7249,7 @@ export const ListProjectsLocationsAuthorizationPoliciesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/authorizationPolicies" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/authorizationPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAuthorizationPoliciesRequest>;
 
@@ -7289,7 +7295,7 @@ export const CreateProjectsLocationsAuthorizationPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/authorizationPolicies",
+      path: "v1beta1/{+parent}/authorizationPolicies",
       hasBody: true,
     }),
     svc,
@@ -7322,7 +7328,7 @@ export const DeleteProjectsLocationsAuthorizationPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAuthorizationPoliciesRequest>;
 
@@ -7359,7 +7365,7 @@ export const PatchProjectsLocationsAuthorizationPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AuthorizationPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAuthorizationPoliciesRequest>;
 
@@ -7390,7 +7396,7 @@ export const GetProjectsLocationsGatewaySecurityPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGatewaySecurityPoliciesRequest>;
 
@@ -7428,7 +7434,10 @@ export const ListProjectsLocationsGatewaySecurityPoliciesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/gatewaySecurityPolicies" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+parent}/gatewaySecurityPolicies",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGatewaySecurityPoliciesRequest>;
 
@@ -7474,7 +7483,7 @@ export const CreateProjectsLocationsGatewaySecurityPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/gatewaySecurityPolicies",
+      path: "v1beta1/{+parent}/gatewaySecurityPolicies",
       hasBody: true,
     }),
     svc,
@@ -7507,7 +7516,7 @@ export const DeleteProjectsLocationsGatewaySecurityPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGatewaySecurityPoliciesRequest>;
 
@@ -7544,7 +7553,7 @@ export const PatchProjectsLocationsGatewaySecurityPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GatewaySecurityPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGatewaySecurityPoliciesRequest>;
 
@@ -7583,7 +7592,7 @@ export const CreateProjectsLocationsGatewaySecurityPoliciesRulesRequest =
     ),
     body: Schema.optional(GatewaySecurityPolicyRule).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/rules", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+parent}/rules", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGatewaySecurityPoliciesRulesRequest>;
 
@@ -7616,7 +7625,7 @@ export const DeleteProjectsLocationsGatewaySecurityPoliciesRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGatewaySecurityPoliciesRulesRequest>;
 
@@ -7655,7 +7664,7 @@ export const PatchProjectsLocationsGatewaySecurityPoliciesRulesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GatewaySecurityPolicyRule).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGatewaySecurityPoliciesRulesRequest>;
 
@@ -7688,7 +7697,7 @@ export const GetProjectsLocationsGatewaySecurityPoliciesRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGatewaySecurityPoliciesRulesRequest>;
 
@@ -7727,7 +7736,7 @@ export const ListProjectsLocationsGatewaySecurityPoliciesRulesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/rules" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/rules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGatewaySecurityPoliciesRulesRequest>;
 
@@ -7770,7 +7779,7 @@ export const ListOrganizationsLocationsSecurityProfileGroupsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/securityProfileGroups" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/securityProfileGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsSecurityProfileGroupsRequest>;
 
@@ -7807,7 +7816,7 @@ export const GetOrganizationsLocationsSecurityProfileGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsSecurityProfileGroupsRequest>;
 
@@ -7845,7 +7854,7 @@ export const PatchOrganizationsLocationsSecurityProfileGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SecurityProfileGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsSecurityProfileGroupsRequest>;
 
@@ -7888,7 +7897,7 @@ export const CreateOrganizationsLocationsSecurityProfileGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/securityProfileGroups",
+      path: "v1beta1/{+parent}/securityProfileGroups",
       hasBody: true,
     }),
     svc,
@@ -7926,7 +7935,7 @@ export const DeleteOrganizationsLocationsSecurityProfileGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsSecurityProfileGroupsRequest>;
 
@@ -7969,7 +7978,7 @@ export const CreateOrganizationsLocationsSecurityProfilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/securityProfiles",
+      path: "v1beta1/{+parent}/securityProfiles",
       hasBody: true,
     }),
     svc,
@@ -8005,7 +8014,7 @@ export const DeleteOrganizationsLocationsSecurityProfilesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsSecurityProfilesRequest>;
 
@@ -8042,7 +8051,7 @@ export const PatchOrganizationsLocationsSecurityProfilesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SecurityProfile).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsSecurityProfilesRequest>;
 
@@ -8079,7 +8088,7 @@ export const ListOrganizationsLocationsSecurityProfilesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/securityProfiles" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/securityProfiles" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsSecurityProfilesRequest>;
 
@@ -8115,7 +8124,7 @@ export const GetOrganizationsLocationsSecurityProfilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsSecurityProfilesRequest>;
 
@@ -8152,7 +8161,7 @@ export const ListReferencesOrganizationsLocationsAddressGroupsRequest =
     addressGroup: Schema.String.pipe(T.HttpPath("addressGroup")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{addressGroup}:listReferences" }),
+    T.Http({ method: "GET", path: "v1beta1/{+addressGroup}:listReferences" }),
     svc,
   ) as unknown as Schema.Schema<ListReferencesOrganizationsLocationsAddressGroupsRequest>;
 
@@ -8194,7 +8203,7 @@ export const AddItemsOrganizationsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{addressGroup}:addItems",
+      path: "v1beta1/{+addressGroup}:addItems",
       hasBody: true,
     }),
     svc,
@@ -8236,7 +8245,7 @@ export const PatchOrganizationsLocationsAddressGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AddressGroup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsAddressGroupsRequest>;
 
@@ -8272,7 +8281,7 @@ export const RemoveItemsOrganizationsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{addressGroup}:removeItems",
+      path: "v1beta1/{+addressGroup}:removeItems",
       hasBody: true,
     }),
     svc,
@@ -8318,7 +8327,7 @@ export const CreateOrganizationsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/addressGroups",
+      path: "v1beta1/{+parent}/addressGroups",
       hasBody: true,
     }),
     svc,
@@ -8356,7 +8365,7 @@ export const CloneItemsOrganizationsLocationsAddressGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{addressGroup}:cloneItems",
+      path: "v1beta1/{+addressGroup}:cloneItems",
       hasBody: true,
     }),
     svc,
@@ -8392,7 +8401,7 @@ export const DeleteOrganizationsLocationsAddressGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsAddressGroupsRequest>;
 
@@ -8434,7 +8443,7 @@ export const ListOrganizationsLocationsAddressGroupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/addressGroups" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/addressGroups" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsAddressGroupsRequest>;
 
@@ -8470,7 +8479,7 @@ export const GetOrganizationsLocationsAddressGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsAddressGroupsRequest>;
 
@@ -8513,7 +8522,7 @@ export const ListOrganizationsLocationsFirewallEndpointsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/firewallEndpoints" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/firewallEndpoints" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsFirewallEndpointsRequest>;
 
@@ -8549,7 +8558,7 @@ export const GetOrganizationsLocationsFirewallEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsFirewallEndpointsRequest>;
 
@@ -8594,7 +8603,7 @@ export const CreateOrganizationsLocationsFirewallEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/firewallEndpoints",
+      path: "v1beta1/{+parent}/firewallEndpoints",
       hasBody: true,
     }),
     svc,
@@ -8630,7 +8639,7 @@ export const DeleteOrganizationsLocationsFirewallEndpointsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsFirewallEndpointsRequest>;
 
@@ -8670,7 +8679,7 @@ export const PatchOrganizationsLocationsFirewallEndpointsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(FirewallEndpoint).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsFirewallEndpointsRequest>;
 
@@ -8701,7 +8710,7 @@ export const DeleteOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsOperationsRequest>;
 
@@ -8735,7 +8744,7 @@ export const CancelOrganizationsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOrganizationsLocationsOperationsRequest>;
 
@@ -8780,7 +8789,7 @@ export const ListOrganizationsLocationsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsOperationsRequest>;
 
@@ -8816,7 +8825,7 @@ export const GetOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/networkservices-v1.ts
+++ b/packages/gcp/src/services/networkservices-v1.ts
@@ -2074,7 +2074,7 @@ export const ListProjectsLocationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2109,7 +2109,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2147,7 +2147,7 @@ export const GetProjectsLocationsWasmPluginsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWasmPluginsRequest>;
 
@@ -2178,7 +2178,7 @@ export const DeleteProjectsLocationsWasmPluginsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWasmPluginsRequest>;
 
@@ -2215,7 +2215,7 @@ export const ListProjectsLocationsWasmPluginsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/wasmPlugins" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/wasmPlugins" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWasmPluginsRequest>;
 
@@ -2258,7 +2258,7 @@ export const CreateProjectsLocationsWasmPluginsRequest =
     ),
     body: Schema.optional(WasmPlugin).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/wasmPlugins", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/wasmPlugins", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsWasmPluginsRequest>;
 
@@ -2295,7 +2295,7 @@ export const PatchProjectsLocationsWasmPluginsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(WasmPlugin).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsWasmPluginsRequest>;
 
@@ -2326,7 +2326,7 @@ export const DeleteProjectsLocationsWasmPluginsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWasmPluginsVersionsRequest>;
 
@@ -2363,7 +2363,7 @@ export const ListProjectsLocationsWasmPluginsVersionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWasmPluginsVersionsRequest>;
 
@@ -2399,7 +2399,7 @@ export const GetProjectsLocationsWasmPluginsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWasmPluginsVersionsRequest>;
 
@@ -2438,7 +2438,7 @@ export const CreateProjectsLocationsWasmPluginsVersionsRequest =
     ),
     body: Schema.optional(WasmPluginVersion).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/versions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/versions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsWasmPluginsVersionsRequest>;
 
@@ -2474,7 +2474,7 @@ export const TestIamPermissionsProjectsLocationsEdgeCacheServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2514,7 +2514,7 @@ export const SetIamPolicyProjectsLocationsEdgeCacheServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2552,7 +2552,7 @@ export const GetIamPolicyProjectsLocationsEdgeCacheServicesRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsEdgeCacheServicesRequest>;
 
@@ -2583,7 +2583,7 @@ export const GetProjectsLocationsEndpointPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEndpointPoliciesRequest>;
 
@@ -2625,7 +2625,7 @@ export const ListProjectsLocationsEndpointPoliciesRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/endpointPolicies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/endpointPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEndpointPoliciesRequest>;
 
@@ -2671,7 +2671,7 @@ export const CreateProjectsLocationsEndpointPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/endpointPolicies",
+      path: "v1/{+parent}/endpointPolicies",
       hasBody: true,
     }),
     svc,
@@ -2710,7 +2710,7 @@ export const PatchProjectsLocationsEndpointPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(EndpointPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEndpointPoliciesRequest>;
 
@@ -2741,7 +2741,7 @@ export const DeleteProjectsLocationsEndpointPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEndpointPoliciesRequest>;
 
@@ -2772,7 +2772,7 @@ export const GetProjectsLocationsHttpRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsHttpRoutesRequest>;
 
@@ -2803,7 +2803,7 @@ export const DeleteProjectsLocationsHttpRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsHttpRoutesRequest>;
 
@@ -2845,7 +2845,7 @@ export const ListProjectsLocationsHttpRoutesRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/httpRoutes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/httpRoutes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsHttpRoutesRequest>;
 
@@ -2888,7 +2888,7 @@ export const CreateProjectsLocationsHttpRoutesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(HttpRoute).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/httpRoutes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/httpRoutes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsHttpRoutesRequest>;
 
@@ -2925,7 +2925,7 @@ export const PatchProjectsLocationsHttpRoutesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(HttpRoute).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsHttpRoutesRequest>;
 
@@ -2956,7 +2956,7 @@ export const GetProjectsLocationsMeshesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMeshesRequest>;
 
@@ -2987,7 +2987,7 @@ export const DeleteProjectsLocationsMeshesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMeshesRequest>;
 
@@ -3029,7 +3029,7 @@ export const ListProjectsLocationsMeshesRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/meshes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/meshes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMeshesRequest>;
 
@@ -3070,7 +3070,7 @@ export const CreateProjectsLocationsMeshesRequest =
     meshId: Schema.optional(Schema.String).pipe(T.HttpQuery("meshId")),
     body: Schema.optional(Mesh).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/meshes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/meshes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsMeshesRequest>;
 
@@ -3107,7 +3107,7 @@ export const PatchProjectsLocationsMeshesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Mesh).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMeshesRequest>;
 
@@ -3138,7 +3138,7 @@ export const GetProjectsLocationsMeshesRouteViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMeshesRouteViewsRequest>;
 
@@ -3175,7 +3175,7 @@ export const ListProjectsLocationsMeshesRouteViewsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/routeViews" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/routeViews" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMeshesRouteViewsRequest>;
 
@@ -3211,7 +3211,7 @@ export const GetProjectsLocationsGatewaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGatewaysRequest>;
 
@@ -3242,7 +3242,7 @@ export const DeleteProjectsLocationsGatewaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGatewaysRequest>;
 
@@ -3279,7 +3279,7 @@ export const ListProjectsLocationsGatewaysRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/gateways" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/gateways" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGatewaysRequest>;
 
@@ -3320,7 +3320,7 @@ export const CreateProjectsLocationsGatewaysRequest =
     gatewayId: Schema.optional(Schema.String).pipe(T.HttpQuery("gatewayId")),
     body: Schema.optional(Gateway).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/gateways", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/gateways", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGatewaysRequest>;
 
@@ -3357,7 +3357,7 @@ export const PatchProjectsLocationsGatewaysRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Gateway).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGatewaysRequest>;
 
@@ -3388,7 +3388,7 @@ export const GetProjectsLocationsGatewaysRouteViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGatewaysRouteViewsRequest>;
 
@@ -3425,7 +3425,7 @@ export const ListProjectsLocationsGatewaysRouteViewsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/routeViews" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/routeViews" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGatewaysRouteViewsRequest>;
 
@@ -3461,7 +3461,7 @@ export const DeleteProjectsLocationsServiceLbPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServiceLbPoliciesRequest>;
 
@@ -3498,7 +3498,7 @@ export const ListProjectsLocationsServiceLbPoliciesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/serviceLbPolicies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/serviceLbPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServiceLbPoliciesRequest>;
 
@@ -3544,7 +3544,7 @@ export const CreateProjectsLocationsServiceLbPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/serviceLbPolicies",
+      path: "v1/{+parent}/serviceLbPolicies",
       hasBody: true,
     }),
     svc,
@@ -3583,7 +3583,7 @@ export const PatchProjectsLocationsServiceLbPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ServiceLbPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServiceLbPoliciesRequest>;
 
@@ -3614,7 +3614,7 @@ export const GetProjectsLocationsServiceLbPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServiceLbPoliciesRequest>;
 
@@ -3657,7 +3657,7 @@ export const ListProjectsLocationsLbEdgeExtensionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/lbEdgeExtensions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/lbEdgeExtensions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsLbEdgeExtensionsRequest>;
 
@@ -3706,7 +3706,7 @@ export const CreateProjectsLocationsLbEdgeExtensionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/lbEdgeExtensions",
+      path: "v1/{+parent}/lbEdgeExtensions",
       hasBody: true,
     }),
     svc,
@@ -3748,7 +3748,7 @@ export const PatchProjectsLocationsLbEdgeExtensionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(LbEdgeExtension).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsLbEdgeExtensionsRequest>;
 
@@ -3782,7 +3782,7 @@ export const DeleteProjectsLocationsLbEdgeExtensionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsLbEdgeExtensionsRequest>;
 
@@ -3813,7 +3813,7 @@ export const GetProjectsLocationsLbEdgeExtensionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsLbEdgeExtensionsRequest>;
 
@@ -3856,7 +3856,7 @@ export const ListProjectsLocationsLbRouteExtensionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/lbRouteExtensions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/lbRouteExtensions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsLbRouteExtensionsRequest>;
 
@@ -3905,7 +3905,7 @@ export const CreateProjectsLocationsLbRouteExtensionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/lbRouteExtensions",
+      path: "v1/{+parent}/lbRouteExtensions",
       hasBody: true,
     }),
     svc,
@@ -3947,7 +3947,7 @@ export const PatchProjectsLocationsLbRouteExtensionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(LbRouteExtension).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsLbRouteExtensionsRequest>;
 
@@ -3981,7 +3981,7 @@ export const DeleteProjectsLocationsLbRouteExtensionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsLbRouteExtensionsRequest>;
 
@@ -4012,7 +4012,7 @@ export const GetProjectsLocationsLbRouteExtensionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsLbRouteExtensionsRequest>;
 
@@ -4043,7 +4043,7 @@ export const GetProjectsLocationsTcpRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTcpRoutesRequest>;
 
@@ -4074,7 +4074,7 @@ export const DeleteProjectsLocationsTcpRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTcpRoutesRequest>;
 
@@ -4116,7 +4116,7 @@ export const ListProjectsLocationsTcpRoutesRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/tcpRoutes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/tcpRoutes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTcpRoutesRequest>;
 
@@ -4157,7 +4157,7 @@ export const CreateProjectsLocationsTcpRoutesRequest =
     tcpRouteId: Schema.optional(Schema.String).pipe(T.HttpQuery("tcpRouteId")),
     body: Schema.optional(TcpRoute).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/tcpRoutes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/tcpRoutes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTcpRoutesRequest>;
 
@@ -4194,7 +4194,7 @@ export const PatchProjectsLocationsTcpRoutesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(TcpRoute).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTcpRoutesRequest>;
 
@@ -4230,7 +4230,7 @@ export const SetIamPolicyProjectsLocationsEdgeCacheOriginsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4268,7 +4268,7 @@ export const GetIamPolicyProjectsLocationsEdgeCacheOriginsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsEdgeCacheOriginsRequest>;
 
@@ -4304,7 +4304,7 @@ export const TestIamPermissionsProjectsLocationsEdgeCacheOriginsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4350,7 +4350,7 @@ export const ListProjectsLocationsGrpcRoutesRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/grpcRoutes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/grpcRoutes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGrpcRoutesRequest>;
 
@@ -4393,7 +4393,7 @@ export const CreateProjectsLocationsGrpcRoutesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GrpcRoute).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/grpcRoutes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/grpcRoutes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGrpcRoutesRequest>;
 
@@ -4430,7 +4430,7 @@ export const PatchProjectsLocationsGrpcRoutesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GrpcRoute).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGrpcRoutesRequest>;
 
@@ -4461,7 +4461,7 @@ export const DeleteProjectsLocationsGrpcRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGrpcRoutesRequest>;
 
@@ -4492,7 +4492,7 @@ export const GetProjectsLocationsGrpcRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGrpcRoutesRequest>;
 
@@ -4528,7 +4528,7 @@ export const TestIamPermissionsProjectsLocationsEdgeCacheKeysetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4568,7 +4568,7 @@ export const SetIamPolicyProjectsLocationsEdgeCacheKeysetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4606,7 +4606,7 @@ export const GetIamPolicyProjectsLocationsEdgeCacheKeysetsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsEdgeCacheKeysetsRequest>;
 
@@ -4651,7 +4651,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -4686,7 +4686,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -4717,7 +4717,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -4751,7 +4751,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -4782,7 +4782,7 @@ export const GetProjectsLocationsServiceBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServiceBindingsRequest>;
 
@@ -4813,7 +4813,7 @@ export const DeleteProjectsLocationsServiceBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServiceBindingsRequest>;
 
@@ -4850,7 +4850,7 @@ export const ListProjectsLocationsServiceBindingsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/serviceBindings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/serviceBindings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServiceBindingsRequest>;
 
@@ -4896,7 +4896,7 @@ export const CreateProjectsLocationsServiceBindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/serviceBindings",
+      path: "v1/{+parent}/serviceBindings",
       hasBody: true,
     }),
     svc,
@@ -4935,7 +4935,7 @@ export const PatchProjectsLocationsServiceBindingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ServiceBinding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServiceBindingsRequest>;
 
@@ -4978,7 +4978,7 @@ export const ListProjectsLocationsLbTrafficExtensionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/lbTrafficExtensions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/lbTrafficExtensions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsLbTrafficExtensionsRequest>;
 
@@ -5027,7 +5027,7 @@ export const CreateProjectsLocationsLbTrafficExtensionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/lbTrafficExtensions",
+      path: "v1/{+parent}/lbTrafficExtensions",
       hasBody: true,
     }),
     svc,
@@ -5069,7 +5069,7 @@ export const PatchProjectsLocationsLbTrafficExtensionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LbTrafficExtension).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsLbTrafficExtensionsRequest>;
 
@@ -5103,7 +5103,7 @@ export const DeleteProjectsLocationsLbTrafficExtensionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsLbTrafficExtensionsRequest>;
 
@@ -5134,7 +5134,7 @@ export const GetProjectsLocationsLbTrafficExtensionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsLbTrafficExtensionsRequest>;
 
@@ -5169,7 +5169,7 @@ export const DeleteProjectsLocationsAuthzExtensionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAuthzExtensionsRequest>;
 
@@ -5212,7 +5212,7 @@ export const ListProjectsLocationsAuthzExtensionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/authzExtensions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/authzExtensions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAuthzExtensionsRequest>;
 
@@ -5261,7 +5261,7 @@ export const CreateProjectsLocationsAuthzExtensionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/authzExtensions",
+      path: "v1/{+parent}/authzExtensions",
       hasBody: true,
     }),
     svc,
@@ -5303,7 +5303,7 @@ export const PatchProjectsLocationsAuthzExtensionsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(AuthzExtension).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAuthzExtensionsRequest>;
 
@@ -5334,7 +5334,7 @@ export const GetProjectsLocationsAuthzExtensionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAuthzExtensionsRequest>;
 
@@ -5365,7 +5365,7 @@ export const GetProjectsLocationsTlsRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTlsRoutesRequest>;
 
@@ -5407,7 +5407,7 @@ export const ListProjectsLocationsTlsRoutesRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/tlsRoutes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/tlsRoutes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTlsRoutesRequest>;
 
@@ -5448,7 +5448,7 @@ export const CreateProjectsLocationsTlsRoutesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(TlsRoute).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/tlsRoutes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/tlsRoutes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTlsRoutesRequest>;
 
@@ -5485,7 +5485,7 @@ export const PatchProjectsLocationsTlsRoutesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(TlsRoute).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTlsRoutesRequest>;
 
@@ -5516,7 +5516,7 @@ export const DeleteProjectsLocationsTlsRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTlsRoutesRequest>;
 

--- a/packages/gcp/src/services/networkservices-v1beta1.ts
+++ b/packages/gcp/src/services/networkservices-v1beta1.ts
@@ -2157,7 +2157,7 @@ export const ListProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2192,7 +2192,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2226,7 +2226,7 @@ export const DeleteProjectsLocationsLbEdgeExtensionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsLbEdgeExtensionsRequest>;
 
@@ -2269,7 +2269,7 @@ export const ListProjectsLocationsLbEdgeExtensionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/lbEdgeExtensions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/lbEdgeExtensions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsLbEdgeExtensionsRequest>;
 
@@ -2305,7 +2305,7 @@ export const GetProjectsLocationsLbEdgeExtensionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsLbEdgeExtensionsRequest>;
 
@@ -2345,7 +2345,7 @@ export const PatchProjectsLocationsLbEdgeExtensionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LbEdgeExtension).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsLbEdgeExtensionsRequest>;
 
@@ -2389,7 +2389,7 @@ export const CreateProjectsLocationsLbEdgeExtensionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/lbEdgeExtensions",
+      path: "v1beta1/{+parent}/lbEdgeExtensions",
       hasBody: true,
     }),
     svc,
@@ -2428,7 +2428,7 @@ export const ListProjectsLocationsWasmPluginsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/wasmPlugins" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/wasmPlugins" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWasmPluginsRequest>;
 
@@ -2470,7 +2470,7 @@ export const GetProjectsLocationsWasmPluginsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWasmPluginsRequest>;
 
@@ -2507,7 +2507,7 @@ export const PatchProjectsLocationsWasmPluginsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(WasmPlugin).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsWasmPluginsRequest>;
 
@@ -2538,7 +2538,7 @@ export const DeleteProjectsLocationsWasmPluginsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWasmPluginsRequest>;
 
@@ -2579,7 +2579,7 @@ export const CreateProjectsLocationsWasmPluginsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/wasmPlugins",
+      path: "v1beta1/{+parent}/wasmPlugins",
       hasBody: true,
     }),
     svc,
@@ -2612,7 +2612,7 @@ export const DeleteProjectsLocationsWasmPluginsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWasmPluginsVersionsRequest>;
 
@@ -2653,7 +2653,7 @@ export const CreateProjectsLocationsWasmPluginsVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/versions",
+      path: "v1beta1/{+parent}/versions",
       hasBody: true,
     }),
     svc,
@@ -2692,7 +2692,7 @@ export const ListProjectsLocationsWasmPluginsVersionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWasmPluginsVersionsRequest>;
 
@@ -2728,7 +2728,7 @@ export const GetProjectsLocationsWasmPluginsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWasmPluginsVersionsRequest>;
 
@@ -2769,7 +2769,7 @@ export const CreateProjectsLocationsHttpRoutesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/httpRoutes",
+      path: "v1beta1/{+parent}/httpRoutes",
       hasBody: true,
     }),
     svc,
@@ -2802,7 +2802,7 @@ export const DeleteProjectsLocationsHttpRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsHttpRoutesRequest>;
 
@@ -2839,7 +2839,7 @@ export const PatchProjectsLocationsHttpRoutesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(HttpRoute).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsHttpRoutesRequest>;
 
@@ -2881,7 +2881,7 @@ export const ListProjectsLocationsHttpRoutesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/httpRoutes" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/httpRoutes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsHttpRoutesRequest>;
 
@@ -2916,7 +2916,7 @@ export const GetProjectsLocationsHttpRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsHttpRoutesRequest>;
 
@@ -2957,7 +2957,7 @@ export const CreateProjectsLocationsServiceLbPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/serviceLbPolicies",
+      path: "v1beta1/{+parent}/serviceLbPolicies",
       hasBody: true,
     }),
     svc,
@@ -2990,7 +2990,7 @@ export const DeleteProjectsLocationsServiceLbPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServiceLbPoliciesRequest>;
 
@@ -3027,7 +3027,7 @@ export const PatchProjectsLocationsServiceLbPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ServiceLbPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServiceLbPoliciesRequest>;
 
@@ -3064,7 +3064,7 @@ export const ListProjectsLocationsServiceLbPoliciesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/serviceLbPolicies" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/serviceLbPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServiceLbPoliciesRequest>;
 
@@ -3100,7 +3100,7 @@ export const GetProjectsLocationsServiceLbPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServiceLbPoliciesRequest>;
 
@@ -3142,7 +3142,7 @@ export const ListProjectsLocationsGrpcRoutesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/grpcRoutes" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/grpcRoutes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGrpcRoutesRequest>;
 
@@ -3177,7 +3177,7 @@ export const GetProjectsLocationsGrpcRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGrpcRoutesRequest>;
 
@@ -3214,7 +3214,7 @@ export const PatchProjectsLocationsGrpcRoutesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GrpcRoute).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGrpcRoutesRequest>;
 
@@ -3245,7 +3245,7 @@ export const DeleteProjectsLocationsGrpcRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGrpcRoutesRequest>;
 
@@ -3286,7 +3286,7 @@ export const CreateProjectsLocationsGrpcRoutesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/grpcRoutes",
+      path: "v1beta1/{+parent}/grpcRoutes",
       hasBody: true,
     }),
     svc,
@@ -3327,7 +3327,7 @@ export const CreateProjectsLocationsTcpRoutesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/tcpRoutes",
+      path: "v1beta1/{+parent}/tcpRoutes",
       hasBody: true,
     }),
     svc,
@@ -3371,7 +3371,7 @@ export const ListProjectsLocationsTcpRoutesRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/tcpRoutes" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/tcpRoutes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTcpRoutesRequest>;
 
@@ -3406,7 +3406,7 @@ export const GetProjectsLocationsTcpRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTcpRoutesRequest>;
 
@@ -3443,7 +3443,7 @@ export const PatchProjectsLocationsTcpRoutesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(TcpRoute).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTcpRoutesRequest>;
 
@@ -3474,7 +3474,7 @@ export const DeleteProjectsLocationsTcpRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTcpRoutesRequest>;
 
@@ -3508,7 +3508,7 @@ export const DeleteProjectsLocationsAgentGatewaysRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAgentGatewaysRequest>;
 
@@ -3545,7 +3545,7 @@ export const PatchProjectsLocationsAgentGatewaysRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AgentGateway).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAgentGatewaysRequest>;
 
@@ -3587,7 +3587,7 @@ export const ListProjectsLocationsAgentGatewaysRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/agentGateways" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/agentGateways" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAgentGatewaysRequest>;
 
@@ -3623,7 +3623,7 @@ export const GetProjectsLocationsAgentGatewaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAgentGatewaysRequest>;
 
@@ -3664,7 +3664,7 @@ export const CreateProjectsLocationsAgentGatewaysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/agentGateways",
+      path: "v1beta1/{+parent}/agentGateways",
       hasBody: true,
     }),
     svc,
@@ -3700,7 +3700,7 @@ export const DeleteProjectsLocationsLbTrafficExtensionsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsLbTrafficExtensionsRequest>;
 
@@ -3743,7 +3743,7 @@ export const ListProjectsLocationsLbTrafficExtensionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/lbTrafficExtensions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/lbTrafficExtensions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsLbTrafficExtensionsRequest>;
 
@@ -3779,7 +3779,7 @@ export const GetProjectsLocationsLbTrafficExtensionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsLbTrafficExtensionsRequest>;
 
@@ -3820,7 +3820,7 @@ export const PatchProjectsLocationsLbTrafficExtensionsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(LbTrafficExtension).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsLbTrafficExtensionsRequest>;
 
@@ -3864,7 +3864,7 @@ export const CreateProjectsLocationsLbTrafficExtensionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/lbTrafficExtensions",
+      path: "v1beta1/{+parent}/lbTrafficExtensions",
       hasBody: true,
     }),
     svc,
@@ -3910,7 +3910,7 @@ export const CreateProjectsLocationsAuthzExtensionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/authzExtensions",
+      path: "v1beta1/{+parent}/authzExtensions",
       hasBody: true,
     }),
     svc,
@@ -3955,7 +3955,7 @@ export const ListProjectsLocationsAuthzExtensionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/authzExtensions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/authzExtensions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAuthzExtensionsRequest>;
 
@@ -3991,7 +3991,7 @@ export const GetProjectsLocationsAuthzExtensionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAuthzExtensionsRequest>;
 
@@ -4031,7 +4031,7 @@ export const PatchProjectsLocationsAuthzExtensionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AuthzExtension).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAuthzExtensionsRequest>;
 
@@ -4065,7 +4065,7 @@ export const DeleteProjectsLocationsAuthzExtensionsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAuthzExtensionsRequest>;
 
@@ -4106,7 +4106,7 @@ export const CreateProjectsLocationsServiceBindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/serviceBindings",
+      path: "v1beta1/{+parent}/serviceBindings",
       hasBody: true,
     }),
     svc,
@@ -4145,7 +4145,7 @@ export const ListProjectsLocationsServiceBindingsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/serviceBindings" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/serviceBindings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServiceBindingsRequest>;
 
@@ -4181,7 +4181,7 @@ export const GetProjectsLocationsServiceBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServiceBindingsRequest>;
 
@@ -4218,7 +4218,7 @@ export const PatchProjectsLocationsServiceBindingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ServiceBinding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServiceBindingsRequest>;
 
@@ -4249,7 +4249,7 @@ export const DeleteProjectsLocationsServiceBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServiceBindingsRequest>;
 
@@ -4293,7 +4293,7 @@ export const CreateProjectsLocationsLbTcpExtensionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/lbTcpExtensions",
+      path: "v1beta1/{+parent}/lbTcpExtensions",
       hasBody: true,
     }),
     svc,
@@ -4329,7 +4329,7 @@ export const DeleteProjectsLocationsLbTcpExtensionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsLbTcpExtensionsRequest>;
 
@@ -4372,7 +4372,7 @@ export const ListProjectsLocationsLbTcpExtensionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/lbTcpExtensions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/lbTcpExtensions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsLbTcpExtensionsRequest>;
 
@@ -4408,7 +4408,7 @@ export const GetProjectsLocationsLbTcpExtensionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsLbTcpExtensionsRequest>;
 
@@ -4448,7 +4448,7 @@ export const PatchProjectsLocationsLbTcpExtensionsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(LbTcpExtension).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsLbTcpExtensionsRequest>;
 
@@ -4487,7 +4487,7 @@ export const CreateProjectsLocationsGatewaysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/gateways",
+      path: "v1beta1/{+parent}/gateways",
       hasBody: true,
     }),
     svc,
@@ -4526,7 +4526,7 @@ export const ListProjectsLocationsGatewaysRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/gateways" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/gateways" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGatewaysRequest>;
 
@@ -4561,7 +4561,7 @@ export const GetProjectsLocationsGatewaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGatewaysRequest>;
 
@@ -4598,7 +4598,7 @@ export const PatchProjectsLocationsGatewaysRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Gateway).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGatewaysRequest>;
 
@@ -4629,7 +4629,7 @@ export const DeleteProjectsLocationsGatewaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGatewaysRequest>;
 
@@ -4660,7 +4660,7 @@ export const GetProjectsLocationsGatewaysRouteViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGatewaysRouteViewsRequest>;
 
@@ -4697,7 +4697,7 @@ export const ListProjectsLocationsGatewaysRouteViewsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/routeViews" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/routeViews" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGatewaysRouteViewsRequest>;
 
@@ -4733,7 +4733,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -4767,7 +4767,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -4812,7 +4812,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -4847,7 +4847,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -4891,7 +4891,7 @@ export const CreateProjectsLocationsLbRouteExtensionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/lbRouteExtensions",
+      path: "v1beta1/{+parent}/lbRouteExtensions",
       hasBody: true,
     }),
     svc,
@@ -4933,7 +4933,7 @@ export const PatchProjectsLocationsLbRouteExtensionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(LbRouteExtension).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsLbRouteExtensionsRequest>;
 
@@ -4976,7 +4976,7 @@ export const ListProjectsLocationsLbRouteExtensionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/lbRouteExtensions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/lbRouteExtensions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsLbRouteExtensionsRequest>;
 
@@ -5012,7 +5012,7 @@ export const GetProjectsLocationsLbRouteExtensionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsLbRouteExtensionsRequest>;
 
@@ -5046,7 +5046,7 @@ export const DeleteProjectsLocationsLbRouteExtensionsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsLbRouteExtensionsRequest>;
 
@@ -5077,7 +5077,7 @@ export const DeleteProjectsLocationsEndpointPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEndpointPoliciesRequest>;
 
@@ -5114,7 +5114,7 @@ export const PatchProjectsLocationsEndpointPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(EndpointPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEndpointPoliciesRequest>;
 
@@ -5156,7 +5156,7 @@ export const ListProjectsLocationsEndpointPoliciesRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/endpointPolicies" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/endpointPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEndpointPoliciesRequest>;
 
@@ -5192,7 +5192,7 @@ export const GetProjectsLocationsEndpointPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEndpointPoliciesRequest>;
 
@@ -5233,7 +5233,7 @@ export const CreateProjectsLocationsEndpointPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/endpointPolicies",
+      path: "v1beta1/{+parent}/endpointPolicies",
       hasBody: true,
     }),
     svc,
@@ -5272,7 +5272,7 @@ export const PatchProjectsLocationsMeshesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Mesh).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMeshesRequest>;
 
@@ -5314,7 +5314,7 @@ export const ListProjectsLocationsMeshesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/meshes" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/meshes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMeshesRequest>;
 
@@ -5349,7 +5349,7 @@ export const GetProjectsLocationsMeshesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMeshesRequest>;
 
@@ -5380,7 +5380,7 @@ export const DeleteProjectsLocationsMeshesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMeshesRequest>;
 
@@ -5417,7 +5417,7 @@ export const CreateProjectsLocationsMeshesRequest =
     meshId: Schema.optional(Schema.String).pipe(T.HttpQuery("meshId")),
     body: Schema.optional(Mesh).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/meshes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+parent}/meshes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsMeshesRequest>;
 
@@ -5448,7 +5448,7 @@ export const GetProjectsLocationsMeshesRouteViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMeshesRouteViewsRequest>;
 
@@ -5485,7 +5485,7 @@ export const ListProjectsLocationsMeshesRouteViewsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/routeViews" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/routeViews" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsMeshesRouteViewsRequest>;
 
@@ -5529,7 +5529,7 @@ export const CreateProjectsLocationsTlsRoutesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/tlsRoutes",
+      path: "v1beta1/{+parent}/tlsRoutes",
       hasBody: true,
     }),
     svc,
@@ -5568,7 +5568,7 @@ export const PatchProjectsLocationsTlsRoutesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(TlsRoute).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTlsRoutesRequest>;
 
@@ -5610,7 +5610,7 @@ export const ListProjectsLocationsTlsRoutesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/tlsRoutes" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/tlsRoutes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTlsRoutesRequest>;
 
@@ -5645,7 +5645,7 @@ export const GetProjectsLocationsTlsRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTlsRoutesRequest>;
 
@@ -5676,7 +5676,7 @@ export const DeleteProjectsLocationsTlsRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTlsRoutesRequest>;
 

--- a/packages/gcp/src/services/notebooks-v1.ts
+++ b/packages/gcp/src/services/notebooks-v1.ts
@@ -1717,7 +1717,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1752,7 +1752,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1786,7 +1786,7 @@ export const SwitchProjectsLocationsRuntimesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SwitchRuntimeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:switch", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:switch", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SwitchProjectsLocationsRuntimesRequest>;
 
@@ -1820,7 +1820,7 @@ export const DeleteProjectsLocationsRuntimesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRuntimesRequest>;
 
@@ -1856,7 +1856,7 @@ export const SetIamPolicyProjectsLocationsRuntimesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1898,7 +1898,7 @@ export const CreateProjectsLocationsRuntimesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Runtime).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/runtimes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/runtimes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRuntimesRequest>;
 
@@ -1936,7 +1936,7 @@ export const RefreshRuntimeTokenInternalProjectsLocationsRuntimesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:refreshRuntimeTokenInternal",
+      path: "v1/{+name}:refreshRuntimeTokenInternal",
       hasBody: true,
     }),
     svc,
@@ -1974,7 +1974,7 @@ export const StopProjectsLocationsRuntimesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopRuntimeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsRuntimesRequest>;
 
@@ -2008,7 +2008,7 @@ export const MigrateProjectsLocationsRuntimesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MigrateRuntimeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:migrate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:migrate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MigrateProjectsLocationsRuntimesRequest>;
 
@@ -2039,7 +2039,7 @@ export const GetProjectsLocationsRuntimesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRuntimesRequest>;
 
@@ -2079,7 +2079,7 @@ export const PatchProjectsLocationsRuntimesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Runtime).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRuntimesRequest>;
 
@@ -2113,7 +2113,7 @@ export const UpgradeProjectsLocationsRuntimesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpgradeRuntimeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:upgrade", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:upgrade", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpgradeProjectsLocationsRuntimesRequest>;
 
@@ -2147,7 +2147,7 @@ export const ReportEventProjectsLocationsRuntimesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ReportRuntimeEventRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:reportEvent", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:reportEvent", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReportEventProjectsLocationsRuntimesRequest>;
 
@@ -2181,7 +2181,7 @@ export const ResetProjectsLocationsRuntimesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResetRuntimeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:reset", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:reset", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResetProjectsLocationsRuntimesRequest>;
 
@@ -2215,7 +2215,7 @@ export const DiagnoseProjectsLocationsRuntimesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DiagnoseRuntimeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:diagnose", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:diagnose", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DiagnoseProjectsLocationsRuntimesRequest>;
 
@@ -2258,7 +2258,7 @@ export const ListProjectsLocationsRuntimesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/runtimes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/runtimes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRuntimesRequest>;
 
@@ -2298,7 +2298,7 @@ export const TestIamPermissionsProjectsLocationsRuntimesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2337,7 +2337,7 @@ export const GetIamPolicyProjectsLocationsRuntimesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsRuntimesRequest>;
 
@@ -2371,7 +2371,7 @@ export const StartProjectsLocationsRuntimesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StartRuntimeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsLocationsRuntimesRequest>;
 
@@ -2410,7 +2410,11 @@ export const CreateProjectsLocationsEnvironmentsRequest =
     ),
     body: Schema.optional(Environment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/environments", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/environments",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsEnvironmentsRequest>;
 
@@ -2441,7 +2445,7 @@ export const GetProjectsLocationsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEnvironmentsRequest>;
 
@@ -2472,7 +2476,7 @@ export const DeleteProjectsLocationsEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEnvironmentsRequest>;
 
@@ -2509,7 +2513,7 @@ export const ListProjectsLocationsEnvironmentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/environments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/environments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEnvironmentsRequest>;
 
@@ -2545,7 +2549,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2590,7 +2594,7 @@ export const ListProjectsLocationsOperationsRequest =
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2628,7 +2632,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2659,7 +2663,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2695,7 +2699,7 @@ export const TestIamPermissionsProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2732,7 +2736,7 @@ export const DiagnoseProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DiagnoseInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:diagnose", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:diagnose", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DiagnoseProjectsLocationsInstancesRequest>;
 
@@ -2775,7 +2779,7 @@ export const ListProjectsLocationsInstancesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesRequest>;
 
@@ -2815,7 +2819,7 @@ export const SetMachineTypeProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1/{name}:setMachineType",
+      path: "v1/{+name}:setMachineType",
       hasBody: true,
     }),
     svc,
@@ -2851,7 +2855,7 @@ export const ResetProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResetInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:reset", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:reset", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResetProjectsLocationsInstancesRequest>;
 
@@ -2889,7 +2893,7 @@ export const UpdateShieldedInstanceConfigProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1/{name}:updateShieldedInstanceConfig",
+      path: "v1/{+name}:updateShieldedInstanceConfig",
       hasBody: true,
     }),
     svc,
@@ -2927,7 +2931,7 @@ export const RollbackProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RollbackInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:rollback", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:rollback", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RollbackProjectsLocationsInstancesRequest>;
 
@@ -2963,7 +2967,7 @@ export const UpgradeInternalProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:upgradeInternal",
+      path: "v1/{+name}:upgradeInternal",
       hasBody: true,
     }),
     svc,
@@ -2999,7 +3003,7 @@ export const UpgradeProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpgradeInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:upgrade", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:upgrade", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpgradeProjectsLocationsInstancesRequest>;
 
@@ -3033,7 +3037,7 @@ export const ReportEventProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ReportInstanceEventRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:reportEvent", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:reportEvent", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReportEventProjectsLocationsInstancesRequest>;
 
@@ -3071,7 +3075,7 @@ export const UpdateMetadataItemsProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1/{name}:updateMetadataItems",
+      path: "v1/{+name}:updateMetadataItems",
       hasBody: true,
     }),
     svc,
@@ -3108,7 +3112,7 @@ export const MigrateProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MigrateInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:migrate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:migrate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MigrateProjectsLocationsInstancesRequest>;
 
@@ -3142,7 +3146,7 @@ export const StopProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsInstancesRequest>;
 
@@ -3178,7 +3182,7 @@ export const RegisterProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/instances:register",
+      path: "v1/{+parent}/instances:register",
       hasBody: true,
     }),
     svc,
@@ -3211,7 +3215,7 @@ export const DeleteProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesRequest>;
 
@@ -3247,7 +3251,7 @@ export const GetIamPolicyProjectsLocationsInstancesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsInstancesRequest>;
 
@@ -3281,7 +3285,7 @@ export const StartProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StartInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsLocationsInstancesRequest>;
 
@@ -3315,7 +3319,7 @@ export const ReportProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ReportInstanceInfoRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:report", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:report", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReportProjectsLocationsInstancesRequest>;
 
@@ -3351,7 +3355,7 @@ export const SetAcceleratorProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1/{name}:setAccelerator",
+      path: "v1/{+name}:setAccelerator",
       hasBody: true,
     }),
     svc,
@@ -3384,7 +3388,7 @@ export const GetInstanceHealthProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getInstanceHealth" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getInstanceHealth" }),
     svc,
   ) as unknown as Schema.Schema<GetInstanceHealthProjectsLocationsInstancesRequest>;
 
@@ -3419,7 +3423,7 @@ export const SetLabelsProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetInstanceLabelsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}:setLabels", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}:setLabels", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetLabelsProjectsLocationsInstancesRequest>;
 
@@ -3450,7 +3454,7 @@ export const GetProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesRequest>;
 
@@ -3484,7 +3488,7 @@ export const UpdateConfigProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateInstanceConfigRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}:updateConfig", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}:updateConfig", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigProjectsLocationsInstancesRequest>;
 
@@ -3521,7 +3525,7 @@ export const CreateProjectsLocationsInstancesRequest =
     instanceId: Schema.optional(Schema.String).pipe(T.HttpQuery("instanceId")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/instances", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/instances", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsInstancesRequest>;
 
@@ -3557,7 +3561,7 @@ export const SetIamPolicyProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3599,7 +3603,7 @@ export const IsUpgradeableProjectsLocationsInstancesRequest =
     notebookInstance: Schema.String.pipe(T.HttpPath("notebookInstance")),
     type: Schema.optional(Schema.String).pipe(T.HttpQuery("type")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{notebookInstance}:isUpgradeable" }),
+    T.Http({ method: "GET", path: "v1/{+notebookInstance}:isUpgradeable" }),
     svc,
   ) as unknown as Schema.Schema<IsUpgradeableProjectsLocationsInstancesRequest>;
 
@@ -3643,7 +3647,7 @@ export const ListProjectsLocationsSchedulesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/schedules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/schedules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSchedulesRequest>;
 
@@ -3678,7 +3682,7 @@ export const DeleteProjectsLocationsSchedulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSchedulesRequest>;
 
@@ -3712,7 +3716,7 @@ export const TriggerProjectsLocationsSchedulesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(TriggerScheduleRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:trigger", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:trigger", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TriggerProjectsLocationsSchedulesRequest>;
 
@@ -3743,7 +3747,7 @@ export const GetProjectsLocationsSchedulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSchedulesRequest>;
 
@@ -3780,7 +3784,7 @@ export const CreateProjectsLocationsSchedulesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Schedule).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/schedules", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/schedules", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSchedulesRequest>;
 
@@ -3811,7 +3815,7 @@ export const DeleteProjectsLocationsExecutionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsExecutionsRequest>;
 
@@ -3854,7 +3858,7 @@ export const ListProjectsLocationsExecutionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/executions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/executions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsExecutionsRequest>;
 
@@ -3897,7 +3901,7 @@ export const CreateProjectsLocationsExecutionsRequest =
     ),
     body: Schema.optional(Execution).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/executions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/executions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsExecutionsRequest>;
 
@@ -3928,7 +3932,7 @@ export const GetProjectsLocationsExecutionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsExecutionsRequest>;
 

--- a/packages/gcp/src/services/notebooks-v2.ts
+++ b/packages/gcp/src/services/notebooks-v2.ts
@@ -956,7 +956,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -991,7 +991,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1022,7 +1022,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1067,7 +1067,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1102,7 +1102,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1136,7 +1136,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1167,7 +1167,7 @@ export const GetProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesRequest>;
 
@@ -1201,7 +1201,7 @@ export const ResetProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResetInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:reset", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:reset", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResetProjectsLocationsInstancesRequest>;
 
@@ -1237,7 +1237,7 @@ export const GetIamPolicyProjectsLocationsInstancesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v2/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsInstancesRequest>;
 
@@ -1271,7 +1271,7 @@ export const RestoreProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestoreInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsInstancesRequest>;
 
@@ -1305,7 +1305,7 @@ export const StartProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StartInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsLocationsInstancesRequest>;
 
@@ -1341,7 +1341,7 @@ export const ReportInfoSystemProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:reportInfoSystem",
+      path: "v2/{+name}:reportInfoSystem",
       hasBody: true,
     }),
     svc,
@@ -1377,7 +1377,7 @@ export const StopProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsInstancesRequest>;
 
@@ -1411,7 +1411,7 @@ export const UpgradeSystemProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpgradeInstanceSystemRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:upgradeSystem", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:upgradeSystem", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpgradeSystemProjectsLocationsInstancesRequest>;
 
@@ -1447,7 +1447,7 @@ export const TestIamPermissionsProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1486,7 +1486,7 @@ export const CheckAuthorizationProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:checkAuthorization",
+      path: "v2/{+name}:checkAuthorization",
       hasBody: true,
     }),
     svc,
@@ -1525,7 +1525,7 @@ export const GenerateAccessTokenProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:generateAccessToken",
+      path: "v2/{+name}:generateAccessToken",
       hasBody: true,
     }),
     svc,
@@ -1562,7 +1562,7 @@ export const RollbackProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RollbackInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:rollback", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:rollback", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RollbackProjectsLocationsInstancesRequest>;
 
@@ -1593,7 +1593,7 @@ export const GetConfigProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/instances:getConfig" }),
+    T.Http({ method: "GET", path: "v2/{+name}/instances:getConfig" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigProjectsLocationsInstancesRequest>;
 
@@ -1629,7 +1629,7 @@ export const ResizeDiskProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{notebookInstance}:resizeDisk",
+      path: "v2/{+notebookInstance}:resizeDisk",
       hasBody: true,
     }),
     svc,
@@ -1665,7 +1665,7 @@ export const DiagnoseProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DiagnoseInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:diagnose", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:diagnose", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DiagnoseProjectsLocationsInstancesRequest>;
 
@@ -1705,7 +1705,7 @@ export const CreateProjectsLocationsInstancesRequest =
     instanceId: Schema.optional(Schema.String).pipe(T.HttpQuery("instanceId")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/instances", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/instances", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsInstancesRequest>;
 
@@ -1739,7 +1739,7 @@ export const DeleteProjectsLocationsInstancesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesRequest>;
 
@@ -1779,7 +1779,7 @@ export const PatchProjectsLocationsInstancesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInstancesRequest>;
 
@@ -1810,7 +1810,10 @@ export const CheckUpgradabilityProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     notebookInstance: Schema.String.pipe(T.HttpPath("notebookInstance")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{notebookInstance}:checkUpgradability" }),
+    T.Http({
+      method: "GET",
+      path: "v2/{+notebookInstance}:checkUpgradability",
+    }),
     svc,
   ) as unknown as Schema.Schema<CheckUpgradabilityProjectsLocationsInstancesRequest>;
 
@@ -1854,7 +1857,7 @@ export const ListProjectsLocationsInstancesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesRequest>;
 
@@ -1892,7 +1895,7 @@ export const UpgradeProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpgradeInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:upgrade", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:upgrade", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpgradeProjectsLocationsInstancesRequest>;
 
@@ -1928,7 +1931,7 @@ export const SetIamPolicyProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/observability-v1.ts
+++ b/packages/gcp/src/services/observability-v1.ts
@@ -402,7 +402,7 @@ export const ListFoldersLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsRequest>;
 
@@ -437,7 +437,7 @@ export const GetFoldersLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsRequest>;
 
@@ -467,7 +467,7 @@ export const GetSettingsFoldersLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSettingsFoldersLocationsRequest>;
 
@@ -504,7 +504,7 @@ export const UpdateSettingsFoldersLocationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Settings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSettingsFoldersLocationsRequest>;
 
@@ -538,7 +538,7 @@ export const CancelFoldersLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelFoldersLocationsOperationsRequest>;
 
@@ -583,7 +583,7 @@ export const ListFoldersLocationsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsOperationsRequest>;
 
@@ -618,7 +618,7 @@ export const GetFoldersLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsOperationsRequest>;
 
@@ -649,7 +649,7 @@ export const DeleteFoldersLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersLocationsOperationsRequest>;
 
@@ -680,7 +680,7 @@ export const GetSettingsOrganizationsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSettingsOrganizationsLocationsRequest>;
 
@@ -725,7 +725,7 @@ export const ListOrganizationsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsRequest>;
 
@@ -760,7 +760,7 @@ export const GetOrganizationsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsRequest>;
 
@@ -797,7 +797,7 @@ export const UpdateSettingsOrganizationsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Settings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSettingsOrganizationsLocationsRequest>;
 
@@ -828,7 +828,7 @@ export const DeleteOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsOperationsRequest>;
 
@@ -862,7 +862,7 @@ export const CancelOrganizationsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOrganizationsLocationsOperationsRequest>;
 
@@ -907,7 +907,7 @@ export const ListOrganizationsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsOperationsRequest>;
 
@@ -943,7 +943,7 @@ export const GetOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsOperationsRequest>;
 
@@ -988,7 +988,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1023,7 +1023,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1054,7 +1054,7 @@ export const GetSettingsProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSettingsProjectsLocationsRequest>;
 
@@ -1091,7 +1091,7 @@ export const UpdateSettingsProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Settings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSettingsProjectsLocationsRequest>;
 
@@ -1122,7 +1122,7 @@ export const GetProjectsLocationsScopesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsScopesRequest>;
 
@@ -1159,7 +1159,7 @@ export const PatchProjectsLocationsScopesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Scope).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsScopesRequest>;
 
@@ -1190,7 +1190,7 @@ export const GetProjectsLocationsTraceScopesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTraceScopesRequest>;
 
@@ -1227,7 +1227,7 @@ export const ListProjectsLocationsTraceScopesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/traceScopes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/traceScopes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTraceScopesRequest>;
 
@@ -1262,7 +1262,7 @@ export const DeleteProjectsLocationsTraceScopesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTraceScopesRequest>;
 
@@ -1299,7 +1299,7 @@ export const PatchProjectsLocationsTraceScopesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(TraceScope).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTraceScopesRequest>;
 
@@ -1338,7 +1338,7 @@ export const CreateProjectsLocationsTraceScopesRequest =
     ),
     body: Schema.optional(TraceScope).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/traceScopes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/traceScopes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTraceScopesRequest>;
 
@@ -1369,7 +1369,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1414,7 +1414,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1449,7 +1449,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1483,7 +1483,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1514,7 +1514,7 @@ export const GetProjectsLocationsBucketsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBucketsRequest>;
 
@@ -1556,7 +1556,7 @@ export const ListProjectsLocationsBucketsRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/buckets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/buckets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBucketsRequest>;
 
@@ -1591,7 +1591,7 @@ export const GetProjectsLocationsBucketsDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBucketsDatasetsRequest>;
 
@@ -1633,7 +1633,7 @@ export const ListProjectsLocationsBucketsDatasetsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/datasets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/datasets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBucketsDatasetsRequest>;
 
@@ -1668,7 +1668,7 @@ export const GetProjectsLocationsBucketsDatasetsViewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBucketsDatasetsViewsRequest>;
 
@@ -1705,7 +1705,7 @@ export const ListProjectsLocationsBucketsDatasetsViewsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/views" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/views" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBucketsDatasetsViewsRequest>;
 
@@ -1747,7 +1747,7 @@ export const PatchProjectsLocationsBucketsDatasetsLinksRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Link).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsBucketsDatasetsLinksRequest>;
 
@@ -1778,7 +1778,7 @@ export const DeleteProjectsLocationsBucketsDatasetsLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBucketsDatasetsLinksRequest>;
 
@@ -1809,7 +1809,7 @@ export const GetProjectsLocationsBucketsDatasetsLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBucketsDatasetsLinksRequest>;
 
@@ -1846,7 +1846,7 @@ export const ListProjectsLocationsBucketsDatasetsLinksRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/links" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/links" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBucketsDatasetsLinksRequest>;
 
@@ -1888,7 +1888,7 @@ export const CreateProjectsLocationsBucketsDatasetsLinksRequest =
     linkId: Schema.optional(Schema.String).pipe(T.HttpQuery("linkId")),
     body: Schema.optional(Link).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/links", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/links", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsBucketsDatasetsLinksRequest>;
 

--- a/packages/gcp/src/services/ondemandscanning-v1.ts
+++ b/packages/gcp/src/services/ondemandscanning-v1.ts
@@ -2024,7 +2024,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2059,7 +2059,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2090,7 +2090,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2121,7 +2121,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2155,7 +2155,7 @@ export const WaitProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsOperationsRequest>;
 
@@ -2191,7 +2191,7 @@ export const AnalyzePackagesProjectsLocationsScansRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/scans:analyzePackages",
+      path: "v1/{+parent}/scans:analyzePackages",
       hasBody: true,
     }),
     svc,
@@ -2230,7 +2230,7 @@ export const ListProjectsLocationsScansVulnerabilitiesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/vulnerabilities" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/vulnerabilities" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsScansVulnerabilitiesRequest>;
 

--- a/packages/gcp/src/services/ondemandscanning-v1beta1.ts
+++ b/packages/gcp/src/services/ondemandscanning-v1beta1.ts
@@ -2022,7 +2022,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2057,7 +2057,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2088,7 +2088,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2119,7 +2119,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2153,7 +2153,7 @@ export const WaitProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     timeout: Schema.optional(Schema.String).pipe(T.HttpQuery("timeout")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsOperationsRequest>;
 
@@ -2189,7 +2189,7 @@ export const AnalyzePackagesProjectsLocationsScansRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/scans:analyzePackages",
+      path: "v1beta1/{+parent}/scans:analyzePackages",
       hasBody: true,
     }),
     svc,
@@ -2228,7 +2228,7 @@ export const ListProjectsLocationsScansVulnerabilitiesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/vulnerabilities" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/vulnerabilities" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsScansVulnerabilitiesRequest>;
 

--- a/packages/gcp/src/services/oracledatabase-v1.ts
+++ b/packages/gcp/src/services/oracledatabase-v1.ts
@@ -2940,7 +2940,7 @@ export const ListProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2975,7 +2975,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -3012,7 +3012,7 @@ export const ListProjectsLocationsDbSystemInitialStorageSizesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dbSystemInitialStorageSizes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dbSystemInitialStorageSizes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDbSystemInitialStorageSizesRequest>;
 
@@ -3052,7 +3052,7 @@ export const DeleteProjectsLocationsDbSystemsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDbSystemsRequest>;
 
@@ -3095,7 +3095,7 @@ export const ListProjectsLocationsDbSystemsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dbSystems" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dbSystems" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDbSystemsRequest>;
 
@@ -3130,7 +3130,7 @@ export const GetProjectsLocationsDbSystemsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDbSystemsRequest>;
 
@@ -3170,7 +3170,7 @@ export const CreateProjectsLocationsDbSystemsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(DbSystem).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/dbSystems", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/dbSystems", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDbSystemsRequest>;
 
@@ -3204,7 +3204,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -3249,7 +3249,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -3284,7 +3284,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -3315,7 +3315,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -3352,7 +3352,7 @@ export const ListProjectsLocationsEntitlementsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/entitlements" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/entitlements" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEntitlementsRequest>;
 
@@ -3391,7 +3391,7 @@ export const DeleteProjectsLocationsOdbNetworksRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOdbNetworksRequest>;
 
@@ -3434,7 +3434,7 @@ export const ListProjectsLocationsOdbNetworksRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/odbNetworks" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/odbNetworks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOdbNetworksRequest>;
 
@@ -3469,7 +3469,7 @@ export const GetProjectsLocationsOdbNetworksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOdbNetworksRequest>;
 
@@ -3511,7 +3511,7 @@ export const CreateProjectsLocationsOdbNetworksRequest =
     ),
     body: Schema.optional(OdbNetwork).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/odbNetworks", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/odbNetworks", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsOdbNetworksRequest>;
 
@@ -3554,7 +3554,7 @@ export const ListProjectsLocationsOdbNetworksOdbSubnetsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/odbSubnets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/odbSubnets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOdbNetworksOdbSubnetsRequest>;
 
@@ -3590,7 +3590,7 @@ export const GetProjectsLocationsOdbNetworksOdbSubnetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOdbNetworksOdbSubnetsRequest>;
 
@@ -3632,7 +3632,7 @@ export const CreateProjectsLocationsOdbNetworksOdbSubnetsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(OdbSubnet).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/odbSubnets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/odbSubnets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsOdbNetworksOdbSubnetsRequest>;
 
@@ -3666,7 +3666,7 @@ export const DeleteProjectsLocationsOdbNetworksOdbSubnetsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOdbNetworksOdbSubnetsRequest>;
 
@@ -3703,7 +3703,7 @@ export const DeleteProjectsLocationsCloudVmClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCloudVmClustersRequest>;
 
@@ -3743,7 +3743,7 @@ export const ListProjectsLocationsCloudVmClustersRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/cloudVmClusters" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/cloudVmClusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCloudVmClustersRequest>;
 
@@ -3779,7 +3779,7 @@ export const GetProjectsLocationsCloudVmClustersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCloudVmClustersRequest>;
 
@@ -3823,7 +3823,7 @@ export const CreateProjectsLocationsCloudVmClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/cloudVmClusters",
+      path: "v1/{+parent}/cloudVmClusters",
       hasBody: true,
     }),
     svc,
@@ -3862,7 +3862,7 @@ export const ListProjectsLocationsCloudVmClustersDbNodesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dbNodes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dbNodes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCloudVmClustersDbNodesRequest>;
 
@@ -3907,7 +3907,7 @@ export const ListProjectsLocationsDatabaseCharacterSetsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/databaseCharacterSets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/databaseCharacterSets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatabaseCharacterSetsRequest>;
 
@@ -3952,7 +3952,7 @@ export const ListProjectsLocationsPluggableDatabasesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/pluggableDatabases" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/pluggableDatabases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPluggableDatabasesRequest>;
 
@@ -3988,7 +3988,7 @@ export const GetProjectsLocationsPluggableDatabasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPluggableDatabasesRequest>;
 
@@ -4028,7 +4028,7 @@ export const ListProjectsLocationsGiVersionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/giVersions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/giVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGiVersionsRequest>;
 
@@ -4072,7 +4072,7 @@ export const ListProjectsLocationsGiVersionsMinorVersionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/minorVersions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/minorVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGiVersionsMinorVersionsRequest>;
 
@@ -4114,7 +4114,7 @@ export const ListProjectsLocationsAutonomousDbVersionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/autonomousDbVersions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/autonomousDbVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAutonomousDbVersionsRequest>;
 
@@ -4162,7 +4162,7 @@ export const ListProjectsLocationsCloudExadataInfrastructuresRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/cloudExadataInfrastructures" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/cloudExadataInfrastructures" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCloudExadataInfrastructuresRequest>;
 
@@ -4199,7 +4199,7 @@ export const GetProjectsLocationsCloudExadataInfrastructuresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCloudExadataInfrastructuresRequest>;
 
@@ -4245,7 +4245,7 @@ export const CreateProjectsLocationsCloudExadataInfrastructuresRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/cloudExadataInfrastructures",
+      path: "v1/{+parent}/cloudExadataInfrastructures",
       hasBody: true,
     }),
     svc,
@@ -4286,7 +4286,7 @@ export const DeleteProjectsLocationsCloudExadataInfrastructuresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCloudExadataInfrastructuresRequest>;
 
@@ -4325,7 +4325,7 @@ export const ListProjectsLocationsCloudExadataInfrastructuresDbServersRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dbServers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dbServers" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCloudExadataInfrastructuresDbServersRequest>;
 
@@ -4371,7 +4371,7 @@ export const ListProjectsLocationsAutonomousDatabaseBackupsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/autonomousDatabaseBackups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/autonomousDatabaseBackups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAutonomousDatabaseBackupsRequest>;
 
@@ -4416,7 +4416,7 @@ export const ListProjectsLocationsDatabasesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/databases" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/databases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatabasesRequest>;
 
@@ -4451,7 +4451,7 @@ export const GetProjectsLocationsDatabasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatabasesRequest>;
 
@@ -4491,7 +4491,7 @@ export const ListProjectsLocationsDbVersionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dbVersions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dbVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDbVersionsRequest>;
 
@@ -4535,7 +4535,7 @@ export const ListProjectsLocationsDbSystemShapesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dbSystemShapes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dbSystemShapes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDbSystemShapesRequest>;
 
@@ -4574,7 +4574,7 @@ export const DeleteProjectsLocationsExadbVmClustersRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsExadbVmClustersRequest>;
 
@@ -4612,7 +4612,7 @@ export const RemoveVirtualMachineProjectsLocationsExadbVmClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:removeVirtualMachine",
+      path: "v1/{+name}:removeVirtualMachine",
       hasBody: true,
     }),
     svc,
@@ -4659,7 +4659,7 @@ export const ListProjectsLocationsExadbVmClustersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/exadbVmClusters" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/exadbVmClusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsExadbVmClustersRequest>;
 
@@ -4695,7 +4695,7 @@ export const GetProjectsLocationsExadbVmClustersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsExadbVmClustersRequest>;
 
@@ -4735,7 +4735,7 @@ export const PatchProjectsLocationsExadbVmClustersRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(ExadbVmCluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsExadbVmClustersRequest>;
 
@@ -4779,7 +4779,7 @@ export const CreateProjectsLocationsExadbVmClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/exadbVmClusters",
+      path: "v1/{+parent}/exadbVmClusters",
       hasBody: true,
     }),
     svc,
@@ -4818,7 +4818,7 @@ export const ListProjectsLocationsExadbVmClustersDbNodesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dbNodes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dbNodes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsExadbVmClustersDbNodesRequest>;
 
@@ -4859,7 +4859,7 @@ export const SwitchoverProjectsLocationsAutonomousDatabasesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:switchover", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:switchover", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SwitchoverProjectsLocationsAutonomousDatabasesRequest>;
 
@@ -4893,7 +4893,7 @@ export const FailoverProjectsLocationsAutonomousDatabasesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(FailoverAutonomousDatabaseRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:failover", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:failover", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<FailoverProjectsLocationsAutonomousDatabasesRequest>;
 
@@ -4927,7 +4927,7 @@ export const DeleteProjectsLocationsAutonomousDatabasesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAutonomousDatabasesRequest>;
 
@@ -4963,7 +4963,11 @@ export const GenerateWalletProjectsLocationsAutonomousDatabasesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:generateWallet", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+name}:generateWallet",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<GenerateWalletProjectsLocationsAutonomousDatabasesRequest>;
 
@@ -4999,7 +5003,7 @@ export const StopProjectsLocationsAutonomousDatabasesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopAutonomousDatabaseRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsAutonomousDatabasesRequest>;
 
@@ -5033,7 +5037,7 @@ export const RestoreProjectsLocationsAutonomousDatabasesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestoreAutonomousDatabaseRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:restore", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:restore", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestoreProjectsLocationsAutonomousDatabasesRequest>;
 
@@ -5073,7 +5077,7 @@ export const PatchProjectsLocationsAutonomousDatabasesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(AutonomousDatabase).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAutonomousDatabasesRequest>;
 
@@ -5107,7 +5111,7 @@ export const RestartProjectsLocationsAutonomousDatabasesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RestartAutonomousDatabaseRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:restart", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:restart", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RestartProjectsLocationsAutonomousDatabasesRequest>;
 
@@ -5150,7 +5154,7 @@ export const ListProjectsLocationsAutonomousDatabasesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/autonomousDatabases" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/autonomousDatabases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAutonomousDatabasesRequest>;
 
@@ -5186,7 +5190,7 @@ export const GetProjectsLocationsAutonomousDatabasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAutonomousDatabasesRequest>;
 
@@ -5231,7 +5235,7 @@ export const CreateProjectsLocationsAutonomousDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/autonomousDatabases",
+      path: "v1/{+parent}/autonomousDatabases",
       hasBody: true,
     }),
     svc,
@@ -5267,7 +5271,7 @@ export const StartProjectsLocationsAutonomousDatabasesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StartAutonomousDatabaseRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsLocationsAutonomousDatabasesRequest>;
 
@@ -5310,7 +5314,7 @@ export const ListProjectsLocationsExascaleDbStorageVaultsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/exascaleDbStorageVaults" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/exascaleDbStorageVaults" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsExascaleDbStorageVaultsRequest>;
 
@@ -5346,7 +5350,7 @@ export const GetProjectsLocationsExascaleDbStorageVaultsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsExascaleDbStorageVaultsRequest>;
 
@@ -5391,7 +5395,7 @@ export const CreateProjectsLocationsExascaleDbStorageVaultsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/exascaleDbStorageVaults",
+      path: "v1/{+parent}/exascaleDbStorageVaults",
       hasBody: true,
     }),
     svc,
@@ -5427,7 +5431,7 @@ export const DeleteProjectsLocationsExascaleDbStorageVaultsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsExascaleDbStorageVaultsRequest>;
 
@@ -5469,7 +5473,7 @@ export const ListProjectsLocationsAutonomousDatabaseCharacterSetsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/autonomousDatabaseCharacterSets",
+      path: "v1/{+parent}/autonomousDatabaseCharacterSets",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAutonomousDatabaseCharacterSetsRequest>;

--- a/packages/gcp/src/services/orgpolicy-v2.ts
+++ b/packages/gcp/src/services/orgpolicy-v2.ts
@@ -393,7 +393,7 @@ export const GetProjectsPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsPoliciesRequest>;
 
@@ -427,7 +427,7 @@ export const CreateProjectsPoliciesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudOrgpolicyV2Policy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/policies", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/policies", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsPoliciesRequest>;
 
@@ -461,7 +461,7 @@ export const DeleteProjectsPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsPoliciesRequest>;
 
@@ -492,7 +492,7 @@ export const GetEffectivePolicyProjectsPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}:getEffectivePolicy" }),
+    T.Http({ method: "GET", path: "v2/{+name}:getEffectivePolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetEffectivePolicyProjectsPoliciesRequest>;
 
@@ -530,7 +530,7 @@ export const PatchProjectsPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudOrgpolicyV2Policy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsPoliciesRequest>;
 
@@ -567,7 +567,7 @@ export const ListProjectsPoliciesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/policies" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/policies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsPoliciesRequest>;
 
@@ -609,7 +609,7 @@ export const ListProjectsConstraintsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/constraints" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/constraints" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsConstraintsRequest>;
 
@@ -651,7 +651,7 @@ export const PatchFoldersPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudOrgpolicyV2Policy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersPoliciesRequest>;
 
@@ -688,7 +688,7 @@ export const ListFoldersPoliciesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/policies" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/policies" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersPoliciesRequest>;
 
@@ -724,7 +724,7 @@ export const GetFoldersPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersPoliciesRequest>;
 
@@ -758,7 +758,7 @@ export const CreateFoldersPoliciesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudOrgpolicyV2Policy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/policies", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/policies", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateFoldersPoliciesRequest>;
 
@@ -792,7 +792,7 @@ export const DeleteFoldersPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersPoliciesRequest>;
 
@@ -823,7 +823,7 @@ export const GetEffectivePolicyFoldersPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}:getEffectivePolicy" }),
+    T.Http({ method: "GET", path: "v2/{+name}:getEffectivePolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetEffectivePolicyFoldersPoliciesRequest>;
 
@@ -861,7 +861,7 @@ export const ListFoldersConstraintsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/constraints" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/constraints" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersConstraintsRequest>;
 
@@ -903,7 +903,7 @@ export const ListOrganizationsConstraintsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/constraints" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/constraints" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsConstraintsRequest>;
 
@@ -944,7 +944,7 @@ export const PatchOrganizationsCustomConstraintsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsCustomConstraintsRequest>;
 
@@ -982,7 +982,7 @@ export const ListOrganizationsCustomConstraintsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/customConstraints" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/customConstraints" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsCustomConstraintsRequest>;
 
@@ -1025,7 +1025,7 @@ export const CreateOrganizationsCustomConstraintsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/customConstraints",
+      path: "v2/{+parent}/customConstraints",
       hasBody: true,
     }),
     svc,
@@ -1059,7 +1059,7 @@ export const GetOrganizationsCustomConstraintsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsCustomConstraintsRequest>;
 
@@ -1091,7 +1091,7 @@ export const DeleteOrganizationsCustomConstraintsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsCustomConstraintsRequest>;
 
@@ -1122,7 +1122,7 @@ export const GetOrganizationsPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsPoliciesRequest>;
 
@@ -1156,7 +1156,7 @@ export const CreateOrganizationsPoliciesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudOrgpolicyV2Policy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/policies", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/policies", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsPoliciesRequest>;
 
@@ -1190,7 +1190,7 @@ export const DeleteOrganizationsPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsPoliciesRequest>;
 
@@ -1221,7 +1221,7 @@ export const GetEffectivePolicyOrganizationsPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}:getEffectivePolicy" }),
+    T.Http({ method: "GET", path: "v2/{+name}:getEffectivePolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetEffectivePolicyOrganizationsPoliciesRequest>;
 
@@ -1259,7 +1259,7 @@ export const ListOrganizationsPoliciesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/policies" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/policies" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsPoliciesRequest>;
 
@@ -1301,7 +1301,7 @@ export const PatchOrganizationsPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudOrgpolicyV2Policy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsPoliciesRequest>;
 

--- a/packages/gcp/src/services/osconfig-v1.ts
+++ b/packages/gcp/src/services/osconfig-v1.ts
@@ -2162,7 +2162,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2197,7 +2197,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2228,7 +2228,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2262,7 +2262,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2293,7 +2293,7 @@ export const GetProjectFeatureSettingsProjectsLocationsGlobalRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectFeatureSettingsProjectsLocationsGlobalRequest>;
 
@@ -2332,7 +2332,7 @@ export const UpdateProjectFeatureSettingsProjectsLocationsGlobalRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ProjectFeatureSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectFeatureSettingsProjectsLocationsGlobalRequest>;
 
@@ -2378,7 +2378,7 @@ export const CreateProjectsLocationsOsPolicyAssignmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/osPolicyAssignments",
+      path: "v1/{+parent}/osPolicyAssignments",
       hasBody: true,
     }),
     svc,
@@ -2425,7 +2425,7 @@ export const PatchProjectsLocationsOsPolicyAssignmentsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(OSPolicyAssignment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsOsPolicyAssignmentsRequest>;
 
@@ -2456,7 +2456,7 @@ export const GetProjectsLocationsOsPolicyAssignmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOsPolicyAssignmentsRequest>;
 
@@ -2494,7 +2494,7 @@ export const ListProjectsLocationsOsPolicyAssignmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/osPolicyAssignments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/osPolicyAssignments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOsPolicyAssignmentsRequest>;
 
@@ -2536,7 +2536,7 @@ export const ListRevisionsProjectsLocationsOsPolicyAssignmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:listRevisions" }),
+    T.Http({ method: "GET", path: "v1/{+name}:listRevisions" }),
     svc,
   ) as unknown as Schema.Schema<ListRevisionsProjectsLocationsOsPolicyAssignmentsRequest>;
 
@@ -2576,7 +2576,7 @@ export const DeleteProjectsLocationsOsPolicyAssignmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOsPolicyAssignmentsRequest>;
 
@@ -2607,7 +2607,7 @@ export const GetProjectsLocationsOsPolicyAssignmentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOsPolicyAssignmentsOperationsRequest>;
 
@@ -2643,7 +2643,7 @@ export const CancelProjectsLocationsOsPolicyAssignmentsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOsPolicyAssignmentsOperationsRequest>;
 
@@ -2676,7 +2676,7 @@ export const GetProjectsLocationsInstancesOsPolicyAssignmentsReportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesOsPolicyAssignmentsReportsRequest>;
 
@@ -2718,7 +2718,7 @@ export const ListProjectsLocationsInstancesOsPolicyAssignmentsReportsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/reports" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/reports" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesOsPolicyAssignmentsReportsRequest>;
 
@@ -2758,7 +2758,7 @@ export const GetProjectsLocationsInstancesInventoriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesInventoriesRequest>;
 
@@ -2801,7 +2801,7 @@ export const ListProjectsLocationsInstancesInventoriesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/inventories" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/inventories" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesInventoriesRequest>;
 
@@ -2837,7 +2837,7 @@ export const GetProjectsLocationsInstancesVulnerabilityReportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesVulnerabilityReportsRequest>;
 
@@ -2879,7 +2879,7 @@ export const ListProjectsLocationsInstancesVulnerabilityReportsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/vulnerabilityReports" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/vulnerabilityReports" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesVulnerabilityReportsRequest>;
 
@@ -2921,7 +2921,7 @@ export const ExecuteProjectsPatchJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/patchJobs:execute",
+      path: "v1/{+parent}/patchJobs:execute",
       hasBody: true,
     }),
     svc,
@@ -2954,7 +2954,7 @@ export const GetProjectsPatchJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsPatchJobsRequest>;
 
@@ -2988,7 +2988,7 @@ export const CancelProjectsPatchJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelPatchJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsPatchJobsRequest>;
 
@@ -3028,7 +3028,7 @@ export const ListProjectsPatchJobsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/patchJobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/patchJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsPatchJobsRequest>;
 
@@ -3072,7 +3072,7 @@ export const ListProjectsPatchJobsInstanceDetailsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/instanceDetails" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/instanceDetails" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsPatchJobsInstanceDetailsRequest>;
 
@@ -3118,7 +3118,7 @@ export const CreateProjectsPatchDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/patchDeployments",
+      path: "v1/{+parent}/patchDeployments",
       hasBody: true,
     }),
     svc,
@@ -3151,7 +3151,7 @@ export const GetProjectsPatchDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsPatchDeploymentsRequest>;
 
@@ -3188,7 +3188,7 @@ export const ListProjectsPatchDeploymentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/patchDeployments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/patchDeployments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsPatchDeploymentsRequest>;
 
@@ -3223,7 +3223,7 @@ export const DeleteProjectsPatchDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsPatchDeploymentsRequest>;
 
@@ -3260,7 +3260,7 @@ export const PatchProjectsPatchDeploymentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(PatchDeployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsPatchDeploymentsRequest>;
 
@@ -3294,7 +3294,7 @@ export const PauseProjectsPatchDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PausePatchDeploymentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsPatchDeploymentsRequest>;
 
@@ -3328,7 +3328,7 @@ export const ResumeProjectsPatchDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResumePatchDeploymentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsPatchDeploymentsRequest>;
 

--- a/packages/gcp/src/services/osconfig-v1alpha.ts
+++ b/packages/gcp/src/services/osconfig-v1alpha.ts
@@ -1656,7 +1656,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1691,7 +1691,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1722,7 +1722,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1756,7 +1756,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1800,7 +1800,7 @@ export const CreateProjectsLocationsOsPolicyAssignmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/osPolicyAssignments",
+      path: "v1alpha/{+parent}/osPolicyAssignments",
       hasBody: true,
     }),
     svc,
@@ -1847,7 +1847,7 @@ export const PatchProjectsLocationsOsPolicyAssignmentsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(OSPolicyAssignment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsOsPolicyAssignmentsRequest>;
 
@@ -1878,7 +1878,7 @@ export const GetProjectsLocationsOsPolicyAssignmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOsPolicyAssignmentsRequest>;
 
@@ -1916,7 +1916,7 @@ export const ListProjectsLocationsOsPolicyAssignmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/osPolicyAssignments" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/osPolicyAssignments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOsPolicyAssignmentsRequest>;
 
@@ -1958,7 +1958,7 @@ export const ListRevisionsProjectsLocationsOsPolicyAssignmentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}:listRevisions" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}:listRevisions" }),
     svc,
   ) as unknown as Schema.Schema<ListRevisionsProjectsLocationsOsPolicyAssignmentsRequest>;
 
@@ -1998,7 +1998,7 @@ export const DeleteProjectsLocationsOsPolicyAssignmentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOsPolicyAssignmentsRequest>;
 
@@ -2029,7 +2029,7 @@ export const GetProjectsLocationsOsPolicyAssignmentsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOsPolicyAssignmentsOperationsRequest>;
 
@@ -2065,7 +2065,7 @@ export const CancelProjectsLocationsOsPolicyAssignmentsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOsPolicyAssignmentsOperationsRequest>;
 
@@ -2098,7 +2098,7 @@ export const GetProjectsLocationsInstanceOSPoliciesCompliancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstanceOSPoliciesCompliancesRequest>;
 
@@ -2142,7 +2142,7 @@ export const ListProjectsLocationsInstanceOSPoliciesCompliancesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha/{parent}/instanceOSPoliciesCompliances",
+      path: "v1alpha/{+parent}/instanceOSPoliciesCompliances",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstanceOSPoliciesCompliancesRequest>;
@@ -2180,7 +2180,7 @@ export const GetProjectsLocationsInstancesOsPolicyAssignmentsReportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesOsPolicyAssignmentsReportsRequest>;
 
@@ -2222,7 +2222,7 @@ export const ListProjectsLocationsInstancesOsPolicyAssignmentsReportsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/reports" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/reports" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesOsPolicyAssignmentsReportsRequest>;
 
@@ -2262,7 +2262,7 @@ export const GetProjectsLocationsInstancesInventoriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesInventoriesRequest>;
 
@@ -2305,7 +2305,7 @@ export const ListProjectsLocationsInstancesInventoriesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/inventories" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/inventories" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesInventoriesRequest>;
 
@@ -2341,7 +2341,7 @@ export const GetProjectsLocationsInstancesVulnerabilityReportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesVulnerabilityReportsRequest>;
 
@@ -2383,7 +2383,7 @@ export const ListProjectsLocationsInstancesVulnerabilityReportsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/vulnerabilityReports" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/vulnerabilityReports" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesVulnerabilityReportsRequest>;
 

--- a/packages/gcp/src/services/osconfig-v1beta.ts
+++ b/packages/gcp/src/services/osconfig-v1beta.ts
@@ -1445,7 +1445,7 @@ export const ExecuteProjectsPatchJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/patchJobs:execute",
+      path: "v1beta/{+parent}/patchJobs:execute",
       hasBody: true,
     }),
     svc,
@@ -1478,7 +1478,7 @@ export const GetProjectsPatchJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsPatchJobsRequest>;
 
@@ -1512,7 +1512,7 @@ export const CancelProjectsPatchJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelPatchJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsPatchJobsRequest>;
 
@@ -1552,7 +1552,7 @@ export const ListProjectsPatchJobsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/patchJobs" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/patchJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsPatchJobsRequest>;
 
@@ -1596,7 +1596,7 @@ export const ListProjectsPatchJobsInstanceDetailsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/instanceDetails" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/instanceDetails" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsPatchJobsInstanceDetailsRequest>;
 
@@ -1642,7 +1642,7 @@ export const CreateProjectsPatchDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/patchDeployments",
+      path: "v1beta/{+parent}/patchDeployments",
       hasBody: true,
     }),
     svc,
@@ -1675,7 +1675,7 @@ export const GetProjectsPatchDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsPatchDeploymentsRequest>;
 
@@ -1712,7 +1712,7 @@ export const ListProjectsPatchDeploymentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/patchDeployments" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/patchDeployments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsPatchDeploymentsRequest>;
 
@@ -1747,7 +1747,7 @@ export const DeleteProjectsPatchDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsPatchDeploymentsRequest>;
 
@@ -1784,7 +1784,7 @@ export const PatchProjectsPatchDeploymentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(PatchDeployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsPatchDeploymentsRequest>;
 
@@ -1818,7 +1818,7 @@ export const PauseProjectsPatchDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PausePatchDeploymentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsPatchDeploymentsRequest>;
 
@@ -1852,7 +1852,7 @@ export const ResumeProjectsPatchDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResumePatchDeploymentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsPatchDeploymentsRequest>;
 
@@ -1893,7 +1893,7 @@ export const CreateProjectsGuestPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/guestPolicies",
+      path: "v1beta/{+parent}/guestPolicies",
       hasBody: true,
     }),
     svc,
@@ -1926,7 +1926,7 @@ export const GetProjectsGuestPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsGuestPoliciesRequest>;
 
@@ -1963,7 +1963,7 @@ export const ListProjectsGuestPoliciesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/guestPolicies" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/guestPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsGuestPoliciesRequest>;
 
@@ -2004,7 +2004,7 @@ export const PatchProjectsGuestPoliciesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GuestPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsGuestPoliciesRequest>;
 
@@ -2035,7 +2035,7 @@ export const DeleteProjectsGuestPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsGuestPoliciesRequest>;
 
@@ -2071,7 +2071,7 @@ export const LookupEffectiveGuestPolicyProjectsZonesInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{instance}:lookupEffectiveGuestPolicy",
+      path: "v1beta/{+instance}:lookupEffectiveGuestPolicy",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/osconfig-v2.ts
+++ b/packages/gcp/src/services/osconfig-v2.ts
@@ -1070,7 +1070,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1105,7 +1105,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1136,7 +1136,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1170,7 +1170,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1216,7 +1216,7 @@ export const CreateProjectsLocationsGlobalPolicyOrchestratorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/policyOrchestrators",
+      path: "v2/{+parent}/policyOrchestrators",
       hasBody: true,
     }),
     svc,
@@ -1263,7 +1263,7 @@ export const ListProjectsLocationsGlobalPolicyOrchestratorsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/policyOrchestrators" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/policyOrchestrators" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -1299,7 +1299,7 @@ export const GetProjectsLocationsGlobalPolicyOrchestratorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -1339,7 +1339,7 @@ export const PatchProjectsLocationsGlobalPolicyOrchestratorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -1377,7 +1377,7 @@ export const DeleteProjectsLocationsGlobalPolicyOrchestratorsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -1424,7 +1424,7 @@ export const ListFoldersLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsOperationsRequest>;
 
@@ -1459,7 +1459,7 @@ export const GetFoldersLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsOperationsRequest>;
 
@@ -1490,7 +1490,7 @@ export const DeleteFoldersLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersLocationsOperationsRequest>;
 
@@ -1524,7 +1524,7 @@ export const CancelFoldersLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelFoldersLocationsOperationsRequest>;
 
@@ -1570,7 +1570,7 @@ export const CreateFoldersLocationsGlobalPolicyOrchestratorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/policyOrchestrators",
+      path: "v2/{+parent}/policyOrchestrators",
       hasBody: true,
     }),
     svc,
@@ -1616,7 +1616,7 @@ export const ListFoldersLocationsGlobalPolicyOrchestratorsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/policyOrchestrators" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/policyOrchestrators" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -1652,7 +1652,7 @@ export const GetFoldersLocationsGlobalPolicyOrchestratorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -1692,7 +1692,7 @@ export const PatchFoldersLocationsGlobalPolicyOrchestratorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -1729,7 +1729,7 @@ export const DeleteFoldersLocationsGlobalPolicyOrchestratorsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -1775,7 +1775,7 @@ export const ListOrganizationsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsOperationsRequest>;
 
@@ -1811,7 +1811,7 @@ export const GetOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsOperationsRequest>;
 
@@ -1842,7 +1842,7 @@ export const DeleteOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsOperationsRequest>;
 
@@ -1876,7 +1876,7 @@ export const CancelOrganizationsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOrganizationsLocationsOperationsRequest>;
 
@@ -1922,7 +1922,7 @@ export const CreateOrganizationsLocationsGlobalPolicyOrchestratorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/policyOrchestrators",
+      path: "v2/{+parent}/policyOrchestrators",
       hasBody: true,
     }),
     svc,
@@ -1969,7 +1969,7 @@ export const ListOrganizationsLocationsGlobalPolicyOrchestratorsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/policyOrchestrators" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/policyOrchestrators" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -2006,7 +2006,7 @@ export const GetOrganizationsLocationsGlobalPolicyOrchestratorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -2047,7 +2047,7 @@ export const PatchOrganizationsLocationsGlobalPolicyOrchestratorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -2086,7 +2086,7 @@ export const DeleteOrganizationsLocationsGlobalPolicyOrchestratorsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsGlobalPolicyOrchestratorsRequest>;
 

--- a/packages/gcp/src/services/osconfig-v2beta.ts
+++ b/packages/gcp/src/services/osconfig-v2beta.ts
@@ -1073,7 +1073,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1108,7 +1108,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1139,7 +1139,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1173,7 +1173,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1219,7 +1219,7 @@ export const CreateProjectsLocationsGlobalPolicyOrchestratorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/policyOrchestrators",
+      path: "v2beta/{+parent}/policyOrchestrators",
       hasBody: true,
     }),
     svc,
@@ -1266,7 +1266,7 @@ export const ListProjectsLocationsGlobalPolicyOrchestratorsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{parent}/policyOrchestrators" }),
+    T.Http({ method: "GET", path: "v2beta/{+parent}/policyOrchestrators" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -1302,7 +1302,7 @@ export const GetProjectsLocationsGlobalPolicyOrchestratorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -1342,7 +1342,7 @@ export const PatchProjectsLocationsGlobalPolicyOrchestratorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -1380,7 +1380,7 @@ export const DeleteProjectsLocationsGlobalPolicyOrchestratorsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -1427,7 +1427,7 @@ export const ListFoldersLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsOperationsRequest>;
 
@@ -1462,7 +1462,7 @@ export const GetFoldersLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsOperationsRequest>;
 
@@ -1493,7 +1493,7 @@ export const DeleteFoldersLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersLocationsOperationsRequest>;
 
@@ -1527,7 +1527,7 @@ export const CancelFoldersLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelFoldersLocationsOperationsRequest>;
 
@@ -1573,7 +1573,7 @@ export const CreateFoldersLocationsGlobalPolicyOrchestratorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/policyOrchestrators",
+      path: "v2beta/{+parent}/policyOrchestrators",
       hasBody: true,
     }),
     svc,
@@ -1619,7 +1619,7 @@ export const ListFoldersLocationsGlobalPolicyOrchestratorsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{parent}/policyOrchestrators" }),
+    T.Http({ method: "GET", path: "v2beta/{+parent}/policyOrchestrators" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -1655,7 +1655,7 @@ export const GetFoldersLocationsGlobalPolicyOrchestratorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -1695,7 +1695,7 @@ export const PatchFoldersLocationsGlobalPolicyOrchestratorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -1732,7 +1732,7 @@ export const DeleteFoldersLocationsGlobalPolicyOrchestratorsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -1778,7 +1778,7 @@ export const ListOrganizationsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsOperationsRequest>;
 
@@ -1814,7 +1814,7 @@ export const GetOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsOperationsRequest>;
 
@@ -1845,7 +1845,7 @@ export const DeleteOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsOperationsRequest>;
 
@@ -1879,7 +1879,7 @@ export const CancelOrganizationsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOrganizationsLocationsOperationsRequest>;
 
@@ -1925,7 +1925,7 @@ export const CreateOrganizationsLocationsGlobalPolicyOrchestratorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/policyOrchestrators",
+      path: "v2beta/{+parent}/policyOrchestrators",
       hasBody: true,
     }),
     svc,
@@ -1972,7 +1972,7 @@ export const ListOrganizationsLocationsGlobalPolicyOrchestratorsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{parent}/policyOrchestrators" }),
+    T.Http({ method: "GET", path: "v2beta/{+parent}/policyOrchestrators" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -2009,7 +2009,7 @@ export const GetOrganizationsLocationsGlobalPolicyOrchestratorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -2050,7 +2050,7 @@ export const PatchOrganizationsLocationsGlobalPolicyOrchestratorsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsGlobalPolicyOrchestratorsRequest>;
 
@@ -2089,7 +2089,7 @@ export const DeleteOrganizationsLocationsGlobalPolicyOrchestratorsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsGlobalPolicyOrchestratorsRequest>;
 

--- a/packages/gcp/src/services/oslogin-v1.ts
+++ b/packages/gcp/src/services/oslogin-v1.ts
@@ -174,7 +174,7 @@ export const SignSshPublicKeyProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:signSshPublicKey",
+      path: "v1/{+parent}:signSshPublicKey",
       hasBody: true,
     }),
     svc,
@@ -214,7 +214,7 @@ export const GetLoginProfileUsersRequest =
     projectId: Schema.optional(Schema.String).pipe(T.HttpQuery("projectId")),
     systemId: Schema.optional(Schema.String).pipe(T.HttpQuery("systemId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/loginProfile" }),
+    T.Http({ method: "GET", path: "v1/{+name}/loginProfile" }),
     svc,
   ) as unknown as Schema.Schema<GetLoginProfileUsersRequest>;
 
@@ -258,7 +258,7 @@ export const ImportSshPublicKeyUsersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:importSshPublicKey",
+      path: "v1/{+parent}:importSshPublicKey",
       hasBody: true,
     }),
     svc,
@@ -296,7 +296,7 @@ export const CreateUsersSshPublicKeysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/sshPublicKeys",
+      path: "v1/{+parent}/sshPublicKeys",
       hasBody: true,
     }),
     svc,
@@ -329,7 +329,7 @@ export const DeleteUsersSshPublicKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteUsersSshPublicKeysRequest>;
 
@@ -360,7 +360,7 @@ export const GetUsersSshPublicKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetUsersSshPublicKeysRequest>;
 
@@ -397,7 +397,7 @@ export const PatchUsersSshPublicKeysRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SshPublicKey).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchUsersSshPublicKeysRequest>;
 
@@ -428,7 +428,7 @@ export const DeleteUsersProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteUsersProjectsRequest>;
 
@@ -461,7 +461,7 @@ export const ProvisionPosixAccountUsersProjectsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ProvisionPosixAccountRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ProvisionPosixAccountUsersProjectsRequest>;
 

--- a/packages/gcp/src/services/oslogin-v1alpha.ts
+++ b/packages/gcp/src/services/oslogin-v1alpha.ts
@@ -244,7 +244,7 @@ export const SignSshPublicKeyProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}:signSshPublicKey",
+      path: "v1alpha/{+parent}:signSshPublicKey",
       hasBody: true,
     }),
     svc,
@@ -300,7 +300,7 @@ export const GetLoginProfileUsersRequest =
     ),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}/loginProfile" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}/loginProfile" }),
     svc,
   ) as unknown as Schema.Schema<GetLoginProfileUsersRequest>;
 
@@ -351,7 +351,7 @@ export const ImportSshPublicKeyUsersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}:importSshPublicKey",
+      path: "v1alpha/{+parent}:importSshPublicKey",
       hasBody: true,
     }),
     svc,
@@ -389,7 +389,7 @@ export const CreateUsersSshPublicKeysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/sshPublicKeys",
+      path: "v1alpha/{+parent}/sshPublicKeys",
       hasBody: true,
     }),
     svc,
@@ -422,7 +422,7 @@ export const DeleteUsersSshPublicKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteUsersSshPublicKeysRequest>;
 
@@ -453,7 +453,7 @@ export const GetUsersSshPublicKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetUsersSshPublicKeysRequest>;
 
@@ -490,7 +490,7 @@ export const PatchUsersSshPublicKeysRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SshPublicKey).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchUsersSshPublicKeysRequest>;
 
@@ -530,7 +530,7 @@ export const DeleteUsersProjectsRequest =
       T.HttpQuery("operatingSystemType"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteUsersProjectsRequest>;
 
@@ -563,7 +563,7 @@ export const ProvisionPosixAccountUsersProjectsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ProvisionPosixAccountRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ProvisionPosixAccountUsersProjectsRequest>;
 
@@ -599,7 +599,7 @@ export const SignSshPublicKeyUsersProjectsZonesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}:signSshPublicKey",
+      path: "v1alpha/{+parent}:signSshPublicKey",
       hasBody: true,
     }),
     svc,
@@ -638,7 +638,7 @@ export const SignSshPublicKeyUsersProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}:signSshPublicKey",
+      path: "v1alpha/{+parent}:signSshPublicKey",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/oslogin-v1beta.ts
+++ b/packages/gcp/src/services/oslogin-v1beta.ts
@@ -244,7 +244,7 @@ export const SignSshPublicKeyProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}:signSshPublicKey",
+      path: "v1beta/{+parent}:signSshPublicKey",
       hasBody: true,
     }),
     svc,
@@ -291,7 +291,7 @@ export const GetLoginProfileUsersRequest =
     systemId: Schema.optional(Schema.String).pipe(T.HttpQuery("systemId")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/loginProfile" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/loginProfile" }),
     svc,
   ) as unknown as Schema.Schema<GetLoginProfileUsersRequest>;
 
@@ -342,7 +342,7 @@ export const ImportSshPublicKeyUsersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}:importSshPublicKey",
+      path: "v1beta/{+parent}:importSshPublicKey",
       hasBody: true,
     }),
     svc,
@@ -380,7 +380,7 @@ export const CreateUsersSshPublicKeysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/sshPublicKeys",
+      path: "v1beta/{+parent}/sshPublicKeys",
       hasBody: true,
     }),
     svc,
@@ -413,7 +413,7 @@ export const DeleteUsersSshPublicKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteUsersSshPublicKeysRequest>;
 
@@ -444,7 +444,7 @@ export const GetUsersSshPublicKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetUsersSshPublicKeysRequest>;
 
@@ -481,7 +481,7 @@ export const PatchUsersSshPublicKeysRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SshPublicKey).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchUsersSshPublicKeysRequest>;
 
@@ -512,7 +512,7 @@ export const DeleteUsersProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteUsersProjectsRequest>;
 
@@ -545,7 +545,7 @@ export const ProvisionPosixAccountUsersProjectsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ProvisionPosixAccountRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ProvisionPosixAccountUsersProjectsRequest>;
 
@@ -581,7 +581,7 @@ export const SignSshPublicKeyUsersProjectsZonesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}:signSshPublicKey",
+      path: "v1beta/{+parent}:signSshPublicKey",
       hasBody: true,
     }),
     svc,
@@ -620,7 +620,7 @@ export const SignSshPublicKeyUsersProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}:signSshPublicKey",
+      path: "v1beta/{+parent}:signSshPublicKey",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/parallelstore-v1.ts
+++ b/packages/gcp/src/services/parallelstore-v1.ts
@@ -376,7 +376,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -411,7 +411,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -442,7 +442,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -473,7 +473,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -507,7 +507,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -552,7 +552,7 @@ export const ListProjectsLocationsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -599,7 +599,7 @@ export const ListProjectsLocationsInstancesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesRequest>;
 
@@ -643,7 +643,7 @@ export const PatchProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInstancesRequest>;
 
@@ -683,7 +683,7 @@ export const CreateProjectsLocationsInstancesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/instances", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/instances", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsInstancesRequest>;
 
@@ -717,7 +717,7 @@ export const DeleteProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesRequest>;
 
@@ -751,7 +751,7 @@ export const ExportDataProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportDataRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:exportData", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:exportData", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportDataProjectsLocationsInstancesRequest>;
 
@@ -782,7 +782,7 @@ export const GetProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesRequest>;
 
@@ -816,7 +816,7 @@ export const ImportDataProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ImportDataRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:importData", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:importData", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportDataProjectsLocationsInstancesRequest>;
 

--- a/packages/gcp/src/services/parallelstore-v1beta.ts
+++ b/packages/gcp/src/services/parallelstore-v1beta.ts
@@ -370,7 +370,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -405,7 +405,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -436,7 +436,7 @@ export const GetProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesRequest>;
 
@@ -479,7 +479,7 @@ export const ListProjectsLocationsInstancesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesRequest>;
 
@@ -517,7 +517,7 @@ export const DeleteProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesRequest>;
 
@@ -551,7 +551,11 @@ export const ImportDataProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ImportDataRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:importData", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+name}:importData",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<ImportDataProjectsLocationsInstancesRequest>;
 
@@ -585,7 +589,11 @@ export const ExportDataProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportDataRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:exportData", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta/{+name}:exportData",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<ExportDataProjectsLocationsInstancesRequest>;
 
@@ -625,7 +633,7 @@ export const PatchProjectsLocationsInstancesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInstancesRequest>;
 
@@ -667,7 +675,7 @@ export const CreateProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/instances",
+      path: "v1beta/{+parent}/instances",
       hasBody: true,
     }),
     svc,
@@ -714,7 +722,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -749,7 +757,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -780,7 +788,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -811,7 +819,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/parametermanager-v1.ts
+++ b/packages/gcp/src/services/parametermanager-v1.ts
@@ -215,7 +215,7 @@ export const ListProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -250,7 +250,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -281,7 +281,7 @@ export const GetProjectsLocationsParametersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsParametersRequest>;
 
@@ -315,7 +315,7 @@ export const DeleteProjectsLocationsParametersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsParametersRequest>;
 
@@ -358,7 +358,7 @@ export const ListProjectsLocationsParametersRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/parameters" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/parameters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsParametersRequest>;
 
@@ -404,7 +404,7 @@ export const CreateProjectsLocationsParametersRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Parameter).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/parameters", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/parameters", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsParametersRequest>;
 
@@ -444,7 +444,7 @@ export const PatchProjectsLocationsParametersRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Parameter).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsParametersRequest>;
 
@@ -487,7 +487,7 @@ export const ListProjectsLocationsParametersVersionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsParametersVersionsRequest>;
 
@@ -534,7 +534,7 @@ export const CreateProjectsLocationsParametersVersionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(ParameterVersion).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/versions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/versions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsParametersVersionsRequest>;
 
@@ -575,7 +575,7 @@ export const PatchProjectsLocationsParametersVersionsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(ParameterVersion).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsParametersVersionsRequest>;
 
@@ -609,7 +609,7 @@ export const GetProjectsLocationsParametersVersionsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsParametersVersionsRequest>;
 
@@ -643,7 +643,7 @@ export const DeleteProjectsLocationsParametersVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsParametersVersionsRequest>;
 
@@ -674,7 +674,7 @@ export const RenderProjectsLocationsParametersVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:render" }),
+    T.Http({ method: "GET", path: "v1/{+name}:render" }),
     svc,
   ) as unknown as Schema.Schema<RenderProjectsLocationsParametersVersionsRequest>;
 

--- a/packages/gcp/src/services/paymentsresellersubscription-v1.ts
+++ b/packages/gcp/src/services/paymentsresellersubscription-v1.ts
@@ -920,7 +920,7 @@ export const ListPartnersProductsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/products" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/products" }),
     svc,
   ) as unknown as Schema.Schema<ListPartnersProductsRequest>;
 
@@ -960,7 +960,7 @@ export const FindEligiblePartnersPromotionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/promotions:findEligible",
+      path: "v1/{+parent}/promotions:findEligible",
       hasBody: true,
     }),
     svc,
@@ -1003,7 +1003,7 @@ export const ListPartnersPromotionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/promotions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/promotions" }),
     svc,
   ) as unknown as Schema.Schema<ListPartnersPromotionsRequest>;
 
@@ -1041,7 +1041,7 @@ export const ExtendPartnersSubscriptionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExtendSubscriptionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:extend", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:extend", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExtendPartnersSubscriptionsRequest>;
 
@@ -1097,7 +1097,7 @@ export const ProvisionPartnersSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/subscriptions:provision",
+      path: "v1/{+parent}/subscriptions:provision",
       hasBody: true,
     }),
     svc,
@@ -1133,7 +1133,7 @@ export const EntitlePartnersSubscriptionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EntitleSubscriptionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:entitle", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:entitle", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EntitlePartnersSubscriptionsRequest>;
 
@@ -1167,7 +1167,7 @@ export const SuspendPartnersSubscriptionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SuspendSubscriptionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:suspend", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:suspend", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SuspendPartnersSubscriptionsRequest>;
 
@@ -1201,7 +1201,7 @@ export const ResumePartnersSubscriptionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResumeSubscriptionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumePartnersSubscriptionsRequest>;
 
@@ -1235,7 +1235,7 @@ export const CancelPartnersSubscriptionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelSubscriptionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelPartnersSubscriptionsRequest>;
 
@@ -1269,7 +1269,7 @@ export const UndoCancelPartnersSubscriptionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndoCancelSubscriptionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undoCancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undoCancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndoCancelPartnersSubscriptionsRequest>;
 
@@ -1301,7 +1301,7 @@ export const GetPartnersSubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPartnersSubscriptionsRequest>;
 
@@ -1342,7 +1342,7 @@ export const CreatePartnersSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/subscriptions",
+      path: "v1/{+parent}/subscriptions",
       hasBody: true,
     }),
     svc,
@@ -1381,7 +1381,7 @@ export const PatchPartnersSubscriptionsLineItemsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SubscriptionLineItem).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchPartnersSubscriptionsLineItemsRequest>;
 
@@ -1417,7 +1417,7 @@ export const GeneratePartnersUserSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/userSessions:generate",
+      path: "v1/{+parent}/userSessions:generate",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/people-v1.ts
+++ b/packages/gcp/src/services/people-v1.ts
@@ -1439,7 +1439,7 @@ export const GetPeopleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("personFields"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{resourceName}" }),
+  T.Http({ method: "GET", path: "v1/{+resourceName}" }),
   svc,
 ) as unknown as Schema.Schema<GetPeopleRequest>;
 
@@ -1590,7 +1590,7 @@ export const UpdateContactPhotoPeopleRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1/{resourceName}:updateContactPhoto",
+      path: "v1/{+resourceName}:updateContactPhoto",
       hasBody: true,
     }),
     svc,
@@ -1741,7 +1741,7 @@ export const DeleteContactPhotoPeopleRequest =
       T.HttpQuery("sources"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{resourceName}:deleteContactPhoto" }),
+    T.Http({ method: "DELETE", path: "v1/{+resourceName}:deleteContactPhoto" }),
     svc,
   ) as unknown as Schema.Schema<DeleteContactPhotoPeopleRequest>;
 
@@ -1899,7 +1899,7 @@ export const UpdateContactPeopleRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1/{resourceName}:updateContact",
+      path: "v1/{+resourceName}:updateContact",
       hasBody: true,
     }),
     svc,
@@ -1992,7 +1992,7 @@ export const DeleteContactPeopleRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     resourceName: Schema.String.pipe(T.HttpPath("resourceName")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{resourceName}:deleteContact" }),
+    T.Http({ method: "DELETE", path: "v1/{+resourceName}:deleteContact" }),
     svc,
   ) as unknown as Schema.Schema<DeleteContactPeopleRequest>;
 
@@ -2065,7 +2065,7 @@ export const ListPeopleConnectionsRequest =
     sortOrder: Schema.optional(Schema.String).pipe(T.HttpQuery("sortOrder")),
     resourceName: Schema.String.pipe(T.HttpPath("resourceName")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resourceName}/connections" }),
+    T.Http({ method: "GET", path: "v1/{+resourceName}/connections" }),
     svc,
   ) as unknown as Schema.Schema<ListPeopleConnectionsRequest>;
 
@@ -2167,7 +2167,7 @@ export const CopyOtherContactToMyContactsGroupOtherContactsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resourceName}:copyOtherContactToMyContactsGroup",
+      path: "v1/{+resourceName}:copyOtherContactToMyContactsGroup",
       hasBody: true,
     }),
     svc,
@@ -2242,7 +2242,7 @@ export const DeleteContactGroupsRequest =
       T.HttpQuery("deleteContacts"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{resourceName}" }),
+    T.Http({ method: "DELETE", path: "v1/{+resourceName}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteContactGroupsRequest>;
 
@@ -2280,7 +2280,7 @@ export const GetContactGroupsRequest =
       T.HttpQuery("groupFields"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resourceName}" }),
+    T.Http({ method: "GET", path: "v1/{+resourceName}" }),
     svc,
   ) as unknown as Schema.Schema<GetContactGroupsRequest>;
 
@@ -2314,7 +2314,7 @@ export const UpdateContactGroupsRequest =
     resourceName: Schema.String.pipe(T.HttpPath("resourceName")),
     body: Schema.optional(UpdateContactGroupRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{resourceName}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+resourceName}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateContactGroupsRequest>;
 
@@ -2468,7 +2468,7 @@ export const ModifyContactGroupsMembersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resourceName}/members:modify",
+      path: "v1/{+resourceName}/members:modify",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/places-v1.ts
+++ b/packages/gcp/src/services/places-v1.ts
@@ -1851,7 +1851,7 @@ export const GetPlacesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   regionCode: Schema.optional(Schema.String).pipe(T.HttpQuery("regionCode")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetPlacesRequest>;
 
@@ -1928,7 +1928,7 @@ export const GetMediaPlacesPhotosRequest =
       T.HttpQuery("maxHeightPx"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetMediaPlacesPhotosRequest>;
 

--- a/packages/gcp/src/services/playdeveloperreporting-v1alpha1.ts
+++ b/packages/gcp/src/services/playdeveloperreporting-v1alpha1.ts
@@ -1150,7 +1150,7 @@ export const QueryVitalsAnrrateRequest =
       GooglePlayDeveloperReportingV1alpha1QueryAnrRateMetricSetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryVitalsAnrrateRequest>;
 
@@ -1182,7 +1182,7 @@ export const GetVitalsAnrrateRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVitalsAnrrateRequest>;
 
@@ -1214,7 +1214,7 @@ export const GetVitalsLmkrateRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVitalsLmkrateRequest>;
 
@@ -1251,7 +1251,7 @@ export const QueryVitalsLmkrateRequest =
       GooglePlayDeveloperReportingV1alpha1QueryLmkRateMetricSetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryVitalsLmkrateRequest>;
 
@@ -1288,7 +1288,7 @@ export const QueryVitalsSlowstartrateRequest =
       GooglePlayDeveloperReportingV1alpha1QuerySlowStartRateMetricSetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryVitalsSlowstartrateRequest>;
 
@@ -1320,7 +1320,7 @@ export const GetVitalsSlowstartrateRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVitalsSlowstartrateRequest>;
 
@@ -1352,7 +1352,7 @@ export const GetVitalsSlowrenderingrateRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVitalsSlowrenderingrateRequest>;
 
@@ -1389,7 +1389,7 @@ export const QueryVitalsSlowrenderingrateRequest =
       GooglePlayDeveloperReportingV1alpha1QuerySlowRenderingRateMetricSetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryVitalsSlowrenderingrateRequest>;
 
@@ -1421,7 +1421,7 @@ export const GetVitalsExcessivewakeuprateRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVitalsExcessivewakeuprateRequest>;
 
@@ -1458,7 +1458,7 @@ export const QueryVitalsExcessivewakeuprateRequest =
       GooglePlayDeveloperReportingV1alpha1QueryExcessiveWakeupRateMetricSetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryVitalsExcessivewakeuprateRequest>;
 
@@ -1490,7 +1490,7 @@ export const GetVitalsCrashrateRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVitalsCrashrateRequest>;
 
@@ -1527,7 +1527,7 @@ export const QueryVitalsCrashrateRequest =
       GooglePlayDeveloperReportingV1alpha1QueryCrashRateMetricSetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryVitalsCrashrateRequest>;
 
@@ -1559,7 +1559,7 @@ export const GetVitalsStuckbackgroundwakelockrateRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVitalsStuckbackgroundwakelockrateRequest>;
 
@@ -1596,7 +1596,7 @@ export const QueryVitalsStuckbackgroundwakelockrateRequest =
       GooglePlayDeveloperReportingV1alpha1QueryStuckBackgroundWakelockRateMetricSetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryVitalsStuckbackgroundwakelockrateRequest>;
 
@@ -1745,7 +1745,7 @@ export const SearchVitalsErrorsIssuesRequest =
       T.HttpQuery("interval.endTime.timeZone.version"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/errorIssues:search" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/errorIssues:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchVitalsErrorsIssuesRequest>;
 
@@ -1890,7 +1890,7 @@ export const SearchVitalsErrorsReportsRequest =
       T.HttpQuery("interval.endTime.nanos"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/errorReports:search" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/errorReports:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchVitalsErrorsReportsRequest>;
 
@@ -1926,7 +1926,7 @@ export const GetVitalsErrorsCountsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVitalsErrorsCountsRequest>;
 
@@ -1963,7 +1963,7 @@ export const QueryVitalsErrorsCountsRequest =
       GooglePlayDeveloperReportingV1alpha1QueryErrorCountMetricSetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryVitalsErrorsCountsRequest>;
 
@@ -1997,7 +1997,7 @@ export const FetchReleaseFilterOptionsAppsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1alpha1/{name}:fetchReleaseFilterOptions",
+      path: "v1alpha1/{+name}:fetchReleaseFilterOptions",
     }),
     svc,
   ) as unknown as Schema.Schema<FetchReleaseFilterOptionsAppsRequest>;
@@ -2076,7 +2076,7 @@ export const ListAnomaliesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1alpha1/{parent}/anomalies" }),
+  T.Http({ method: "GET", path: "v1alpha1/{+parent}/anomalies" }),
   svc,
 ) as unknown as Schema.Schema<ListAnomaliesRequest>;
 

--- a/packages/gcp/src/services/playdeveloperreporting-v1beta1.ts
+++ b/packages/gcp/src/services/playdeveloperreporting-v1beta1.ts
@@ -1142,7 +1142,7 @@ export const QueryVitalsAnrrateRequest =
       GooglePlayDeveloperReportingV1beta1QueryAnrRateMetricSetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryVitalsAnrrateRequest>;
 
@@ -1174,7 +1174,7 @@ export const GetVitalsAnrrateRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVitalsAnrrateRequest>;
 
@@ -1211,7 +1211,7 @@ export const QueryVitalsLmkrateRequest =
       GooglePlayDeveloperReportingV1beta1QueryLmkRateMetricSetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryVitalsLmkrateRequest>;
 
@@ -1243,7 +1243,7 @@ export const GetVitalsLmkrateRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVitalsLmkrateRequest>;
 
@@ -1280,7 +1280,7 @@ export const QueryVitalsSlowstartrateRequest =
       GooglePlayDeveloperReportingV1beta1QuerySlowStartRateMetricSetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryVitalsSlowstartrateRequest>;
 
@@ -1312,7 +1312,7 @@ export const GetVitalsSlowstartrateRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVitalsSlowstartrateRequest>;
 
@@ -1349,7 +1349,7 @@ export const QueryVitalsSlowrenderingrateRequest =
       GooglePlayDeveloperReportingV1beta1QuerySlowRenderingRateMetricSetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryVitalsSlowrenderingrateRequest>;
 
@@ -1381,7 +1381,7 @@ export const GetVitalsSlowrenderingrateRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVitalsSlowrenderingrateRequest>;
 
@@ -1413,7 +1413,7 @@ export const GetVitalsExcessivewakeuprateRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVitalsExcessivewakeuprateRequest>;
 
@@ -1450,7 +1450,7 @@ export const QueryVitalsExcessivewakeuprateRequest =
       GooglePlayDeveloperReportingV1beta1QueryExcessiveWakeupRateMetricSetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryVitalsExcessivewakeuprateRequest>;
 
@@ -1482,7 +1482,7 @@ export const GetVitalsCrashrateRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVitalsCrashrateRequest>;
 
@@ -1519,7 +1519,7 @@ export const QueryVitalsCrashrateRequest =
       GooglePlayDeveloperReportingV1beta1QueryCrashRateMetricSetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryVitalsCrashrateRequest>;
 
@@ -1551,7 +1551,7 @@ export const GetVitalsStuckbackgroundwakelockrateRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVitalsStuckbackgroundwakelockrateRequest>;
 
@@ -1588,7 +1588,7 @@ export const QueryVitalsStuckbackgroundwakelockrateRequest =
       GooglePlayDeveloperReportingV1beta1QueryStuckBackgroundWakelockRateMetricSetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryVitalsStuckbackgroundwakelockrateRequest>;
 
@@ -1737,7 +1737,7 @@ export const SearchVitalsErrorsIssuesRequest =
       T.HttpQuery("interval.startTime.minutes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/errorIssues:search" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/errorIssues:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchVitalsErrorsIssuesRequest>;
 
@@ -1882,7 +1882,7 @@ export const SearchVitalsErrorsReportsRequest =
       T.HttpQuery("interval.endTime.utcOffset"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/errorReports:search" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/errorReports:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchVitalsErrorsReportsRequest>;
 
@@ -1923,7 +1923,7 @@ export const QueryVitalsErrorsCountsRequest =
       GooglePlayDeveloperReportingV1beta1QueryErrorCountMetricSetRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:query", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:query", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<QueryVitalsErrorsCountsRequest>;
 
@@ -1955,7 +1955,7 @@ export const GetVitalsErrorsCountsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVitalsErrorsCountsRequest>;
 
@@ -1987,7 +1987,10 @@ export const FetchReleaseFilterOptionsAppsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:fetchReleaseFilterOptions" }),
+    T.Http({
+      method: "GET",
+      path: "v1beta1/{+name}:fetchReleaseFilterOptions",
+    }),
     svc,
   ) as unknown as Schema.Schema<FetchReleaseFilterOptionsAppsRequest>;
 
@@ -2065,7 +2068,7 @@ export const ListAnomaliesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta1/{parent}/anomalies" }),
+  T.Http({ method: "GET", path: "v1beta1/{+parent}/anomalies" }),
   svc,
 ) as unknown as Schema.Schema<ListAnomaliesRequest>;
 

--- a/packages/gcp/src/services/playgrouping-v1alpha1.ts
+++ b/packages/gcp/src/services/playgrouping-v1alpha1.ts
@@ -99,7 +99,7 @@ export const VerifyAppsTokensRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{appPackage}/{token}:verify",
+      path: "v1alpha1/{+appPackage}/{+token}:verify",
       hasBody: true,
     }),
     svc,
@@ -140,7 +140,7 @@ export const CreateOrUpdateAppsTokensTagsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{appPackage}/{token}/tags:createOrUpdate",
+      path: "v1alpha1/{+appPackage}/{+token}/tags:createOrUpdate",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/playintegrity-v1.ts
+++ b/packages/gcp/src/services/playintegrity-v1.ts
@@ -420,7 +420,7 @@ export const DecodeIntegrityTokenV1Request =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{packageName}:decodeIntegrityToken",
+      path: "v1/{+packageName}:decodeIntegrityToken",
       hasBody: true,
     }),
     svc,
@@ -458,7 +458,7 @@ export const DecodePcIntegrityTokenV1Request =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{packageName}:decodePcIntegrityToken",
+      path: "v1/{+packageName}:decodePcIntegrityToken",
       hasBody: true,
     }),
     svc,
@@ -496,7 +496,7 @@ export const WriteDeviceRecallRequest_Op =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{packageName}/deviceRecall:write",
+      path: "v1/{+packageName}/deviceRecall:write",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/policyanalyzer-v1.ts
+++ b/packages/gcp/src/services/policyanalyzer-v1.ts
@@ -95,7 +95,7 @@ export const QueryOrganizationsLocationsActivityTypesActivitiesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/activities:query" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/activities:query" }),
     svc,
   ) as unknown as Schema.Schema<QueryOrganizationsLocationsActivityTypesActivitiesRequest>;
 
@@ -141,7 +141,7 @@ export const QueryFoldersLocationsActivityTypesActivitiesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/activities:query" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/activities:query" }),
     svc,
   ) as unknown as Schema.Schema<QueryFoldersLocationsActivityTypesActivitiesRequest>;
 
@@ -186,7 +186,7 @@ export const QueryProjectsLocationsActivityTypesActivitiesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/activities:query" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/activities:query" }),
     svc,
   ) as unknown as Schema.Schema<QueryProjectsLocationsActivityTypesActivitiesRequest>;
 

--- a/packages/gcp/src/services/policyanalyzer-v1beta1.ts
+++ b/packages/gcp/src/services/policyanalyzer-v1beta1.ts
@@ -97,7 +97,7 @@ export const QueryProjectsLocationsActivityTypesActivitiesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/activities:query" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/activities:query" }),
     svc,
   ) as unknown as Schema.Schema<QueryProjectsLocationsActivityTypesActivitiesRequest>;
 
@@ -142,7 +142,7 @@ export const QueryOrganizationsLocationsActivityTypesActivitiesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/activities:query" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/activities:query" }),
     svc,
   ) as unknown as Schema.Schema<QueryOrganizationsLocationsActivityTypesActivitiesRequest>;
 
@@ -188,7 +188,7 @@ export const QueryFoldersLocationsActivityTypesActivitiesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/activities:query" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/activities:query" }),
     svc,
   ) as unknown as Schema.Schema<QueryFoldersLocationsActivityTypesActivitiesRequest>;
 

--- a/packages/gcp/src/services/policysimulator-v1.ts
+++ b/packages/gcp/src/services/policysimulator-v1.ts
@@ -1008,7 +1008,7 @@ export const GetFoldersLocationsOrgPolicyViolationsPreviewsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsOrgPolicyViolationsPreviewsOperationsRequest>;
 
@@ -1041,7 +1041,7 @@ export const GetFoldersLocationsAccessPolicySimulationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsAccessPolicySimulationsOperationsRequest>;
 
@@ -1074,7 +1074,7 @@ export const GetFoldersLocationsReplaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsReplaysRequest>;
 
@@ -1111,7 +1111,7 @@ export const CreateFoldersLocationsReplaysRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/replays", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/replays", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateFoldersLocationsReplaysRequest>;
 
@@ -1156,7 +1156,7 @@ export const ListFoldersLocationsReplaysOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsReplaysOperationsRequest>;
 
@@ -1192,7 +1192,7 @@ export const GetFoldersLocationsReplaysOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsReplaysOperationsRequest>;
 
@@ -1230,7 +1230,7 @@ export const ListFoldersLocationsReplaysResultsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/results" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/results" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsReplaysResultsRequest>;
 
@@ -1279,7 +1279,7 @@ export const ListOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<ListOperationsRequest>;
 
@@ -1313,7 +1313,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -1344,7 +1344,7 @@ export const GetProjectsLocationsOrgPolicyViolationsPreviewsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOrgPolicyViolationsPreviewsOperationsRequest>;
 
@@ -1377,7 +1377,7 @@ export const GetProjectsLocationsAccessPolicySimulationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAccessPolicySimulationsOperationsRequest>;
 
@@ -1410,7 +1410,7 @@ export const GetProjectsLocationsReplaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReplaysRequest>;
 
@@ -1447,7 +1447,7 @@ export const CreateProjectsLocationsReplaysRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/replays", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/replays", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsReplaysRequest>;
 
@@ -1492,7 +1492,7 @@ export const ListProjectsLocationsReplaysOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReplaysOperationsRequest>;
 
@@ -1528,7 +1528,7 @@ export const GetProjectsLocationsReplaysOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReplaysOperationsRequest>;
 
@@ -1566,7 +1566,7 @@ export const ListProjectsLocationsReplaysResultsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/results" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/results" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReplaysResultsRequest>;
 
@@ -1602,7 +1602,7 @@ export const GetOrganizationsLocationsAccessPolicySimulationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsAccessPolicySimulationsOperationsRequest>;
 
@@ -1647,7 +1647,7 @@ export const CreateOrganizationsLocationsOrgPolicyViolationsPreviewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/orgPolicyViolationsPreviews",
+      path: "v1/{+parent}/orgPolicyViolationsPreviews",
       hasBody: true,
     }),
     svc,
@@ -1688,7 +1688,7 @@ export const ListOrganizationsLocationsOrgPolicyViolationsPreviewsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/orgPolicyViolationsPreviews" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/orgPolicyViolationsPreviews" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsOrgPolicyViolationsPreviewsRequest>;
 
@@ -1725,7 +1725,7 @@ export const GetOrganizationsLocationsOrgPolicyViolationsPreviewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsOrgPolicyViolationsPreviewsRequest>;
 
@@ -1758,7 +1758,7 @@ export const GetOrganizationsLocationsOrgPolicyViolationsPreviewsOperationsReque
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsOrgPolicyViolationsPreviewsOperationsRequest>;
 
@@ -1798,7 +1798,7 @@ export const ListOrganizationsLocationsOrgPolicyViolationsPreviewsOrgPolicyViola
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/orgPolicyViolations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/orgPolicyViolations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsOrgPolicyViolationsPreviewsOrgPolicyViolationsRequest>;
 
@@ -1837,7 +1837,7 @@ export const GetOrganizationsLocationsReplaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsReplaysRequest>;
 
@@ -1874,7 +1874,7 @@ export const CreateOrganizationsLocationsReplaysRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/replays", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/replays", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsLocationsReplaysRequest>;
 
@@ -1920,7 +1920,7 @@ export const ListOrganizationsLocationsReplaysOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsReplaysOperationsRequest>;
 
@@ -1956,7 +1956,7 @@ export const GetOrganizationsLocationsReplaysOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsReplaysOperationsRequest>;
 
@@ -1994,7 +1994,7 @@ export const ListOrganizationsLocationsReplaysResultsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/results" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/results" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsReplaysResultsRequest>;
 

--- a/packages/gcp/src/services/policysimulator-v1alpha.ts
+++ b/packages/gcp/src/services/policysimulator-v1alpha.ts
@@ -594,7 +594,7 @@ export const GetFoldersLocationsAccessPolicySimulationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsAccessPolicySimulationsOperationsRequest>;
 
@@ -641,7 +641,7 @@ export const ListFoldersLocationsReplaysOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsReplaysOperationsRequest>;
 
@@ -677,7 +677,7 @@ export const GetFoldersLocationsReplaysOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsReplaysOperationsRequest>;
 
@@ -709,7 +709,7 @@ export const GetFoldersLocationsOrgPolicyViolationsPreviewsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsOrgPolicyViolationsPreviewsOperationsRequest>;
 
@@ -756,7 +756,7 @@ export const ListOrganizationsLocationsReplaysOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsReplaysOperationsRequest>;
 
@@ -792,7 +792,7 @@ export const GetOrganizationsLocationsReplaysOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsReplaysOperationsRequest>;
 
@@ -824,7 +824,7 @@ export const GetOrganizationsLocationsOrgPolicyViolationsPreviewsOperationsReque
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsOrgPolicyViolationsPreviewsOperationsRequest>;
 
@@ -858,7 +858,7 @@ export const GetOrganizationsLocationsAccessPolicySimulationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsAccessPolicySimulationsOperationsRequest>;
 
@@ -904,7 +904,7 @@ export const ListOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1alpha/{name}" }),
+  T.Http({ method: "GET", path: "v1alpha/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<ListOperationsRequest>;
 
@@ -938,7 +938,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1alpha/{name}" }),
+  T.Http({ method: "GET", path: "v1alpha/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -969,7 +969,7 @@ export const GetProjectsLocationsAccessPolicySimulationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAccessPolicySimulationsOperationsRequest>;
 
@@ -1016,7 +1016,7 @@ export const ListProjectsLocationsReplaysOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReplaysOperationsRequest>;
 
@@ -1052,7 +1052,7 @@ export const GetProjectsLocationsReplaysOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReplaysOperationsRequest>;
 
@@ -1084,7 +1084,7 @@ export const GetProjectsLocationsOrgPolicyViolationsPreviewsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOrgPolicyViolationsPreviewsOperationsRequest>;
 

--- a/packages/gcp/src/services/policysimulator-v1beta.ts
+++ b/packages/gcp/src/services/policysimulator-v1beta.ts
@@ -1001,7 +1001,7 @@ export const CreateProjectsLocationsReplaysRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/replays", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/replays", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsReplaysRequest>;
 
@@ -1032,7 +1032,7 @@ export const GetProjectsLocationsReplaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReplaysRequest>;
 
@@ -1070,7 +1070,7 @@ export const ListProjectsLocationsReplaysRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/replays" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/replays" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReplaysRequest>;
 
@@ -1112,7 +1112,7 @@ export const ListProjectsLocationsReplaysResultsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/results" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/results" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReplaysResultsRequest>;
 
@@ -1162,7 +1162,7 @@ export const ListProjectsLocationsReplaysOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReplaysOperationsRequest>;
 
@@ -1198,7 +1198,7 @@ export const GetProjectsLocationsReplaysOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReplaysOperationsRequest>;
 
@@ -1230,7 +1230,7 @@ export const GetProjectsLocationsOrgPolicyViolationsPreviewsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOrgPolicyViolationsPreviewsOperationsRequest>;
 
@@ -1263,7 +1263,7 @@ export const GetProjectsLocationsAccessPolicySimulationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAccessPolicySimulationsOperationsRequest>;
 
@@ -1296,7 +1296,7 @@ export const GetOrganizationsLocationsAccessPolicySimulationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsAccessPolicySimulationsOperationsRequest>;
 
@@ -1336,7 +1336,7 @@ export const GenerateOrganizationsLocationsOrgPolicyViolationsPreviewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/orgPolicyViolationsPreviews:generate",
+      path: "v1beta/{+parent}/orgPolicyViolationsPreviews:generate",
       hasBody: true,
     }),
     svc,
@@ -1383,7 +1383,7 @@ export const CreateOrganizationsLocationsOrgPolicyViolationsPreviewsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/orgPolicyViolationsPreviews",
+      path: "v1beta/{+parent}/orgPolicyViolationsPreviews",
       hasBody: true,
     }),
     svc,
@@ -1418,7 +1418,7 @@ export const GetOrganizationsLocationsOrgPolicyViolationsPreviewsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsOrgPolicyViolationsPreviewsRequest>;
 
@@ -1459,7 +1459,7 @@ export const ListOrganizationsLocationsOrgPolicyViolationsPreviewsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta/{parent}/orgPolicyViolationsPreviews",
+      path: "v1beta/{+parent}/orgPolicyViolationsPreviews",
     }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsOrgPolicyViolationsPreviewsRequest>;
@@ -1497,7 +1497,7 @@ export const GetOrganizationsLocationsOrgPolicyViolationsPreviewsOperationsReque
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsOrgPolicyViolationsPreviewsOperationsRequest>;
 
@@ -1537,7 +1537,7 @@ export const ListOrganizationsLocationsOrgPolicyViolationsPreviewsOrgPolicyViola
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/orgPolicyViolations" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/orgPolicyViolations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsOrgPolicyViolationsPreviewsOrgPolicyViolationsRequest>;
 
@@ -1581,7 +1581,7 @@ export const CreateOrganizationsLocationsReplaysRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/replays", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/replays", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsLocationsReplaysRequest>;
 
@@ -1613,7 +1613,7 @@ export const GetOrganizationsLocationsReplaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsReplaysRequest>;
 
@@ -1651,7 +1651,7 @@ export const ListOrganizationsLocationsReplaysRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/replays" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/replays" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsReplaysRequest>;
 
@@ -1701,7 +1701,7 @@ export const ListOrganizationsLocationsReplaysOperationsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsReplaysOperationsRequest>;
 
@@ -1737,7 +1737,7 @@ export const GetOrganizationsLocationsReplaysOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsReplaysOperationsRequest>;
 
@@ -1775,7 +1775,7 @@ export const ListOrganizationsLocationsReplaysResultsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/results" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/results" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsReplaysResultsRequest>;
 
@@ -1824,7 +1824,7 @@ export const ListOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta/{name}" }),
+  T.Http({ method: "GET", path: "v1beta/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<ListOperationsRequest>;
 
@@ -1858,7 +1858,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta/{name}" }),
+  T.Http({ method: "GET", path: "v1beta/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -1889,7 +1889,7 @@ export const GetFoldersLocationsAccessPolicySimulationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsAccessPolicySimulationsOperationsRequest>;
 
@@ -1922,7 +1922,7 @@ export const GetFoldersLocationsOrgPolicyViolationsPreviewsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsOrgPolicyViolationsPreviewsOperationsRequest>;
 
@@ -1960,7 +1960,7 @@ export const CreateFoldersLocationsReplaysRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{parent}/replays", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+parent}/replays", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateFoldersLocationsReplaysRequest>;
 
@@ -1991,7 +1991,7 @@ export const GetFoldersLocationsReplaysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsReplaysRequest>;
 
@@ -2029,7 +2029,7 @@ export const ListFoldersLocationsReplaysRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/replays" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/replays" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsReplaysRequest>;
 
@@ -2071,7 +2071,7 @@ export const ListFoldersLocationsReplaysResultsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/results" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/results" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsReplaysResultsRequest>;
 
@@ -2121,7 +2121,7 @@ export const ListFoldersLocationsReplaysOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsReplaysOperationsRequest>;
 
@@ -2157,7 +2157,7 @@ export const GetFoldersLocationsReplaysOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsReplaysOperationsRequest>;
 

--- a/packages/gcp/src/services/privateca-v1.ts
+++ b/packages/gcp/src/services/privateca-v1.ts
@@ -1346,7 +1346,7 @@ export const ListProjectsLocationsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1381,7 +1381,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1412,7 +1412,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1443,7 +1443,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1477,7 +1477,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1522,7 +1522,7 @@ export const ListProjectsLocationsOperationsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1569,7 +1569,7 @@ export const ListProjectsLocationsCertificateTemplatesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/certificateTemplates" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/certificateTemplates" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCertificateTemplatesRequest>;
 
@@ -1610,7 +1610,7 @@ export const GetIamPolicyProjectsLocationsCertificateTemplatesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsCertificateTemplatesRequest>;
 
@@ -1645,7 +1645,7 @@ export const DeleteProjectsLocationsCertificateTemplatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCertificateTemplatesRequest>;
 
@@ -1676,7 +1676,7 @@ export const GetProjectsLocationsCertificateTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCertificateTemplatesRequest>;
 
@@ -1721,7 +1721,7 @@ export const CreateProjectsLocationsCertificateTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/certificateTemplates",
+      path: "v1/{+parent}/certificateTemplates",
       hasBody: true,
     }),
     svc,
@@ -1763,7 +1763,7 @@ export const PatchProjectsLocationsCertificateTemplatesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(CertificateTemplate).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCertificateTemplatesRequest>;
 
@@ -1799,7 +1799,7 @@ export const SetIamPolicyProjectsLocationsCertificateTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1838,7 +1838,7 @@ export const TestIamPermissionsProjectsLocationsCertificateTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1873,7 +1873,7 @@ export const GetProjectsLocationsCaPoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCaPoolsRequest>;
 
@@ -1909,7 +1909,7 @@ export const GetIamPolicyProjectsLocationsCaPoolsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsCaPoolsRequest>;
 
@@ -1943,7 +1943,11 @@ export const FetchCaCertsProjectsLocationsCaPoolsRequest =
     caPool: Schema.String.pipe(T.HttpPath("caPool")),
     body: Schema.optional(FetchCaCertsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{caPool}:fetchCaCerts", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+caPool}:fetchCaCerts",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<FetchCaCertsProjectsLocationsCaPoolsRequest>;
 
@@ -1983,7 +1987,7 @@ export const CreateProjectsLocationsCaPoolsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(CaPool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/caPools", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/caPools", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCaPoolsRequest>;
 
@@ -2023,7 +2027,7 @@ export const PatchProjectsLocationsCaPoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CaPool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCaPoolsRequest>;
 
@@ -2059,7 +2063,7 @@ export const SetIamPolicyProjectsLocationsCaPoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2097,7 +2101,7 @@ export const TestIamPermissionsProjectsLocationsCaPoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2143,7 +2147,7 @@ export const ListProjectsLocationsCaPoolsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/caPools" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/caPools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCaPoolsRequest>;
 
@@ -2186,7 +2190,7 @@ export const DeleteProjectsLocationsCaPoolsRequest =
       T.HttpQuery("ignoreDependentResources"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCaPoolsRequest>;
 
@@ -2217,7 +2221,7 @@ export const GetProjectsLocationsCaPoolsCertificatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCaPoolsCertificatesRequest>;
 
@@ -2269,7 +2273,11 @@ export const CreateProjectsLocationsCaPoolsCertificatesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Certificate).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/certificates", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/certificates",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCaPoolsCertificatesRequest>;
 
@@ -2309,7 +2317,7 @@ export const PatchProjectsLocationsCaPoolsCertificatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Certificate).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCaPoolsCertificatesRequest>;
 
@@ -2343,7 +2351,7 @@ export const RevokeProjectsLocationsCaPoolsCertificatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RevokeCertificateRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:revoke", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:revoke", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RevokeProjectsLocationsCaPoolsCertificatesRequest>;
 
@@ -2386,7 +2394,7 @@ export const ListProjectsLocationsCaPoolsCertificatesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/certificates" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/certificates" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCaPoolsCertificatesRequest>;
 
@@ -2422,7 +2430,7 @@ export const GetProjectsLocationsCaPoolsCertificateAuthoritiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCaPoolsCertificateAuthoritiesRequest>;
 
@@ -2455,7 +2463,7 @@ export const FetchProjectsLocationsCaPoolsCertificateAuthoritiesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:fetch" }),
+    T.Http({ method: "GET", path: "v1/{+name}:fetch" }),
     svc,
   ) as unknown as Schema.Schema<FetchProjectsLocationsCaPoolsCertificateAuthoritiesRequest>;
 
@@ -2493,7 +2501,7 @@ export const DisableProjectsLocationsCaPoolsCertificateAuthoritiesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:disable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:disable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DisableProjectsLocationsCaPoolsCertificateAuthoritiesRequest>;
 
@@ -2539,7 +2547,7 @@ export const CreateProjectsLocationsCaPoolsCertificateAuthoritiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/certificateAuthorities",
+      path: "v1/{+parent}/certificateAuthorities",
       hasBody: true,
     }),
     svc,
@@ -2577,7 +2585,7 @@ export const EnableProjectsLocationsCaPoolsCertificateAuthoritiesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EnableCertificateAuthorityRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:enable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:enable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EnableProjectsLocationsCaPoolsCertificateAuthoritiesRequest>;
 
@@ -2619,7 +2627,7 @@ export const PatchProjectsLocationsCaPoolsCertificateAuthoritiesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CertificateAuthority).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCaPoolsCertificateAuthoritiesRequest>;
 
@@ -2657,7 +2665,7 @@ export const ActivateProjectsLocationsCaPoolsCertificateAuthoritiesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:activate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:activate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ActivateProjectsLocationsCaPoolsCertificateAuthoritiesRequest>;
 
@@ -2702,7 +2710,7 @@ export const ListProjectsLocationsCaPoolsCertificateAuthoritiesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/certificateAuthorities" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/certificateAuthorities" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCaPoolsCertificateAuthoritiesRequest>;
 
@@ -2744,7 +2752,7 @@ export const UndeleteProjectsLocationsCaPoolsCertificateAuthoritiesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsLocationsCaPoolsCertificateAuthoritiesRequest>;
 
@@ -2795,7 +2803,7 @@ export const DeleteProjectsLocationsCaPoolsCertificateAuthoritiesRequest =
       T.HttpQuery("skipGracePeriod"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCaPoolsCertificateAuthoritiesRequest>;
 
@@ -2837,7 +2845,7 @@ export const PatchProjectsLocationsCaPoolsCertificateAuthoritiesCertificateRevoc
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CertificateRevocationList).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCaPoolsCertificateAuthoritiesCertificateRevocationListsRequest>;
 
@@ -2877,7 +2885,7 @@ export const SetIamPolicyProjectsLocationsCaPoolsCertificateAuthoritiesCertifica
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2919,7 +2927,7 @@ export const TestIamPermissionsProjectsLocationsCaPoolsCertificateAuthoritiesCer
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2956,7 +2964,7 @@ export const GetProjectsLocationsCaPoolsCertificateAuthoritiesCertificateRevocat
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCaPoolsCertificateAuthoritiesCertificateRevocationListsRequest>;
 
@@ -2996,7 +3004,7 @@ export const GetIamPolicyProjectsLocationsCaPoolsCertificateAuthoritiesCertifica
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsCaPoolsCertificateAuthoritiesCertificateRevocationListsRequest>;
 
@@ -3043,7 +3051,7 @@ export const ListProjectsLocationsCaPoolsCertificateAuthoritiesCertificateRevoca
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/certificateRevocationLists" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/certificateRevocationLists" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCaPoolsCertificateAuthoritiesCertificateRevocationListsRequest>;
 

--- a/packages/gcp/src/services/privateca-v1beta1.ts
+++ b/packages/gcp/src/services/privateca-v1beta1.ts
@@ -261,7 +261,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -296,7 +296,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -332,7 +332,7 @@ export const GetIamPolicyProjectsLocationsCertificateAuthoritiesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsCertificateAuthoritiesRequest>;
 
@@ -370,7 +370,7 @@ export const TestIamPermissionsProjectsLocationsCertificateAuthoritiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -410,7 +410,7 @@ export const SetIamPolicyProjectsLocationsCertificateAuthoritiesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -450,7 +450,7 @@ export const GetIamPolicyProjectsLocationsCertificateAuthoritiesCertificateRevoc
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsCertificateAuthoritiesCertificateRevocationListsRequest>;
 
@@ -490,7 +490,7 @@ export const TestIamPermissionsProjectsLocationsCertificateAuthoritiesCertificat
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -532,7 +532,7 @@ export const SetIamPolicyProjectsLocationsCertificateAuthoritiesCertificateRevoc
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -583,7 +583,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -618,7 +618,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -649,7 +649,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -683,7 +683,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -719,7 +719,7 @@ export const SetIamPolicyProjectsLocationsReusableConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -757,7 +757,7 @@ export const TestIamPermissionsProjectsLocationsReusableConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -797,7 +797,7 @@ export const GetIamPolicyProjectsLocationsReusableConfigsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsReusableConfigsRequest>;
 

--- a/packages/gcp/src/services/prod_tt_sasportal-v1alpha1.ts
+++ b/packages/gcp/src/services/prod_tt_sasportal-v1alpha1.ts
@@ -816,7 +816,7 @@ export interface GetNodesRequest {
 export const GetNodesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+  T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetNodesRequest>;
 
@@ -846,7 +846,7 @@ export const DeleteNodesDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNodesDeploymentsRequest>;
 
@@ -877,7 +877,7 @@ export const GetNodesDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNodesDeploymentsRequest>;
 
@@ -917,7 +917,7 @@ export const ListNodesDeploymentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListNodesDeploymentsRequest>;
 
@@ -958,7 +958,7 @@ export const PatchNodesDeploymentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SasPortalDeployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchNodesDeploymentsRequest>;
 
@@ -992,7 +992,7 @@ export const MoveNodesDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SasPortalMoveDeploymentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveNodesDeploymentsRequest>;
 
@@ -1030,7 +1030,7 @@ export const CreateSignedNodesDeploymentsDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices:createSigned",
+      path: "v1alpha1/{+parent}/devices:createSigned",
       hasBody: true,
     }),
     svc,
@@ -1072,7 +1072,7 @@ export const ListNodesDeploymentsDevicesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/devices" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/devices" }),
     svc,
   ) as unknown as Schema.Schema<ListNodesDeploymentsDevicesRequest>;
 
@@ -1112,7 +1112,7 @@ export const CreateNodesDeploymentsDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices",
+      path: "v1alpha1/{+parent}/devices",
       hasBody: true,
     }),
     svc,
@@ -1148,7 +1148,7 @@ export const MoveNodesDevicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SasPortalMoveDeviceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveNodesDevicesRequest>;
 
@@ -1184,7 +1184,7 @@ export const CreateNodesDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices",
+      path: "v1alpha1/{+parent}/devices",
       hasBody: true,
     }),
     svc,
@@ -1224,7 +1224,7 @@ export const CreateSignedNodesDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices:createSigned",
+      path: "v1alpha1/{+parent}/devices:createSigned",
       hasBody: true,
     }),
     svc,
@@ -1263,7 +1263,7 @@ export const PatchNodesDevicesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SasPortalDevice).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchNodesDevicesRequest>;
 
@@ -1295,7 +1295,7 @@ export const GetNodesDevicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     name: Schema.String.pipe(T.HttpPath("name")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+  T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetNodesDevicesRequest>;
 
@@ -1335,7 +1335,7 @@ export const ListNodesDevicesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/devices" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/devices" }),
     svc,
   ) as unknown as Schema.Schema<ListNodesDevicesRequest>;
 
@@ -1375,7 +1375,7 @@ export const SignDeviceNodesDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{name}:signDevice",
+      path: "v1alpha1/{+name}:signDevice",
       hasBody: true,
     }),
     svc,
@@ -1408,7 +1408,7 @@ export const DeleteNodesDevicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNodesDevicesRequest>;
 
@@ -1446,7 +1446,7 @@ export const UpdateSignedNodesDevicesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1alpha1/{name}:updateSigned",
+      path: "v1alpha1/{+name}:updateSigned",
       hasBody: true,
     }),
     svc,
@@ -1486,7 +1486,7 @@ export const PatchNodesNodesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     body: Schema.optional(SasPortalNode).pipe(T.HttpBody()),
   },
 ).pipe(
-  T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchNodesNodesRequest>;
 
@@ -1519,7 +1519,7 @@ export const MoveNodesNodesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(SasPortalMoveNodeRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v1alpha1/{name}:move", hasBody: true }),
+  T.Http({ method: "POST", path: "v1alpha1/{+name}:move", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<MoveNodesNodesRequest>;
 
@@ -1549,7 +1549,7 @@ export interface GetNodesNodesRequest {
 export const GetNodesNodesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+  T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetNodesNodesRequest>;
 
@@ -1587,7 +1587,7 @@ export const ListNodesNodesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   parent: Schema.String.pipe(T.HttpPath("parent")),
   filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1alpha1/{parent}/nodes" }),
+  T.Http({ method: "GET", path: "v1alpha1/{+parent}/nodes" }),
   svc,
 ) as unknown as Schema.Schema<ListNodesNodesRequest>;
 
@@ -1625,7 +1625,7 @@ export const CreateNodesNodesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(SasPortalNode).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{parent}/nodes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+parent}/nodes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateNodesNodesRequest>;
 
@@ -1656,7 +1656,7 @@ export const DeleteNodesNodesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNodesNodesRequest>;
 
@@ -1692,7 +1692,7 @@ export const CreateNodesNodesDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices",
+      path: "v1alpha1/{+parent}/devices",
       hasBody: true,
     }),
     svc,
@@ -1732,7 +1732,7 @@ export const CreateSignedNodesNodesDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices:createSigned",
+      path: "v1alpha1/{+parent}/devices:createSigned",
       hasBody: true,
     }),
     svc,
@@ -1774,7 +1774,7 @@ export const ListNodesNodesDevicesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/devices" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/devices" }),
     svc,
   ) as unknown as Schema.Schema<ListNodesNodesDevicesRequest>;
 
@@ -1812,7 +1812,7 @@ export const CreateNodesNodesNodesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(SasPortalNode).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{parent}/nodes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+parent}/nodes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateNodesNodesNodesRequest>;
 
@@ -1852,7 +1852,7 @@ export const ListNodesNodesNodesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/nodes" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/nodes" }),
     svc,
   ) as unknown as Schema.Schema<ListNodesNodesNodesRequest>;
 
@@ -1892,7 +1892,7 @@ export const CreateNodesNodesDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/deployments",
+      path: "v1alpha1/{+parent}/deployments",
       hasBody: true,
     }),
     svc,
@@ -1934,7 +1934,7 @@ export const ListNodesNodesDeploymentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListNodesNodesDeploymentsRequest>;
 
@@ -2125,7 +2125,7 @@ export interface GetCustomersRequest {
 export const GetCustomersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+  T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetCustomersRequest>;
 
@@ -2300,7 +2300,7 @@ export const PatchCustomersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(SasPortalCustomer).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchCustomersRequest>;
 
@@ -2331,7 +2331,7 @@ export const GetCustomersDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersDeploymentsRequest>;
 
@@ -2371,7 +2371,7 @@ export const ListCustomersDeploymentsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersDeploymentsRequest>;
 
@@ -2411,7 +2411,7 @@ export const CreateCustomersDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/deployments",
+      path: "v1alpha1/{+parent}/deployments",
       hasBody: true,
     }),
     svc,
@@ -2450,7 +2450,7 @@ export const PatchCustomersDeploymentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SasPortalDeployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchCustomersDeploymentsRequest>;
 
@@ -2484,7 +2484,7 @@ export const MoveCustomersDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SasPortalMoveDeploymentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveCustomersDeploymentsRequest>;
 
@@ -2515,7 +2515,7 @@ export const DeleteCustomersDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteCustomersDeploymentsRequest>;
 
@@ -2553,7 +2553,7 @@ export const CreateSignedCustomersDeploymentsDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices:createSigned",
+      path: "v1alpha1/{+parent}/devices:createSigned",
       hasBody: true,
     }),
     svc,
@@ -2595,7 +2595,7 @@ export const ListCustomersDeploymentsDevicesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/devices" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/devices" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersDeploymentsDevicesRequest>;
 
@@ -2636,7 +2636,7 @@ export const CreateCustomersDeploymentsDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices",
+      path: "v1alpha1/{+parent}/devices",
       hasBody: true,
     }),
     svc,
@@ -2676,7 +2676,7 @@ export const UpdateSignedCustomersDevicesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1alpha1/{name}:updateSigned",
+      path: "v1alpha1/{+name}:updateSigned",
       hasBody: true,
     }),
     svc,
@@ -2714,7 +2714,7 @@ export const SignDeviceCustomersDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{name}:signDevice",
+      path: "v1alpha1/{+name}:signDevice",
       hasBody: true,
     }),
     svc,
@@ -2747,7 +2747,7 @@ export const DeleteCustomersDevicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteCustomersDevicesRequest>;
 
@@ -2778,7 +2778,7 @@ export const GetCustomersDevicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersDevicesRequest>;
 
@@ -2818,7 +2818,7 @@ export const ListCustomersDevicesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/devices" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/devices" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersDevicesRequest>;
 
@@ -2859,7 +2859,7 @@ export const PatchCustomersDevicesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SasPortalDevice).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchCustomersDevicesRequest>;
 
@@ -2895,7 +2895,7 @@ export const CreateCustomersDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices",
+      path: "v1alpha1/{+parent}/devices",
       hasBody: true,
     }),
     svc,
@@ -2935,7 +2935,7 @@ export const CreateSignedCustomersDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices:createSigned",
+      path: "v1alpha1/{+parent}/devices:createSigned",
       hasBody: true,
     }),
     svc,
@@ -2971,7 +2971,7 @@ export const MoveCustomersDevicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SasPortalMoveDeviceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveCustomersDevicesRequest>;
 
@@ -3002,7 +3002,7 @@ export const DeleteCustomersNodesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteCustomersNodesRequest>;
 
@@ -3036,7 +3036,7 @@ export const CreateCustomersNodesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(SasPortalNode).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{parent}/nodes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+parent}/nodes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateCustomersNodesRequest>;
 
@@ -3067,7 +3067,7 @@ export const GetCustomersNodesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersNodesRequest>;
 
@@ -3107,7 +3107,7 @@ export const ListCustomersNodesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/nodes" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/nodes" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersNodesRequest>;
 
@@ -3145,7 +3145,7 @@ export const MoveCustomersNodesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SasPortalMoveNodeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveCustomersNodesRequest>;
 
@@ -3182,7 +3182,7 @@ export const PatchCustomersNodesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SasPortalNode).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchCustomersNodesRequest>;
 
@@ -3220,7 +3220,7 @@ export const CreateSignedCustomersNodesDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices:createSigned",
+      path: "v1alpha1/{+parent}/devices:createSigned",
       hasBody: true,
     }),
     svc,
@@ -3262,7 +3262,7 @@ export const ListCustomersNodesDevicesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/devices" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/devices" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersNodesDevicesRequest>;
 
@@ -3302,7 +3302,7 @@ export const CreateCustomersNodesDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices",
+      path: "v1alpha1/{+parent}/devices",
       hasBody: true,
     }),
     svc,
@@ -3338,7 +3338,7 @@ export const CreateCustomersNodesNodesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(SasPortalNode).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{parent}/nodes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+parent}/nodes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateCustomersNodesNodesRequest>;
 
@@ -3378,7 +3378,7 @@ export const ListCustomersNodesNodesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/nodes" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/nodes" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersNodesNodesRequest>;
 
@@ -3418,7 +3418,7 @@ export const CreateCustomersNodesDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/deployments",
+      path: "v1alpha1/{+parent}/deployments",
       hasBody: true,
     }),
     svc,
@@ -3460,7 +3460,7 @@ export const ListCustomersNodesDeploymentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersNodesDeploymentsRequest>;
 
@@ -3565,7 +3565,7 @@ export interface GetDeploymentsRequest {
 export const GetDeploymentsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+  T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetDeploymentsRequest>;
 
@@ -3596,7 +3596,7 @@ export const GetDeploymentsDevicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDeploymentsDevicesRequest>;
 
@@ -3633,7 +3633,7 @@ export const PatchDeploymentsDevicesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SasPortalDevice).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchDeploymentsDevicesRequest>;
 
@@ -3667,7 +3667,7 @@ export const MoveDeploymentsDevicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SasPortalMoveDeviceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveDeploymentsDevicesRequest>;
 
@@ -3705,7 +3705,7 @@ export const UpdateSignedDeploymentsDevicesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1alpha1/{name}:updateSigned",
+      path: "v1alpha1/{+name}:updateSigned",
       hasBody: true,
     }),
     svc,
@@ -3738,7 +3738,7 @@ export const DeleteDeploymentsDevicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDeploymentsDevicesRequest>;
 
@@ -3774,7 +3774,7 @@ export const SignDeviceDeploymentsDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{name}:signDevice",
+      path: "v1alpha1/{+name}:signDevice",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/publicca-v1.ts
+++ b/packages/gcp/src/services/publicca-v1.ts
@@ -55,7 +55,7 @@ export const CreateProjectsLocationsExternalAccountKeysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/externalAccountKeys",
+      path: "v1/{+parent}/externalAccountKeys",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/publicca-v1alpha1.ts
+++ b/packages/gcp/src/services/publicca-v1alpha1.ts
@@ -55,7 +55,7 @@ export const CreateProjectsLocationsExternalAccountKeysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/externalAccountKeys",
+      path: "v1alpha1/{+parent}/externalAccountKeys",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/publicca-v1beta1.ts
+++ b/packages/gcp/src/services/publicca-v1beta1.ts
@@ -55,7 +55,7 @@ export const CreateProjectsLocationsExternalAccountKeysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/externalAccountKeys",
+      path: "v1beta1/{+parent}/externalAccountKeys",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/pubsub-v1.ts
+++ b/packages/gcp/src/services/pubsub-v1.ts
@@ -1145,7 +1145,7 @@ export const SetIamPolicyProjectsTopicsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1183,7 +1183,7 @@ export const GetIamPolicyProjectsTopicsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsTopicsRequest>;
 
@@ -1219,7 +1219,7 @@ export const TestIamPermissionsProjectsTopicsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1256,7 +1256,7 @@ export const CreateProjectsTopicsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Topic).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsTopicsRequest>;
 
@@ -1289,7 +1289,7 @@ export const PatchProjectsTopicsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateTopicRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsTopicsRequest>;
 
@@ -1322,7 +1322,7 @@ export const PublishProjectsTopicsRequest =
     topic: Schema.String.pipe(T.HttpPath("topic")),
     body: Schema.optional(PublishRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{topic}:publish", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+topic}:publish", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PublishProjectsTopicsRequest>;
 
@@ -1353,7 +1353,7 @@ export const GetProjectsTopicsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     topic: Schema.String.pipe(T.HttpPath("topic")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{topic}" }),
+    T.Http({ method: "GET", path: "v1/{+topic}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsTopicsRequest>;
 
@@ -1389,7 +1389,7 @@ export const ListProjectsTopicsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{project}/topics" }),
+    T.Http({ method: "GET", path: "v1/{+project}/topics" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTopicsRequest>;
 
@@ -1424,7 +1424,7 @@ export const DeleteProjectsTopicsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     topic: Schema.String.pipe(T.HttpPath("topic")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{topic}" }),
+    T.Http({ method: "DELETE", path: "v1/{+topic}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsTopicsRequest>;
 
@@ -1460,7 +1460,7 @@ export const ListProjectsTopicsSubscriptionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{topic}/subscriptions" }),
+    T.Http({ method: "GET", path: "v1/{+topic}/subscriptions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTopicsSubscriptionsRequest>;
 
@@ -1502,7 +1502,7 @@ export const ListProjectsTopicsSnapshotsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{topic}/snapshots" }),
+    T.Http({ method: "GET", path: "v1/{+topic}/snapshots" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTopicsSnapshotsRequest>;
 
@@ -1542,7 +1542,7 @@ export const SetIamPolicyProjectsSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1580,7 +1580,7 @@ export const GetIamPolicyProjectsSubscriptionsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsSubscriptionsRequest>;
 
@@ -1616,7 +1616,7 @@ export const TestIamPermissionsProjectsSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1650,7 +1650,11 @@ export const DetachProjectsSubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     subscription: Schema.String.pipe(T.HttpPath("subscription")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{subscription}:detach", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+subscription}:detach",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<DetachProjectsSubscriptionsRequest>;
 
@@ -1684,7 +1688,7 @@ export const CreateProjectsSubscriptionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Subscription).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsSubscriptionsRequest>;
 
@@ -1715,7 +1719,7 @@ export const GetProjectsSubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     subscription: Schema.String.pipe(T.HttpPath("subscription")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{subscription}" }),
+    T.Http({ method: "GET", path: "v1/{+subscription}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSubscriptionsRequest>;
 
@@ -1749,7 +1753,7 @@ export const PatchProjectsSubscriptionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateSubscriptionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsSubscriptionsRequest>;
 
@@ -1786,7 +1790,7 @@ export const ListProjectsSubscriptionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{project}/subscriptions" }),
+    T.Http({ method: "GET", path: "v1/{+project}/subscriptions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSubscriptionsRequest>;
 
@@ -1821,7 +1825,7 @@ export const DeleteProjectsSubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     subscription: Schema.String.pipe(T.HttpPath("subscription")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{subscription}" }),
+    T.Http({ method: "DELETE", path: "v1/{+subscription}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsSubscriptionsRequest>;
 
@@ -1857,7 +1861,7 @@ export const ModifyAckDeadlineProjectsSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{subscription}:modifyAckDeadline",
+      path: "v1/{+subscription}:modifyAckDeadline",
       hasBody: true,
     }),
     svc,
@@ -1895,7 +1899,7 @@ export const AcknowledgeProjectsSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{subscription}:acknowledge",
+      path: "v1/{+subscription}:acknowledge",
       hasBody: true,
     }),
     svc,
@@ -1931,7 +1935,7 @@ export const PullProjectsSubscriptionsRequest =
     subscription: Schema.String.pipe(T.HttpPath("subscription")),
     body: Schema.optional(PullRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{subscription}:pull", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+subscription}:pull", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PullProjectsSubscriptionsRequest>;
 
@@ -1967,7 +1971,7 @@ export const ModifyPushConfigProjectsSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{subscription}:modifyPushConfig",
+      path: "v1/{+subscription}:modifyPushConfig",
       hasBody: true,
     }),
     svc,
@@ -2003,7 +2007,7 @@ export const SeekProjectsSubscriptionsRequest =
     subscription: Schema.String.pipe(T.HttpPath("subscription")),
     body: Schema.optional(SeekRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{subscription}:seek", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+subscription}:seek", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SeekProjectsSubscriptionsRequest>;
 
@@ -2039,7 +2043,7 @@ export const SetIamPolicyProjectsSnapshotsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2077,7 +2081,7 @@ export const GetIamPolicyProjectsSnapshotsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsSnapshotsRequest>;
 
@@ -2113,7 +2117,7 @@ export const TestIamPermissionsProjectsSnapshotsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2147,7 +2151,7 @@ export const GetProjectsSnapshotsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     snapshot: Schema.String.pipe(T.HttpPath("snapshot")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{snapshot}" }),
+    T.Http({ method: "GET", path: "v1/{+snapshot}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSnapshotsRequest>;
 
@@ -2184,7 +2188,7 @@ export const ListProjectsSnapshotsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{project}/snapshots" }),
+    T.Http({ method: "GET", path: "v1/{+project}/snapshots" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSnapshotsRequest>;
 
@@ -2222,7 +2226,7 @@ export const CreateProjectsSnapshotsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CreateSnapshotRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsSnapshotsRequest>;
 
@@ -2256,7 +2260,7 @@ export const PatchProjectsSnapshotsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateSnapshotRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsSnapshotsRequest>;
 
@@ -2287,7 +2291,7 @@ export const DeleteProjectsSnapshotsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     snapshot: Schema.String.pipe(T.HttpPath("snapshot")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{snapshot}" }),
+    T.Http({ method: "DELETE", path: "v1/{+snapshot}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsSnapshotsRequest>;
 
@@ -2323,7 +2327,7 @@ export const SetIamPolicyProjectsSchemasRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2361,7 +2365,7 @@ export const GetIamPolicyProjectsSchemasRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsSchemasRequest>;
 
@@ -2397,7 +2401,7 @@ export const TestIamPermissionsProjectsSchemasRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2437,7 +2441,7 @@ export const CreateProjectsSchemasRequest =
     schemaId: Schema.optional(Schema.String).pipe(T.HttpQuery("schemaId")),
     body: Schema.optional(Pubsub_Schema).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/schemas", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/schemas", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsSchemasRequest>;
 
@@ -2471,7 +2475,7 @@ export const GetProjectsSchemasRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSchemasRequest>;
 
@@ -2511,7 +2515,7 @@ export const ListProjectsSchemasRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/schemas" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/schemas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSchemasRequest>;
 
@@ -2555,7 +2559,7 @@ export const ListRevisionsProjectsSchemasRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:listRevisions" }),
+    T.Http({ method: "GET", path: "v1/{+name}:listRevisions" }),
     svc,
   ) as unknown as Schema.Schema<ListRevisionsProjectsSchemasRequest>;
 
@@ -2593,7 +2597,7 @@ export const CommitProjectsSchemasRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CommitSchemaRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:commit", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:commit", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CommitProjectsSchemasRequest>;
 
@@ -2627,7 +2631,7 @@ export const RollbackProjectsSchemasRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RollbackSchemaRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:rollback", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:rollback", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RollbackProjectsSchemasRequest>;
 
@@ -2661,7 +2665,7 @@ export const DeleteRevisionProjectsSchemasRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     revisionId: Schema.optional(Schema.String).pipe(T.HttpQuery("revisionId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}:deleteRevision" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}:deleteRevision" }),
     svc,
   ) as unknown as Schema.Schema<DeleteRevisionProjectsSchemasRequest>;
 
@@ -2692,7 +2696,7 @@ export const DeleteProjectsSchemasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsSchemasRequest>;
 
@@ -2727,7 +2731,7 @@ export const ValidateProjectsSchemasRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/schemas:validate",
+      path: "v1/{+parent}/schemas:validate",
       hasBody: true,
     }),
     svc,
@@ -2765,7 +2769,7 @@ export const ValidateMessageProjectsSchemasRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/schemas:validateMessage",
+      path: "v1/{+parent}/schemas:validateMessage",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/pubsub-v1beta1a.ts
+++ b/packages/gcp/src/services/pubsub-v1beta1a.ts
@@ -370,7 +370,7 @@ export interface GetTopicsRequest {
 export const GetTopicsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   topic: Schema.String.pipe(T.HttpPath("topic")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta1a/topics/{topic}" }),
+  T.Http({ method: "GET", path: "v1beta1a/topics/{+topic}" }),
   svc,
 ) as unknown as Schema.Schema<GetTopicsRequest>;
 
@@ -439,7 +439,7 @@ export interface DeleteTopicsRequest {
 export const DeleteTopicsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   topic: Schema.String.pipe(T.HttpPath("topic")),
 }).pipe(
-  T.Http({ method: "DELETE", path: "v1beta1a/topics/{topic}" }),
+  T.Http({ method: "DELETE", path: "v1beta1a/topics/{+topic}" }),
   svc,
 ) as unknown as Schema.Schema<DeleteTopicsRequest>;
 
@@ -500,7 +500,7 @@ export const GetSubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     subscription: Schema.String.pipe(T.HttpPath("subscription")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1a/subscriptions/{subscription}" }),
+    T.Http({ method: "GET", path: "v1beta1a/subscriptions/{+subscription}" }),
     svc,
   ) as unknown as Schema.Schema<GetSubscriptionsRequest>;
 
@@ -572,7 +572,10 @@ export const DeleteSubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     subscription: Schema.String.pipe(T.HttpPath("subscription")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1a/subscriptions/{subscription}" }),
+    T.Http({
+      method: "DELETE",
+      path: "v1beta1a/subscriptions/{+subscription}",
+    }),
     svc,
   ) as unknown as Schema.Schema<DeleteSubscriptionsRequest>;
 

--- a/packages/gcp/src/services/pubsub-v1beta2.ts
+++ b/packages/gcp/src/services/pubsub-v1beta2.ts
@@ -319,7 +319,7 @@ export const SetIamPolicyProjectsSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{resource}:setIamPolicy",
+      path: "v1beta2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -357,7 +357,7 @@ export const GetIamPolicyProjectsSubscriptionsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta2/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsSubscriptionsRequest>;
 
@@ -393,7 +393,7 @@ export const TestIamPermissionsProjectsSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{resource}:testIamPermissions",
+      path: "v1beta2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -430,7 +430,7 @@ export const CreateProjectsSubscriptionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Subscription).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsSubscriptionsRequest>;
 
@@ -461,7 +461,7 @@ export const GetProjectsSubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     subscription: Schema.String.pipe(T.HttpPath("subscription")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{subscription}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+subscription}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSubscriptionsRequest>;
 
@@ -498,7 +498,7 @@ export const ListProjectsSubscriptionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{project}/subscriptions" }),
+    T.Http({ method: "GET", path: "v1beta2/{+project}/subscriptions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSubscriptionsRequest>;
 
@@ -533,7 +533,7 @@ export const DeleteProjectsSubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     subscription: Schema.String.pipe(T.HttpPath("subscription")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta2/{subscription}" }),
+    T.Http({ method: "DELETE", path: "v1beta2/{+subscription}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsSubscriptionsRequest>;
 
@@ -569,7 +569,7 @@ export const ModifyAckDeadlineProjectsSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{subscription}:modifyAckDeadline",
+      path: "v1beta2/{+subscription}:modifyAckDeadline",
       hasBody: true,
     }),
     svc,
@@ -607,7 +607,7 @@ export const AcknowledgeProjectsSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{subscription}:acknowledge",
+      path: "v1beta2/{+subscription}:acknowledge",
       hasBody: true,
     }),
     svc,
@@ -645,7 +645,7 @@ export const PullProjectsSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{subscription}:pull",
+      path: "v1beta2/{+subscription}:pull",
       hasBody: true,
     }),
     svc,
@@ -683,7 +683,7 @@ export const ModifyPushConfigProjectsSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{subscription}:modifyPushConfig",
+      path: "v1beta2/{+subscription}:modifyPushConfig",
       hasBody: true,
     }),
     svc,
@@ -721,7 +721,7 @@ export const SetIamPolicyProjectsTopicsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{resource}:setIamPolicy",
+      path: "v1beta2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -759,7 +759,7 @@ export const GetIamPolicyProjectsTopicsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta2/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsTopicsRequest>;
 
@@ -795,7 +795,7 @@ export const TestIamPermissionsProjectsTopicsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{resource}:testIamPermissions",
+      path: "v1beta2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -832,7 +832,7 @@ export const CreateProjectsTopicsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Topic).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsTopicsRequest>;
 
@@ -865,7 +865,7 @@ export const PublishProjectsTopicsRequest =
     topic: Schema.String.pipe(T.HttpPath("topic")),
     body: Schema.optional(PublishRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta2/{topic}:publish", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta2/{+topic}:publish", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PublishProjectsTopicsRequest>;
 
@@ -896,7 +896,7 @@ export const GetProjectsTopicsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     topic: Schema.String.pipe(T.HttpPath("topic")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{topic}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+topic}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsTopicsRequest>;
 
@@ -932,7 +932,7 @@ export const ListProjectsTopicsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{project}/topics" }),
+    T.Http({ method: "GET", path: "v1beta2/{+project}/topics" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTopicsRequest>;
 
@@ -967,7 +967,7 @@ export const DeleteProjectsTopicsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     topic: Schema.String.pipe(T.HttpPath("topic")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta2/{topic}" }),
+    T.Http({ method: "DELETE", path: "v1beta2/{+topic}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsTopicsRequest>;
 
@@ -1003,7 +1003,7 @@ export const ListProjectsTopicsSubscriptionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{topic}/subscriptions" }),
+    T.Http({ method: "GET", path: "v1beta2/{+topic}/subscriptions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsTopicsSubscriptionsRequest>;
 

--- a/packages/gcp/src/services/pubsublite-v1.ts
+++ b/packages/gcp/src/services/pubsublite-v1.ts
@@ -503,7 +503,7 @@ export const GetAdminProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/admin/{name}" }),
+    T.Http({ method: "GET", path: "v1/admin/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAdminProjectsLocationsOperationsRequest>;
 
@@ -548,7 +548,7 @@ export const ListAdminProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/admin/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/admin/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListAdminProjectsLocationsOperationsRequest>;
 
@@ -584,7 +584,7 @@ export const DeleteAdminProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/admin/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/admin/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdminProjectsLocationsOperationsRequest>;
 
@@ -618,7 +618,7 @@ export const CancelAdminProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/admin/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/admin/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelAdminProjectsLocationsOperationsRequest>;
 
@@ -655,7 +655,7 @@ export const PatchAdminProjectsLocationsTopicsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Topic).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/admin/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/admin/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAdminProjectsLocationsTopicsRequest>;
 
@@ -692,7 +692,11 @@ export const CreateAdminProjectsLocationsTopicsRequest =
     topicId: Schema.optional(Schema.String).pipe(T.HttpQuery("topicId")),
     body: Schema.optional(Topic).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/admin/{parent}/topics", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/admin/{+parent}/topics",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateAdminProjectsLocationsTopicsRequest>;
 
@@ -723,7 +727,7 @@ export const GetAdminProjectsLocationsTopicsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/admin/{name}" }),
+    T.Http({ method: "GET", path: "v1/admin/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAdminProjectsLocationsTopicsRequest>;
 
@@ -754,7 +758,7 @@ export const GetPartitionsAdminProjectsLocationsTopicsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/admin/{name}/partitions" }),
+    T.Http({ method: "GET", path: "v1/admin/{+name}/partitions" }),
     svc,
   ) as unknown as Schema.Schema<GetPartitionsAdminProjectsLocationsTopicsRequest>;
 
@@ -791,7 +795,7 @@ export const ListAdminProjectsLocationsTopicsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/admin/{parent}/topics" }),
+    T.Http({ method: "GET", path: "v1/admin/{+parent}/topics" }),
     svc,
   ) as unknown as Schema.Schema<ListAdminProjectsLocationsTopicsRequest>;
 
@@ -826,7 +830,7 @@ export const DeleteAdminProjectsLocationsTopicsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/admin/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/admin/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdminProjectsLocationsTopicsRequest>;
 
@@ -863,7 +867,7 @@ export const ListAdminProjectsLocationsTopicsSubscriptionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/admin/{name}/subscriptions" }),
+    T.Http({ method: "GET", path: "v1/admin/{+name}/subscriptions" }),
     svc,
   ) as unknown as Schema.Schema<ListAdminProjectsLocationsTopicsSubscriptionsRequest>;
 
@@ -902,7 +906,7 @@ export const SeekAdminProjectsLocationsSubscriptionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SeekSubscriptionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/admin/{name}:seek", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/admin/{+name}:seek", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SeekAdminProjectsLocationsSubscriptionsRequest>;
 
@@ -939,7 +943,7 @@ export const PatchAdminProjectsLocationsSubscriptionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Subscription).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/admin/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/admin/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAdminProjectsLocationsSubscriptionsRequest>;
 
@@ -976,7 +980,7 @@ export const ListAdminProjectsLocationsSubscriptionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/admin/{parent}/subscriptions" }),
+    T.Http({ method: "GET", path: "v1/admin/{+parent}/subscriptions" }),
     svc,
   ) as unknown as Schema.Schema<ListAdminProjectsLocationsSubscriptionsRequest>;
 
@@ -1012,7 +1016,7 @@ export const DeleteAdminProjectsLocationsSubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/admin/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/admin/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdminProjectsLocationsSubscriptionsRequest>;
 
@@ -1058,7 +1062,7 @@ export const CreateAdminProjectsLocationsSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/admin/{parent}/subscriptions",
+      path: "v1/admin/{+parent}/subscriptions",
       hasBody: true,
     }),
     svc,
@@ -1091,7 +1095,7 @@ export const GetAdminProjectsLocationsSubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/admin/{name}" }),
+    T.Http({ method: "GET", path: "v1/admin/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAdminProjectsLocationsSubscriptionsRequest>;
 
@@ -1132,7 +1136,7 @@ export const CreateAdminProjectsLocationsReservationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/admin/{parent}/reservations",
+      path: "v1/admin/{+parent}/reservations",
       hasBody: true,
     }),
     svc,
@@ -1165,7 +1169,7 @@ export const GetAdminProjectsLocationsReservationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/admin/{name}" }),
+    T.Http({ method: "GET", path: "v1/admin/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAdminProjectsLocationsReservationsRequest>;
 
@@ -1202,7 +1206,7 @@ export const ListAdminProjectsLocationsReservationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/admin/{parent}/reservations" }),
+    T.Http({ method: "GET", path: "v1/admin/{+parent}/reservations" }),
     svc,
   ) as unknown as Schema.Schema<ListAdminProjectsLocationsReservationsRequest>;
 
@@ -1238,7 +1242,7 @@ export const DeleteAdminProjectsLocationsReservationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/admin/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/admin/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAdminProjectsLocationsReservationsRequest>;
 
@@ -1275,7 +1279,7 @@ export const PatchAdminProjectsLocationsReservationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Reservation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/admin/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/admin/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchAdminProjectsLocationsReservationsRequest>;
 
@@ -1312,7 +1316,7 @@ export const ListAdminProjectsLocationsReservationsTopicsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/admin/{name}/topics" }),
+    T.Http({ method: "GET", path: "v1/admin/{+name}/topics" }),
     svc,
   ) as unknown as Schema.Schema<ListAdminProjectsLocationsReservationsTopicsRequest>;
 
@@ -1353,7 +1357,7 @@ export const CommitCursorCursorProjectsLocationsSubscriptionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/cursor/{subscription}:commitCursor",
+      path: "v1/cursor/{+subscription}:commitCursor",
       hasBody: true,
     }),
     svc,
@@ -1394,7 +1398,7 @@ export const ListCursorProjectsLocationsSubscriptionsCursorsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/cursor/{parent}/cursors" }),
+    T.Http({ method: "GET", path: "v1/cursor/{+parent}/cursors" }),
     svc,
   ) as unknown as Schema.Schema<ListCursorProjectsLocationsSubscriptionsCursorsRequest>;
 
@@ -1436,7 +1440,7 @@ export const ComputeTimeCursorTopicStatsProjectsLocationsTopicsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/topicStats/{topic}:computeTimeCursor",
+      path: "v1/topicStats/{+topic}:computeTimeCursor",
       hasBody: true,
     }),
     svc,
@@ -1476,7 +1480,7 @@ export const ComputeMessageStatsTopicStatsProjectsLocationsTopicsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/topicStats/{topic}:computeMessageStats",
+      path: "v1/topicStats/{+topic}:computeMessageStats",
       hasBody: true,
     }),
     svc,
@@ -1516,7 +1520,7 @@ export const ComputeHeadCursorTopicStatsProjectsLocationsTopicsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/topicStats/{topic}:computeHeadCursor",
+      path: "v1/topicStats/{+topic}:computeHeadCursor",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/rapidmigrationassessment-v1.ts
+++ b/packages/gcp/src/services/rapidmigrationassessment-v1.ts
@@ -324,7 +324,7 @@ export const ListProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -359,7 +359,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -390,7 +390,7 @@ export const GetProjectsLocationsAnnotationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAnnotationsRequest>;
 
@@ -427,7 +427,7 @@ export const CreateProjectsLocationsAnnotationsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Annotation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/annotations", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/annotations", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAnnotationsRequest>;
 
@@ -458,7 +458,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -498,7 +498,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -536,7 +536,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -567,7 +567,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -598,7 +598,7 @@ export const GetProjectsLocationsCollectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCollectorsRequest>;
 
@@ -641,7 +641,7 @@ export const ListProjectsLocationsCollectorsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/collectors" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/collectors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCollectorsRequest>;
 
@@ -679,7 +679,7 @@ export const DeleteProjectsLocationsCollectorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCollectorsRequest>;
 
@@ -713,7 +713,7 @@ export const PauseProjectsLocationsCollectorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PauseCollectorRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsLocationsCollectorsRequest>;
 
@@ -755,7 +755,7 @@ export const CreateProjectsLocationsCollectorsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Collector).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/collectors", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/collectors", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCollectorsRequest>;
 
@@ -789,7 +789,7 @@ export const ResumeProjectsLocationsCollectorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResumeCollectorRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsCollectorsRequest>;
 
@@ -829,7 +829,7 @@ export const PatchProjectsLocationsCollectorsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Collector).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCollectorsRequest>;
 
@@ -863,7 +863,7 @@ export const RegisterProjectsLocationsCollectorsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RegisterCollectorRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:register", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:register", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RegisterProjectsLocationsCollectorsRequest>;
 

--- a/packages/gcp/src/services/readerrevenuesubscriptionlinking-v1.ts
+++ b/packages/gcp/src/services/readerrevenuesubscriptionlinking-v1.ts
@@ -92,7 +92,7 @@ export const GetEntitlementsPublicationsReadersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEntitlementsPublicationsReadersRequest>;
 
@@ -129,7 +129,7 @@ export const UpdateEntitlementsPublicationsReadersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ReaderEntitlements).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateEntitlementsPublicationsReadersRequest>;
 
@@ -160,7 +160,7 @@ export const GetPublicationsReadersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetPublicationsReadersRequest>;
 
@@ -194,7 +194,7 @@ export const DeletePublicationsReadersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeletePublicationsReadersRequest>;
 

--- a/packages/gcp/src/services/realtimebidding-v1.ts
+++ b/packages/gcp/src/services/realtimebidding-v1.ts
@@ -1262,7 +1262,7 @@ export interface GetBiddersRequest {
 export const GetBiddersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetBiddersRequest>;
 
@@ -1335,7 +1335,7 @@ export const PatchBiddersEndpointsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Endpoint).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchBiddersEndpointsRequest>;
 
@@ -1366,7 +1366,7 @@ export const GetBiddersEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBiddersEndpointsRequest>;
 
@@ -1402,7 +1402,7 @@ export const ListBiddersEndpointsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/endpoints" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/endpoints" }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersEndpointsRequest>;
 
@@ -1442,7 +1442,7 @@ export const WatchBiddersCreativesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/creatives:watch",
+      path: "v1/{+parent}/creatives:watch",
       hasBody: true,
     }),
     svc,
@@ -1491,7 +1491,7 @@ export const ListBiddersCreativesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/creatives" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/creatives" }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersCreativesRequest>;
 
@@ -1529,7 +1529,7 @@ export const ActivateBiddersPretargetingConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ActivatePretargetingConfigRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:activate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:activate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ActivateBiddersPretargetingConfigsRequest>;
 
@@ -1565,7 +1565,7 @@ export const CreateBiddersPretargetingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/pretargetingConfigs",
+      path: "v1/{+parent}/pretargetingConfigs",
       hasBody: true,
     }),
     svc,
@@ -1603,7 +1603,7 @@ export const RemoveTargetedPublishersBiddersPretargetingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{pretargetingConfig}:removeTargetedPublishers",
+      path: "v1/{+pretargetingConfig}:removeTargetedPublishers",
       hasBody: true,
     }),
     svc,
@@ -1643,7 +1643,7 @@ export const AddTargetedPublishersBiddersPretargetingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{pretargetingConfig}:addTargetedPublishers",
+      path: "v1/{+pretargetingConfig}:addTargetedPublishers",
       hasBody: true,
     }),
     svc,
@@ -1678,7 +1678,7 @@ export const DeleteBiddersPretargetingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteBiddersPretargetingConfigsRequest>;
 
@@ -1715,7 +1715,7 @@ export const ListBiddersPretargetingConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/pretargetingConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/pretargetingConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersPretargetingConfigsRequest>;
 
@@ -1756,7 +1756,7 @@ export const RemoveTargetedSitesBiddersPretargetingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{pretargetingConfig}:removeTargetedSites",
+      path: "v1/{+pretargetingConfig}:removeTargetedSites",
       hasBody: true,
     }),
     svc,
@@ -1796,7 +1796,7 @@ export const PatchBiddersPretargetingConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(PretargetingConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchBiddersPretargetingConfigsRequest>;
 
@@ -1832,7 +1832,7 @@ export const RemoveTargetedAppsBiddersPretargetingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{pretargetingConfig}:removeTargetedApps",
+      path: "v1/{+pretargetingConfig}:removeTargetedApps",
       hasBody: true,
     }),
     svc,
@@ -1866,7 +1866,7 @@ export const GetBiddersPretargetingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBiddersPretargetingConfigsRequest>;
 
@@ -1900,7 +1900,7 @@ export const SuspendBiddersPretargetingConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SuspendPretargetingConfigRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:suspend", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:suspend", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SuspendBiddersPretargetingConfigsRequest>;
 
@@ -1936,7 +1936,7 @@ export const AddTargetedSitesBiddersPretargetingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{pretargetingConfig}:addTargetedSites",
+      path: "v1/{+pretargetingConfig}:addTargetedSites",
       hasBody: true,
     }),
     svc,
@@ -1975,7 +1975,7 @@ export const AddTargetedAppsBiddersPretargetingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{pretargetingConfig}:addTargetedApps",
+      path: "v1/{+pretargetingConfig}:addTargetedApps",
       hasBody: true,
     }),
     svc,
@@ -2016,7 +2016,7 @@ export const BatchApproveBiddersPublisherConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/publisherConnections:batchApprove",
+      path: "v1/{+parent}/publisherConnections:batchApprove",
       hasBody: true,
     }),
     svc,
@@ -2050,7 +2050,7 @@ export const GetBiddersPublisherConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBiddersPublisherConnectionsRequest>;
 
@@ -2093,7 +2093,7 @@ export const ListBiddersPublisherConnectionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/publisherConnections" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/publisherConnections" }),
     svc,
   ) as unknown as Schema.Schema<ListBiddersPublisherConnectionsRequest>;
 
@@ -2136,7 +2136,7 @@ export const BatchRejectBiddersPublisherConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/publisherConnections:batchReject",
+      path: "v1/{+parent}/publisherConnections:batchReject",
       hasBody: true,
     }),
     svc,
@@ -2169,7 +2169,7 @@ export interface GetBuyersRequest {
 export const GetBuyersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetBuyersRequest>;
 
@@ -2236,7 +2236,7 @@ export const GetRemarketingTagBuyersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getRemarketingTag" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getRemarketingTag" }),
     svc,
   ) as unknown as Schema.Schema<GetRemarketingTagBuyersRequest>;
 
@@ -2273,7 +2273,7 @@ export const PatchBuyersCreativesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Creative).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchBuyersCreativesRequest>;
 
@@ -2311,7 +2311,7 @@ export const GetBuyersCreativesRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBuyersCreativesRequest>;
 
@@ -2357,7 +2357,7 @@ export const ListBuyersCreativesRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/creatives" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/creatives" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersCreativesRequest>;
 
@@ -2395,7 +2395,7 @@ export const CreateBuyersCreativesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Creative).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/creatives", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/creatives", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateBuyersCreativesRequest>;
 
@@ -2426,7 +2426,7 @@ export const GetBuyersUserListsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBuyersUserListsRequest>;
 
@@ -2459,7 +2459,7 @@ export const UpdateBuyersUserListsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UserList).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateBuyersUserListsRequest>;
 
@@ -2493,7 +2493,7 @@ export const CreateBuyersUserListsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(UserList).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/userLists", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/userLists", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateBuyersUserListsRequest>;
 
@@ -2527,7 +2527,7 @@ export const CloseBuyersUserListsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CloseUserListRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:close", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:close", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CloseBuyersUserListsRequest>;
 
@@ -2561,7 +2561,7 @@ export const OpenBuyersUserListsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(OpenUserListRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:open", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:open", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<OpenBuyersUserListsRequest>;
 
@@ -2591,7 +2591,7 @@ export const GetRemarketingTagBuyersUserListsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:getRemarketingTag" }),
+    T.Http({ method: "GET", path: "v1/{+name}:getRemarketingTag" }),
     svc,
   ) as unknown as Schema.Schema<GetRemarketingTagBuyersUserListsRequest>;
 
@@ -2629,7 +2629,7 @@ export const ListBuyersUserListsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/userLists" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/userLists" }),
     svc,
   ) as unknown as Schema.Schema<ListBuyersUserListsRequest>;
 

--- a/packages/gcp/src/services/recaptchaenterprise-v1.ts
+++ b/packages/gcp/src/services/recaptchaenterprise-v1.ts
@@ -1638,7 +1638,7 @@ export const CreateProjectsAssessmentsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/assessments", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/assessments", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsAssessmentsRequest>;
 
@@ -1675,7 +1675,7 @@ export const AnnotateProjectsAssessmentsRequest =
       GoogleCloudRecaptchaenterpriseV1AnnotateAssessmentRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:annotate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:annotate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AnnotateProjectsAssessmentsRequest>;
 
@@ -1714,7 +1714,7 @@ export const SearchProjectsRelatedaccountgroupmembershipsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{project}/relatedaccountgroupmemberships:search",
+      path: "v1/{+project}/relatedaccountgroupmemberships:search",
       hasBody: true,
     }),
     svc,
@@ -1754,7 +1754,7 @@ export const ListProjectsFirewallpoliciesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/firewallpolicies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/firewallpolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsFirewallpoliciesRequest>;
 
@@ -1790,7 +1790,7 @@ export const GetProjectsFirewallpoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsFirewallpoliciesRequest>;
 
@@ -1822,7 +1822,7 @@ export const DeleteProjectsFirewallpoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsFirewallpoliciesRequest>;
 
@@ -1860,7 +1860,7 @@ export const ReorderProjectsFirewallpoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/firewallpolicies:reorder",
+      path: "v1/{+parent}/firewallpolicies:reorder",
       hasBody: true,
     }),
     svc,
@@ -1901,7 +1901,7 @@ export const CreateProjectsFirewallpoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/firewallpolicies",
+      path: "v1/{+parent}/firewallpolicies",
       hasBody: true,
     }),
     svc,
@@ -1943,7 +1943,7 @@ export const PatchProjectsFirewallpoliciesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsFirewallpoliciesRequest>;
 
@@ -1981,7 +1981,7 @@ export const ListProjectsRelatedaccountgroupsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/relatedaccountgroups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/relatedaccountgroups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsRelatedaccountgroupsRequest>;
 
@@ -2023,7 +2023,7 @@ export const ListProjectsRelatedaccountgroupsMembershipsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/memberships" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/memberships" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsRelatedaccountgroupsMembershipsRequest>;
 
@@ -2067,7 +2067,7 @@ export const PatchProjectsKeysRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsKeysRequest>;
 
@@ -2104,7 +2104,7 @@ export const ListIpOverridesProjectsKeysRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}:listIpOverrides" }),
+    T.Http({ method: "GET", path: "v1/{+parent}:listIpOverrides" }),
     svc,
   ) as unknown as Schema.Schema<ListIpOverridesProjectsKeysRequest>;
 
@@ -2146,7 +2146,7 @@ export const ListProjectsKeysRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/keys" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/keys" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsKeysRequest>;
 
@@ -2177,7 +2177,7 @@ export interface RetrieveLegacySecretKeyProjectsKeysRequest {}
 
 export const RetrieveLegacySecretKeyProjectsKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
-    T.Http({ method: "GET", path: "v1/{key}:retrieveLegacySecretKey" }),
+    T.Http({ method: "GET", path: "v1/{+key}:retrieveLegacySecretKey" }),
     svc,
   ) as unknown as Schema.Schema<RetrieveLegacySecretKeyProjectsKeysRequest>;
 
@@ -2214,7 +2214,7 @@ export const MigrateProjectsKeysRequest =
       GoogleCloudRecaptchaenterpriseV1MigrateKeyRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:migrate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:migrate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MigrateProjectsKeysRequest>;
 
@@ -2252,7 +2252,7 @@ export const RemoveIpOverrideProjectsKeysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:removeIpOverride",
+      path: "v1/{+name}:removeIpOverride",
       hasBody: true,
     }),
     svc,
@@ -2286,7 +2286,7 @@ export const GetMetricsProjectsKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetMetricsProjectsKeysRequest>;
 
@@ -2323,7 +2323,7 @@ export const CreateProjectsKeysRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/keys", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/keys", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsKeysRequest>;
 
@@ -2354,7 +2354,7 @@ export const DeleteProjectsKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsKeysRequest>;
 
@@ -2386,7 +2386,7 @@ export const GetProjectsKeysRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     name: Schema.String.pipe(T.HttpPath("name")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetProjectsKeysRequest>;
 
@@ -2422,7 +2422,7 @@ export const AddIpOverrideProjectsKeysRequest =
       GoogleCloudRecaptchaenterpriseV1AddIpOverrideRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:addIpOverride", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:addIpOverride", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AddIpOverrideProjectsKeysRequest>;
 

--- a/packages/gcp/src/services/recommendationengine-v1beta1.ts
+++ b/packages/gcp/src/services/recommendationengine-v1beta1.ts
@@ -1093,7 +1093,7 @@ export const PatchProjectsLocationsCatalogsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsRequest>;
 
@@ -1131,7 +1131,7 @@ export const ListProjectsLocationsCatalogsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/catalogs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/catalogs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsRequest>;
 
@@ -1181,7 +1181,7 @@ export const ListProjectsLocationsCatalogsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsOperationsRequest>;
 
@@ -1217,7 +1217,7 @@ export const GetProjectsLocationsCatalogsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsOperationsRequest>;
 
@@ -1256,7 +1256,7 @@ export const CreateProjectsLocationsCatalogsCatalogItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/catalogItems",
+      path: "v1beta1/{+parent}/catalogItems",
       hasBody: true,
     }),
     svc,
@@ -1290,7 +1290,7 @@ export const GetProjectsLocationsCatalogsCatalogItemsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsCatalogItemsRequest>;
 
@@ -1329,7 +1329,7 @@ export const ImportProjectsLocationsCatalogsCatalogItemsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/catalogItems:import",
+      path: "v1beta1/{+parent}/catalogItems:import",
       hasBody: true,
     }),
     svc,
@@ -1371,7 +1371,7 @@ export const PatchProjectsLocationsCatalogsCatalogItemsRequest =
       GoogleCloudRecommendationengineV1beta1CatalogItem,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsCatalogItemsRequest>;
 
@@ -1412,7 +1412,7 @@ export const ListProjectsLocationsCatalogsCatalogItemsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/catalogItems" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/catalogItems" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsCatalogItemsRequest>;
 
@@ -1448,7 +1448,7 @@ export const DeleteProjectsLocationsCatalogsCatalogItemsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCatalogsCatalogItemsRequest>;
 
@@ -1484,7 +1484,7 @@ export const PredictProjectsLocationsCatalogsEventStoresPlacementsRequest =
       GoogleCloudRecommendationengineV1beta1PredictRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:predict", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:predict", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PredictProjectsLocationsCatalogsEventStoresPlacementsRequest>;
 
@@ -1525,7 +1525,7 @@ export const ListProjectsLocationsCatalogsEventStoresPredictionApiKeyRegistratio
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta1/{parent}/predictionApiKeyRegistrations",
+      path: "v1beta1/{+parent}/predictionApiKeyRegistrations",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsEventStoresPredictionApiKeyRegistrationsRequest>;
@@ -1565,7 +1565,7 @@ export const DeleteProjectsLocationsCatalogsEventStoresPredictionApiKeyRegistrat
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCatalogsEventStoresPredictionApiKeyRegistrationsRequest>;
 
@@ -1607,7 +1607,7 @@ export const CreateProjectsLocationsCatalogsEventStoresPredictionApiKeyRegistrat
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/predictionApiKeyRegistrations",
+      path: "v1beta1/{+parent}/predictionApiKeyRegistrations",
       hasBody: true,
     }),
     svc,
@@ -1651,7 +1651,7 @@ export const PurgeProjectsLocationsCatalogsEventStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/userEvents:purge",
+      path: "v1beta1/{+parent}/userEvents:purge",
       hasBody: true,
     }),
     svc,
@@ -1695,7 +1695,7 @@ export const ListProjectsLocationsCatalogsEventStoresUserEventsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/userEvents" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/userEvents" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsEventStoresUserEventsRequest>;
 
@@ -1741,7 +1741,7 @@ export const CollectProjectsLocationsCatalogsEventStoresUserEventsRequest =
     uri: Schema.optional(Schema.String).pipe(T.HttpQuery("uri")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/userEvents:collect" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/userEvents:collect" }),
     svc,
   ) as unknown as Schema.Schema<CollectProjectsLocationsCatalogsEventStoresUserEventsRequest>;
 
@@ -1781,7 +1781,7 @@ export const WriteProjectsLocationsCatalogsEventStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/userEvents:write",
+      path: "v1beta1/{+parent}/userEvents:write",
       hasBody: true,
     }),
     svc,
@@ -1823,7 +1823,7 @@ export const ImportProjectsLocationsCatalogsEventStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/userEvents:import",
+      path: "v1beta1/{+parent}/userEvents:import",
       hasBody: true,
     }),
     svc,
@@ -1865,7 +1865,7 @@ export const RejoinProjectsLocationsCatalogsEventStoresUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/userEvents:rejoin",
+      path: "v1beta1/{+parent}/userEvents:rejoin",
       hasBody: true,
     }),
     svc,
@@ -1914,7 +1914,7 @@ export const ListProjectsLocationsCatalogsEventStoresOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsEventStoresOperationsRequest>;
 
@@ -1951,7 +1951,7 @@ export const GetProjectsLocationsCatalogsEventStoresOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsEventStoresOperationsRequest>;
 

--- a/packages/gcp/src/services/recommender-v1.ts
+++ b/packages/gcp/src/services/recommender-v1.ts
@@ -584,7 +584,7 @@ export const GetConfigProjectsLocationsRecommendersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigProjectsLocationsRecommendersRequest>;
 
@@ -629,7 +629,7 @@ export const UpdateConfigProjectsLocationsRecommendersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigProjectsLocationsRecommendersRequest>;
 
@@ -666,7 +666,7 @@ export const MarkFailedProjectsLocationsRecommendersRecommendationsRequest =
       GoogleCloudRecommenderV1MarkRecommendationFailedRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markFailed", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markFailed", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkFailedProjectsLocationsRecommendersRecommendationsRequest>;
 
@@ -704,7 +704,7 @@ export const MarkDismissedProjectsLocationsRecommendersRecommendationsRequest =
       GoogleCloudRecommenderV1MarkRecommendationDismissedRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markDismissed", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markDismissed", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkDismissedProjectsLocationsRecommendersRecommendationsRequest>;
 
@@ -742,7 +742,7 @@ export const MarkSucceededProjectsLocationsRecommendersRecommendationsRequest =
       GoogleCloudRecommenderV1MarkRecommendationSucceededRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markSucceeded", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markSucceeded", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkSucceededProjectsLocationsRecommendersRecommendationsRequest>;
 
@@ -784,7 +784,7 @@ export const ListProjectsLocationsRecommendersRecommendationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/recommendations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/recommendations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRecommendersRecommendationsRequest>;
 
@@ -826,7 +826,7 @@ export const MarkClaimedProjectsLocationsRecommendersRecommendationsRequest =
       GoogleCloudRecommenderV1MarkRecommendationClaimedRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markClaimed", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markClaimed", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkClaimedProjectsLocationsRecommendersRecommendationsRequest>;
 
@@ -859,7 +859,7 @@ export const GetProjectsLocationsRecommendersRecommendationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRecommendersRecommendationsRequest>;
 
@@ -892,7 +892,7 @@ export const GetConfigProjectsLocationsInsightTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigProjectsLocationsInsightTypesRequest>;
 
@@ -937,7 +937,7 @@ export const UpdateConfigProjectsLocationsInsightTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigProjectsLocationsInsightTypesRequest>;
 
@@ -969,7 +969,7 @@ export const GetProjectsLocationsInsightTypesInsightsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInsightTypesInsightsRequest>;
 
@@ -1006,7 +1006,7 @@ export const MarkAcceptedProjectsLocationsInsightTypesInsightsRequest =
       GoogleCloudRecommenderV1MarkInsightAcceptedRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markAccepted", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markAccepted", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkAcceptedProjectsLocationsInsightTypesInsightsRequest>;
 
@@ -1048,7 +1048,7 @@ export const ListProjectsLocationsInsightTypesInsightsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/insights" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/insights" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInsightTypesInsightsRequest>;
 
@@ -1097,7 +1097,7 @@ export const UpdateConfigBillingAccountsLocationsRecommendersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigBillingAccountsLocationsRecommendersRequest>;
 
@@ -1130,7 +1130,7 @@ export const GetConfigBillingAccountsLocationsRecommendersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigBillingAccountsLocationsRecommendersRequest>;
 
@@ -1167,7 +1167,7 @@ export const MarkDismissedBillingAccountsLocationsRecommendersRecommendationsReq
       GoogleCloudRecommenderV1MarkRecommendationDismissedRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markDismissed", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markDismissed", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkDismissedBillingAccountsLocationsRecommendersRecommendationsRequest>;
 
@@ -1207,7 +1207,7 @@ export const MarkSucceededBillingAccountsLocationsRecommendersRecommendationsReq
       GoogleCloudRecommenderV1MarkRecommendationSucceededRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markSucceeded", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markSucceeded", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkSucceededBillingAccountsLocationsRecommendersRecommendationsRequest>;
 
@@ -1247,7 +1247,7 @@ export const MarkFailedBillingAccountsLocationsRecommendersRecommendationsReques
       GoogleCloudRecommenderV1MarkRecommendationFailedRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markFailed", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markFailed", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkFailedBillingAccountsLocationsRecommendersRecommendationsRequest>;
 
@@ -1289,7 +1289,7 @@ export const ListBillingAccountsLocationsRecommendersRecommendationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/recommendations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/recommendations" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsLocationsRecommendersRecommendationsRequest>;
 
@@ -1331,7 +1331,7 @@ export const MarkClaimedBillingAccountsLocationsRecommendersRecommendationsReque
       GoogleCloudRecommenderV1MarkRecommendationClaimedRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markClaimed", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markClaimed", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkClaimedBillingAccountsLocationsRecommendersRecommendationsRequest>;
 
@@ -1365,7 +1365,7 @@ export const GetBillingAccountsLocationsRecommendersRecommendationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsLocationsRecommendersRecommendationsRequest>;
 
@@ -1411,7 +1411,7 @@ export const UpdateConfigBillingAccountsLocationsInsightTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigBillingAccountsLocationsInsightTypesRequest>;
 
@@ -1444,7 +1444,7 @@ export const GetConfigBillingAccountsLocationsInsightTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigBillingAccountsLocationsInsightTypesRequest>;
 
@@ -1485,7 +1485,7 @@ export const ListBillingAccountsLocationsInsightTypesInsightsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/insights" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/insights" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsLocationsInsightTypesInsightsRequest>;
 
@@ -1522,7 +1522,7 @@ export const GetBillingAccountsLocationsInsightTypesInsightsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsLocationsInsightTypesInsightsRequest>;
 
@@ -1560,7 +1560,7 @@ export const MarkAcceptedBillingAccountsLocationsInsightTypesInsightsRequest =
       GoogleCloudRecommenderV1MarkInsightAcceptedRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markAccepted", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markAccepted", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkAcceptedBillingAccountsLocationsInsightTypesInsightsRequest>;
 
@@ -1593,7 +1593,7 @@ export const GetConfigOrganizationsLocationsRecommendersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigOrganizationsLocationsRecommendersRequest>;
 
@@ -1638,7 +1638,7 @@ export const UpdateConfigOrganizationsLocationsRecommendersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigOrganizationsLocationsRecommendersRequest>;
 
@@ -1679,7 +1679,7 @@ export const ListOrganizationsLocationsRecommendersRecommendationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/recommendations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/recommendations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsRecommendersRecommendationsRequest>;
 
@@ -1721,7 +1721,7 @@ export const MarkClaimedOrganizationsLocationsRecommendersRecommendationsRequest
       GoogleCloudRecommenderV1MarkRecommendationClaimedRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markClaimed", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markClaimed", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkClaimedOrganizationsLocationsRecommendersRecommendationsRequest>;
 
@@ -1754,7 +1754,7 @@ export const GetOrganizationsLocationsRecommendersRecommendationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsRecommendersRecommendationsRequest>;
 
@@ -1792,7 +1792,7 @@ export const MarkDismissedOrganizationsLocationsRecommendersRecommendationsReque
       GoogleCloudRecommenderV1MarkRecommendationDismissedRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markDismissed", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markDismissed", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkDismissedOrganizationsLocationsRecommendersRecommendationsRequest>;
 
@@ -1831,7 +1831,7 @@ export const MarkSucceededOrganizationsLocationsRecommendersRecommendationsReque
       GoogleCloudRecommenderV1MarkRecommendationSucceededRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markSucceeded", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markSucceeded", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkSucceededOrganizationsLocationsRecommendersRecommendationsRequest>;
 
@@ -1870,7 +1870,7 @@ export const MarkFailedOrganizationsLocationsRecommendersRecommendationsRequest 
       GoogleCloudRecommenderV1MarkRecommendationFailedRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markFailed", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markFailed", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkFailedOrganizationsLocationsRecommendersRecommendationsRequest>;
 
@@ -1916,7 +1916,7 @@ export const UpdateConfigOrganizationsLocationsInsightTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigOrganizationsLocationsInsightTypesRequest>;
 
@@ -1948,7 +1948,7 @@ export const GetConfigOrganizationsLocationsInsightTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigOrganizationsLocationsInsightTypesRequest>;
 
@@ -1989,7 +1989,7 @@ export const ListOrganizationsLocationsInsightTypesInsightsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/insights" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/insights" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsInsightTypesInsightsRequest>;
 
@@ -2025,7 +2025,7 @@ export const GetOrganizationsLocationsInsightTypesInsightsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsInsightTypesInsightsRequest>;
 
@@ -2062,7 +2062,7 @@ export const MarkAcceptedOrganizationsLocationsInsightTypesInsightsRequest =
       GoogleCloudRecommenderV1MarkInsightAcceptedRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markAccepted", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markAccepted", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkAcceptedOrganizationsLocationsInsightTypesInsightsRequest>;
 
@@ -2095,7 +2095,7 @@ export const GetFoldersLocationsInsightTypesInsightsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsInsightTypesInsightsRequest>;
 
@@ -2132,7 +2132,7 @@ export const MarkAcceptedFoldersLocationsInsightTypesInsightsRequest =
       GoogleCloudRecommenderV1MarkInsightAcceptedRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markAccepted", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markAccepted", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkAcceptedFoldersLocationsInsightTypesInsightsRequest>;
 
@@ -2174,7 +2174,7 @@ export const ListFoldersLocationsInsightTypesInsightsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/insights" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/insights" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsInsightTypesInsightsRequest>;
 
@@ -2215,7 +2215,7 @@ export const MarkFailedFoldersLocationsRecommendersRecommendationsRequest =
       GoogleCloudRecommenderV1MarkRecommendationFailedRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markFailed", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markFailed", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkFailedFoldersLocationsRecommendersRecommendationsRequest>;
 
@@ -2253,7 +2253,7 @@ export const MarkDismissedFoldersLocationsRecommendersRecommendationsRequest =
       GoogleCloudRecommenderV1MarkRecommendationDismissedRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markDismissed", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markDismissed", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkDismissedFoldersLocationsRecommendersRecommendationsRequest>;
 
@@ -2291,7 +2291,7 @@ export const MarkSucceededFoldersLocationsRecommendersRecommendationsRequest =
       GoogleCloudRecommenderV1MarkRecommendationSucceededRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markSucceeded", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markSucceeded", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkSucceededFoldersLocationsRecommendersRecommendationsRequest>;
 
@@ -2324,7 +2324,7 @@ export const GetFoldersLocationsRecommendersRecommendationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsRecommendersRecommendationsRequest>;
 
@@ -2365,7 +2365,7 @@ export const ListFoldersLocationsRecommendersRecommendationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/recommendations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/recommendations" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsRecommendersRecommendationsRequest>;
 
@@ -2407,7 +2407,7 @@ export const MarkClaimedFoldersLocationsRecommendersRecommendationsRequest =
       GoogleCloudRecommenderV1MarkRecommendationClaimedRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:markClaimed", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:markClaimed", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MarkClaimedFoldersLocationsRecommendersRecommendationsRequest>;
 

--- a/packages/gcp/src/services/recommender-v1beta1.ts
+++ b/packages/gcp/src/services/recommender-v1beta1.ts
@@ -712,7 +712,7 @@ export const ListOrganizationsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsRequest>;
 
@@ -748,7 +748,7 @@ export const GetConfigOrganizationsLocationsRecommendersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigOrganizationsLocationsRecommendersRequest>;
 
@@ -793,7 +793,7 @@ export const UpdateConfigOrganizationsLocationsRecommendersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigOrganizationsLocationsRecommendersRequest>;
 
@@ -825,7 +825,7 @@ export const GetOrganizationsLocationsRecommendersRecommendationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsRecommendersRecommendationsRequest>;
 
@@ -865,7 +865,7 @@ export const MarkSucceededOrganizationsLocationsRecommendersRecommendationsReque
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markSucceeded",
+      path: "v1beta1/{+name}:markSucceeded",
       hasBody: true,
     }),
     svc,
@@ -908,7 +908,7 @@ export const MarkClaimedOrganizationsLocationsRecommendersRecommendationsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markClaimed",
+      path: "v1beta1/{+name}:markClaimed",
       hasBody: true,
     }),
     svc,
@@ -950,7 +950,7 @@ export const MarkFailedOrganizationsLocationsRecommendersRecommendationsRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markFailed",
+      path: "v1beta1/{+name}:markFailed",
       hasBody: true,
     }),
     svc,
@@ -994,7 +994,7 @@ export const ListOrganizationsLocationsRecommendersRecommendationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/recommendations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/recommendations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsRecommendersRecommendationsRequest>;
 
@@ -1038,7 +1038,7 @@ export const MarkDismissedOrganizationsLocationsRecommendersRecommendationsReque
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markDismissed",
+      path: "v1beta1/{+name}:markDismissed",
       hasBody: true,
     }),
     svc,
@@ -1074,7 +1074,7 @@ export const GetConfigOrganizationsLocationsInsightTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigOrganizationsLocationsInsightTypesRequest>;
 
@@ -1119,7 +1119,7 @@ export const UpdateConfigOrganizationsLocationsInsightTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigOrganizationsLocationsInsightTypesRequest>;
 
@@ -1151,7 +1151,7 @@ export const GetOrganizationsLocationsInsightTypesInsightsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsInsightTypesInsightsRequest>;
 
@@ -1190,7 +1190,7 @@ export const MarkAcceptedOrganizationsLocationsInsightTypesInsightsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markAccepted",
+      path: "v1beta1/{+name}:markAccepted",
       hasBody: true,
     }),
     svc,
@@ -1234,7 +1234,7 @@ export const ListOrganizationsLocationsInsightTypesInsightsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/insights" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/insights" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsInsightTypesInsightsRequest>;
 
@@ -1284,7 +1284,7 @@ export const ListProjectsLocationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1320,7 +1320,7 @@ export const GetConfigProjectsLocationsRecommendersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigProjectsLocationsRecommendersRequest>;
 
@@ -1365,7 +1365,7 @@ export const UpdateConfigProjectsLocationsRecommendersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigProjectsLocationsRecommendersRequest>;
 
@@ -1397,7 +1397,7 @@ export const GetProjectsLocationsRecommendersRecommendationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRecommendersRecommendationsRequest>;
 
@@ -1437,7 +1437,7 @@ export const MarkSucceededProjectsLocationsRecommendersRecommendationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markSucceeded",
+      path: "v1beta1/{+name}:markSucceeded",
       hasBody: true,
     }),
     svc,
@@ -1479,7 +1479,7 @@ export const MarkFailedProjectsLocationsRecommendersRecommendationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markFailed",
+      path: "v1beta1/{+name}:markFailed",
       hasBody: true,
     }),
     svc,
@@ -1521,7 +1521,7 @@ export const MarkClaimedProjectsLocationsRecommendersRecommendationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markClaimed",
+      path: "v1beta1/{+name}:markClaimed",
       hasBody: true,
     }),
     svc,
@@ -1563,7 +1563,7 @@ export const MarkDismissedProjectsLocationsRecommendersRecommendationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markDismissed",
+      path: "v1beta1/{+name}:markDismissed",
       hasBody: true,
     }),
     svc,
@@ -1607,7 +1607,7 @@ export const ListProjectsLocationsRecommendersRecommendationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/recommendations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/recommendations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRecommendersRecommendationsRequest>;
 
@@ -1644,7 +1644,7 @@ export const GetConfigProjectsLocationsInsightTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigProjectsLocationsInsightTypesRequest>;
 
@@ -1689,7 +1689,7 @@ export const UpdateConfigProjectsLocationsInsightTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigProjectsLocationsInsightTypesRequest>;
 
@@ -1730,7 +1730,7 @@ export const ListProjectsLocationsInsightTypesInsightsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/insights" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/insights" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInsightTypesInsightsRequest>;
 
@@ -1773,7 +1773,7 @@ export const MarkAcceptedProjectsLocationsInsightTypesInsightsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markAccepted",
+      path: "v1beta1/{+name}:markAccepted",
       hasBody: true,
     }),
     svc,
@@ -1808,7 +1808,7 @@ export const GetProjectsLocationsInsightTypesInsightsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInsightTypesInsightsRequest>;
 
@@ -1932,7 +1932,7 @@ export const ListFoldersLocationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsRequest>;
 
@@ -1977,7 +1977,7 @@ export const ListFoldersLocationsInsightTypesInsightsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/insights" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/insights" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsInsightTypesInsightsRequest>;
 
@@ -2020,7 +2020,7 @@ export const MarkAcceptedFoldersLocationsInsightTypesInsightsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markAccepted",
+      path: "v1beta1/{+name}:markAccepted",
       hasBody: true,
     }),
     svc,
@@ -2055,7 +2055,7 @@ export const GetFoldersLocationsInsightTypesInsightsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsInsightTypesInsightsRequest>;
 
@@ -2087,7 +2087,7 @@ export const GetFoldersLocationsRecommendersRecommendationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsRecommendersRecommendationsRequest>;
 
@@ -2126,7 +2126,7 @@ export const MarkSucceededFoldersLocationsRecommendersRecommendationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markSucceeded",
+      path: "v1beta1/{+name}:markSucceeded",
       hasBody: true,
     }),
     svc,
@@ -2168,7 +2168,7 @@ export const MarkFailedFoldersLocationsRecommendersRecommendationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markFailed",
+      path: "v1beta1/{+name}:markFailed",
       hasBody: true,
     }),
     svc,
@@ -2210,7 +2210,7 @@ export const MarkClaimedFoldersLocationsRecommendersRecommendationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markClaimed",
+      path: "v1beta1/{+name}:markClaimed",
       hasBody: true,
     }),
     svc,
@@ -2252,7 +2252,7 @@ export const MarkDismissedFoldersLocationsRecommendersRecommendationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markDismissed",
+      path: "v1beta1/{+name}:markDismissed",
       hasBody: true,
     }),
     svc,
@@ -2296,7 +2296,7 @@ export const ListFoldersLocationsRecommendersRecommendationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/recommendations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/recommendations" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersLocationsRecommendersRecommendationsRequest>;
 
@@ -2347,7 +2347,7 @@ export const ListBillingAccountsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsLocationsRequest>;
 
@@ -2383,7 +2383,7 @@ export const GetConfigBillingAccountsLocationsRecommendersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigBillingAccountsLocationsRecommendersRequest>;
 
@@ -2428,7 +2428,7 @@ export const UpdateConfigBillingAccountsLocationsRecommendersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigBillingAccountsLocationsRecommendersRequest>;
 
@@ -2461,7 +2461,7 @@ export const GetBillingAccountsLocationsRecommendersRecommendationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsLocationsRecommendersRecommendationsRequest>;
 
@@ -2501,7 +2501,7 @@ export const MarkSucceededBillingAccountsLocationsRecommendersRecommendationsReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markSucceeded",
+      path: "v1beta1/{+name}:markSucceeded",
       hasBody: true,
     }),
     svc,
@@ -2545,7 +2545,7 @@ export const MarkFailedBillingAccountsLocationsRecommendersRecommendationsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markFailed",
+      path: "v1beta1/{+name}:markFailed",
       hasBody: true,
     }),
     svc,
@@ -2587,7 +2587,7 @@ export const MarkClaimedBillingAccountsLocationsRecommendersRecommendationsReque
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markClaimed",
+      path: "v1beta1/{+name}:markClaimed",
       hasBody: true,
     }),
     svc,
@@ -2630,7 +2630,7 @@ export const MarkDismissedBillingAccountsLocationsRecommendersRecommendationsReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markDismissed",
+      path: "v1beta1/{+name}:markDismissed",
       hasBody: true,
     }),
     svc,
@@ -2676,7 +2676,7 @@ export const ListBillingAccountsLocationsRecommendersRecommendationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/recommendations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/recommendations" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsLocationsRecommendersRecommendationsRequest>;
 
@@ -2713,7 +2713,7 @@ export const GetConfigBillingAccountsLocationsInsightTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetConfigBillingAccountsLocationsInsightTypesRequest>;
 
@@ -2758,7 +2758,7 @@ export const UpdateConfigBillingAccountsLocationsInsightTypesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateConfigBillingAccountsLocationsInsightTypesRequest>;
 
@@ -2791,7 +2791,7 @@ export const GetBillingAccountsLocationsInsightTypesInsightsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBillingAccountsLocationsInsightTypesInsightsRequest>;
 
@@ -2833,7 +2833,7 @@ export const ListBillingAccountsLocationsInsightTypesInsightsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/insights" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/insights" }),
     svc,
   ) as unknown as Schema.Schema<ListBillingAccountsLocationsInsightTypesInsightsRequest>;
 
@@ -2877,7 +2877,7 @@ export const MarkAcceptedBillingAccountsLocationsInsightTypesInsightsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:markAccepted",
+      path: "v1beta1/{+name}:markAccepted",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/redis-v1.ts
+++ b/packages/gcp/src/services/redis-v1.ts
@@ -2786,7 +2786,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2821,7 +2821,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2852,7 +2852,7 @@ export const GetSharedRegionalCertificateAuthorityProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSharedRegionalCertificateAuthorityProjectsLocationsRequest>;
 
@@ -2899,7 +2899,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2934,7 +2934,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2965,7 +2965,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2996,7 +2996,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -3033,7 +3033,7 @@ export const ListProjectsLocationsClustersRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/clusters" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/clusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersRequest>;
 
@@ -3068,7 +3068,7 @@ export const GetProjectsLocationsClustersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersRequest>;
 
@@ -3108,7 +3108,7 @@ export const PatchProjectsLocationsClustersRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Cluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsClustersRequest>;
 
@@ -3142,7 +3142,7 @@ export const DeleteProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersRequest>;
 
@@ -3182,7 +3182,7 @@ export const CreateProjectsLocationsClustersRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Cluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/clusters", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/clusters", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsClustersRequest>;
 
@@ -3213,7 +3213,7 @@ export const GetCertificateAuthorityProjectsLocationsClustersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCertificateAuthorityProjectsLocationsClustersRequest>;
 
@@ -3253,7 +3253,7 @@ export const RescheduleClusterMaintenanceProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:rescheduleClusterMaintenance",
+      path: "v1/{+name}:rescheduleClusterMaintenance",
       hasBody: true,
     }),
     svc,
@@ -3291,7 +3291,7 @@ export const BackupProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(BackupClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:backup", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:backup", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<BackupProjectsLocationsClustersRequest>;
 
@@ -3327,7 +3327,7 @@ export const AddTokenAuthUserProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{cluster}:addTokenAuthUser",
+      path: "v1/{+cluster}:addTokenAuthUser",
       hasBody: true,
     }),
     svc,
@@ -3372,7 +3372,7 @@ export const ListProjectsLocationsClustersTokenAuthUsersRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/tokenAuthUsers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/tokenAuthUsers" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersTokenAuthUsersRequest>;
 
@@ -3408,7 +3408,7 @@ export const GetProjectsLocationsClustersTokenAuthUsersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersTokenAuthUsersRequest>;
 
@@ -3445,7 +3445,7 @@ export const DeleteProjectsLocationsClustersTokenAuthUsersRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersTokenAuthUsersRequest>;
 
@@ -3481,7 +3481,7 @@ export const AddAuthTokenProjectsLocationsClustersTokenAuthUsersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{tokenAuthUser}:addAuthToken",
+      path: "v1/{+tokenAuthUser}:addAuthToken",
       hasBody: true,
     }),
     svc,
@@ -3528,7 +3528,7 @@ export const ListProjectsLocationsClustersTokenAuthUsersAuthTokensRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/authTokens" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/authTokens" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersTokenAuthUsersAuthTokensRequest>;
 
@@ -3565,7 +3565,7 @@ export const GetProjectsLocationsClustersTokenAuthUsersAuthTokensRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersTokenAuthUsersAuthTokensRequest>;
 
@@ -3598,7 +3598,7 @@ export const DeleteProjectsLocationsClustersTokenAuthUsersAuthTokensRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersTokenAuthUsersAuthTokensRequest>;
 
@@ -3637,7 +3637,7 @@ export const ListProjectsLocationsAclPoliciesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/aclPolicies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/aclPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAclPoliciesRequest>;
 
@@ -3672,7 +3672,7 @@ export const GetProjectsLocationsAclPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAclPoliciesRequest>;
 
@@ -3712,7 +3712,7 @@ export const PatchProjectsLocationsAclPoliciesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(AclPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAclPoliciesRequest>;
 
@@ -3749,7 +3749,7 @@ export const DeleteProjectsLocationsAclPoliciesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAclPoliciesRequest>;
 
@@ -3791,7 +3791,7 @@ export const CreateProjectsLocationsAclPoliciesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(AclPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/aclPolicies", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/aclPolicies", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsAclPoliciesRequest>;
 
@@ -3828,7 +3828,7 @@ export const ListProjectsLocationsBackupCollectionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backupCollections" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backupCollections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupCollectionsRequest>;
 
@@ -3864,7 +3864,7 @@ export const GetProjectsLocationsBackupCollectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupCollectionsRequest>;
 
@@ -3901,7 +3901,7 @@ export const ListProjectsLocationsBackupCollectionsBackupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupCollectionsBackupsRequest>;
 
@@ -3937,7 +3937,7 @@ export const GetProjectsLocationsBackupCollectionsBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupCollectionsBackupsRequest>;
 
@@ -3971,7 +3971,7 @@ export const DeleteProjectsLocationsBackupCollectionsBackupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupCollectionsBackupsRequest>;
 
@@ -4006,7 +4006,7 @@ export const ExportProjectsLocationsBackupCollectionsBackupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportBackupRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsBackupCollectionsBackupsRequest>;
 
@@ -4044,7 +4044,7 @@ export const ListProjectsLocationsInstancesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesRequest>;
 
@@ -4079,7 +4079,7 @@ export const GetProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesRequest>;
 
@@ -4110,7 +4110,7 @@ export const GetAuthStringProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/authString" }),
+    T.Http({ method: "GET", path: "v1/{+name}/authString" }),
     svc,
   ) as unknown as Schema.Schema<GetAuthStringProjectsLocationsInstancesRequest>;
 
@@ -4148,7 +4148,7 @@ export const CreateProjectsLocationsInstancesRequest =
     instanceId: Schema.optional(Schema.String).pipe(T.HttpQuery("instanceId")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/instances", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/instances", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsInstancesRequest>;
 
@@ -4185,7 +4185,7 @@ export const PatchProjectsLocationsInstancesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInstancesRequest>;
 
@@ -4219,7 +4219,7 @@ export const UpgradeProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpgradeInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:upgrade", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:upgrade", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpgradeProjectsLocationsInstancesRequest>;
 
@@ -4253,7 +4253,7 @@ export const ImportProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ImportInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:import", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:import", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsLocationsInstancesRequest>;
 
@@ -4287,7 +4287,7 @@ export const ExportProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsInstancesRequest>;
 
@@ -4321,7 +4321,7 @@ export const FailoverProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(FailoverInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:failover", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:failover", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<FailoverProjectsLocationsInstancesRequest>;
 
@@ -4352,7 +4352,7 @@ export const DeleteProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesRequest>;
 
@@ -4388,7 +4388,7 @@ export const RescheduleMaintenanceProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:rescheduleMaintenance",
+      path: "v1/{+name}:rescheduleMaintenance",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/redis-v1beta1.ts
+++ b/packages/gcp/src/services/redis-v1beta1.ts
@@ -2786,7 +2786,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2821,7 +2821,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2852,7 +2852,7 @@ export const GetSharedRegionalCertificateAuthorityProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSharedRegionalCertificateAuthorityProjectsLocationsRequest>;
 
@@ -2899,7 +2899,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2934,7 +2934,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2965,7 +2965,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2996,7 +2996,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -3033,7 +3033,7 @@ export const ListProjectsLocationsClustersRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/clusters" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/clusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersRequest>;
 
@@ -3068,7 +3068,7 @@ export const GetProjectsLocationsClustersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersRequest>;
 
@@ -3108,7 +3108,7 @@ export const PatchProjectsLocationsClustersRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Cluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsClustersRequest>;
 
@@ -3142,7 +3142,7 @@ export const DeleteProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersRequest>;
 
@@ -3184,7 +3184,7 @@ export const CreateProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/clusters",
+      path: "v1beta1/{+parent}/clusters",
       hasBody: true,
     }),
     svc,
@@ -3217,7 +3217,7 @@ export const GetCertificateAuthorityProjectsLocationsClustersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCertificateAuthorityProjectsLocationsClustersRequest>;
 
@@ -3257,7 +3257,7 @@ export const RescheduleClusterMaintenanceProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:rescheduleClusterMaintenance",
+      path: "v1beta1/{+name}:rescheduleClusterMaintenance",
       hasBody: true,
     }),
     svc,
@@ -3295,7 +3295,7 @@ export const BackupProjectsLocationsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(BackupClusterRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:backup", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:backup", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<BackupProjectsLocationsClustersRequest>;
 
@@ -3331,7 +3331,7 @@ export const AddTokenAuthUserProjectsLocationsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{cluster}:addTokenAuthUser",
+      path: "v1beta1/{+cluster}:addTokenAuthUser",
       hasBody: true,
     }),
     svc,
@@ -3376,7 +3376,7 @@ export const ListProjectsLocationsClustersTokenAuthUsersRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/tokenAuthUsers" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/tokenAuthUsers" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersTokenAuthUsersRequest>;
 
@@ -3412,7 +3412,7 @@ export const GetProjectsLocationsClustersTokenAuthUsersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersTokenAuthUsersRequest>;
 
@@ -3449,7 +3449,7 @@ export const DeleteProjectsLocationsClustersTokenAuthUsersRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersTokenAuthUsersRequest>;
 
@@ -3485,7 +3485,7 @@ export const AddAuthTokenProjectsLocationsClustersTokenAuthUsersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{tokenAuthUser}:addAuthToken",
+      path: "v1beta1/{+tokenAuthUser}:addAuthToken",
       hasBody: true,
     }),
     svc,
@@ -3532,7 +3532,7 @@ export const ListProjectsLocationsClustersTokenAuthUsersAuthTokensRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/authTokens" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/authTokens" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsClustersTokenAuthUsersAuthTokensRequest>;
 
@@ -3569,7 +3569,7 @@ export const GetProjectsLocationsClustersTokenAuthUsersAuthTokensRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsClustersTokenAuthUsersAuthTokensRequest>;
 
@@ -3602,7 +3602,7 @@ export const DeleteProjectsLocationsClustersTokenAuthUsersAuthTokensRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsClustersTokenAuthUsersAuthTokensRequest>;
 
@@ -3641,7 +3641,7 @@ export const ListProjectsLocationsAclPoliciesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/aclPolicies" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/aclPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAclPoliciesRequest>;
 
@@ -3676,7 +3676,7 @@ export const GetProjectsLocationsAclPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAclPoliciesRequest>;
 
@@ -3716,7 +3716,7 @@ export const PatchProjectsLocationsAclPoliciesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(AclPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsAclPoliciesRequest>;
 
@@ -3753,7 +3753,7 @@ export const DeleteProjectsLocationsAclPoliciesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAclPoliciesRequest>;
 
@@ -3797,7 +3797,7 @@ export const CreateProjectsLocationsAclPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/aclPolicies",
+      path: "v1beta1/{+parent}/aclPolicies",
       hasBody: true,
     }),
     svc,
@@ -3836,7 +3836,7 @@ export const ListProjectsLocationsBackupCollectionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/backupCollections" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/backupCollections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupCollectionsRequest>;
 
@@ -3872,7 +3872,7 @@ export const GetProjectsLocationsBackupCollectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupCollectionsRequest>;
 
@@ -3909,7 +3909,7 @@ export const ListProjectsLocationsBackupCollectionsBackupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsBackupCollectionsBackupsRequest>;
 
@@ -3945,7 +3945,7 @@ export const GetProjectsLocationsBackupCollectionsBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsBackupCollectionsBackupsRequest>;
 
@@ -3979,7 +3979,7 @@ export const DeleteProjectsLocationsBackupCollectionsBackupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsBackupCollectionsBackupsRequest>;
 
@@ -4014,7 +4014,7 @@ export const ExportProjectsLocationsBackupCollectionsBackupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportBackupRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsBackupCollectionsBackupsRequest>;
 
@@ -4052,7 +4052,7 @@ export const ListProjectsLocationsInstancesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesRequest>;
 
@@ -4087,7 +4087,7 @@ export const GetProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesRequest>;
 
@@ -4118,7 +4118,7 @@ export const GetAuthStringProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/authString" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/authString" }),
     svc,
   ) as unknown as Schema.Schema<GetAuthStringProjectsLocationsInstancesRequest>;
 
@@ -4158,7 +4158,7 @@ export const CreateProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/instances",
+      path: "v1beta1/{+parent}/instances",
       hasBody: true,
     }),
     svc,
@@ -4197,7 +4197,7 @@ export const PatchProjectsLocationsInstancesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInstancesRequest>;
 
@@ -4231,7 +4231,7 @@ export const UpgradeProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpgradeInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:upgrade", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:upgrade", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpgradeProjectsLocationsInstancesRequest>;
 
@@ -4265,7 +4265,7 @@ export const ImportProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ImportInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:import", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:import", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportProjectsLocationsInstancesRequest>;
 
@@ -4299,7 +4299,7 @@ export const ExportProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ExportInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:export", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:export", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectsLocationsInstancesRequest>;
 
@@ -4333,7 +4333,7 @@ export const FailoverProjectsLocationsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(FailoverInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:failover", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:failover", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<FailoverProjectsLocationsInstancesRequest>;
 
@@ -4364,7 +4364,7 @@ export const DeleteProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesRequest>;
 
@@ -4400,7 +4400,7 @@ export const RescheduleMaintenanceProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{name}:rescheduleMaintenance",
+      path: "v1beta1/{+name}:rescheduleMaintenance",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/retail-v2.ts
+++ b/packages/gcp/src/services/retail-v2.ts
@@ -4837,7 +4837,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -4873,7 +4873,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -4912,7 +4912,7 @@ export const UpdateAttributesConfigProjectsLocationsCatalogsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAttributesConfigProjectsLocationsCatalogsRequest>;
 
@@ -4947,7 +4947,7 @@ export const GetConversationalSearchCustomizationConfigProjectsLocationsCatalogs
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2/{name}/conversationalSearchCustomizationConfig",
+      path: "v2/{+name}/conversationalSearchCustomizationConfig",
     }),
     svc,
   ) as unknown as Schema.Schema<GetConversationalSearchCustomizationConfigProjectsLocationsCatalogsRequest>;
@@ -4983,7 +4983,7 @@ export const GetCompletionConfigProjectsLocationsCatalogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCompletionConfigProjectsLocationsCatalogsRequest>;
 
@@ -5023,7 +5023,7 @@ export const UpdateCompletionConfigProjectsLocationsCatalogsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateCompletionConfigProjectsLocationsCatalogsRequest>;
 
@@ -5066,7 +5066,7 @@ export const UpdateGenerativeQuestionProjectsLocationsCatalogsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2/{catalog}/generativeQuestion",
+      path: "v2/{+catalog}/generativeQuestion",
       hasBody: true,
     }),
     svc,
@@ -5131,7 +5131,7 @@ export const CompleteQueryProjectsLocationsCatalogsRequest =
     ),
     catalog: Schema.String.pipe(T.HttpPath("catalog")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{catalog}:completeQuery" }),
+    T.Http({ method: "GET", path: "v2/{+catalog}:completeQuery" }),
     svc,
   ) as unknown as Schema.Schema<CompleteQueryProjectsLocationsCatalogsRequest>;
 
@@ -5173,7 +5173,7 @@ export const UpdateGenerativeQuestionFeatureProjectsLocationsCatalogsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2/{catalog}/generativeQuestionFeature",
+      path: "v2/{+catalog}/generativeQuestionFeature",
       hasBody: true,
     }),
     svc,
@@ -5208,7 +5208,7 @@ export const GetGenerativeQuestionFeatureProjectsLocationsCatalogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     catalog: Schema.String.pipe(T.HttpPath("catalog")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{catalog}/generativeQuestionFeature" }),
+    T.Http({ method: "GET", path: "v2/{+catalog}/generativeQuestionFeature" }),
     svc,
   ) as unknown as Schema.Schema<GetGenerativeQuestionFeatureProjectsLocationsCatalogsRequest>;
 
@@ -5248,7 +5248,7 @@ export const ExportAnalyticsMetricsProjectsLocationsCatalogsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{catalog}:exportAnalyticsMetrics",
+      path: "v2/{+catalog}:exportAnalyticsMetrics",
       hasBody: true,
     }),
     svc,
@@ -5289,7 +5289,7 @@ export const ListProjectsLocationsCatalogsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/catalogs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/catalogs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsRequest>;
 
@@ -5332,7 +5332,7 @@ export const SetDefaultBranchProjectsLocationsCatalogsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{catalog}:setDefaultBranch",
+      path: "v2/{+catalog}:setDefaultBranch",
       hasBody: true,
     }),
     svc,
@@ -5366,7 +5366,7 @@ export const GetDefaultBranchProjectsLocationsCatalogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     catalog: Schema.String.pipe(T.HttpPath("catalog")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{catalog}:getDefaultBranch" }),
+    T.Http({ method: "GET", path: "v2/{+catalog}:getDefaultBranch" }),
     svc,
   ) as unknown as Schema.Schema<GetDefaultBranchProjectsLocationsCatalogsRequest>;
 
@@ -5404,7 +5404,7 @@ export const PatchProjectsLocationsCatalogsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudRetailV2Catalog).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsRequest>;
 
@@ -5445,7 +5445,7 @@ export const UpdateConversationalSearchCustomizationConfigProjectsLocationsCatal
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2/{catalog}/conversationalSearchCustomizationConfig",
+      path: "v2/{+catalog}/conversationalSearchCustomizationConfig",
       hasBody: true,
     }),
     svc,
@@ -5482,7 +5482,7 @@ export const GetAttributesConfigProjectsLocationsCatalogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAttributesConfigProjectsLocationsCatalogsRequest>;
 
@@ -5520,7 +5520,7 @@ export const CreateProjectsLocationsCatalogsModelsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudRetailV2Model).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/models", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/models", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCatalogsModelsRequest>;
 
@@ -5558,7 +5558,7 @@ export const PatchProjectsLocationsCatalogsModelsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudRetailV2Model).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsModelsRequest>;
 
@@ -5590,7 +5590,7 @@ export const GetProjectsLocationsCatalogsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsModelsRequest>;
 
@@ -5628,7 +5628,7 @@ export const ListProjectsLocationsCatalogsModelsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/models" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/models" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsModelsRequest>;
 
@@ -5669,7 +5669,7 @@ export const PauseProjectsLocationsCatalogsModelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsLocationsCatalogsModelsRequest>;
 
@@ -5706,7 +5706,7 @@ export const TuneProjectsLocationsCatalogsModelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:tune", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:tune", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TuneProjectsLocationsCatalogsModelsRequest>;
 
@@ -5743,7 +5743,7 @@ export const ResumeProjectsLocationsCatalogsModelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsCatalogsModelsRequest>;
 
@@ -5775,7 +5775,7 @@ export const DeleteProjectsLocationsCatalogsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCatalogsModelsRequest>;
 
@@ -5806,7 +5806,7 @@ export const DeleteProjectsLocationsCatalogsControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCatalogsControlsRequest>;
 
@@ -5838,7 +5838,7 @@ export const GetProjectsLocationsCatalogsControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsControlsRequest>;
 
@@ -5879,7 +5879,7 @@ export const ListProjectsLocationsCatalogsControlsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/controls" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/controls" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsControlsRequest>;
 
@@ -5921,7 +5921,7 @@ export const CreateProjectsLocationsCatalogsControlsRequest =
     controlId: Schema.optional(Schema.String).pipe(T.HttpQuery("controlId")),
     body: Schema.optional(GoogleCloudRetailV2Control).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/controls", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/controls", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCatalogsControlsRequest>;
 
@@ -5959,7 +5959,7 @@ export const PatchProjectsLocationsCatalogsControlsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudRetailV2Control).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsControlsRequest>;
 
@@ -5998,7 +5998,7 @@ export const BatchUpdateProjectsLocationsCatalogsGenerativeQuestionRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/generativeQuestion:batchUpdate",
+      path: "v2/{+parent}/generativeQuestion:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -6036,7 +6036,7 @@ export const SearchProjectsLocationsCatalogsPlacementsRequest =
     placement: Schema.String.pipe(T.HttpPath("placement")),
     body: Schema.optional(GoogleCloudRetailV2SearchRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{placement}:search", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+placement}:search", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsLocationsCatalogsPlacementsRequest>;
 
@@ -6071,7 +6071,7 @@ export const PredictProjectsLocationsCatalogsPlacementsRequest =
     placement: Schema.String.pipe(T.HttpPath("placement")),
     body: Schema.optional(GoogleCloudRetailV2PredictRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{placement}:predict", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+placement}:predict", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PredictProjectsLocationsCatalogsPlacementsRequest>;
 
@@ -6110,7 +6110,7 @@ export const ConversationalSearchProjectsLocationsCatalogsPlacementsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{placement}:conversationalSearch",
+      path: "v2/{+placement}:conversationalSearch",
       hasBody: true,
     }),
     svc,
@@ -6159,7 +6159,7 @@ export const ListProjectsLocationsCatalogsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsOperationsRequest>;
 
@@ -6195,7 +6195,7 @@ export const GetProjectsLocationsCatalogsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsOperationsRequest>;
 
@@ -6230,7 +6230,7 @@ export const SearchProjectsLocationsCatalogsServingConfigsRequest =
     placement: Schema.String.pipe(T.HttpPath("placement")),
     body: Schema.optional(GoogleCloudRetailV2SearchRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{placement}:search", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+placement}:search", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsLocationsCatalogsServingConfigsRequest>;
 
@@ -6269,7 +6269,7 @@ export const RemoveControlProjectsLocationsCatalogsServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{servingConfig}:removeControl",
+      path: "v2/{+servingConfig}:removeControl",
       hasBody: true,
     }),
     svc,
@@ -6304,7 +6304,7 @@ export const GetProjectsLocationsCatalogsServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsServingConfigsRequest>;
 
@@ -6343,7 +6343,7 @@ export const AddControlProjectsLocationsCatalogsServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{servingConfig}:addControl",
+      path: "v2/{+servingConfig}:addControl",
       hasBody: true,
     }),
     svc,
@@ -6378,7 +6378,7 @@ export const DeleteProjectsLocationsCatalogsServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCatalogsServingConfigsRequest>;
 
@@ -6420,7 +6420,7 @@ export const CreateProjectsLocationsCatalogsServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/servingConfigs",
+      path: "v2/{+parent}/servingConfigs",
       hasBody: true,
     }),
     svc,
@@ -6460,7 +6460,7 @@ export const PatchProjectsLocationsCatalogsServingConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudRetailV2ServingConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsServingConfigsRequest>;
 
@@ -6499,7 +6499,7 @@ export const ConversationalSearchProjectsLocationsCatalogsServingConfigsRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{placement}:conversationalSearch",
+      path: "v2/{+placement}:conversationalSearch",
       hasBody: true,
     }),
     svc,
@@ -6540,7 +6540,7 @@ export const ListProjectsLocationsCatalogsServingConfigsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/servingConfigs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/servingConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsServingConfigsRequest>;
 
@@ -6579,7 +6579,7 @@ export const PredictProjectsLocationsCatalogsServingConfigsRequest =
     placement: Schema.String.pipe(T.HttpPath("placement")),
     body: Schema.optional(GoogleCloudRetailV2PredictRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{placement}:predict", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+placement}:predict", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PredictProjectsLocationsCatalogsServingConfigsRequest>;
 
@@ -6618,7 +6618,7 @@ export const AddFulfillmentPlacesProjectsLocationsCatalogsBranchesProductsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{product}:addFulfillmentPlaces",
+      path: "v2/{+product}:addFulfillmentPlaces",
       hasBody: true,
     }),
     svc,
@@ -6653,7 +6653,7 @@ export const GetProjectsLocationsCatalogsBranchesProductsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsBranchesProductsRequest>;
 
@@ -6692,7 +6692,7 @@ export const RemoveLocalInventoriesProjectsLocationsCatalogsBranchesProductsRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{product}:removeLocalInventories",
+      path: "v2/{+product}:removeLocalInventories",
       hasBody: true,
     }),
     svc,
@@ -6728,7 +6728,7 @@ export const DeleteProjectsLocationsCatalogsBranchesProductsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCatalogsBranchesProductsRequest>;
 
@@ -6768,7 +6768,7 @@ export const RemoveFulfillmentPlacesProjectsLocationsCatalogsBranchesProductsReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{product}:removeFulfillmentPlaces",
+      path: "v2/{+product}:removeFulfillmentPlaces",
       hasBody: true,
     }),
     svc,
@@ -6812,7 +6812,7 @@ export const PurgeProjectsLocationsCatalogsBranchesProductsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/products:purge",
+      path: "v2/{+parent}/products:purge",
       hasBody: true,
     }),
     svc,
@@ -6853,7 +6853,7 @@ export const ImportProjectsLocationsCatalogsBranchesProductsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/products:import",
+      path: "v2/{+parent}/products:import",
       hasBody: true,
     }),
     svc,
@@ -6894,7 +6894,7 @@ export const CreateProjectsLocationsCatalogsBranchesProductsRequest =
     productId: Schema.optional(Schema.String).pipe(T.HttpQuery("productId")),
     body: Schema.optional(GoogleCloudRetailV2Product).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/products", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/products", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCatalogsBranchesProductsRequest>;
 
@@ -6938,7 +6938,7 @@ export const PatchProjectsLocationsCatalogsBranchesProductsRequest =
     ),
     body: Schema.optional(GoogleCloudRetailV2Product).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsBranchesProductsRequest>;
 
@@ -6982,7 +6982,7 @@ export const ListProjectsLocationsCatalogsBranchesProductsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/products" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/products" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsBranchesProductsRequest>;
 
@@ -7023,7 +7023,7 @@ export const SetInventoryProjectsLocationsCatalogsBranchesProductsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:setInventory", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:setInventory", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetInventoryProjectsLocationsCatalogsBranchesProductsRequest>;
 
@@ -7063,7 +7063,7 @@ export const AddLocalInventoriesProjectsLocationsCatalogsBranchesProductsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{product}:addLocalInventories",
+      path: "v2/{+product}:addLocalInventories",
       hasBody: true,
     }),
     svc,
@@ -7098,7 +7098,7 @@ export const GetProjectsLocationsCatalogsBranchesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsBranchesOperationsRequest>;
 
@@ -7137,7 +7137,7 @@ export const AddCatalogAttributeProjectsLocationsCatalogsAttributesConfigRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{attributesConfig}:addCatalogAttribute",
+      path: "v2/{+attributesConfig}:addCatalogAttribute",
       hasBody: true,
     }),
     svc,
@@ -7179,7 +7179,7 @@ export const RemoveCatalogAttributeProjectsLocationsCatalogsAttributesConfigRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{attributesConfig}:removeCatalogAttribute",
+      path: "v2/{+attributesConfig}:removeCatalogAttribute",
       hasBody: true,
     }),
     svc,
@@ -7222,7 +7222,7 @@ export const ReplaceCatalogAttributeProjectsLocationsCatalogsAttributesConfigReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{attributesConfig}:replaceCatalogAttribute",
+      path: "v2/{+attributesConfig}:replaceCatalogAttribute",
       hasBody: true,
     }),
     svc,
@@ -7266,7 +7266,7 @@ export const ImportProjectsLocationsCatalogsCompletionDataRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/completionData:import",
+      path: "v2/{+parent}/completionData:import",
       hasBody: true,
     }),
     svc,
@@ -7300,7 +7300,7 @@ export const ListProjectsLocationsCatalogsGenerativeQuestionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/generativeQuestions" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/generativeQuestions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsGenerativeQuestionsRequest>;
 
@@ -7341,7 +7341,7 @@ export const WriteProjectsLocationsCatalogsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/userEvents:write",
+      path: "v2/{+parent}/userEvents:write",
       hasBody: true,
     }),
     svc,
@@ -7382,7 +7382,7 @@ export const PurgeProjectsLocationsCatalogsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/userEvents:purge",
+      path: "v2/{+parent}/userEvents:purge",
       hasBody: true,
     }),
     svc,
@@ -7423,7 +7423,7 @@ export const CollectProjectsLocationsCatalogsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/userEvents:collect",
+      path: "v2/{+parent}/userEvents:collect",
       hasBody: true,
     }),
     svc,
@@ -7464,7 +7464,7 @@ export const ImportProjectsLocationsCatalogsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/userEvents:import",
+      path: "v2/{+parent}/userEvents:import",
       hasBody: true,
     }),
     svc,
@@ -7505,7 +7505,7 @@ export const RejoinProjectsLocationsCatalogsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/userEvents:rejoin",
+      path: "v2/{+parent}/userEvents:rejoin",
       hasBody: true,
     }),
     svc,
@@ -7553,7 +7553,7 @@ export const ListProjectsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsOperationsRequest>;
 
@@ -7589,7 +7589,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 

--- a/packages/gcp/src/services/retail-v2alpha.ts
+++ b/packages/gcp/src/services/retail-v2alpha.ts
@@ -5329,7 +5329,7 @@ export const UpdateAlertConfigProjectsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAlertConfigProjectsRequest>;
 
@@ -5369,7 +5369,7 @@ export const UpdateLoggingConfigProjectsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateLoggingConfigProjectsRequest>;
 
@@ -5401,7 +5401,7 @@ export const GetLoggingConfigProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLoggingConfigProjectsRequest>;
 
@@ -5440,7 +5440,7 @@ export const EnrollSolutionProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{project}:enrollSolution",
+      path: "v2alpha/{+project}:enrollSolution",
       hasBody: true,
     }),
     svc,
@@ -5473,7 +5473,7 @@ export const ListEnrolledSolutionsProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{parent}:enrolledSolutions" }),
+    T.Http({ method: "GET", path: "v2alpha/{+parent}:enrolledSolutions" }),
     svc,
   ) as unknown as Schema.Schema<ListEnrolledSolutionsProjectsRequest>;
 
@@ -5505,7 +5505,7 @@ export const GetAlertConfigProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAlertConfigProjectsRequest>;
 
@@ -5537,7 +5537,7 @@ export const GetRetailProjectProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetRetailProjectProjectsRequest>;
 
@@ -5575,7 +5575,7 @@ export const AcceptTermsProjectsRetailProjectRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{project}:acceptTerms",
+      path: "v2alpha/{+project}:acceptTerms",
       hasBody: true,
     }),
     svc,
@@ -5623,7 +5623,7 @@ export const ListProjectsOperationsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsOperationsRequest>;
 
@@ -5659,7 +5659,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 
@@ -5704,7 +5704,7 @@ export const ListProjectsLocationsOperationsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -5740,7 +5740,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -5778,7 +5778,7 @@ export const ExportAnalyticsMetricsProjectsLocationsCatalogsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{catalog}:exportAnalyticsMetrics",
+      path: "v2alpha/{+catalog}:exportAnalyticsMetrics",
       hasBody: true,
     }),
     svc,
@@ -5813,7 +5813,7 @@ export const GetDefaultBranchProjectsLocationsCatalogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     catalog: Schema.String.pipe(T.HttpPath("catalog")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{catalog}:getDefaultBranch" }),
+    T.Http({ method: "GET", path: "v2alpha/{+catalog}:getDefaultBranch" }),
     svc,
   ) as unknown as Schema.Schema<GetDefaultBranchProjectsLocationsCatalogsRequest>;
 
@@ -5855,7 +5855,7 @@ export const UpdateGenerativeQuestionProjectsLocationsCatalogsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2alpha/{catalog}/generativeQuestion",
+      path: "v2alpha/{+catalog}/generativeQuestion",
       hasBody: true,
     }),
     svc,
@@ -5892,7 +5892,7 @@ export const GetConversationalSearchCustomizationConfigProjectsLocationsCatalogs
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2alpha/{name}/conversationalSearchCustomizationConfig",
+      path: "v2alpha/{+name}/conversationalSearchCustomizationConfig",
     }),
     svc,
   ) as unknown as Schema.Schema<GetConversationalSearchCustomizationConfigProjectsLocationsCatalogsRequest>;
@@ -5930,7 +5930,7 @@ export const GetGenerativeQuestionFeatureProjectsLocationsCatalogsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2alpha/{catalog}/generativeQuestionFeature",
+      path: "v2alpha/{+catalog}/generativeQuestionFeature",
     }),
     svc,
   ) as unknown as Schema.Schema<GetGenerativeQuestionFeatureProjectsLocationsCatalogsRequest>;
@@ -5974,7 +5974,7 @@ export const UpdateConversationalSearchCustomizationConfigProjectsLocationsCatal
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2alpha/{catalog}/conversationalSearchCustomizationConfig",
+      path: "v2alpha/{+catalog}/conversationalSearchCustomizationConfig",
       hasBody: true,
     }),
     svc,
@@ -6011,7 +6011,7 @@ export const GetAttributesConfigProjectsLocationsCatalogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAttributesConfigProjectsLocationsCatalogsRequest>;
 
@@ -6049,7 +6049,7 @@ export const ListProjectsLocationsCatalogsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{parent}/catalogs" }),
+    T.Http({ method: "GET", path: "v2alpha/{+parent}/catalogs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsRequest>;
 
@@ -6093,7 +6093,7 @@ export const UpdateCompletionConfigProjectsLocationsCatalogsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateCompletionConfigProjectsLocationsCatalogsRequest>;
 
@@ -6133,7 +6133,7 @@ export const SetDefaultBranchProjectsLocationsCatalogsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{catalog}:setDefaultBranch",
+      path: "v2alpha/{+catalog}:setDefaultBranch",
       hasBody: true,
     }),
     svc,
@@ -6175,7 +6175,7 @@ export const UpdateAttributesConfigProjectsLocationsCatalogsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAttributesConfigProjectsLocationsCatalogsRequest>;
 
@@ -6208,7 +6208,7 @@ export const GetCompletionConfigProjectsLocationsCatalogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCompletionConfigProjectsLocationsCatalogsRequest>;
 
@@ -6270,7 +6270,7 @@ export const CompleteQueryProjectsLocationsCatalogsRequest =
       T.HttpQuery("maxSuggestions"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{catalog}:completeQuery" }),
+    T.Http({ method: "GET", path: "v2alpha/{+catalog}:completeQuery" }),
     svc,
   ) as unknown as Schema.Schema<CompleteQueryProjectsLocationsCatalogsRequest>;
 
@@ -6312,7 +6312,7 @@ export const UpdateGenerativeQuestionFeatureProjectsLocationsCatalogsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2alpha/{catalog}/generativeQuestionFeature",
+      path: "v2alpha/{+catalog}/generativeQuestionFeature",
       hasBody: true,
     }),
     svc,
@@ -6353,7 +6353,7 @@ export const PatchProjectsLocationsCatalogsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudRetailV2alphaCatalog).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsRequest>;
 
@@ -6391,7 +6391,7 @@ export const PatchProjectsLocationsCatalogsControlsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudRetailV2alphaControl).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsControlsRequest>;
 
@@ -6423,7 +6423,7 @@ export const GetProjectsLocationsCatalogsControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsControlsRequest>;
 
@@ -6464,7 +6464,7 @@ export const ListProjectsLocationsCatalogsControlsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{parent}/controls" }),
+    T.Http({ method: "GET", path: "v2alpha/{+parent}/controls" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsControlsRequest>;
 
@@ -6508,7 +6508,7 @@ export const CreateProjectsLocationsCatalogsControlsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{parent}/controls",
+      path: "v2alpha/{+parent}/controls",
       hasBody: true,
     }),
     svc,
@@ -6542,7 +6542,7 @@ export const DeleteProjectsLocationsCatalogsControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCatalogsControlsRequest>;
 
@@ -6581,7 +6581,7 @@ export const PredictProjectsLocationsCatalogsPlacementsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{placement}:predict",
+      path: "v2alpha/{+placement}:predict",
       hasBody: true,
     }),
     svc,
@@ -6622,7 +6622,7 @@ export const SearchProjectsLocationsCatalogsPlacementsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{placement}:search",
+      path: "v2alpha/{+placement}:search",
       hasBody: true,
     }),
     svc,
@@ -6663,7 +6663,7 @@ export const ConversationalSearchProjectsLocationsCatalogsPlacementsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{placement}:conversationalSearch",
+      path: "v2alpha/{+placement}:conversationalSearch",
       hasBody: true,
     }),
     svc,
@@ -6705,7 +6705,7 @@ export const ImportProjectsLocationsCatalogsCompletionDataRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{parent}/completionData:import",
+      path: "v2alpha/{+parent}/completionData:import",
       hasBody: true,
     }),
     svc,
@@ -6746,7 +6746,7 @@ export const ExportProjectsLocationsCatalogsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{parent}/userEvents:export",
+      path: "v2alpha/{+parent}/userEvents:export",
       hasBody: true,
     }),
     svc,
@@ -6787,7 +6787,7 @@ export const RejoinProjectsLocationsCatalogsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{parent}/userEvents:rejoin",
+      path: "v2alpha/{+parent}/userEvents:rejoin",
       hasBody: true,
     }),
     svc,
@@ -6828,7 +6828,7 @@ export const PurgeProjectsLocationsCatalogsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{parent}/userEvents:purge",
+      path: "v2alpha/{+parent}/userEvents:purge",
       hasBody: true,
     }),
     svc,
@@ -6869,7 +6869,7 @@ export const ImportProjectsLocationsCatalogsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{parent}/userEvents:import",
+      path: "v2alpha/{+parent}/userEvents:import",
       hasBody: true,
     }),
     svc,
@@ -6911,7 +6911,7 @@ export const WriteProjectsLocationsCatalogsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{parent}/userEvents:write",
+      path: "v2alpha/{+parent}/userEvents:write",
       hasBody: true,
     }),
     svc,
@@ -6952,7 +6952,7 @@ export const CollectProjectsLocationsCatalogsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{parent}/userEvents:collect",
+      path: "v2alpha/{+parent}/userEvents:collect",
       hasBody: true,
     }),
     svc,
@@ -6988,7 +6988,7 @@ export const ListProjectsLocationsCatalogsMerchantCenterAccountLinksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2alpha/{parent}/merchantCenterAccountLinks",
+      path: "v2alpha/{+parent}/merchantCenterAccountLinks",
     }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsMerchantCenterAccountLinksRequest>;
@@ -7029,7 +7029,7 @@ export const CreateProjectsLocationsCatalogsMerchantCenterAccountLinksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{parent}/merchantCenterAccountLinks",
+      path: "v2alpha/{+parent}/merchantCenterAccountLinks",
       hasBody: true,
     }),
     svc,
@@ -7064,7 +7064,7 @@ export const DeleteProjectsLocationsCatalogsMerchantCenterAccountLinksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCatalogsMerchantCenterAccountLinksRequest>;
 
@@ -7104,7 +7104,7 @@ export const ListProjectsLocationsCatalogsBranchesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{parent}/branches" }),
+    T.Http({ method: "GET", path: "v2alpha/{+parent}/branches" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsBranchesRequest>;
 
@@ -7143,7 +7143,7 @@ export const GetProjectsLocationsCatalogsBranchesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsBranchesRequest>;
 
@@ -7175,7 +7175,7 @@ export const GetProjectsLocationsCatalogsBranchesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsBranchesOperationsRequest>;
 
@@ -7207,7 +7207,7 @@ export const GetProjectsLocationsCatalogsBranchesPlacesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsBranchesPlacesOperationsRequest>;
 
@@ -7247,7 +7247,7 @@ export const SetInventoryProjectsLocationsCatalogsBranchesProductsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{name}:setInventory",
+      path: "v2alpha/{+name}:setInventory",
       hasBody: true,
     }),
     svc,
@@ -7289,7 +7289,7 @@ export const PurgeProjectsLocationsCatalogsBranchesProductsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{parent}/products:purge",
+      path: "v2alpha/{+parent}/products:purge",
       hasBody: true,
     }),
     svc,
@@ -7330,7 +7330,7 @@ export const ExportProjectsLocationsCatalogsBranchesProductsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{parent}/products:export",
+      path: "v2alpha/{+parent}/products:export",
       hasBody: true,
     }),
     svc,
@@ -7376,7 +7376,7 @@ export const PatchProjectsLocationsCatalogsBranchesProductsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudRetailV2alphaProduct).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsBranchesProductsRequest>;
 
@@ -7411,7 +7411,7 @@ export const DeleteProjectsLocationsCatalogsBranchesProductsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCatalogsBranchesProductsRequest>;
 
@@ -7451,7 +7451,7 @@ export const AddFulfillmentPlacesProjectsLocationsCatalogsBranchesProductsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{product}:addFulfillmentPlaces",
+      path: "v2alpha/{+product}:addFulfillmentPlaces",
       hasBody: true,
     }),
     svc,
@@ -7486,7 +7486,7 @@ export const GetProjectsLocationsCatalogsBranchesProductsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsBranchesProductsRequest>;
 
@@ -7525,7 +7525,7 @@ export const ImportProjectsLocationsCatalogsBranchesProductsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{parent}/products:import",
+      path: "v2alpha/{+parent}/products:import",
       hasBody: true,
     }),
     svc,
@@ -7567,7 +7567,7 @@ export const RemoveFulfillmentPlacesProjectsLocationsCatalogsBranchesProductsReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{product}:removeFulfillmentPlaces",
+      path: "v2alpha/{+product}:removeFulfillmentPlaces",
       hasBody: true,
     }),
     svc,
@@ -7612,7 +7612,7 @@ export const CreateProjectsLocationsCatalogsBranchesProductsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{parent}/products",
+      path: "v2alpha/{+parent}/products",
       hasBody: true,
     }),
     svc,
@@ -7654,7 +7654,7 @@ export const RemoveLocalInventoriesProjectsLocationsCatalogsBranchesProductsRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{product}:removeLocalInventories",
+      path: "v2alpha/{+product}:removeLocalInventories",
       hasBody: true,
     }),
     svc,
@@ -7707,7 +7707,7 @@ export const ListProjectsLocationsCatalogsBranchesProductsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{parent}/products" }),
+    T.Http({ method: "GET", path: "v2alpha/{+parent}/products" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsBranchesProductsRequest>;
 
@@ -7750,7 +7750,7 @@ export const AddLocalInventoriesProjectsLocationsCatalogsBranchesProductsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{product}:addLocalInventories",
+      path: "v2alpha/{+product}:addLocalInventories",
       hasBody: true,
     }),
     svc,
@@ -7792,7 +7792,7 @@ export const BatchUpdateProjectsLocationsCatalogsGenerativeQuestionRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{parent}/generativeQuestion:batchUpdate",
+      path: "v2alpha/{+parent}/generativeQuestion:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -7832,7 +7832,7 @@ export const PauseProjectsLocationsCatalogsModelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2alpha/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v2alpha/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsLocationsCatalogsModelsRequest>;
 
@@ -7870,7 +7870,7 @@ export const ListProjectsLocationsCatalogsModelsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{parent}/models" }),
+    T.Http({ method: "GET", path: "v2alpha/{+parent}/models" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsModelsRequest>;
 
@@ -7911,7 +7911,7 @@ export const TuneProjectsLocationsCatalogsModelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2alpha/{name}:tune", hasBody: true }),
+    T.Http({ method: "POST", path: "v2alpha/{+name}:tune", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TuneProjectsLocationsCatalogsModelsRequest>;
 
@@ -7948,7 +7948,7 @@ export const ResumeProjectsLocationsCatalogsModelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2alpha/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v2alpha/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsCatalogsModelsRequest>;
 
@@ -7986,7 +7986,7 @@ export const CreateProjectsLocationsCatalogsModelsRequest =
     dryRun: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("dryRun")),
     body: Schema.optional(GoogleCloudRetailV2alphaModel).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2alpha/{parent}/models", hasBody: true }),
+    T.Http({ method: "POST", path: "v2alpha/{+parent}/models", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCatalogsModelsRequest>;
 
@@ -8018,7 +8018,7 @@ export const DeleteProjectsLocationsCatalogsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCatalogsModelsRequest>;
 
@@ -8049,7 +8049,7 @@ export const GetProjectsLocationsCatalogsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsModelsRequest>;
 
@@ -8087,7 +8087,7 @@ export const PatchProjectsLocationsCatalogsModelsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudRetailV2alphaModel).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsModelsRequest>;
 
@@ -8133,7 +8133,7 @@ export const ListProjectsLocationsCatalogsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsOperationsRequest>;
 
@@ -8169,7 +8169,7 @@ export const GetProjectsLocationsCatalogsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsOperationsRequest>;
 
@@ -8207,7 +8207,7 @@ export const ListProjectsLocationsCatalogsServingConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{parent}/servingConfigs" }),
+    T.Http({ method: "GET", path: "v2alpha/{+parent}/servingConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsServingConfigsRequest>;
 
@@ -8250,7 +8250,7 @@ export const ConversationalSearchProjectsLocationsCatalogsServingConfigsRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{placement}:conversationalSearch",
+      path: "v2alpha/{+placement}:conversationalSearch",
       hasBody: true,
     }),
     svc,
@@ -8297,7 +8297,7 @@ export const CreateProjectsLocationsCatalogsServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{parent}/servingConfigs",
+      path: "v2alpha/{+parent}/servingConfigs",
       hasBody: true,
     }),
     svc,
@@ -8338,7 +8338,7 @@ export const RemoveControlProjectsLocationsCatalogsServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{servingConfig}:removeControl",
+      path: "v2alpha/{+servingConfig}:removeControl",
       hasBody: true,
     }),
     svc,
@@ -8380,7 +8380,7 @@ export const PredictProjectsLocationsCatalogsServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{placement}:predict",
+      path: "v2alpha/{+placement}:predict",
       hasBody: true,
     }),
     svc,
@@ -8422,7 +8422,7 @@ export const PatchProjectsLocationsCatalogsServingConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsServingConfigsRequest>;
 
@@ -8461,7 +8461,7 @@ export const AddControlProjectsLocationsCatalogsServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{servingConfig}:addControl",
+      path: "v2alpha/{+servingConfig}:addControl",
       hasBody: true,
     }),
     svc,
@@ -8503,7 +8503,7 @@ export const SearchProjectsLocationsCatalogsServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{placement}:search",
+      path: "v2alpha/{+placement}:search",
       hasBody: true,
     }),
     svc,
@@ -8537,7 +8537,7 @@ export const DeleteProjectsLocationsCatalogsServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCatalogsServingConfigsRequest>;
 
@@ -8569,7 +8569,7 @@ export const GetProjectsLocationsCatalogsServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsServingConfigsRequest>;
 
@@ -8601,7 +8601,7 @@ export const ListProjectsLocationsCatalogsGenerativeQuestionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha/{parent}/generativeQuestions" }),
+    T.Http({ method: "GET", path: "v2alpha/{+parent}/generativeQuestions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsGenerativeQuestionsRequest>;
 
@@ -8641,7 +8641,7 @@ export const RemoveCatalogAttributeProjectsLocationsCatalogsAttributesConfigRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{attributesConfig}:removeCatalogAttribute",
+      path: "v2alpha/{+attributesConfig}:removeCatalogAttribute",
       hasBody: true,
     }),
     svc,
@@ -8684,7 +8684,7 @@ export const AddCatalogAttributeProjectsLocationsCatalogsAttributesConfigRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{attributesConfig}:addCatalogAttribute",
+      path: "v2alpha/{+attributesConfig}:addCatalogAttribute",
       hasBody: true,
     }),
     svc,
@@ -8726,7 +8726,7 @@ export const BatchRemoveCatalogAttributesProjectsLocationsCatalogsAttributesConf
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{attributesConfig}:batchRemoveCatalogAttributes",
+      path: "v2alpha/{+attributesConfig}:batchRemoveCatalogAttributes",
       hasBody: true,
     }),
     svc,
@@ -8770,7 +8770,7 @@ export const ReplaceCatalogAttributeProjectsLocationsCatalogsAttributesConfigReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha/{attributesConfig}:replaceCatalogAttribute",
+      path: "v2alpha/{+attributesConfig}:replaceCatalogAttribute",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/retail-v2beta.ts
+++ b/packages/gcp/src/services/retail-v2beta.ts
@@ -5059,7 +5059,7 @@ export const GetAlertConfigProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAlertConfigProjectsRequest>;
 
@@ -5098,7 +5098,7 @@ export const UpdateAlertConfigProjectsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAlertConfigProjectsRequest>;
 
@@ -5140,7 +5140,7 @@ export const UpdateGenerativeQuestionFeatureProjectsLocationsCatalogsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2beta/{catalog}/generativeQuestionFeature",
+      path: "v2beta/{+catalog}/generativeQuestionFeature",
       hasBody: true,
     }),
     svc,
@@ -5177,7 +5177,7 @@ export const GetGenerativeQuestionFeatureProjectsLocationsCatalogsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta/{catalog}/generativeQuestionFeature",
+      path: "v2beta/{+catalog}/generativeQuestionFeature",
     }),
     svc,
   ) as unknown as Schema.Schema<GetGenerativeQuestionFeatureProjectsLocationsCatalogsRequest>;
@@ -5221,7 +5221,7 @@ export const UpdateGenerativeQuestionProjectsLocationsCatalogsRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2beta/{catalog}/generativeQuestion",
+      path: "v2beta/{+catalog}/generativeQuestion",
       hasBody: true,
     }),
     svc,
@@ -5266,7 +5266,7 @@ export const UpdateConversationalSearchCustomizationConfigProjectsLocationsCatal
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v2beta/{catalog}/conversationalSearchCustomizationConfig",
+      path: "v2beta/{+catalog}/conversationalSearchCustomizationConfig",
       hasBody: true,
     }),
     svc,
@@ -5305,7 +5305,7 @@ export const GetConversationalSearchCustomizationConfigProjectsLocationsCatalogs
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v2beta/{name}/conversationalSearchCustomizationConfig",
+      path: "v2beta/{+name}/conversationalSearchCustomizationConfig",
     }),
     svc,
   ) as unknown as Schema.Schema<GetConversationalSearchCustomizationConfigProjectsLocationsCatalogsRequest>;
@@ -5371,7 +5371,7 @@ export const CompleteQueryProjectsLocationsCatalogsRequest =
     ),
     deviceType: Schema.optional(Schema.String).pipe(T.HttpQuery("deviceType")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{catalog}:completeQuery" }),
+    T.Http({ method: "GET", path: "v2beta/{+catalog}:completeQuery" }),
     svc,
   ) as unknown as Schema.Schema<CompleteQueryProjectsLocationsCatalogsRequest>;
 
@@ -5409,7 +5409,7 @@ export const ListProjectsLocationsCatalogsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{parent}/catalogs" }),
+    T.Http({ method: "GET", path: "v2beta/{+parent}/catalogs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsRequest>;
 
@@ -5453,7 +5453,7 @@ export const UpdateAttributesConfigProjectsLocationsCatalogsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAttributesConfigProjectsLocationsCatalogsRequest>;
 
@@ -5492,7 +5492,7 @@ export const PatchProjectsLocationsCatalogsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(GoogleCloudRetailV2betaCatalog).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsRequest>;
 
@@ -5524,7 +5524,7 @@ export const GetDefaultBranchProjectsLocationsCatalogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     catalog: Schema.String.pipe(T.HttpPath("catalog")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{catalog}:getDefaultBranch" }),
+    T.Http({ method: "GET", path: "v2beta/{+catalog}:getDefaultBranch" }),
     svc,
   ) as unknown as Schema.Schema<GetDefaultBranchProjectsLocationsCatalogsRequest>;
 
@@ -5564,7 +5564,7 @@ export const UpdateCompletionConfigProjectsLocationsCatalogsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateCompletionConfigProjectsLocationsCatalogsRequest>;
 
@@ -5597,7 +5597,7 @@ export const GetAttributesConfigProjectsLocationsCatalogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetAttributesConfigProjectsLocationsCatalogsRequest>;
 
@@ -5636,7 +5636,7 @@ export const ExportAnalyticsMetricsProjectsLocationsCatalogsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{catalog}:exportAnalyticsMetrics",
+      path: "v2beta/{+catalog}:exportAnalyticsMetrics",
       hasBody: true,
     }),
     svc,
@@ -5671,7 +5671,7 @@ export const GetCompletionConfigProjectsLocationsCatalogsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCompletionConfigProjectsLocationsCatalogsRequest>;
 
@@ -5710,7 +5710,7 @@ export const SetDefaultBranchProjectsLocationsCatalogsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{catalog}:setDefaultBranch",
+      path: "v2beta/{+catalog}:setDefaultBranch",
       hasBody: true,
     }),
     svc,
@@ -5751,7 +5751,7 @@ export const RemoveCatalogAttributeProjectsLocationsCatalogsAttributesConfigRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{attributesConfig}:removeCatalogAttribute",
+      path: "v2beta/{+attributesConfig}:removeCatalogAttribute",
       hasBody: true,
     }),
     svc,
@@ -5794,7 +5794,7 @@ export const BatchRemoveCatalogAttributesProjectsLocationsCatalogsAttributesConf
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{attributesConfig}:batchRemoveCatalogAttributes",
+      path: "v2beta/{+attributesConfig}:batchRemoveCatalogAttributes",
       hasBody: true,
     }),
     svc,
@@ -5838,7 +5838,7 @@ export const AddCatalogAttributeProjectsLocationsCatalogsAttributesConfigRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{attributesConfig}:addCatalogAttribute",
+      path: "v2beta/{+attributesConfig}:addCatalogAttribute",
       hasBody: true,
     }),
     svc,
@@ -5880,7 +5880,7 @@ export const ReplaceCatalogAttributeProjectsLocationsCatalogsAttributesConfigReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{attributesConfig}:replaceCatalogAttribute",
+      path: "v2beta/{+attributesConfig}:replaceCatalogAttribute",
       hasBody: true,
     }),
     svc,
@@ -5923,7 +5923,7 @@ export const ListProjectsLocationsCatalogsServingConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{parent}/servingConfigs" }),
+    T.Http({ method: "GET", path: "v2beta/{+parent}/servingConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsServingConfigsRequest>;
 
@@ -5966,7 +5966,7 @@ export const SearchProjectsLocationsCatalogsServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{placement}:search",
+      path: "v2beta/{+placement}:search",
       hasBody: true,
     }),
     svc,
@@ -6007,7 +6007,7 @@ export const RemoveControlProjectsLocationsCatalogsServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{servingConfig}:removeControl",
+      path: "v2beta/{+servingConfig}:removeControl",
       hasBody: true,
     }),
     svc,
@@ -6054,7 +6054,7 @@ export const CreateProjectsLocationsCatalogsServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/servingConfigs",
+      path: "v2beta/{+parent}/servingConfigs",
       hasBody: true,
     }),
     svc,
@@ -6095,7 +6095,7 @@ export const PredictProjectsLocationsCatalogsServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{placement}:predict",
+      path: "v2beta/{+placement}:predict",
       hasBody: true,
     }),
     svc,
@@ -6129,7 +6129,7 @@ export const DeleteProjectsLocationsCatalogsServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCatalogsServingConfigsRequest>;
 
@@ -6169,7 +6169,7 @@ export const PatchProjectsLocationsCatalogsServingConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsServingConfigsRequest>;
 
@@ -6208,7 +6208,7 @@ export const AddControlProjectsLocationsCatalogsServingConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{servingConfig}:addControl",
+      path: "v2beta/{+servingConfig}:addControl",
       hasBody: true,
     }),
     svc,
@@ -6243,7 +6243,7 @@ export const GetProjectsLocationsCatalogsServingConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsServingConfigsRequest>;
 
@@ -6282,7 +6282,7 @@ export const ConversationalSearchProjectsLocationsCatalogsServingConfigsRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{placement}:conversationalSearch",
+      path: "v2beta/{+placement}:conversationalSearch",
       hasBody: true,
     }),
     svc,
@@ -6324,7 +6324,7 @@ export const SearchProjectsLocationsCatalogsPlacementsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{placement}:search",
+      path: "v2beta/{+placement}:search",
       hasBody: true,
     }),
     svc,
@@ -6365,7 +6365,7 @@ export const PredictProjectsLocationsCatalogsPlacementsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{placement}:predict",
+      path: "v2beta/{+placement}:predict",
       hasBody: true,
     }),
     svc,
@@ -6406,7 +6406,7 @@ export const ConversationalSearchProjectsLocationsCatalogsPlacementsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{placement}:conversationalSearch",
+      path: "v2beta/{+placement}:conversationalSearch",
       hasBody: true,
     }),
     svc,
@@ -6448,7 +6448,7 @@ export const ImportProjectsLocationsCatalogsCompletionDataRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/completionData:import",
+      path: "v2beta/{+parent}/completionData:import",
       hasBody: true,
     }),
     svc,
@@ -6489,7 +6489,7 @@ export const BatchUpdateProjectsLocationsCatalogsGenerativeQuestionRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/generativeQuestion:batchUpdate",
+      path: "v2beta/{+parent}/generativeQuestion:batchUpdate",
       hasBody: true,
     }),
     svc,
@@ -6531,7 +6531,7 @@ export const CollectProjectsLocationsCatalogsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/userEvents:collect",
+      path: "v2beta/{+parent}/userEvents:collect",
       hasBody: true,
     }),
     svc,
@@ -6572,7 +6572,7 @@ export const ImportProjectsLocationsCatalogsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/userEvents:import",
+      path: "v2beta/{+parent}/userEvents:import",
       hasBody: true,
     }),
     svc,
@@ -6613,7 +6613,7 @@ export const PurgeProjectsLocationsCatalogsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/userEvents:purge",
+      path: "v2beta/{+parent}/userEvents:purge",
       hasBody: true,
     }),
     svc,
@@ -6654,7 +6654,7 @@ export const ExportProjectsLocationsCatalogsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/userEvents:export",
+      path: "v2beta/{+parent}/userEvents:export",
       hasBody: true,
     }),
     svc,
@@ -6696,7 +6696,7 @@ export const WriteProjectsLocationsCatalogsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/userEvents:write",
+      path: "v2beta/{+parent}/userEvents:write",
       hasBody: true,
     }),
     svc,
@@ -6737,7 +6737,7 @@ export const RejoinProjectsLocationsCatalogsUserEventsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/userEvents:rejoin",
+      path: "v2beta/{+parent}/userEvents:rejoin",
       hasBody: true,
     }),
     svc,
@@ -6771,7 +6771,7 @@ export const ListProjectsLocationsCatalogsGenerativeQuestionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{parent}/generativeQuestions" }),
+    T.Http({ method: "GET", path: "v2beta/{+parent}/generativeQuestions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsGenerativeQuestionsRequest>;
 
@@ -6804,7 +6804,7 @@ export const GetProjectsLocationsCatalogsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsOperationsRequest>;
 
@@ -6850,7 +6850,7 @@ export const ListProjectsLocationsCatalogsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsOperationsRequest>;
 
@@ -6886,7 +6886,7 @@ export const GetProjectsLocationsCatalogsBranchesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsBranchesOperationsRequest>;
 
@@ -6925,7 +6925,7 @@ export const SetInventoryProjectsLocationsCatalogsBranchesProductsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{name}:setInventory",
+      path: "v2beta/{+name}:setInventory",
       hasBody: true,
     }),
     svc,
@@ -6967,7 +6967,7 @@ export const PurgeProjectsLocationsCatalogsBranchesProductsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/products:purge",
+      path: "v2beta/{+parent}/products:purge",
       hasBody: true,
     }),
     svc,
@@ -7001,7 +7001,7 @@ export const GetProjectsLocationsCatalogsBranchesProductsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsBranchesProductsRequest>;
 
@@ -7039,7 +7039,11 @@ export const CreateProjectsLocationsCatalogsBranchesProductsRequest =
     productId: Schema.optional(Schema.String).pipe(T.HttpQuery("productId")),
     body: Schema.optional(GoogleCloudRetailV2betaProduct).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta/{parent}/products", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2beta/{+parent}/products",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCatalogsBranchesProductsRequest>;
 
@@ -7079,7 +7083,7 @@ export const ImportProjectsLocationsCatalogsBranchesProductsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/products:import",
+      path: "v2beta/{+parent}/products:import",
       hasBody: true,
     }),
     svc,
@@ -7121,7 +7125,7 @@ export const RemoveLocalInventoriesProjectsLocationsCatalogsBranchesProductsRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{product}:removeLocalInventories",
+      path: "v2beta/{+product}:removeLocalInventories",
       hasBody: true,
     }),
     svc,
@@ -7164,7 +7168,7 @@ export const AddFulfillmentPlacesProjectsLocationsCatalogsBranchesProductsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{product}:addFulfillmentPlaces",
+      path: "v2beta/{+product}:addFulfillmentPlaces",
       hasBody: true,
     }),
     svc,
@@ -7206,7 +7210,7 @@ export const AddLocalInventoriesProjectsLocationsCatalogsBranchesProductsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{product}:addLocalInventories",
+      path: "v2beta/{+product}:addLocalInventories",
       hasBody: true,
     }),
     svc,
@@ -7252,7 +7256,7 @@ export const PatchProjectsLocationsCatalogsBranchesProductsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudRetailV2betaProduct).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsBranchesProductsRequest>;
 
@@ -7284,7 +7288,7 @@ export const DeleteProjectsLocationsCatalogsBranchesProductsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCatalogsBranchesProductsRequest>;
 
@@ -7329,7 +7333,7 @@ export const ListProjectsLocationsCatalogsBranchesProductsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     readMask: Schema.optional(Schema.String).pipe(T.HttpQuery("readMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{parent}/products" }),
+    T.Http({ method: "GET", path: "v2beta/{+parent}/products" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsBranchesProductsRequest>;
 
@@ -7372,7 +7376,7 @@ export const ExportProjectsLocationsCatalogsBranchesProductsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{parent}/products:export",
+      path: "v2beta/{+parent}/products:export",
       hasBody: true,
     }),
     svc,
@@ -7414,7 +7418,7 @@ export const RemoveFulfillmentPlacesProjectsLocationsCatalogsBranchesProductsReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2beta/{product}:removeFulfillmentPlaces",
+      path: "v2beta/{+product}:removeFulfillmentPlaces",
       hasBody: true,
     }),
     svc,
@@ -7460,7 +7464,7 @@ export const ListProjectsLocationsCatalogsControlsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{parent}/controls" }),
+    T.Http({ method: "GET", path: "v2beta/{+parent}/controls" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsControlsRequest>;
 
@@ -7496,7 +7500,7 @@ export const GetProjectsLocationsCatalogsControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsControlsRequest>;
 
@@ -7534,7 +7538,11 @@ export const CreateProjectsLocationsCatalogsControlsRequest =
     controlId: Schema.optional(Schema.String).pipe(T.HttpQuery("controlId")),
     body: Schema.optional(GoogleCloudRetailV2betaControl).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta/{parent}/controls", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v2beta/{+parent}/controls",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCatalogsControlsRequest>;
 
@@ -7566,7 +7574,7 @@ export const DeleteProjectsLocationsCatalogsControlsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCatalogsControlsRequest>;
 
@@ -7604,7 +7612,7 @@ export const PatchProjectsLocationsCatalogsControlsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudRetailV2betaControl).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsControlsRequest>;
 
@@ -7641,7 +7649,7 @@ export const ResumeProjectsLocationsCatalogsModelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeProjectsLocationsCatalogsModelsRequest>;
 
@@ -7678,7 +7686,7 @@ export const TuneProjectsLocationsCatalogsModelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta/{name}:tune", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta/{+name}:tune", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TuneProjectsLocationsCatalogsModelsRequest>;
 
@@ -7710,7 +7718,7 @@ export const DeleteProjectsLocationsCatalogsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCatalogsModelsRequest>;
 
@@ -7747,7 +7755,7 @@ export const PatchProjectsLocationsCatalogsModelsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudRetailV2betaModel).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCatalogsModelsRequest>;
 
@@ -7785,7 +7793,7 @@ export const CreateProjectsLocationsCatalogsModelsRequest =
     dryRun: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("dryRun")),
     body: Schema.optional(GoogleCloudRetailV2betaModel).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta/{parent}/models", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta/{+parent}/models", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsCatalogsModelsRequest>;
 
@@ -7817,7 +7825,7 @@ export const GetProjectsLocationsCatalogsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCatalogsModelsRequest>;
 
@@ -7854,7 +7862,7 @@ export const PauseProjectsLocationsCatalogsModelsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2beta/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v2beta/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseProjectsLocationsCatalogsModelsRequest>;
 
@@ -7892,7 +7900,7 @@ export const ListProjectsLocationsCatalogsModelsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{parent}/models" }),
+    T.Http({ method: "GET", path: "v2beta/{+parent}/models" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCatalogsModelsRequest>;
 
@@ -7928,7 +7936,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -7973,7 +7981,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -8023,7 +8031,7 @@ export const ListProjectsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsOperationsRequest>;
 
@@ -8059,7 +8067,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2beta/{name}" }),
+    T.Http({ method: "GET", path: "v2beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 

--- a/packages/gcp/src/services/run-v1.ts
+++ b/packages/gcp/src/services/run-v1.ts
@@ -3060,7 +3060,7 @@ export const ListProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -3124,7 +3124,7 @@ export const ListProjectsLocationsConfigurationsRequest =
       T.HttpQuery("resourceVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/configurations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/configurations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConfigurationsRequest>;
 
@@ -3156,7 +3156,7 @@ export const GetProjectsLocationsConfigurationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConfigurationsRequest>;
 
@@ -3192,7 +3192,7 @@ export const GetIamPolicyProjectsLocationsJobsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsJobsRequest>;
 
@@ -3228,7 +3228,7 @@ export const TestIamPermissionsProjectsLocationsJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3267,7 +3267,7 @@ export const SetIamPolicyProjectsLocationsJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3305,7 +3305,7 @@ export const SetIamPolicyProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3343,7 +3343,7 @@ export const GetIamPolicyProjectsLocationsInstancesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsInstancesRequest>;
 
@@ -3379,7 +3379,7 @@ export const TestIamPermissionsProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3418,7 +3418,7 @@ export const SetIamPolicyProjectsLocationsWorkerpoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3456,7 +3456,7 @@ export const GetIamPolicyProjectsLocationsWorkerpoolsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsWorkerpoolsRequest>;
 
@@ -3492,7 +3492,7 @@ export const TestIamPermissionsProjectsLocationsWorkerpoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3555,7 +3555,7 @@ export const ListProjectsLocationsRoutesRequest =
       T.HttpQuery("includeUninitialized"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/routes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/routes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRoutesRequest>;
 
@@ -3586,7 +3586,7 @@ export const GetProjectsLocationsRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRoutesRequest>;
 
@@ -3646,7 +3646,7 @@ export const ListProjectsLocationsDomainmappingsRequest =
     limit: Schema.optional(Schema.Number).pipe(T.HttpQuery("limit")),
     continue: Schema.optional(Schema.String).pipe(T.HttpQuery("continue")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/domainmappings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/domainmappings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDomainmappingsRequest>;
 
@@ -3678,7 +3678,7 @@ export const GetProjectsLocationsDomainmappingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDomainmappingsRequest>;
 
@@ -3723,7 +3723,7 @@ export const DeleteProjectsLocationsDomainmappingsRequest =
     kind: Schema.optional(Schema.String).pipe(T.HttpQuery("kind")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDomainmappingsRequest>;
 
@@ -3762,7 +3762,7 @@ export const CreateProjectsLocationsDomainmappingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/domainmappings",
+      path: "v1/{+parent}/domainmappings",
       hasBody: true,
     }),
     svc,
@@ -3824,7 +3824,7 @@ export const ListProjectsLocationsServicesRequest =
     ),
     watch: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("watch")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/services" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/services" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesRequest>;
 
@@ -3869,7 +3869,7 @@ export const DeleteProjectsLocationsServicesRequest =
     apiVersion: Schema.optional(Schema.String).pipe(T.HttpQuery("apiVersion")),
     dryRun: Schema.optional(Schema.String).pipe(T.HttpQuery("dryRun")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesRequest>;
 
@@ -3905,7 +3905,7 @@ export const GetIamPolicyProjectsLocationsServicesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsServicesRequest>;
 
@@ -3942,7 +3942,7 @@ export const CreateProjectsLocationsServicesRequest =
     dryRun: Schema.optional(Schema.String).pipe(T.HttpQuery("dryRun")),
     body: Schema.optional(Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/services", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/services", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsServicesRequest>;
 
@@ -3973,7 +3973,7 @@ export const GetProjectsLocationsServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesRequest>;
 
@@ -4009,7 +4009,7 @@ export const SetIamPolicyProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4048,7 +4048,7 @@ export const ReplaceServiceProjectsLocationsServicesRequest =
     dryRun: Schema.optional(Schema.String).pipe(T.HttpQuery("dryRun")),
     body: Schema.optional(Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReplaceServiceProjectsLocationsServicesRequest>;
 
@@ -4084,7 +4084,7 @@ export const TestIamPermissionsProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4124,7 +4124,7 @@ export const ListProjectsLocationsAuthorizeddomainsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/authorizeddomains" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/authorizeddomains" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAuthorizeddomainsRequest>;
 
@@ -4160,7 +4160,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -4196,7 +4196,7 @@ export const WaitProjectsLocationsOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsOperationsRequest>;
 
@@ -4242,7 +4242,7 @@ export const ListProjectsLocationsOperationsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -4278,7 +4278,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -4338,7 +4338,7 @@ export const ListProjectsLocationsRevisionsRequest =
     ),
     watch: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("watch")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/revisions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/revisions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRevisionsRequest>;
 
@@ -4369,7 +4369,7 @@ export const GetProjectsLocationsRevisionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRevisionsRequest>;
 
@@ -4414,7 +4414,7 @@ export const DeleteProjectsLocationsRevisionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     kind: Schema.optional(Schema.String).pipe(T.HttpQuery("kind")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRevisionsRequest>;
 
@@ -4451,7 +4451,7 @@ export const ListProjectsAuthorizeddomainsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/authorizeddomains" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/authorizeddomains" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAuthorizeddomainsRequest>;
 
@@ -4500,7 +4500,7 @@ export const ListNamespacesWorkerpoolsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "apis/run.googleapis.com/v1/{parent}/workerpools",
+      path: "apis/run.googleapis.com/v1/{+parent}/workerpools",
     }),
     svc,
   ) as unknown as Schema.Schema<ListNamespacesWorkerpoolsRequest>;
@@ -4540,7 +4540,7 @@ export const ReplaceWorkerPoolNamespacesWorkerpoolsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "apis/run.googleapis.com/v1/{name}",
+      path: "apis/run.googleapis.com/v1/{+name}",
       hasBody: true,
     }),
     svc,
@@ -4576,7 +4576,7 @@ export const DeleteNamespacesWorkerpoolsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     dryRun: Schema.optional(Schema.String).pipe(T.HttpQuery("dryRun")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "apis/run.googleapis.com/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "apis/run.googleapis.com/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNamespacesWorkerpoolsRequest>;
 
@@ -4615,7 +4615,7 @@ export const CreateNamespacesWorkerpoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "apis/run.googleapis.com/v1/{parent}/workerpools",
+      path: "apis/run.googleapis.com/v1/{+parent}/workerpools",
       hasBody: true,
     }),
     svc,
@@ -4648,7 +4648,7 @@ export const GetNamespacesWorkerpoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "apis/run.googleapis.com/v1/{name}" }),
+    T.Http({ method: "GET", path: "apis/run.googleapis.com/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNamespacesWorkerpoolsRequest>;
 
@@ -4710,7 +4710,7 @@ export const ListNamespacesDomainmappingsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "apis/domains.cloudrun.com/v1/{parent}/domainmappings",
+      path: "apis/domains.cloudrun.com/v1/{+parent}/domainmappings",
     }),
     svc,
   ) as unknown as Schema.Schema<ListNamespacesDomainmappingsRequest>;
@@ -4742,7 +4742,7 @@ export const GetNamespacesDomainmappingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "apis/domains.cloudrun.com/v1/{name}" }),
+    T.Http({ method: "GET", path: "apis/domains.cloudrun.com/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNamespacesDomainmappingsRequest>;
 
@@ -4781,7 +4781,7 @@ export const CreateNamespacesDomainmappingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "apis/domains.cloudrun.com/v1/{parent}/domainmappings",
+      path: "apis/domains.cloudrun.com/v1/{+parent}/domainmappings",
       hasBody: true,
     }),
     svc,
@@ -4828,7 +4828,7 @@ export const DeleteNamespacesDomainmappingsRequest =
     kind: Schema.optional(Schema.String).pipe(T.HttpQuery("kind")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "apis/domains.cloudrun.com/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "apis/domains.cloudrun.com/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNamespacesDomainmappingsRequest>;
 
@@ -4873,7 +4873,7 @@ export const DeleteNamespacesServicesRequest =
     kind: Schema.optional(Schema.String).pipe(T.HttpQuery("kind")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "apis/serving.knative.dev/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "apis/serving.knative.dev/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNamespacesServicesRequest>;
 
@@ -4912,7 +4912,7 @@ export const CreateNamespacesServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "apis/serving.knative.dev/v1/{parent}/services",
+      path: "apis/serving.knative.dev/v1/{+parent}/services",
       hasBody: true,
     }),
     svc,
@@ -4976,7 +4976,7 @@ export const ListNamespacesServicesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "apis/serving.knative.dev/v1/{parent}/services",
+      path: "apis/serving.knative.dev/v1/{+parent}/services",
     }),
     svc,
   ) as unknown as Schema.Schema<ListNamespacesServicesRequest>;
@@ -5016,7 +5016,7 @@ export const ReplaceServiceNamespacesServicesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "apis/serving.knative.dev/v1/{name}",
+      path: "apis/serving.knative.dev/v1/{+name}",
       hasBody: true,
     }),
     svc,
@@ -5049,7 +5049,7 @@ export const GetNamespacesServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "apis/serving.knative.dev/v1/{name}" }),
+    T.Http({ method: "GET", path: "apis/serving.knative.dev/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNamespacesServicesRequest>;
 
@@ -5080,7 +5080,7 @@ export const GetNamespacesExecutionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "apis/run.googleapis.com/v1/{name}" }),
+    T.Http({ method: "GET", path: "apis/run.googleapis.com/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNamespacesExecutionsRequest>;
 
@@ -5142,7 +5142,7 @@ export const ListNamespacesExecutionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "apis/run.googleapis.com/v1/{parent}/executions",
+      path: "apis/run.googleapis.com/v1/{+parent}/executions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListNamespacesExecutionsRequest>;
@@ -5185,7 +5185,7 @@ export const DeleteNamespacesExecutionsRequest =
     kind: Schema.optional(Schema.String).pipe(T.HttpQuery("kind")),
     apiVersion: Schema.optional(Schema.String).pipe(T.HttpQuery("apiVersion")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "apis/run.googleapis.com/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "apis/run.googleapis.com/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNamespacesExecutionsRequest>;
 
@@ -5221,7 +5221,7 @@ export const CancelNamespacesExecutionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "apis/run.googleapis.com/v1/{name}:cancel",
+      path: "apis/run.googleapis.com/v1/{+name}:cancel",
       hasBody: true,
     }),
     svc,
@@ -5285,7 +5285,7 @@ export const ListNamespacesRoutesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "apis/serving.knative.dev/v1/{parent}/routes",
+      path: "apis/serving.knative.dev/v1/{+parent}/routes",
     }),
     svc,
   ) as unknown as Schema.Schema<ListNamespacesRoutesRequest>;
@@ -5317,7 +5317,7 @@ export const GetNamespacesRoutesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "apis/serving.knative.dev/v1/{name}" }),
+    T.Http({ method: "GET", path: "apis/serving.knative.dev/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNamespacesRoutesRequest>;
 
@@ -5376,7 +5376,10 @@ export const ListNamespacesJobsRequest =
       T.HttpQuery("resourceVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "apis/run.googleapis.com/v1/{parent}/jobs" }),
+    T.Http({
+      method: "GET",
+      path: "apis/run.googleapis.com/v1/{+parent}/jobs",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListNamespacesJobsRequest>;
 
@@ -5418,7 +5421,7 @@ export const DeleteNamespacesJobsRequest =
     kind: Schema.optional(Schema.String).pipe(T.HttpQuery("kind")),
     apiVersion: Schema.optional(Schema.String).pipe(T.HttpQuery("apiVersion")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "apis/run.googleapis.com/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "apis/run.googleapis.com/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNamespacesJobsRequest>;
 
@@ -5453,7 +5456,7 @@ export const CreateNamespacesJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "apis/run.googleapis.com/v1/{parent}/jobs",
+      path: "apis/run.googleapis.com/v1/{+parent}/jobs",
       hasBody: true,
     }),
     svc,
@@ -5490,7 +5493,7 @@ export const ReplaceJobNamespacesJobsRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "apis/run.googleapis.com/v1/{name}",
+      path: "apis/run.googleapis.com/v1/{+name}",
       hasBody: true,
     }),
     svc,
@@ -5522,7 +5525,7 @@ export const GetNamespacesJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "apis/run.googleapis.com/v1/{name}" }),
+    T.Http({ method: "GET", path: "apis/run.googleapis.com/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNamespacesJobsRequest>;
 
@@ -5557,7 +5560,7 @@ export const RunNamespacesJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "apis/run.googleapis.com/v1/{name}:run",
+      path: "apis/run.googleapis.com/v1/{+name}:run",
       hasBody: true,
     }),
     svc,
@@ -5620,7 +5623,7 @@ export const ListNamespacesConfigurationsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "apis/serving.knative.dev/v1/{parent}/configurations",
+      path: "apis/serving.knative.dev/v1/{+parent}/configurations",
     }),
     svc,
   ) as unknown as Schema.Schema<ListNamespacesConfigurationsRequest>;
@@ -5652,7 +5655,7 @@ export const GetNamespacesConfigurationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "apis/serving.knative.dev/v1/{name}" }),
+    T.Http({ method: "GET", path: "apis/serving.knative.dev/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNamespacesConfigurationsRequest>;
 
@@ -5688,7 +5691,7 @@ export const CreateNamespacesInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "apis/run.googleapis.com/v1/{parent}/instances",
+      path: "apis/run.googleapis.com/v1/{+parent}/instances",
       hasBody: true,
     }),
     svc,
@@ -5732,7 +5735,7 @@ export const DeleteNamespacesInstancesRequest =
     kind: Schema.optional(Schema.String).pipe(T.HttpQuery("kind")),
     apiVersion: Schema.optional(Schema.String).pipe(T.HttpQuery("apiVersion")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "apis/run.googleapis.com/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "apis/run.googleapis.com/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNamespacesInstancesRequest>;
 
@@ -5768,7 +5771,7 @@ export const StartNamespacesInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "apis/run.googleapis.com/v1/{name}:start",
+      path: "apis/run.googleapis.com/v1/{+name}:start",
       hasBody: true,
     }),
     svc,
@@ -5806,7 +5809,7 @@ export const StopNamespacesInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "apis/run.googleapis.com/v1/{name}:stop",
+      path: "apis/run.googleapis.com/v1/{+name}:stop",
       hasBody: true,
     }),
     svc,
@@ -5870,7 +5873,7 @@ export const ListNamespacesInstancesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "apis/run.googleapis.com/v1/{parent}/instances",
+      path: "apis/run.googleapis.com/v1/{+parent}/instances",
     }),
     svc,
   ) as unknown as Schema.Schema<ListNamespacesInstancesRequest>;
@@ -5907,7 +5910,7 @@ export const ReplaceInstanceNamespacesInstancesRequest =
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "apis/run.googleapis.com/v1/{name}",
+      path: "apis/run.googleapis.com/v1/{+name}",
       hasBody: true,
     }),
     svc,
@@ -5940,7 +5943,7 @@ export const GetNamespacesInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "apis/run.googleapis.com/v1/{name}" }),
+    T.Http({ method: "GET", path: "apis/run.googleapis.com/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNamespacesInstancesRequest>;
 
@@ -5971,7 +5974,7 @@ export const GetNamespacesTasksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "apis/run.googleapis.com/v1/{name}" }),
+    T.Http({ method: "GET", path: "apis/run.googleapis.com/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNamespacesTasksRequest>;
 
@@ -6032,7 +6035,7 @@ export const ListNamespacesTasksRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "apis/run.googleapis.com/v1/{parent}/tasks",
+      path: "apis/run.googleapis.com/v1/{+parent}/tasks",
     }),
     svc,
   ) as unknown as Schema.Schema<ListNamespacesTasksRequest>;
@@ -6072,7 +6075,7 @@ export const ListNamespacesAuthorizeddomainsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "apis/domains.cloudrun.com/v1/{parent}/authorizeddomains",
+      path: "apis/domains.cloudrun.com/v1/{+parent}/authorizeddomains",
     }),
     svc,
   ) as unknown as Schema.Schema<ListNamespacesAuthorizeddomainsRequest>;
@@ -6123,7 +6126,7 @@ export const DeleteNamespacesRevisionsRequest =
     ),
     apiVersion: Schema.optional(Schema.String).pipe(T.HttpQuery("apiVersion")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "apis/serving.knative.dev/v1/{name}" }),
+    T.Http({ method: "DELETE", path: "apis/serving.knative.dev/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNamespacesRevisionsRequest>;
 
@@ -6185,7 +6188,7 @@ export const ListNamespacesRevisionsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "apis/serving.knative.dev/v1/{parent}/revisions",
+      path: "apis/serving.knative.dev/v1/{+parent}/revisions",
     }),
     svc,
   ) as unknown as Schema.Schema<ListNamespacesRevisionsRequest>;
@@ -6217,7 +6220,7 @@ export const GetNamespacesRevisionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "apis/serving.knative.dev/v1/{name}" }),
+    T.Http({ method: "GET", path: "apis/serving.knative.dev/v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNamespacesRevisionsRequest>;
 

--- a/packages/gcp/src/services/run-v2.ts
+++ b/packages/gcp/src/services/run-v2.ts
@@ -3592,7 +3592,7 @@ export const ExportImageProjectsLocationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:exportImage", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:exportImage", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportImageProjectsLocationsRequest>;
 
@@ -3624,7 +3624,7 @@ export const ExportMetadataProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}:exportMetadata" }),
+    T.Http({ method: "GET", path: "v2/{+name}:exportMetadata" }),
     svc,
   ) as unknown as Schema.Schema<ExportMetadataProjectsLocationsRequest>;
 
@@ -3655,7 +3655,7 @@ export const ExportImageMetadataProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}:exportImageMetadata" }),
+    T.Http({ method: "GET", path: "v2/{+name}:exportImageMetadata" }),
     svc,
   ) as unknown as Schema.Schema<ExportImageMetadataProjectsLocationsRequest>;
 
@@ -3687,7 +3687,7 @@ export const ExportProjectMetadataProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}:exportProjectMetadata" }),
+    T.Http({ method: "GET", path: "v2/{+name}:exportProjectMetadata" }),
     svc,
   ) as unknown as Schema.Schema<ExportProjectMetadataProjectsLocationsRequest>;
 
@@ -3724,7 +3724,7 @@ export const SetIamPolicyProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3765,7 +3765,7 @@ export const DeleteProjectsLocationsServicesRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesRequest>;
 
@@ -3808,7 +3808,7 @@ export const ListProjectsLocationsServicesRequest =
     ),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/services" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/services" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesRequest>;
 
@@ -3851,7 +3851,7 @@ export const TestIamPermissionsProjectsLocationsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3890,7 +3890,7 @@ export const GetIamPolicyProjectsLocationsServicesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v2/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsServicesRequest>;
 
@@ -3932,7 +3932,7 @@ export const CreateProjectsLocationsServicesRequest =
     ),
     body: Schema.optional(GoogleCloudRunV2Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/services", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/services", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsServicesRequest>;
 
@@ -3964,7 +3964,7 @@ export const GetProjectsLocationsServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesRequest>;
 
@@ -4016,7 +4016,7 @@ export const PatchProjectsLocationsServicesRequest =
     ),
     body: Schema.optional(GoogleCloudRunV2Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsServicesRequest>;
 
@@ -4050,7 +4050,7 @@ export const ExportStatusProjectsLocationsServicesRevisionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     operationId: Schema.String.pipe(T.HttpPath("operationId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/{operationId}:exportStatus" }),
+    T.Http({ method: "GET", path: "v2/{+name}/{+operationId}:exportStatus" }),
     svc,
   ) as unknown as Schema.Schema<ExportStatusProjectsLocationsServicesRevisionsRequest>;
 
@@ -4090,7 +4090,7 @@ export const DeleteProjectsLocationsServicesRevisionsRequest =
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsServicesRevisionsRequest>;
 
@@ -4122,7 +4122,7 @@ export const GetProjectsLocationsServicesRevisionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsServicesRevisionsRequest>;
 
@@ -4165,7 +4165,7 @@ export const ListProjectsLocationsServicesRevisionsRequest =
     ),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/revisions" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/revisions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsServicesRevisionsRequest>;
 
@@ -4209,7 +4209,7 @@ export const DeleteProjectsLocationsJobsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsJobsRequest>;
 
@@ -4243,7 +4243,7 @@ export const RunProjectsLocationsJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GoogleCloudRunV2RunJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsJobsRequest>;
 
@@ -4287,7 +4287,7 @@ export const PatchProjectsLocationsJobsRequest =
     ),
     body: Schema.optional(GoogleCloudRunV2Job).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsJobsRequest>;
 
@@ -4329,7 +4329,7 @@ export const CreateProjectsLocationsJobsRequest =
     jobId: Schema.optional(Schema.String).pipe(T.HttpQuery("jobId")),
     body: Schema.optional(GoogleCloudRunV2Job).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/jobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/jobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsJobsRequest>;
 
@@ -4371,7 +4371,7 @@ export const ListProjectsLocationsJobsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/jobs" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/jobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsJobsRequest>;
 
@@ -4414,7 +4414,7 @@ export const TestIamPermissionsProjectsLocationsJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4453,7 +4453,7 @@ export const SetIamPolicyProjectsLocationsJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4486,7 +4486,7 @@ export const GetProjectsLocationsJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsJobsRequest>;
 
@@ -4522,7 +4522,7 @@ export const GetIamPolicyProjectsLocationsJobsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v2/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsJobsRequest>;
 
@@ -4556,7 +4556,7 @@ export const ExportStatusProjectsLocationsJobsExecutionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     operationId: Schema.String.pipe(T.HttpPath("operationId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/{operationId}:exportStatus" }),
+    T.Http({ method: "GET", path: "v2/{+name}/{+operationId}:exportStatus" }),
     svc,
   ) as unknown as Schema.Schema<ExportStatusProjectsLocationsJobsExecutionsRequest>;
 
@@ -4588,7 +4588,7 @@ export const GetProjectsLocationsJobsExecutionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsJobsExecutionsRequest>;
 
@@ -4631,7 +4631,7 @@ export const ListProjectsLocationsJobsExecutionsRequest =
       T.HttpQuery("showDeleted"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/executions" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/executions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsJobsExecutionsRequest>;
 
@@ -4675,7 +4675,7 @@ export const DeleteProjectsLocationsJobsExecutionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsJobsExecutionsRequest>;
 
@@ -4712,7 +4712,7 @@ export const CancelProjectsLocationsJobsExecutionsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsJobsExecutionsRequest>;
 
@@ -4744,7 +4744,7 @@ export const GetProjectsLocationsJobsExecutionsTasksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsJobsExecutionsTasksRequest>;
 
@@ -4787,7 +4787,7 @@ export const ListProjectsLocationsJobsExecutionsTasksRequest =
     ),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/tasks" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/tasks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsJobsExecutionsTasksRequest>;
 
@@ -4831,7 +4831,7 @@ export const DeleteProjectsLocationsWorkerPoolsRequest =
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWorkerPoolsRequest>;
 
@@ -4868,7 +4868,7 @@ export const SetIamPolicyProjectsLocationsWorkerPoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:setIamPolicy",
+      path: "v2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4923,7 +4923,7 @@ export const PatchProjectsLocationsWorkerPoolsRequest =
     ),
     body: Schema.optional(GoogleCloudRunV2WorkerPool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsWorkerPoolsRequest>;
 
@@ -4968,7 +4968,7 @@ export const CreateProjectsLocationsWorkerPoolsRequest =
     ),
     body: Schema.optional(GoogleCloudRunV2WorkerPool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/workerPools", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/workerPools", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsWorkerPoolsRequest>;
 
@@ -5000,7 +5000,7 @@ export const GetProjectsLocationsWorkerPoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkerPoolsRequest>;
 
@@ -5037,7 +5037,7 @@ export const GetIamPolicyProjectsLocationsWorkerPoolsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v2/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsWorkerPoolsRequest>;
 
@@ -5080,7 +5080,7 @@ export const ListProjectsLocationsWorkerPoolsRequest =
     ),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/workerPools" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/workerPools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkerPoolsRequest>;
 
@@ -5123,7 +5123,7 @@ export const TestIamPermissionsProjectsLocationsWorkerPoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{resource}:testIamPermissions",
+      path: "v2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5168,7 +5168,7 @@ export const ListProjectsLocationsWorkerPoolsRevisionsRequest =
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/revisions" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/revisions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkerPoolsRevisionsRequest>;
 
@@ -5212,7 +5212,7 @@ export const DeleteProjectsLocationsWorkerPoolsRevisionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWorkerPoolsRevisionsRequest>;
 
@@ -5244,7 +5244,7 @@ export const GetProjectsLocationsWorkerPoolsRevisionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkerPoolsRevisionsRequest>;
 
@@ -5283,7 +5283,7 @@ export const SubmitProjectsLocationsBuildsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/builds:submit",
+      path: "v2/{+parent}/builds:submit",
       hasBody: true,
     }),
     svc,
@@ -5327,7 +5327,7 @@ export const CreateProjectsLocationsInstancesRequest =
     ),
     body: Schema.optional(GoogleCloudRunV2Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/instances", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/instances", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsInstancesRequest>;
 
@@ -5358,7 +5358,7 @@ export const GetProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesRequest>;
 
@@ -5405,7 +5405,7 @@ export const PatchProjectsLocationsInstancesRequest =
     ),
     body: Schema.optional(GoogleCloudRunV2Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsInstancesRequest>;
 
@@ -5448,7 +5448,7 @@ export const ListProjectsLocationsInstancesRequest =
     ),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesRequest>;
 
@@ -5489,7 +5489,7 @@ export const StartProjectsLocationsInstancesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsLocationsInstancesRequest>;
 
@@ -5528,7 +5528,7 @@ export const DeleteProjectsLocationsInstancesRequest =
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesRequest>;
 
@@ -5565,7 +5565,7 @@ export const StopProjectsLocationsInstancesRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsInstancesRequest>;
 
@@ -5610,7 +5610,7 @@ export const ListProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -5646,7 +5646,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -5677,7 +5677,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -5713,7 +5713,7 @@ export const WaitProjectsLocationsOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/runtimeconfig-v1.ts
+++ b/packages/gcp/src/services/runtimeconfig-v1.ts
@@ -115,7 +115,7 @@ export const ListOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<ListOperationsRequest>;
 
@@ -153,7 +153,7 @@ export const CancelOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOperationsRequest>;
 
@@ -183,7 +183,7 @@ export const DeleteOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOperationsRequest>;
 

--- a/packages/gcp/src/services/runtimeconfig-v1beta1.ts
+++ b/packages/gcp/src/services/runtimeconfig-v1beta1.ts
@@ -282,7 +282,7 @@ export const GetProjectsConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsConfigsRequest>;
 
@@ -313,7 +313,7 @@ export const DeleteProjectsConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsConfigsRequest>;
 
@@ -348,7 +348,7 @@ export const TestIamPermissionsProjectsConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -387,7 +387,7 @@ export const GetIamPolicyProjectsConfigsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsConfigsRequest>;
 
@@ -423,7 +423,7 @@ export const SetIamPolicyProjectsConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -462,7 +462,11 @@ export const CreateProjectsConfigsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(RuntimeConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/configs", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/configs",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsConfigsRequest>;
 
@@ -496,7 +500,7 @@ export const UpdateProjectsConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RuntimeConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsConfigsRequest>;
 
@@ -533,7 +537,7 @@ export const ListProjectsConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/configs" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/configs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsConfigsRequest>;
 
@@ -568,7 +572,7 @@ export const GetProjectsConfigsVariablesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsConfigsVariablesRequest>;
 
@@ -602,7 +606,7 @@ export const WatchProjectsConfigsVariablesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(WatchVariableRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:watch", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:watch", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WatchProjectsConfigsVariablesRequest>;
 
@@ -641,7 +645,7 @@ export const CreateProjectsConfigsVariablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/variables",
+      path: "v1beta1/{+parent}/variables",
       hasBody: true,
     }),
     svc,
@@ -677,7 +681,7 @@ export const UpdateProjectsConfigsVariablesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Variable).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PUT", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateProjectsConfigsVariablesRequest>;
 
@@ -722,7 +726,7 @@ export const ListProjectsConfigsVariablesRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/variables" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/variables" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsConfigsVariablesRequest>;
 
@@ -760,7 +764,7 @@ export const DeleteProjectsConfigsVariablesRequest =
     recursive: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("recursive")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsConfigsVariablesRequest>;
 
@@ -796,7 +800,7 @@ export const TestIamPermissionsProjectsConfigsVariablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -835,7 +839,7 @@ export const TestIamPermissionsProjectsConfigsWaitersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -875,7 +879,11 @@ export const CreateProjectsConfigsWaitersRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Waiter).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/waiters", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/waiters",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsConfigsWaitersRequest>;
 
@@ -912,7 +920,7 @@ export const ListProjectsConfigsWaitersRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/waiters" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/waiters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsConfigsWaitersRequest>;
 
@@ -947,7 +955,7 @@ export const DeleteProjectsConfigsWaitersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsConfigsWaitersRequest>;
 
@@ -978,7 +986,7 @@ export const GetProjectsConfigsWaitersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsConfigsWaitersRequest>;
 
@@ -1009,7 +1017,7 @@ export const GetProjectsConfigsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsConfigsOperationsRequest>;
 
@@ -1045,7 +1053,7 @@ export const TestIamPermissionsProjectsConfigsOperationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/saasservicemgmt-v1.ts
+++ b/packages/gcp/src/services/saasservicemgmt-v1.ts
@@ -1051,7 +1051,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1086,7 +1086,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1129,7 +1129,7 @@ export const ListProjectsLocationsSaasRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/saas" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/saas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSaasRequest>;
 
@@ -1164,7 +1164,7 @@ export const GetProjectsLocationsSaasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSaasRequest>;
 
@@ -1209,7 +1209,7 @@ export const CreateProjectsLocationsSaasRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Saas).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/saas", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/saas", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSaasRequest>;
 
@@ -1254,7 +1254,7 @@ export const PatchProjectsLocationsSaasRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Saas).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSaasRequest>;
 
@@ -1296,7 +1296,7 @@ export const DeleteProjectsLocationsSaasRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSaasRequest>;
 
@@ -1339,7 +1339,7 @@ export const ListProjectsLocationsTenantsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/tenants" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/tenants" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTenantsRequest>;
 
@@ -1374,7 +1374,7 @@ export const GetProjectsLocationsTenantsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTenantsRequest>;
 
@@ -1419,7 +1419,7 @@ export const CreateProjectsLocationsTenantsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Tenant).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/tenants", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/tenants", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTenantsRequest>;
 
@@ -1464,7 +1464,7 @@ export const PatchProjectsLocationsTenantsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Tenant).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTenantsRequest>;
 
@@ -1506,7 +1506,7 @@ export const DeleteProjectsLocationsTenantsRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTenantsRequest>;
 
@@ -1549,7 +1549,7 @@ export const ListProjectsLocationsUnitKindsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/unitKinds" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/unitKinds" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsUnitKindsRequest>;
 
@@ -1584,7 +1584,7 @@ export const GetProjectsLocationsUnitKindsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsUnitKindsRequest>;
 
@@ -1629,7 +1629,7 @@ export const CreateProjectsLocationsUnitKindsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(UnitKind).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/unitKinds", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/unitKinds", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsUnitKindsRequest>;
 
@@ -1674,7 +1674,7 @@ export const PatchProjectsLocationsUnitKindsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(UnitKind).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsUnitKindsRequest>;
 
@@ -1716,7 +1716,7 @@ export const DeleteProjectsLocationsUnitKindsRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsUnitKindsRequest>;
 
@@ -1759,7 +1759,7 @@ export const ListProjectsLocationsUnitsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/units" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/units" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsUnitsRequest>;
 
@@ -1794,7 +1794,7 @@ export const GetProjectsLocationsUnitsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsUnitsRequest>;
 
@@ -1839,7 +1839,7 @@ export const CreateProjectsLocationsUnitsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Unit).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/units", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/units", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsUnitsRequest>;
 
@@ -1884,7 +1884,7 @@ export const PatchProjectsLocationsUnitsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Unit).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsUnitsRequest>;
 
@@ -1926,7 +1926,7 @@ export const DeleteProjectsLocationsUnitsRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsUnitsRequest>;
 
@@ -1969,7 +1969,7 @@ export const ListProjectsLocationsUnitOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/unitOperations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/unitOperations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsUnitOperationsRequest>;
 
@@ -2005,7 +2005,7 @@ export const GetProjectsLocationsUnitOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsUnitOperationsRequest>;
 
@@ -2054,7 +2054,7 @@ export const CreateProjectsLocationsUnitOperationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/unitOperations",
+      path: "v1/{+parent}/unitOperations",
       hasBody: true,
     }),
     svc,
@@ -2101,7 +2101,7 @@ export const PatchProjectsLocationsUnitOperationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(UnitOperation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsUnitOperationsRequest>;
 
@@ -2143,7 +2143,7 @@ export const DeleteProjectsLocationsUnitOperationsRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsUnitOperationsRequest>;
 
@@ -2186,7 +2186,7 @@ export const ListProjectsLocationsReleasesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/releases" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/releases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReleasesRequest>;
 
@@ -2221,7 +2221,7 @@ export const GetProjectsLocationsReleasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReleasesRequest>;
 
@@ -2266,7 +2266,7 @@ export const CreateProjectsLocationsReleasesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Release).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/releases", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/releases", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsReleasesRequest>;
 
@@ -2311,7 +2311,7 @@ export const PatchProjectsLocationsReleasesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Release).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsReleasesRequest>;
 
@@ -2353,7 +2353,7 @@ export const DeleteProjectsLocationsReleasesRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReleasesRequest>;
 
@@ -2396,7 +2396,7 @@ export const ListProjectsLocationsRolloutsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/rollouts" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/rollouts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRolloutsRequest>;
 
@@ -2431,7 +2431,7 @@ export const GetProjectsLocationsRolloutsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRolloutsRequest>;
 
@@ -2476,7 +2476,7 @@ export const CreateProjectsLocationsRolloutsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Rollout).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/rollouts", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/rollouts", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRolloutsRequest>;
 
@@ -2521,7 +2521,7 @@ export const PatchProjectsLocationsRolloutsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Rollout).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRolloutsRequest>;
 
@@ -2563,7 +2563,7 @@ export const DeleteProjectsLocationsRolloutsRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRolloutsRequest>;
 
@@ -2606,7 +2606,7 @@ export const ListProjectsLocationsRolloutKindsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/rolloutKinds" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/rolloutKinds" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRolloutKindsRequest>;
 
@@ -2642,7 +2642,7 @@ export const GetProjectsLocationsRolloutKindsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRolloutKindsRequest>;
 
@@ -2689,7 +2689,11 @@ export const CreateProjectsLocationsRolloutKindsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(RolloutKind).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/rolloutKinds", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/rolloutKinds",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRolloutKindsRequest>;
 
@@ -2734,7 +2738,7 @@ export const PatchProjectsLocationsRolloutKindsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(RolloutKind).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRolloutKindsRequest>;
 
@@ -2776,7 +2780,7 @@ export const DeleteProjectsLocationsRolloutKindsRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRolloutKindsRequest>;
 

--- a/packages/gcp/src/services/saasservicemgmt-v1beta1.ts
+++ b/packages/gcp/src/services/saasservicemgmt-v1beta1.ts
@@ -1534,7 +1534,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1569,7 +1569,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1612,7 +1612,7 @@ export const ListProjectsLocationsSaasRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/saas" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/saas" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSaasRequest>;
 
@@ -1647,7 +1647,7 @@ export const GetProjectsLocationsSaasRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSaasRequest>;
 
@@ -1692,7 +1692,7 @@ export const CreateProjectsLocationsSaasRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Saas).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/saas", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+parent}/saas", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSaasRequest>;
 
@@ -1737,7 +1737,7 @@ export const PatchProjectsLocationsSaasRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Saas).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSaasRequest>;
 
@@ -1779,7 +1779,7 @@ export const DeleteProjectsLocationsSaasRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSaasRequest>;
 
@@ -1822,7 +1822,7 @@ export const ListProjectsLocationsTenantsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/tenants" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/tenants" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTenantsRequest>;
 
@@ -1857,7 +1857,7 @@ export const GetProjectsLocationsTenantsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTenantsRequest>;
 
@@ -1902,7 +1902,11 @@ export const CreateProjectsLocationsTenantsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Tenant).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/tenants", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/tenants",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsTenantsRequest>;
 
@@ -1947,7 +1951,7 @@ export const PatchProjectsLocationsTenantsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Tenant).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTenantsRequest>;
 
@@ -1989,7 +1993,7 @@ export const DeleteProjectsLocationsTenantsRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTenantsRequest>;
 
@@ -2032,7 +2036,7 @@ export const ListProjectsLocationsUnitKindsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/unitKinds" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/unitKinds" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsUnitKindsRequest>;
 
@@ -2067,7 +2071,7 @@ export const GetProjectsLocationsUnitKindsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsUnitKindsRequest>;
 
@@ -2114,7 +2118,7 @@ export const CreateProjectsLocationsUnitKindsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/unitKinds",
+      path: "v1beta1/{+parent}/unitKinds",
       hasBody: true,
     }),
     svc,
@@ -2161,7 +2165,7 @@ export const PatchProjectsLocationsUnitKindsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(UnitKind).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsUnitKindsRequest>;
 
@@ -2203,7 +2207,7 @@ export const DeleteProjectsLocationsUnitKindsRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsUnitKindsRequest>;
 
@@ -2246,7 +2250,7 @@ export const ListProjectsLocationsUnitsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/units" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/units" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsUnitsRequest>;
 
@@ -2281,7 +2285,7 @@ export const GetProjectsLocationsUnitsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsUnitsRequest>;
 
@@ -2326,7 +2330,7 @@ export const CreateProjectsLocationsUnitsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Unit).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/units", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+parent}/units", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsUnitsRequest>;
 
@@ -2371,7 +2375,7 @@ export const PatchProjectsLocationsUnitsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Unit).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsUnitsRequest>;
 
@@ -2413,7 +2417,7 @@ export const DeleteProjectsLocationsUnitsRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsUnitsRequest>;
 
@@ -2456,7 +2460,7 @@ export const ListProjectsLocationsUnitOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/unitOperations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/unitOperations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsUnitOperationsRequest>;
 
@@ -2492,7 +2496,7 @@ export const GetProjectsLocationsUnitOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsUnitOperationsRequest>;
 
@@ -2541,7 +2545,7 @@ export const CreateProjectsLocationsUnitOperationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/unitOperations",
+      path: "v1beta1/{+parent}/unitOperations",
       hasBody: true,
     }),
     svc,
@@ -2588,7 +2592,7 @@ export const PatchProjectsLocationsUnitOperationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(UnitOperation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsUnitOperationsRequest>;
 
@@ -2630,7 +2634,7 @@ export const DeleteProjectsLocationsUnitOperationsRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsUnitOperationsRequest>;
 
@@ -2673,7 +2677,7 @@ export const ListProjectsLocationsReleasesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/releases" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/releases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReleasesRequest>;
 
@@ -2708,7 +2712,7 @@ export const GetProjectsLocationsReleasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsReleasesRequest>;
 
@@ -2755,7 +2759,7 @@ export const CreateProjectsLocationsReleasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/releases",
+      path: "v1beta1/{+parent}/releases",
       hasBody: true,
     }),
     svc,
@@ -2802,7 +2806,7 @@ export const PatchProjectsLocationsReleasesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Release).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsReleasesRequest>;
 
@@ -2844,7 +2848,7 @@ export const DeleteProjectsLocationsReleasesRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsReleasesRequest>;
 
@@ -2887,7 +2891,7 @@ export const ListProjectsLocationsFlagsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/flags" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/flags" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFlagsRequest>;
 
@@ -2922,7 +2926,7 @@ export const GetProjectsLocationsFlagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFlagsRequest>;
 
@@ -2967,7 +2971,7 @@ export const CreateProjectsLocationsFlagsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Flag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/flags", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+parent}/flags", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsFlagsRequest>;
 
@@ -3012,7 +3016,7 @@ export const PatchProjectsLocationsFlagsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Flag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFlagsRequest>;
 
@@ -3054,7 +3058,7 @@ export const DeleteProjectsLocationsFlagsRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFlagsRequest>;
 
@@ -3097,7 +3101,7 @@ export const ListProjectsLocationsFlagRevisionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/flagRevisions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/flagRevisions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFlagRevisionsRequest>;
 
@@ -3133,7 +3137,7 @@ export const GetProjectsLocationsFlagRevisionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFlagRevisionsRequest>;
 
@@ -3182,7 +3186,7 @@ export const CreateProjectsLocationsFlagRevisionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/flagRevisions",
+      path: "v1beta1/{+parent}/flagRevisions",
       hasBody: true,
     }),
     svc,
@@ -3229,7 +3233,7 @@ export const PatchProjectsLocationsFlagRevisionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(FlagRevision).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFlagRevisionsRequest>;
 
@@ -3271,7 +3275,7 @@ export const DeleteProjectsLocationsFlagRevisionsRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFlagRevisionsRequest>;
 
@@ -3314,7 +3318,7 @@ export const ListProjectsLocationsFlagReleasesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/flagReleases" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/flagReleases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFlagReleasesRequest>;
 
@@ -3350,7 +3354,7 @@ export const GetProjectsLocationsFlagReleasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFlagReleasesRequest>;
 
@@ -3399,7 +3403,7 @@ export const CreateProjectsLocationsFlagReleasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/flagReleases",
+      path: "v1beta1/{+parent}/flagReleases",
       hasBody: true,
     }),
     svc,
@@ -3446,7 +3450,7 @@ export const PatchProjectsLocationsFlagReleasesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(FlagRelease).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFlagReleasesRequest>;
 
@@ -3488,7 +3492,7 @@ export const DeleteProjectsLocationsFlagReleasesRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFlagReleasesRequest>;
 
@@ -3531,7 +3535,7 @@ export const ListProjectsLocationsFlagAttributesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/flagAttributes" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/flagAttributes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsFlagAttributesRequest>;
 
@@ -3567,7 +3571,7 @@ export const GetProjectsLocationsFlagAttributesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsFlagAttributesRequest>;
 
@@ -3616,7 +3620,7 @@ export const CreateProjectsLocationsFlagAttributesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/flagAttributes",
+      path: "v1beta1/{+parent}/flagAttributes",
       hasBody: true,
     }),
     svc,
@@ -3663,7 +3667,7 @@ export const PatchProjectsLocationsFlagAttributesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(FlagAttribute).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsFlagAttributesRequest>;
 
@@ -3705,7 +3709,7 @@ export const DeleteProjectsLocationsFlagAttributesRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsFlagAttributesRequest>;
 
@@ -3748,7 +3752,7 @@ export const ListProjectsLocationsRolloutsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/rollouts" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/rollouts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRolloutsRequest>;
 
@@ -3783,7 +3787,7 @@ export const GetProjectsLocationsRolloutsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRolloutsRequest>;
 
@@ -3830,7 +3834,7 @@ export const CreateProjectsLocationsRolloutsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/rollouts",
+      path: "v1beta1/{+parent}/rollouts",
       hasBody: true,
     }),
     svc,
@@ -3877,7 +3881,7 @@ export const PatchProjectsLocationsRolloutsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Rollout).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRolloutsRequest>;
 
@@ -3919,7 +3923,7 @@ export const DeleteProjectsLocationsRolloutsRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRolloutsRequest>;
 
@@ -3962,7 +3966,7 @@ export const ListProjectsLocationsRolloutKindsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/rolloutKinds" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/rolloutKinds" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRolloutKindsRequest>;
 
@@ -3998,7 +4002,7 @@ export const GetProjectsLocationsRolloutKindsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRolloutKindsRequest>;
 
@@ -4047,7 +4051,7 @@ export const CreateProjectsLocationsRolloutKindsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/rolloutKinds",
+      path: "v1beta1/{+parent}/rolloutKinds",
       hasBody: true,
     }),
     svc,
@@ -4094,7 +4098,7 @@ export const PatchProjectsLocationsRolloutKindsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(RolloutKind).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRolloutKindsRequest>;
 
@@ -4136,7 +4140,7 @@ export const DeleteProjectsLocationsRolloutKindsRequest =
     ),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRolloutKindsRequest>;
 

--- a/packages/gcp/src/services/sasportal-v1alpha1.ts
+++ b/packages/gcp/src/services/sasportal-v1alpha1.ts
@@ -816,7 +816,7 @@ export interface GetDeploymentsRequest {
 export const GetDeploymentsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+  T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetDeploymentsRequest>;
 
@@ -847,7 +847,7 @@ export const DeleteDeploymentsDevicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteDeploymentsDevicesRequest>;
 
@@ -881,7 +881,7 @@ export const MoveDeploymentsDevicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SasPortalMoveDeviceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveDeploymentsDevicesRequest>;
 
@@ -912,7 +912,7 @@ export const GetDeploymentsDevicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDeploymentsDevicesRequest>;
 
@@ -949,7 +949,7 @@ export const PatchDeploymentsDevicesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SasPortalDevice).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchDeploymentsDevicesRequest>;
 
@@ -987,7 +987,7 @@ export const UpdateSignedDeploymentsDevicesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1alpha1/{name}:updateSigned",
+      path: "v1alpha1/{+name}:updateSigned",
       hasBody: true,
     }),
     svc,
@@ -1025,7 +1025,7 @@ export const SignDeviceDeploymentsDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{name}:signDevice",
+      path: "v1alpha1/{+name}:signDevice",
       hasBody: true,
     }),
     svc,
@@ -1183,7 +1183,7 @@ export interface GetCustomersRequest {
 export const GetCustomersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+  T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetCustomersRequest>;
 
@@ -1388,7 +1388,7 @@ export const PatchCustomersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
   body: Schema.optional(SasPortalCustomer).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchCustomersRequest>;
 
@@ -1424,7 +1424,7 @@ export const CreateCustomersDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices",
+      path: "v1alpha1/{+parent}/devices",
       hasBody: true,
     }),
     svc,
@@ -1464,7 +1464,7 @@ export const CreateSignedCustomersDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices:createSigned",
+      path: "v1alpha1/{+parent}/devices:createSigned",
       hasBody: true,
     }),
     svc,
@@ -1504,7 +1504,7 @@ export const UpdateSignedCustomersDevicesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1alpha1/{name}:updateSigned",
+      path: "v1alpha1/{+name}:updateSigned",
       hasBody: true,
     }),
     svc,
@@ -1542,7 +1542,7 @@ export const SignDeviceCustomersDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{name}:signDevice",
+      path: "v1alpha1/{+name}:signDevice",
       hasBody: true,
     }),
     svc,
@@ -1575,7 +1575,7 @@ export const GetCustomersDevicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersDevicesRequest>;
 
@@ -1609,7 +1609,7 @@ export const MoveCustomersDevicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SasPortalMoveDeviceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveCustomersDevicesRequest>;
 
@@ -1646,7 +1646,7 @@ export const PatchCustomersDevicesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SasPortalDevice).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchCustomersDevicesRequest>;
 
@@ -1677,7 +1677,7 @@ export const DeleteCustomersDevicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteCustomersDevicesRequest>;
 
@@ -1717,7 +1717,7 @@ export const ListCustomersDevicesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/devices" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/devices" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersDevicesRequest>;
 
@@ -1755,7 +1755,7 @@ export const CreateCustomersNodesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(SasPortalNode).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{parent}/nodes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+parent}/nodes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateCustomersNodesRequest>;
 
@@ -1792,7 +1792,7 @@ export const PatchCustomersNodesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SasPortalNode).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchCustomersNodesRequest>;
 
@@ -1823,7 +1823,7 @@ export const GetCustomersNodesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersNodesRequest>;
 
@@ -1854,7 +1854,7 @@ export const DeleteCustomersNodesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteCustomersNodesRequest>;
 
@@ -1894,7 +1894,7 @@ export const ListCustomersNodesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/nodes" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/nodes" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersNodesRequest>;
 
@@ -1932,7 +1932,7 @@ export const MoveCustomersNodesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SasPortalMoveNodeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveCustomersNodesRequest>;
 
@@ -1972,7 +1972,7 @@ export const ListCustomersNodesDevicesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/devices" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/devices" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersNodesDevicesRequest>;
 
@@ -2014,7 +2014,7 @@ export const CreateSignedCustomersNodesDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices:createSigned",
+      path: "v1alpha1/{+parent}/devices:createSigned",
       hasBody: true,
     }),
     svc,
@@ -2052,7 +2052,7 @@ export const CreateCustomersNodesDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices",
+      path: "v1alpha1/{+parent}/devices",
       hasBody: true,
     }),
     svc,
@@ -2088,7 +2088,7 @@ export const CreateCustomersNodesNodesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(SasPortalNode).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{parent}/nodes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+parent}/nodes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateCustomersNodesNodesRequest>;
 
@@ -2128,7 +2128,7 @@ export const ListCustomersNodesNodesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/nodes" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/nodes" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersNodesNodesRequest>;
 
@@ -2168,7 +2168,7 @@ export const CreateCustomersNodesDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/deployments",
+      path: "v1alpha1/{+parent}/deployments",
       hasBody: true,
     }),
     svc,
@@ -2210,7 +2210,7 @@ export const ListCustomersNodesDeploymentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersNodesDeploymentsRequest>;
 
@@ -2246,7 +2246,7 @@ export const GetCustomersDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersDeploymentsRequest>;
 
@@ -2277,7 +2277,7 @@ export const DeleteCustomersDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteCustomersDeploymentsRequest>;
 
@@ -2317,7 +2317,7 @@ export const ListCustomersDeploymentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersDeploymentsRequest>;
 
@@ -2355,7 +2355,7 @@ export const MoveCustomersDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SasPortalMoveDeploymentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveCustomersDeploymentsRequest>;
 
@@ -2391,7 +2391,7 @@ export const CreateCustomersDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/deployments",
+      path: "v1alpha1/{+parent}/deployments",
       hasBody: true,
     }),
     svc,
@@ -2430,7 +2430,7 @@ export const PatchCustomersDeploymentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SasPortalDeployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchCustomersDeploymentsRequest>;
 
@@ -2468,7 +2468,7 @@ export const CreateSignedCustomersDeploymentsDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices:createSigned",
+      path: "v1alpha1/{+parent}/devices:createSigned",
       hasBody: true,
     }),
     svc,
@@ -2506,7 +2506,7 @@ export const CreateCustomersDeploymentsDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices",
+      path: "v1alpha1/{+parent}/devices",
       hasBody: true,
     }),
     svc,
@@ -2548,7 +2548,7 @@ export const ListCustomersDeploymentsDevicesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/devices" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/devices" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersDeploymentsDevicesRequest>;
 
@@ -2583,7 +2583,7 @@ export interface GetNodesRequest {
 export const GetNodesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+  T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetNodesRequest>;
 
@@ -2619,7 +2619,7 @@ export const PatchNodesDevicesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SasPortalDevice).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchNodesDevicesRequest>;
 
@@ -2650,7 +2650,7 @@ export const DeleteNodesDevicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNodesDevicesRequest>;
 
@@ -2690,7 +2690,7 @@ export const ListNodesDevicesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/devices" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/devices" }),
     svc,
   ) as unknown as Schema.Schema<ListNodesDevicesRequest>;
 
@@ -2732,7 +2732,7 @@ export const CreateSignedNodesDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices:createSigned",
+      path: "v1alpha1/{+parent}/devices:createSigned",
       hasBody: true,
     }),
     svc,
@@ -2772,7 +2772,7 @@ export const UpdateSignedNodesDevicesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1alpha1/{name}:updateSigned",
+      path: "v1alpha1/{+name}:updateSigned",
       hasBody: true,
     }),
     svc,
@@ -2810,7 +2810,7 @@ export const SignDeviceNodesDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{name}:signDevice",
+      path: "v1alpha1/{+name}:signDevice",
       hasBody: true,
     }),
     svc,
@@ -2848,7 +2848,7 @@ export const CreateNodesDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices",
+      path: "v1alpha1/{+parent}/devices",
       hasBody: true,
     }),
     svc,
@@ -2884,7 +2884,7 @@ export const MoveNodesDevicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SasPortalMoveDeviceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveNodesDevicesRequest>;
 
@@ -2916,7 +2916,7 @@ export const GetNodesDevicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     name: Schema.String.pipe(T.HttpPath("name")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+  T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetNodesDevicesRequest>;
 
@@ -2953,7 +2953,7 @@ export const PatchNodesDeploymentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SasPortalDeployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchNodesDeploymentsRequest>;
 
@@ -2984,7 +2984,7 @@ export const DeleteNodesDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNodesDeploymentsRequest>;
 
@@ -3024,7 +3024,7 @@ export const ListNodesDeploymentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListNodesDeploymentsRequest>;
 
@@ -3062,7 +3062,7 @@ export const MoveNodesDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SasPortalMoveDeploymentRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveNodesDeploymentsRequest>;
 
@@ -3093,7 +3093,7 @@ export const GetNodesDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetNodesDeploymentsRequest>;
 
@@ -3133,7 +3133,7 @@ export const ListNodesDeploymentsDevicesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/devices" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/devices" }),
     svc,
   ) as unknown as Schema.Schema<ListNodesDeploymentsDevicesRequest>;
 
@@ -3173,7 +3173,7 @@ export const CreateNodesDeploymentsDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices",
+      path: "v1alpha1/{+parent}/devices",
       hasBody: true,
     }),
     svc,
@@ -3213,7 +3213,7 @@ export const CreateSignedNodesDeploymentsDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices:createSigned",
+      path: "v1alpha1/{+parent}/devices:createSigned",
       hasBody: true,
     }),
     svc,
@@ -3246,7 +3246,7 @@ export const DeleteNodesNodesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteNodesNodesRequest>;
 
@@ -3285,7 +3285,7 @@ export const ListNodesNodesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1alpha1/{parent}/nodes" }),
+  T.Http({ method: "GET", path: "v1alpha1/{+parent}/nodes" }),
   svc,
 ) as unknown as Schema.Schema<ListNodesNodesRequest>;
 
@@ -3322,7 +3322,7 @@ export const MoveNodesNodesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(SasPortalMoveNodeRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v1alpha1/{name}:move", hasBody: true }),
+  T.Http({ method: "POST", path: "v1alpha1/{+name}:move", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<MoveNodesNodesRequest>;
 
@@ -3352,7 +3352,7 @@ export interface GetNodesNodesRequest {
 export const GetNodesNodesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+  T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetNodesNodesRequest>;
 
@@ -3389,7 +3389,7 @@ export const PatchNodesNodesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     body: Schema.optional(SasPortalNode).pipe(T.HttpBody()),
   },
 ).pipe(
-  T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+  T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<PatchNodesNodesRequest>;
 
@@ -3423,7 +3423,7 @@ export const CreateNodesNodesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(SasPortalNode).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{parent}/nodes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+parent}/nodes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateNodesNodesRequest>;
 
@@ -3459,7 +3459,7 @@ export const CreateNodesNodesDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices",
+      path: "v1alpha1/{+parent}/devices",
       hasBody: true,
     }),
     svc,
@@ -3499,7 +3499,7 @@ export const CreateSignedNodesNodesDevicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/devices:createSigned",
+      path: "v1alpha1/{+parent}/devices:createSigned",
       hasBody: true,
     }),
     svc,
@@ -3541,7 +3541,7 @@ export const ListNodesNodesDevicesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/devices" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/devices" }),
     svc,
   ) as unknown as Schema.Schema<ListNodesNodesDevicesRequest>;
 
@@ -3581,7 +3581,7 @@ export const CreateNodesNodesDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/deployments",
+      path: "v1alpha1/{+parent}/deployments",
       hasBody: true,
     }),
     svc,
@@ -3623,7 +3623,7 @@ export const ListNodesNodesDeploymentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListNodesNodesDeploymentsRequest>;
 
@@ -3662,7 +3662,7 @@ export const CreateNodesNodesNodesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(SasPortalNode).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{parent}/nodes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+parent}/nodes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateNodesNodesNodesRequest>;
 
@@ -3702,7 +3702,7 @@ export const ListNodesNodesNodesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/nodes" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/nodes" }),
     svc,
   ) as unknown as Schema.Schema<ListNodesNodesNodesRequest>;
 

--- a/packages/gcp/src/services/searchads360-v0.ts
+++ b/packages/gcp/src/services/searchads360-v0.ts
@@ -6084,7 +6084,7 @@ export const GetSearchAds360FieldsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     resourceName: Schema.String.pipe(T.HttpPath("resourceName")),
   }).pipe(
-    T.Http({ method: "GET", path: "v0/{resourceName}" }),
+    T.Http({ method: "GET", path: "v0/{+resourceName}" }),
     svc,
   ) as unknown as Schema.Schema<GetSearchAds360FieldsRequest>;
 
@@ -6143,7 +6143,7 @@ export const ListCustomersCustomColumnsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     customerId: Schema.String.pipe(T.HttpPath("customerId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v0/customers/{customerId}/customColumns" }),
+    T.Http({ method: "GET", path: "v0/customers/{+customerId}/customColumns" }),
     svc,
   ) as unknown as Schema.Schema<ListCustomersCustomColumnsRequest>;
 
@@ -6175,7 +6175,7 @@ export const GetCustomersCustomColumnsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     resourceName: Schema.String.pipe(T.HttpPath("resourceName")),
   }).pipe(
-    T.Http({ method: "GET", path: "v0/{resourceName}" }),
+    T.Http({ method: "GET", path: "v0/{+resourceName}" }),
     svc,
   ) as unknown as Schema.Schema<GetCustomersCustomColumnsRequest>;
 
@@ -6214,7 +6214,7 @@ export const SearchCustomersSearchAds360Request =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v0/customers/{customerId}/searchAds360:search",
+      path: "v0/customers/{+customerId}/searchAds360:search",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/secretmanager-v1.ts
+++ b/packages/gcp/src/services/secretmanager-v1.ts
@@ -558,7 +558,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -603,7 +603,7 @@ export const ListProjectsLocationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -643,7 +643,7 @@ export const GetIamPolicyProjectsLocationsSecretsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsSecretsRequest>;
 
@@ -679,7 +679,7 @@ export const TestIamPermissionsProjectsLocationsSecretsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -718,7 +718,7 @@ export const SetIamPolicyProjectsLocationsSecretsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -754,7 +754,7 @@ export const DeleteProjectsLocationsSecretsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSecretsRequest>;
 
@@ -794,7 +794,7 @@ export const ListProjectsLocationsSecretsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/secrets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/secrets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSecretsRequest>;
 
@@ -835,7 +835,7 @@ export const CreateProjectsLocationsSecretsRequest =
     secretId: Schema.optional(Schema.String).pipe(T.HttpQuery("secretId")),
     body: Schema.optional(Secret).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/secrets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/secrets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSecretsRequest>;
 
@@ -866,7 +866,7 @@ export const GetProjectsLocationsSecretsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSecretsRequest>;
 
@@ -903,7 +903,7 @@ export const PatchProjectsLocationsSecretsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Secret).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSecretsRequest>;
 
@@ -937,7 +937,7 @@ export const AddVersionProjectsLocationsSecretsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(AddSecretVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:addVersion", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}:addVersion", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AddVersionProjectsLocationsSecretsRequest>;
 
@@ -968,7 +968,7 @@ export const GetProjectsLocationsSecretsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSecretsVersionsRequest>;
 
@@ -1002,7 +1002,7 @@ export const DestroyProjectsLocationsSecretsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DestroySecretVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:destroy", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:destroy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DestroyProjectsLocationsSecretsVersionsRequest>;
 
@@ -1036,7 +1036,7 @@ export const EnableProjectsLocationsSecretsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EnableSecretVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:enable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:enable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EnableProjectsLocationsSecretsVersionsRequest>;
 
@@ -1067,7 +1067,7 @@ export const AccessProjectsLocationsSecretsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:access" }),
+    T.Http({ method: "GET", path: "v1/{+name}:access" }),
     svc,
   ) as unknown as Schema.Schema<AccessProjectsLocationsSecretsVersionsRequest>;
 
@@ -1108,7 +1108,7 @@ export const ListProjectsLocationsSecretsVersionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSecretsVersionsRequest>;
 
@@ -1147,7 +1147,7 @@ export const DisableProjectsLocationsSecretsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DisableSecretVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:disable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:disable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DisableProjectsLocationsSecretsVersionsRequest>;
 
@@ -1183,7 +1183,7 @@ export const SetIamPolicyProjectsSecretsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1219,7 +1219,7 @@ export const DeleteProjectsSecretsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsSecretsRequest>;
 
@@ -1254,7 +1254,7 @@ export const GetIamPolicyProjectsSecretsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsSecretsRequest>;
 
@@ -1290,7 +1290,7 @@ export const TestIamPermissionsProjectsSecretsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1330,7 +1330,7 @@ export const CreateProjectsSecretsRequest =
     secretId: Schema.optional(Schema.String).pipe(T.HttpQuery("secretId")),
     body: Schema.optional(Secret).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/secrets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/secrets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsSecretsRequest>;
 
@@ -1360,7 +1360,7 @@ export const GetProjectsSecretsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSecretsRequest>;
 
@@ -1396,7 +1396,7 @@ export const PatchProjectsSecretsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Secret).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsSecretsRequest>;
 
@@ -1429,7 +1429,7 @@ export const AddVersionProjectsSecretsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(AddSecretVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:addVersion", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}:addVersion", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AddVersionProjectsSecretsRequest>;
 
@@ -1469,7 +1469,7 @@ export const ListProjectsSecretsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/secrets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/secrets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSecretsRequest>;
 
@@ -1504,7 +1504,7 @@ export const GetProjectsSecretsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSecretsVersionsRequest>;
 
@@ -1538,7 +1538,7 @@ export const DestroyProjectsSecretsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DestroySecretVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:destroy", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:destroy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DestroyProjectsSecretsVersionsRequest>;
 
@@ -1569,7 +1569,7 @@ export const AccessProjectsSecretsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:access" }),
+    T.Http({ method: "GET", path: "v1/{+name}:access" }),
     svc,
   ) as unknown as Schema.Schema<AccessProjectsSecretsVersionsRequest>;
 
@@ -1603,7 +1603,7 @@ export const EnableProjectsSecretsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EnableSecretVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:enable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:enable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EnableProjectsSecretsVersionsRequest>;
 
@@ -1643,7 +1643,7 @@ export const ListProjectsSecretsVersionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSecretsVersionsRequest>;
 
@@ -1681,7 +1681,7 @@ export const DisableProjectsSecretsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DisableSecretVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:disable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:disable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DisableProjectsSecretsVersionsRequest>;
 

--- a/packages/gcp/src/services/secretmanager-v1beta1.ts
+++ b/packages/gcp/src/services/secretmanager-v1beta1.ts
@@ -415,7 +415,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -460,7 +460,7 @@ export const ListProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -500,7 +500,7 @@ export const TestIamPermissionsProjectsSecretsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -540,7 +540,7 @@ export const PatchProjectsSecretsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Secret).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsSecretsRequest>;
 
@@ -576,7 +576,11 @@ export const CreateProjectsSecretsRequest =
     secretId: Schema.optional(Schema.String).pipe(T.HttpQuery("secretId")),
     body: Schema.optional(Secret).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/secrets", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/secrets",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsSecretsRequest>;
 
@@ -606,7 +610,7 @@ export const DeleteProjectsSecretsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsSecretsRequest>;
 
@@ -641,7 +645,7 @@ export const AddVersionProjectsSecretsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:addVersion",
+      path: "v1beta1/{+parent}:addVersion",
       hasBody: true,
     }),
     svc,
@@ -679,7 +683,7 @@ export const SetIamPolicyProjectsSecretsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -717,7 +721,7 @@ export const GetIamPolicyProjectsSecretsRequest =
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsSecretsRequest>;
 
@@ -748,7 +752,7 @@ export const GetProjectsSecretsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSecretsRequest>;
 
@@ -784,7 +788,7 @@ export const ListProjectsSecretsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/secrets" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/secrets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSecretsRequest>;
 
@@ -822,7 +826,7 @@ export const DestroyProjectsSecretsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DestroySecretVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:destroy", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:destroy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DestroyProjectsSecretsVersionsRequest>;
 
@@ -853,7 +857,7 @@ export const GetProjectsSecretsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSecretsVersionsRequest>;
 
@@ -890,7 +894,7 @@ export const ListProjectsSecretsVersionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSecretsVersionsRequest>;
 
@@ -925,7 +929,7 @@ export const AccessProjectsSecretsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}:access" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}:access" }),
     svc,
   ) as unknown as Schema.Schema<AccessProjectsSecretsVersionsRequest>;
 
@@ -959,7 +963,7 @@ export const EnableProjectsSecretsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EnableSecretVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:enable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:enable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EnableProjectsSecretsVersionsRequest>;
 
@@ -993,7 +997,7 @@ export const DisableProjectsSecretsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DisableSecretVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:disable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:disable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DisableProjectsSecretsVersionsRequest>;
 

--- a/packages/gcp/src/services/secretmanager-v1beta2.ts
+++ b/packages/gcp/src/services/secretmanager-v1beta2.ts
@@ -561,7 +561,7 @@ export const DeleteProjectsSecretsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta2/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsSecretsRequest>;
 
@@ -591,7 +591,7 @@ export const GetProjectsSecretsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSecretsRequest>;
 
@@ -627,7 +627,7 @@ export const PatchProjectsSecretsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Secret).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsSecretsRequest>;
 
@@ -662,7 +662,7 @@ export const SetIamPolicyProjectsSecretsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{resource}:setIamPolicy",
+      path: "v1beta2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -700,7 +700,7 @@ export const TestIamPermissionsProjectsSecretsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{resource}:testIamPermissions",
+      path: "v1beta2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -743,7 +743,7 @@ export const ListProjectsSecretsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{parent}/secrets" }),
+    T.Http({ method: "GET", path: "v1beta2/{+parent}/secrets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSecretsRequest>;
 
@@ -784,7 +784,11 @@ export const CreateProjectsSecretsRequest =
     secretId: Schema.optional(Schema.String).pipe(T.HttpQuery("secretId")),
     body: Schema.optional(Secret).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta2/{parent}/secrets", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta2/{+parent}/secrets",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsSecretsRequest>;
 
@@ -819,7 +823,7 @@ export const AddVersionProjectsSecretsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{parent}:addVersion",
+      path: "v1beta2/{+parent}:addVersion",
       hasBody: true,
     }),
     svc,
@@ -857,7 +861,7 @@ export const GetIamPolicyProjectsSecretsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta2/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsSecretsRequest>;
 
@@ -891,7 +895,7 @@ export const EnableProjectsSecretsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EnableSecretVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta2/{name}:enable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta2/{+name}:enable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EnableProjectsSecretsVersionsRequest>;
 
@@ -931,7 +935,7 @@ export const ListProjectsSecretsVersionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1beta2/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSecretsVersionsRequest>;
 
@@ -966,7 +970,7 @@ export const GetProjectsSecretsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSecretsVersionsRequest>;
 
@@ -1000,7 +1004,7 @@ export const DisableProjectsSecretsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DisableSecretVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta2/{name}:disable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta2/{+name}:disable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DisableProjectsSecretsVersionsRequest>;
 
@@ -1034,7 +1038,7 @@ export const DestroyProjectsSecretsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DestroySecretVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta2/{name}:destroy", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta2/{+name}:destroy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DestroyProjectsSecretsVersionsRequest>;
 
@@ -1065,7 +1069,7 @@ export const AccessProjectsSecretsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:access" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:access" }),
     svc,
   ) as unknown as Schema.Schema<AccessProjectsSecretsVersionsRequest>;
 
@@ -1096,7 +1100,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1141,7 +1145,7 @@ export const ListProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1179,7 +1183,7 @@ export const DeleteProjectsLocationsSecretsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta2/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSecretsRequest>;
 
@@ -1210,7 +1214,7 @@ export const GetProjectsLocationsSecretsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSecretsRequest>;
 
@@ -1247,7 +1251,7 @@ export const PatchProjectsLocationsSecretsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Secret).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSecretsRequest>;
 
@@ -1283,7 +1287,7 @@ export const SetIamPolicyProjectsLocationsSecretsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{resource}:setIamPolicy",
+      path: "v1beta2/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1321,7 +1325,7 @@ export const TestIamPermissionsProjectsLocationsSecretsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{resource}:testIamPermissions",
+      path: "v1beta2/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1360,7 +1364,7 @@ export const GetIamPolicyProjectsLocationsSecretsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta2/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsSecretsRequest>;
 
@@ -1397,7 +1401,11 @@ export const CreateProjectsLocationsSecretsRequest =
     secretId: Schema.optional(Schema.String).pipe(T.HttpQuery("secretId")),
     body: Schema.optional(Secret).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta2/{parent}/secrets", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta2/{+parent}/secrets",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSecretsRequest>;
 
@@ -1437,7 +1445,7 @@ export const ListProjectsLocationsSecretsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{parent}/secrets" }),
+    T.Http({ method: "GET", path: "v1beta2/{+parent}/secrets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSecretsRequest>;
 
@@ -1477,7 +1485,7 @@ export const AddVersionProjectsLocationsSecretsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta2/{parent}:addVersion",
+      path: "v1beta2/{+parent}:addVersion",
       hasBody: true,
     }),
     svc,
@@ -1510,7 +1518,7 @@ export const AccessProjectsLocationsSecretsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:access" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:access" }),
     svc,
   ) as unknown as Schema.Schema<AccessProjectsLocationsSecretsVersionsRequest>;
 
@@ -1545,7 +1553,7 @@ export const EnableProjectsLocationsSecretsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EnableSecretVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta2/{name}:enable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta2/{+name}:enable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EnableProjectsLocationsSecretsVersionsRequest>;
 
@@ -1585,7 +1593,7 @@ export const ListProjectsLocationsSecretsVersionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1beta2/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSecretsVersionsRequest>;
 
@@ -1621,7 +1629,7 @@ export const GetProjectsLocationsSecretsVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSecretsVersionsRequest>;
 
@@ -1655,7 +1663,7 @@ export const DisableProjectsLocationsSecretsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DisableSecretVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta2/{name}:disable", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta2/{+name}:disable", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DisableProjectsLocationsSecretsVersionsRequest>;
 
@@ -1689,7 +1697,7 @@ export const DestroyProjectsLocationsSecretsVersionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DestroySecretVersionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta2/{name}:destroy", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta2/{+name}:destroy", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DestroyProjectsLocationsSecretsVersionsRequest>;
 

--- a/packages/gcp/src/services/securesourcemanager-v1.ts
+++ b/packages/gcp/src/services/securesourcemanager-v1.ts
@@ -1064,7 +1064,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1099,7 +1099,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1135,7 +1135,7 @@ export const SetIamPolicyProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1173,7 +1173,7 @@ export const GetIamPolicyProjectsLocationsInstancesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsInstancesRequest>;
 
@@ -1209,7 +1209,7 @@ export const TestIamPermissionsProjectsLocationsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1255,7 +1255,7 @@ export const ListProjectsLocationsInstancesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsInstancesRequest>;
 
@@ -1290,7 +1290,7 @@ export const GetProjectsLocationsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsInstancesRequest>;
 
@@ -1330,7 +1330,7 @@ export const CreateProjectsLocationsInstancesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Instance).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/instances", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/instances", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsInstancesRequest>;
 
@@ -1367,7 +1367,7 @@ export const DeleteProjectsLocationsInstancesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInstancesRequest>;
 
@@ -1412,7 +1412,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1447,7 +1447,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1478,7 +1478,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1512,7 +1512,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1555,7 +1555,7 @@ export const ListProjectsLocationsRepositoriesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     instance: Schema.optional(Schema.String).pipe(T.HttpQuery("instance")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/repositories" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/repositories" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesRequest>;
 
@@ -1591,7 +1591,7 @@ export const GetProjectsLocationsRepositoriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesRequest>;
 
@@ -1630,7 +1630,11 @@ export const CreateProjectsLocationsRepositoriesRequest =
     ),
     body: Schema.optional(Repository).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/repositories", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/repositories",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRepositoriesRequest>;
 
@@ -1672,7 +1676,7 @@ export const PatchProjectsLocationsRepositoriesRequest =
     ),
     body: Schema.optional(Repository).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesRequest>;
 
@@ -1708,7 +1712,7 @@ export const DeleteProjectsLocationsRepositoriesRequest =
       T.HttpQuery("allowMissing"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesRequest>;
 
@@ -1744,7 +1748,7 @@ export const GetIamPolicyProjectsLocationsRepositoriesRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsRepositoriesRequest>;
 
@@ -1780,7 +1784,7 @@ export const SetIamPolicyProjectsLocationsRepositoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1818,7 +1822,7 @@ export const TestIamPermissionsProjectsLocationsRepositoriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1865,7 +1869,7 @@ export const FetchTreeProjectsLocationsRepositoriesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{repository}:fetchTree" }),
+    T.Http({ method: "GET", path: "v1/{+repository}:fetchTree" }),
     svc,
   ) as unknown as Schema.Schema<FetchTreeProjectsLocationsRepositoriesRequest>;
 
@@ -1903,7 +1907,7 @@ export const FetchBlobProjectsLocationsRepositoriesRequest =
     repository: Schema.String.pipe(T.HttpPath("repository")),
     sha: Schema.optional(Schema.String).pipe(T.HttpQuery("sha")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{repository}:fetchBlob" }),
+    T.Http({ method: "GET", path: "v1/{+repository}:fetchBlob" }),
     svc,
   ) as unknown as Schema.Schema<FetchBlobProjectsLocationsRepositoriesRequest>;
 
@@ -1940,7 +1944,7 @@ export const ListProjectsLocationsRepositoriesHooksRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/hooks" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/hooks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesHooksRequest>;
 
@@ -1975,7 +1979,7 @@ export const GetProjectsLocationsRepositoriesHooksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesHooksRequest>;
 
@@ -2012,7 +2016,7 @@ export const CreateProjectsLocationsRepositoriesHooksRequest =
     hookId: Schema.optional(Schema.String).pipe(T.HttpQuery("hookId")),
     body: Schema.optional(Hook).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/hooks", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/hooks", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRepositoriesHooksRequest>;
 
@@ -2049,7 +2053,7 @@ export const PatchProjectsLocationsRepositoriesHooksRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Hook).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesHooksRequest>;
 
@@ -2080,7 +2084,7 @@ export const DeleteProjectsLocationsRepositoriesHooksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesHooksRequest>;
 
@@ -2117,7 +2121,7 @@ export const CreateProjectsLocationsRepositoriesBranchRulesRequest =
     ),
     body: Schema.optional(BranchRule).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/branchRules", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/branchRules", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRepositoriesBranchRulesRequest>;
 
@@ -2153,7 +2157,7 @@ export const ListProjectsLocationsRepositoriesBranchRulesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/branchRules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/branchRules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesBranchRulesRequest>;
 
@@ -2189,7 +2193,7 @@ export const GetProjectsLocationsRepositoriesBranchRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesBranchRulesRequest>;
 
@@ -2231,7 +2235,7 @@ export const PatchProjectsLocationsRepositoriesBranchRulesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(BranchRule).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesBranchRulesRequest>;
 
@@ -2266,7 +2270,7 @@ export const DeleteProjectsLocationsRepositoriesBranchRulesRequest =
       T.HttpQuery("allowMissing"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesBranchRulesRequest>;
 
@@ -2300,7 +2304,11 @@ export const CreateProjectsLocationsRepositoriesPullRequestsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(PullRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/pullRequests", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/pullRequests",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRepositoriesPullRequestsRequest>;
 
@@ -2332,7 +2340,7 @@ export const GetProjectsLocationsRepositoriesPullRequestsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesPullRequestsRequest>;
 
@@ -2369,7 +2377,7 @@ export const ListProjectsLocationsRepositoriesPullRequestsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/pullRequests" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/pullRequests" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesPullRequestsRequest>;
 
@@ -2411,7 +2419,7 @@ export const PatchProjectsLocationsRepositoriesPullRequestsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(PullRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesPullRequestsRequest>;
 
@@ -2445,7 +2453,7 @@ export const MergeProjectsLocationsRepositoriesPullRequestsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MergePullRequestRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:merge", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:merge", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MergeProjectsLocationsRepositoriesPullRequestsRequest>;
 
@@ -2479,7 +2487,7 @@ export const OpenProjectsLocationsRepositoriesPullRequestsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(OpenPullRequestRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:open", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:open", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<OpenProjectsLocationsRepositoriesPullRequestsRequest>;
 
@@ -2513,7 +2521,7 @@ export const CloseProjectsLocationsRepositoriesPullRequestsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ClosePullRequestRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:close", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:close", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CloseProjectsLocationsRepositoriesPullRequestsRequest>;
 
@@ -2550,7 +2558,7 @@ export const ListFileDiffsProjectsLocationsRepositoriesPullRequestsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:listFileDiffs" }),
+    T.Http({ method: "GET", path: "v1/{+name}:listFileDiffs" }),
     svc,
   ) as unknown as Schema.Schema<ListFileDiffsProjectsLocationsRepositoriesPullRequestsRequest>;
 
@@ -2587,7 +2595,7 @@ export const GetProjectsLocationsRepositoriesPullRequestsPullRequestCommentsRequ
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesPullRequestsPullRequestCommentsRequest>;
 
@@ -2627,7 +2635,7 @@ export const ListProjectsLocationsRepositoriesPullRequestsPullRequestCommentsReq
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/pullRequestComments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/pullRequestComments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesPullRequestsPullRequestCommentsRequest>;
 
@@ -2671,7 +2679,7 @@ export const CreateProjectsLocationsRepositoriesPullRequestsPullRequestCommentsR
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/pullRequestComments",
+      path: "v1/{+parent}/pullRequestComments",
       hasBody: true,
     }),
     svc,
@@ -2714,7 +2722,7 @@ export const PatchProjectsLocationsRepositoriesPullRequestsPullRequestCommentsRe
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(PullRequestComment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesPullRequestsPullRequestCommentsRequest>;
 
@@ -2749,7 +2757,7 @@ export const DeleteProjectsLocationsRepositoriesPullRequestsPullRequestCommentsR
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesPullRequestsPullRequestCommentsRequest>;
 
@@ -2791,7 +2799,7 @@ export const BatchCreateProjectsLocationsRepositoriesPullRequestsPullRequestComm
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/pullRequestComments:batchCreate",
+      path: "v1/{+parent}/pullRequestComments:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -2833,7 +2841,7 @@ export const ResolveProjectsLocationsRepositoriesPullRequestsPullRequestComments
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/pullRequestComments:resolve",
+      path: "v1/{+parent}/pullRequestComments:resolve",
       hasBody: true,
     }),
     svc,
@@ -2877,7 +2885,7 @@ export const UnresolveProjectsLocationsRepositoriesPullRequestsPullRequestCommen
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/pullRequestComments:unresolve",
+      path: "v1/{+parent}/pullRequestComments:unresolve",
       hasBody: true,
     }),
     svc,
@@ -2917,7 +2925,7 @@ export const CreateProjectsLocationsRepositoriesIssuesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Issue).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/issues", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/issues", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsRepositoriesIssuesRequest>;
 
@@ -2948,7 +2956,7 @@ export const GetProjectsLocationsRepositoriesIssuesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesIssuesRequest>;
 
@@ -2988,7 +2996,7 @@ export const ListProjectsLocationsRepositoriesIssuesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/issues" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/issues" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesIssuesRequest>;
 
@@ -3030,7 +3038,7 @@ export const PatchProjectsLocationsRepositoriesIssuesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Issue).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesIssuesRequest>;
 
@@ -3064,7 +3072,7 @@ export const DeleteProjectsLocationsRepositoriesIssuesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesIssuesRequest>;
 
@@ -3098,7 +3106,7 @@ export const OpenProjectsLocationsRepositoriesIssuesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(OpenIssueRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:open", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:open", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<OpenProjectsLocationsRepositoriesIssuesRequest>;
 
@@ -3132,7 +3140,7 @@ export const CloseProjectsLocationsRepositoriesIssuesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CloseIssueRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:close", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:close", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CloseProjectsLocationsRepositoriesIssuesRequest>;
 
@@ -3168,7 +3176,7 @@ export const CreateProjectsLocationsRepositoriesIssuesIssueCommentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/issueComments",
+      path: "v1/{+parent}/issueComments",
       hasBody: true,
     }),
     svc,
@@ -3203,7 +3211,7 @@ export const GetProjectsLocationsRepositoriesIssuesIssueCommentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRepositoriesIssuesIssueCommentsRequest>;
 
@@ -3242,7 +3250,7 @@ export const ListProjectsLocationsRepositoriesIssuesIssueCommentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/issueComments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/issueComments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRepositoriesIssuesIssueCommentsRequest>;
 
@@ -3285,7 +3293,7 @@ export const PatchProjectsLocationsRepositoriesIssuesIssueCommentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(IssueComment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsRepositoriesIssuesIssueCommentsRequest>;
 
@@ -3318,7 +3326,7 @@ export const DeleteProjectsLocationsRepositoriesIssuesIssueCommentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsRepositoriesIssuesIssueCommentsRequest>;
 

--- a/packages/gcp/src/services/securitycenter-v1.ts
+++ b/packages/gcp/src/services/securitycenter-v1.ts
@@ -8361,7 +8361,7 @@ export const GetOrganizationSettingsOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationSettingsOrganizationsRequest>;
 
@@ -8398,7 +8398,7 @@ export const UpdateOrganizationSettingsOrganizationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(OrganizationSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationSettingsOrganizationsRequest>;
 
@@ -8430,7 +8430,7 @@ export const DeleteOrganizationsResourceValueConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsResourceValueConfigsRequest>;
 
@@ -8461,7 +8461,7 @@ export const GetOrganizationsResourceValueConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsResourceValueConfigsRequest>;
 
@@ -8501,7 +8501,7 @@ export const PatchOrganizationsResourceValueConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsResourceValueConfigsRequest>;
 
@@ -8540,7 +8540,7 @@ export const BatchCreateOrganizationsResourceValueConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/resourceValueConfigs:batchCreate",
+      path: "v1/{+parent}/resourceValueConfigs:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -8580,7 +8580,7 @@ export const ListOrganizationsResourceValueConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/resourceValueConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/resourceValueConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsResourceValueConfigsRequest>;
 
@@ -8616,7 +8616,7 @@ export const DeleteOrganizationsMuteConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsMuteConfigsRequest>;
 
@@ -8655,7 +8655,7 @@ export const PatchOrganizationsMuteConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsMuteConfigsRequest>;
 
@@ -8687,7 +8687,7 @@ export const GetOrganizationsMuteConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsMuteConfigsRequest>;
 
@@ -8729,7 +8729,7 @@ export const CreateOrganizationsMuteConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/muteConfigs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/muteConfigs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsMuteConfigsRequest>;
 
@@ -8767,7 +8767,7 @@ export const ListOrganizationsMuteConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/muteConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/muteConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsMuteConfigsRequest>;
 
@@ -8810,7 +8810,7 @@ export const PatchOrganizationsLocationsMuteConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsMuteConfigsRequest>;
 
@@ -8842,7 +8842,7 @@ export const GetOrganizationsLocationsMuteConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsMuteConfigsRequest>;
 
@@ -8874,7 +8874,7 @@ export const DeleteOrganizationsLocationsMuteConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsMuteConfigsRequest>;
 
@@ -8914,7 +8914,7 @@ export const ListOrganizationsAttackPathsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/attackPaths" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/attackPaths" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsAttackPathsRequest>;
 
@@ -8961,7 +8961,7 @@ export const ListOrganizationsValuedResourcesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/valuedResources" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/valuedResources" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsValuedResourcesRequest>;
 
@@ -8997,7 +8997,7 @@ export const GetOrganizationsSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsSourcesRequest>;
 
@@ -9033,7 +9033,7 @@ export const TestIamPermissionsOrganizationsSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -9073,7 +9073,7 @@ export const PatchOrganizationsSourcesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Source).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsSourcesRequest>;
 
@@ -9107,7 +9107,7 @@ export const CreateOrganizationsSourcesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Source).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/sources", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/sources", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsSourcesRequest>;
 
@@ -9143,7 +9143,7 @@ export const GetIamPolicyOrganizationsSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -9182,7 +9182,7 @@ export const ListOrganizationsSourcesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sources" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sources" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSourcesRequest>;
 
@@ -9222,7 +9222,7 @@ export const SetIamPolicyOrganizationsSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -9258,7 +9258,7 @@ export const SetStateOrganizationsSourcesFindingsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetFindingStateRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setState", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setState", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetStateOrganizationsSourcesFindingsRequest>;
 
@@ -9292,7 +9292,7 @@ export const SetMuteOrganizationsSourcesFindingsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetMuteRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setMute", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setMute", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetMuteOrganizationsSourcesFindingsRequest>;
 
@@ -9329,7 +9329,7 @@ export const PatchOrganizationsSourcesFindingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Finding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsSourcesFindingsRequest>;
 
@@ -9366,7 +9366,7 @@ export const CreateOrganizationsSourcesFindingsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Finding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/findings", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/findings", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsSourcesFindingsRequest>;
 
@@ -9402,7 +9402,7 @@ export const GroupOrganizationsSourcesFindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/findings:group",
+      path: "v1/{+parent}/findings:group",
       hasBody: true,
     }),
     svc,
@@ -9458,7 +9458,7 @@ export const ListOrganizationsSourcesFindingsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/findings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/findings" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSourcesFindingsRequest>;
 
@@ -9502,7 +9502,7 @@ export const UpdateSecurityMarksOrganizationsSourcesFindingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SecurityMarks).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSecurityMarksOrganizationsSourcesFindingsRequest>;
 
@@ -9543,7 +9543,7 @@ export const PatchOrganizationsSourcesFindingsExternalSystemsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsSourcesFindingsExternalSystemsRequest>;
 
@@ -9584,7 +9584,7 @@ export const CreateOrganizationsNotificationConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/notificationConfigs",
+      path: "v1/{+parent}/notificationConfigs",
       hasBody: true,
     }),
     svc,
@@ -9623,7 +9623,7 @@ export const ListOrganizationsNotificationConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/notificationConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/notificationConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsNotificationConfigsRequest>;
 
@@ -9659,7 +9659,7 @@ export const DeleteOrganizationsNotificationConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsNotificationConfigsRequest>;
 
@@ -9690,7 +9690,7 @@ export const GetOrganizationsNotificationConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsNotificationConfigsRequest>;
 
@@ -9727,7 +9727,7 @@ export const PatchOrganizationsNotificationConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(NotificationConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsNotificationConfigsRequest>;
 
@@ -9761,7 +9761,11 @@ export const GroupOrganizationsAssetsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GroupAssetsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/assets:group", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/assets:group",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<GroupOrganizationsAssetsRequest>;
 
@@ -9815,7 +9819,7 @@ export const ListOrganizationsAssetsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/assets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/assets" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsAssetsRequest>;
 
@@ -9859,7 +9863,7 @@ export const UpdateSecurityMarksOrganizationsAssetsRequest =
     startTime: Schema.optional(Schema.String).pipe(T.HttpQuery("startTime")),
     body: Schema.optional(SecurityMarks).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSecurityMarksOrganizationsAssetsRequest>;
 
@@ -9895,7 +9899,7 @@ export const RunDiscoveryOrganizationsAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/assets:runDiscovery",
+      path: "v1/{+parent}/assets:runDiscovery",
       hasBody: true,
     }),
     svc,
@@ -9928,7 +9932,7 @@ export const DeleteOrganizationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsOperationsRequest>;
 
@@ -9959,7 +9963,7 @@ export const CancelOrganizationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOrganizationsOperationsRequest>;
 
@@ -9990,7 +9994,7 @@ export const GetOrganizationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsOperationsRequest>;
 
@@ -10035,7 +10039,7 @@ export const ListOrganizationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsOperationsRequest>;
 
@@ -10082,7 +10086,7 @@ export const CreateOrganizationsBigQueryExportsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/bigQueryExports",
+      path: "v1/{+parent}/bigQueryExports",
       hasBody: true,
     }),
     svc,
@@ -10122,7 +10126,7 @@ export const ListOrganizationsBigQueryExportsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/bigQueryExports" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/bigQueryExports" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsBigQueryExportsRequest>;
 
@@ -10158,7 +10162,7 @@ export const GetOrganizationsBigQueryExportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsBigQueryExportsRequest>;
 
@@ -10198,7 +10202,7 @@ export const PatchOrganizationsBigQueryExportsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsBigQueryExportsRequest>;
 
@@ -10230,7 +10234,7 @@ export const DeleteOrganizationsBigQueryExportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsBigQueryExportsRequest>;
 
@@ -10261,7 +10265,7 @@ export const GetOrganizationsSimulationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsSimulationsRequest>;
 
@@ -10292,7 +10296,7 @@ export const GetOrganizationsSimulationsValuedResourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsSimulationsValuedResourcesRequest>;
 
@@ -10335,7 +10339,7 @@ export const ListOrganizationsSimulationsValuedResourcesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/valuedResources" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/valuedResources" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSimulationsValuedResourcesRequest>;
 
@@ -10380,7 +10384,7 @@ export const ListOrganizationsSimulationsValuedResourcesAttackPathsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/attackPaths" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/attackPaths" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSimulationsValuedResourcesAttackPathsRequest>;
 
@@ -10426,7 +10430,7 @@ export const ListOrganizationsSimulationsAttackPathsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/attackPaths" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/attackPaths" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSimulationsAttackPathsRequest>;
 
@@ -10471,7 +10475,7 @@ export const ListOrganizationsSimulationsAttackExposureResultsAttackPathsRequest
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/attackPaths" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/attackPaths" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSimulationsAttackExposureResultsAttackPathsRequest>;
 
@@ -10520,7 +10524,7 @@ export const ListOrganizationsSimulationsAttackExposureResultsValuedResourcesReq
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/valuedResources" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/valuedResources" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSimulationsAttackExposureResultsValuedResourcesRequest>;
 
@@ -10566,7 +10570,7 @@ export const CreateOrganizationsSecurityHealthAnalyticsSettingsCustomModulesRequ
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/customModules",
+      path: "v1/{+parent}/customModules",
       hasBody: true,
     }),
     svc,
@@ -10608,7 +10612,7 @@ export const ListOrganizationsSecurityHealthAnalyticsSettingsCustomModulesReques
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customModules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/customModules" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSecurityHealthAnalyticsSettingsCustomModulesRequest>;
 
@@ -10652,7 +10656,7 @@ export const SimulateOrganizationsSecurityHealthAnalyticsSettingsCustomModulesRe
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/customModules:simulate",
+      path: "v1/{+parent}/customModules:simulate",
       hasBody: true,
     }),
     svc,
@@ -10695,7 +10699,10 @@ export const ListDescendantOrganizationsSecurityHealthAnalyticsSettingsCustomMod
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customModules:listDescendant" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+parent}/customModules:listDescendant",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListDescendantOrganizationsSecurityHealthAnalyticsSettingsCustomModulesRequest>;
 
@@ -10742,7 +10749,7 @@ export const PatchOrganizationsSecurityHealthAnalyticsSettingsCustomModulesReque
       GoogleCloudSecuritycenterV1SecurityHealthAnalyticsCustomModule,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsSecurityHealthAnalyticsSettingsCustomModulesRequest>;
 
@@ -10776,7 +10783,7 @@ export const GetOrganizationsSecurityHealthAnalyticsSettingsCustomModulesRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsSecurityHealthAnalyticsSettingsCustomModulesRequest>;
 
@@ -10809,7 +10816,7 @@ export const DeleteOrganizationsSecurityHealthAnalyticsSettingsCustomModulesRequ
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsSecurityHealthAnalyticsSettingsCustomModulesRequest>;
 
@@ -10843,7 +10850,7 @@ export const GetOrganizationsSecurityHealthAnalyticsSettingsEffectiveCustomModul
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsSecurityHealthAnalyticsSettingsEffectiveCustomModulesRequest>;
 
@@ -10884,7 +10891,7 @@ export const ListOrganizationsSecurityHealthAnalyticsSettingsEffectiveCustomModu
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/effectiveCustomModules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/effectiveCustomModules" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSecurityHealthAnalyticsSettingsEffectiveCustomModulesRequest>;
 
@@ -10930,7 +10937,7 @@ export const ValidateCustomModuleOrganizationsEventThreatDetectionSettingsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:validateCustomModule",
+      path: "v1/{+parent}:validateCustomModule",
       hasBody: true,
     }),
     svc,
@@ -10970,7 +10977,7 @@ export const CreateOrganizationsEventThreatDetectionSettingsCustomModulesRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/customModules",
+      path: "v1/{+parent}/customModules",
       hasBody: true,
     }),
     svc,
@@ -11011,7 +11018,7 @@ export const ListOrganizationsEventThreatDetectionSettingsCustomModulesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customModules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/customModules" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsEventThreatDetectionSettingsCustomModulesRequest>;
 
@@ -11048,7 +11055,7 @@ export const DeleteOrganizationsEventThreatDetectionSettingsCustomModulesRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsEventThreatDetectionSettingsCustomModulesRequest>;
 
@@ -11081,7 +11088,7 @@ export const GetOrganizationsEventThreatDetectionSettingsCustomModulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEventThreatDetectionSettingsCustomModulesRequest>;
 
@@ -11120,7 +11127,10 @@ export const ListDescendantOrganizationsEventThreatDetectionSettingsCustomModule
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customModules:listDescendant" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+parent}/customModules:listDescendant",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListDescendantOrganizationsEventThreatDetectionSettingsCustomModulesRequest>;
 
@@ -11165,7 +11175,7 @@ export const PatchOrganizationsEventThreatDetectionSettingsCustomModulesRequest 
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(EventThreatDetectionCustomModule).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsEventThreatDetectionSettingsCustomModulesRequest>;
 
@@ -11198,7 +11208,7 @@ export const GetOrganizationsEventThreatDetectionSettingsEffectiveCustomModulesR
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsEventThreatDetectionSettingsEffectiveCustomModulesRequest>;
 
@@ -11239,7 +11249,7 @@ export const ListOrganizationsEventThreatDetectionSettingsEffectiveCustomModules
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/effectiveCustomModules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/effectiveCustomModules" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsEventThreatDetectionSettingsEffectiveCustomModulesRequest>;
 
@@ -11283,7 +11293,7 @@ export const BulkMuteOrganizationsFindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/findings:bulkMute",
+      path: "v1/{+parent}/findings:bulkMute",
       hasBody: true,
     }),
     svc,
@@ -11321,7 +11331,7 @@ export const BulkMuteFoldersFindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/findings:bulkMute",
+      path: "v1/{+parent}/findings:bulkMute",
       hasBody: true,
     }),
     svc,
@@ -11360,7 +11370,7 @@ export const ListFoldersSourcesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sources" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sources" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersSourcesRequest>;
 
@@ -11400,7 +11410,7 @@ export const GroupFoldersSourcesFindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/findings:group",
+      path: "v1/{+parent}/findings:group",
       hasBody: true,
     }),
     svc,
@@ -11456,7 +11466,7 @@ export const ListFoldersSourcesFindingsRequest =
     readTime: Schema.optional(Schema.String).pipe(T.HttpQuery("readTime")),
     fieldMask: Schema.optional(Schema.String).pipe(T.HttpQuery("fieldMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/findings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/findings" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersSourcesFindingsRequest>;
 
@@ -11500,7 +11510,7 @@ export const UpdateSecurityMarksFoldersSourcesFindingsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SecurityMarks).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSecurityMarksFoldersSourcesFindingsRequest>;
 
@@ -11534,7 +11544,7 @@ export const SetStateFoldersSourcesFindingsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetFindingStateRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setState", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setState", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetStateFoldersSourcesFindingsRequest>;
 
@@ -11568,7 +11578,7 @@ export const SetMuteFoldersSourcesFindingsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetMuteRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setMute", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setMute", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetMuteFoldersSourcesFindingsRequest>;
 
@@ -11605,7 +11615,7 @@ export const PatchFoldersSourcesFindingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Finding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersSourcesFindingsRequest>;
 
@@ -11644,7 +11654,7 @@ export const PatchFoldersSourcesFindingsExternalSystemsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersSourcesFindingsExternalSystemsRequest>;
 
@@ -11683,7 +11693,7 @@ export const ValidateCustomModuleFoldersEventThreatDetectionSettingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:validateCustomModule",
+      path: "v1/{+parent}:validateCustomModule",
       hasBody: true,
     }),
     svc,
@@ -11718,7 +11728,7 @@ export const GetFoldersEventThreatDetectionSettingsCustomModulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersEventThreatDetectionSettingsCustomModulesRequest>;
 
@@ -11757,7 +11767,10 @@ export const ListDescendantFoldersEventThreatDetectionSettingsCustomModulesReque
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customModules:listDescendant" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+parent}/customModules:listDescendant",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListDescendantFoldersEventThreatDetectionSettingsCustomModulesRequest>;
 
@@ -11801,7 +11814,7 @@ export const PatchFoldersEventThreatDetectionSettingsCustomModulesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(EventThreatDetectionCustomModule).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersEventThreatDetectionSettingsCustomModulesRequest>;
 
@@ -11834,7 +11847,7 @@ export const DeleteFoldersEventThreatDetectionSettingsCustomModulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersEventThreatDetectionSettingsCustomModulesRequest>;
 
@@ -11872,7 +11885,7 @@ export const CreateFoldersEventThreatDetectionSettingsCustomModulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/customModules",
+      path: "v1/{+parent}/customModules",
       hasBody: true,
     }),
     svc,
@@ -11913,7 +11926,7 @@ export const ListFoldersEventThreatDetectionSettingsCustomModulesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customModules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/customModules" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersEventThreatDetectionSettingsCustomModulesRequest>;
 
@@ -11950,7 +11963,7 @@ export const GetFoldersEventThreatDetectionSettingsEffectiveCustomModulesRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersEventThreatDetectionSettingsEffectiveCustomModulesRequest>;
 
@@ -11989,7 +12002,7 @@ export const ListFoldersEventThreatDetectionSettingsEffectiveCustomModulesReques
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/effectiveCustomModules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/effectiveCustomModules" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersEventThreatDetectionSettingsEffectiveCustomModulesRequest>;
 
@@ -12029,7 +12042,11 @@ export const GroupFoldersAssetsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GroupAssetsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/assets:group", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/assets:group",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<GroupFoldersAssetsRequest>;
 
@@ -12083,7 +12100,7 @@ export const ListFoldersAssetsRequest =
       T.HttpQuery("compareDuration"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/assets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/assets" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersAssetsRequest>;
 
@@ -12127,7 +12144,7 @@ export const UpdateSecurityMarksFoldersAssetsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SecurityMarks).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSecurityMarksFoldersAssetsRequest>;
 
@@ -12166,7 +12183,7 @@ export const CreateFoldersNotificationConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/notificationConfigs",
+      path: "v1/{+parent}/notificationConfigs",
       hasBody: true,
     }),
     svc,
@@ -12205,7 +12222,7 @@ export const ListFoldersNotificationConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/notificationConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/notificationConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersNotificationConfigsRequest>;
 
@@ -12241,7 +12258,7 @@ export const DeleteFoldersNotificationConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersNotificationConfigsRequest>;
 
@@ -12272,7 +12289,7 @@ export const GetFoldersNotificationConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersNotificationConfigsRequest>;
 
@@ -12309,7 +12326,7 @@ export const PatchFoldersNotificationConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(NotificationConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersNotificationConfigsRequest>;
 
@@ -12340,7 +12357,7 @@ export const DeleteFoldersMuteConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersMuteConfigsRequest>;
 
@@ -12371,7 +12388,7 @@ export const GetFoldersMuteConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersMuteConfigsRequest>;
 
@@ -12411,7 +12428,7 @@ export const PatchFoldersMuteConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersMuteConfigsRequest>;
 
@@ -12453,7 +12470,7 @@ export const CreateFoldersMuteConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/muteConfigs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/muteConfigs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateFoldersMuteConfigsRequest>;
 
@@ -12491,7 +12508,7 @@ export const ListFoldersMuteConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/muteConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/muteConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersMuteConfigsRequest>;
 
@@ -12526,7 +12543,7 @@ export const GetFoldersBigQueryExportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersBigQueryExportsRequest>;
 
@@ -12566,7 +12583,7 @@ export const PatchFoldersBigQueryExportsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersBigQueryExportsRequest>;
 
@@ -12598,7 +12615,7 @@ export const DeleteFoldersBigQueryExportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersBigQueryExportsRequest>;
 
@@ -12641,7 +12658,7 @@ export const CreateFoldersBigQueryExportsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/bigQueryExports",
+      path: "v1/{+parent}/bigQueryExports",
       hasBody: true,
     }),
     svc,
@@ -12681,7 +12698,7 @@ export const ListFoldersBigQueryExportsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/bigQueryExports" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/bigQueryExports" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersBigQueryExportsRequest>;
 
@@ -12716,7 +12733,7 @@ export const DeleteFoldersSecurityHealthAnalyticsSettingsCustomModulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersSecurityHealthAnalyticsSettingsCustomModulesRequest>;
 
@@ -12755,7 +12772,10 @@ export const ListDescendantFoldersSecurityHealthAnalyticsSettingsCustomModulesRe
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customModules:listDescendant" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+parent}/customModules:listDescendant",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListDescendantFoldersSecurityHealthAnalyticsSettingsCustomModulesRequest>;
 
@@ -12802,7 +12822,7 @@ export const PatchFoldersSecurityHealthAnalyticsSettingsCustomModulesRequest =
       GoogleCloudSecuritycenterV1SecurityHealthAnalyticsCustomModule,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersSecurityHealthAnalyticsSettingsCustomModulesRequest>;
 
@@ -12835,7 +12855,7 @@ export const GetFoldersSecurityHealthAnalyticsSettingsCustomModulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersSecurityHealthAnalyticsSettingsCustomModulesRequest>;
 
@@ -12875,7 +12895,7 @@ export const CreateFoldersSecurityHealthAnalyticsSettingsCustomModulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/customModules",
+      path: "v1/{+parent}/customModules",
       hasBody: true,
     }),
     svc,
@@ -12916,7 +12936,7 @@ export const ListFoldersSecurityHealthAnalyticsSettingsCustomModulesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customModules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/customModules" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersSecurityHealthAnalyticsSettingsCustomModulesRequest>;
 
@@ -12960,7 +12980,7 @@ export const SimulateFoldersSecurityHealthAnalyticsSettingsCustomModulesRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/customModules:simulate",
+      path: "v1/{+parent}/customModules:simulate",
       hasBody: true,
     }),
     svc,
@@ -12995,7 +13015,7 @@ export const GetFoldersSecurityHealthAnalyticsSettingsEffectiveCustomModulesRequ
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersSecurityHealthAnalyticsSettingsEffectiveCustomModulesRequest>;
 
@@ -13035,7 +13055,7 @@ export const ListFoldersSecurityHealthAnalyticsSettingsEffectiveCustomModulesReq
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/effectiveCustomModules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/effectiveCustomModules" }),
     svc,
   ) as unknown as Schema.Schema<ListFoldersSecurityHealthAnalyticsSettingsEffectiveCustomModulesRequest>;
 
@@ -13074,7 +13094,7 @@ export const DeleteFoldersLocationsMuteConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteFoldersLocationsMuteConfigsRequest>;
 
@@ -13105,7 +13125,7 @@ export const GetFoldersLocationsMuteConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetFoldersLocationsMuteConfigsRequest>;
 
@@ -13145,7 +13165,7 @@ export const PatchFoldersLocationsMuteConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchFoldersLocationsMuteConfigsRequest>;
 
@@ -13185,7 +13205,7 @@ export const PatchProjectsMuteConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsMuteConfigsRequest>;
 
@@ -13217,7 +13237,7 @@ export const GetProjectsMuteConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsMuteConfigsRequest>;
 
@@ -13249,7 +13269,7 @@ export const DeleteProjectsMuteConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsMuteConfigsRequest>;
 
@@ -13290,7 +13310,7 @@ export const CreateProjectsMuteConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/muteConfigs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/muteConfigs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsMuteConfigsRequest>;
 
@@ -13328,7 +13348,7 @@ export const ListProjectsMuteConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/muteConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/muteConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsMuteConfigsRequest>;
 
@@ -13363,7 +13383,7 @@ export const GetProjectsBigQueryExportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsBigQueryExportsRequest>;
 
@@ -13403,7 +13423,7 @@ export const PatchProjectsBigQueryExportsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsBigQueryExportsRequest>;
 
@@ -13435,7 +13455,7 @@ export const DeleteProjectsBigQueryExportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsBigQueryExportsRequest>;
 
@@ -13478,7 +13498,7 @@ export const CreateProjectsBigQueryExportsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/bigQueryExports",
+      path: "v1/{+parent}/bigQueryExports",
       hasBody: true,
     }),
     svc,
@@ -13518,7 +13538,7 @@ export const ListProjectsBigQueryExportsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/bigQueryExports" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/bigQueryExports" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsBigQueryExportsRequest>;
 
@@ -13553,7 +13573,7 @@ export const DeleteProjectsLocationsMuteConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsMuteConfigsRequest>;
 
@@ -13592,7 +13612,7 @@ export const PatchProjectsLocationsMuteConfigsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsMuteConfigsRequest>;
 
@@ -13624,7 +13644,7 @@ export const GetProjectsLocationsMuteConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsMuteConfigsRequest>;
 
@@ -13656,7 +13676,7 @@ export const GetProjectsSecurityHealthAnalyticsSettingsCustomModulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSecurityHealthAnalyticsSettingsCustomModulesRequest>;
 
@@ -13695,7 +13715,10 @@ export const ListDescendantProjectsSecurityHealthAnalyticsSettingsCustomModulesR
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customModules:listDescendant" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+parent}/customModules:listDescendant",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListDescendantProjectsSecurityHealthAnalyticsSettingsCustomModulesRequest>;
 
@@ -13742,7 +13765,7 @@ export const PatchProjectsSecurityHealthAnalyticsSettingsCustomModulesRequest =
       GoogleCloudSecuritycenterV1SecurityHealthAnalyticsCustomModule,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsSecurityHealthAnalyticsSettingsCustomModulesRequest>;
 
@@ -13775,7 +13798,7 @@ export const DeleteProjectsSecurityHealthAnalyticsSettingsCustomModulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsSecurityHealthAnalyticsSettingsCustomModulesRequest>;
 
@@ -13815,7 +13838,7 @@ export const CreateProjectsSecurityHealthAnalyticsSettingsCustomModulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/customModules",
+      path: "v1/{+parent}/customModules",
       hasBody: true,
     }),
     svc,
@@ -13856,7 +13879,7 @@ export const ListProjectsSecurityHealthAnalyticsSettingsCustomModulesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customModules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/customModules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSecurityHealthAnalyticsSettingsCustomModulesRequest>;
 
@@ -13900,7 +13923,7 @@ export const SimulateProjectsSecurityHealthAnalyticsSettingsCustomModulesRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/customModules:simulate",
+      path: "v1/{+parent}/customModules:simulate",
       hasBody: true,
     }),
     svc,
@@ -13935,7 +13958,7 @@ export const GetProjectsSecurityHealthAnalyticsSettingsEffectiveCustomModulesReq
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsSecurityHealthAnalyticsSettingsEffectiveCustomModulesRequest>;
 
@@ -13976,7 +13999,7 @@ export const ListProjectsSecurityHealthAnalyticsSettingsEffectiveCustomModulesRe
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/effectiveCustomModules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/effectiveCustomModules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSecurityHealthAnalyticsSettingsEffectiveCustomModulesRequest>;
 
@@ -14022,7 +14045,7 @@ export const ValidateCustomModuleProjectsEventThreatDetectionSettingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:validateCustomModule",
+      path: "v1/{+parent}:validateCustomModule",
       hasBody: true,
     }),
     svc,
@@ -14062,7 +14085,7 @@ export const CreateProjectsEventThreatDetectionSettingsCustomModulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/customModules",
+      path: "v1/{+parent}/customModules",
       hasBody: true,
     }),
     svc,
@@ -14103,7 +14126,7 @@ export const ListProjectsEventThreatDetectionSettingsCustomModulesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customModules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/customModules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsEventThreatDetectionSettingsCustomModulesRequest>;
 
@@ -14140,7 +14163,7 @@ export const GetProjectsEventThreatDetectionSettingsCustomModulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsEventThreatDetectionSettingsCustomModulesRequest>;
 
@@ -14179,7 +14202,10 @@ export const ListDescendantProjectsEventThreatDetectionSettingsCustomModulesRequ
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customModules:listDescendant" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+parent}/customModules:listDescendant",
+    }),
     svc,
   ) as unknown as Schema.Schema<ListDescendantProjectsEventThreatDetectionSettingsCustomModulesRequest>;
 
@@ -14223,7 +14249,7 @@ export const PatchProjectsEventThreatDetectionSettingsCustomModulesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(EventThreatDetectionCustomModule).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsEventThreatDetectionSettingsCustomModulesRequest>;
 
@@ -14256,7 +14282,7 @@ export const DeleteProjectsEventThreatDetectionSettingsCustomModulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsEventThreatDetectionSettingsCustomModulesRequest>;
 
@@ -14295,7 +14321,7 @@ export const ListProjectsEventThreatDetectionSettingsEffectiveCustomModulesReque
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/effectiveCustomModules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/effectiveCustomModules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsEventThreatDetectionSettingsEffectiveCustomModulesRequest>;
 
@@ -14333,7 +14359,7 @@ export const GetProjectsEventThreatDetectionSettingsEffectiveCustomModulesReques
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsEventThreatDetectionSettingsEffectiveCustomModulesRequest>;
 
@@ -14371,7 +14397,7 @@ export const BulkMuteProjectsFindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/findings:bulkMute",
+      path: "v1/{+parent}/findings:bulkMute",
       hasBody: true,
     }),
     svc,
@@ -14410,7 +14436,7 @@ export const ListProjectsSourcesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sources" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSourcesRequest>;
 
@@ -14450,7 +14476,7 @@ export const GroupProjectsSourcesFindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/findings:group",
+      path: "v1/{+parent}/findings:group",
       hasBody: true,
     }),
     svc,
@@ -14506,7 +14532,7 @@ export const ListProjectsSourcesFindingsRequest =
       T.HttpQuery("compareDuration"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/findings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/findings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsSourcesFindingsRequest>;
 
@@ -14550,7 +14576,7 @@ export const UpdateSecurityMarksProjectsSourcesFindingsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SecurityMarks).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSecurityMarksProjectsSourcesFindingsRequest>;
 
@@ -14587,7 +14613,7 @@ export const PatchProjectsSourcesFindingsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Finding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsSourcesFindingsRequest>;
 
@@ -14621,7 +14647,7 @@ export const SetStateProjectsSourcesFindingsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetFindingStateRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setState", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setState", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetStateProjectsSourcesFindingsRequest>;
 
@@ -14655,7 +14681,7 @@ export const SetMuteProjectsSourcesFindingsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetMuteRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:setMute", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:setMute", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetMuteProjectsSourcesFindingsRequest>;
 
@@ -14694,7 +14720,7 @@ export const PatchProjectsSourcesFindingsExternalSystemsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsSourcesFindingsExternalSystemsRequest>;
 
@@ -14726,7 +14752,7 @@ export const DeleteProjectsNotificationConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsNotificationConfigsRequest>;
 
@@ -14757,7 +14783,7 @@ export const GetProjectsNotificationConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsNotificationConfigsRequest>;
 
@@ -14794,7 +14820,7 @@ export const PatchProjectsNotificationConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(NotificationConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsNotificationConfigsRequest>;
 
@@ -14833,7 +14859,7 @@ export const CreateProjectsNotificationConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/notificationConfigs",
+      path: "v1/{+parent}/notificationConfigs",
       hasBody: true,
     }),
     svc,
@@ -14872,7 +14898,7 @@ export const ListProjectsNotificationConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/notificationConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/notificationConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsNotificationConfigsRequest>;
 
@@ -14911,7 +14937,11 @@ export const GroupProjectsAssetsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GroupAssetsRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/assets:group", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/assets:group",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<GroupProjectsAssetsRequest>;
 
@@ -14965,7 +14995,7 @@ export const ListProjectsAssetsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/assets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/assets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAssetsRequest>;
 
@@ -15009,7 +15039,7 @@ export const UpdateSecurityMarksProjectsAssetsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SecurityMarks).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSecurityMarksProjectsAssetsRequest>;
 

--- a/packages/gcp/src/services/securitycenter-v1beta1.ts
+++ b/packages/gcp/src/services/securitycenter-v1beta1.ts
@@ -7638,7 +7638,7 @@ export const GetOrganizationSettingsOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationSettingsOrganizationsRequest>;
 
@@ -7675,7 +7675,7 @@ export const UpdateOrganizationSettingsOrganizationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(OrganizationSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateOrganizationSettingsOrganizationsRequest>;
 
@@ -7712,7 +7712,7 @@ export const RunDiscoveryOrganizationsAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/assets:runDiscovery",
+      path: "v1beta1/{+parent}/assets:runDiscovery",
       hasBody: true,
     }),
     svc,
@@ -7750,7 +7750,7 @@ export const GroupOrganizationsAssetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/assets:group",
+      path: "v1beta1/{+parent}/assets:group",
       hasBody: true,
     }),
     svc,
@@ -7806,7 +7806,7 @@ export const ListOrganizationsAssetsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     readTime: Schema.optional(Schema.String).pipe(T.HttpQuery("readTime")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/assets" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/assets" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsAssetsRequest>;
 
@@ -7852,7 +7852,7 @@ export const UpdateSecurityMarksOrganizationsAssetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSecurityMarksOrganizationsAssetsRequest>;
 
@@ -7898,7 +7898,7 @@ export const ListOrganizationsOperationsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsOperationsRequest>;
 
@@ -7936,7 +7936,7 @@ export const CancelOrganizationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOrganizationsOperationsRequest>;
 
@@ -7967,7 +7967,7 @@ export const GetOrganizationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsOperationsRequest>;
 
@@ -7998,7 +7998,7 @@ export const DeleteOrganizationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsOperationsRequest>;
 
@@ -8034,7 +8034,7 @@ export const GetIamPolicyOrganizationsSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -8070,7 +8070,11 @@ export const CreateOrganizationsSourcesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Source).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{parent}/sources", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1beta1/{+parent}/sources",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsSourcesRequest>;
 
@@ -8106,7 +8110,7 @@ export const TestIamPermissionsOrganizationsSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -8146,7 +8150,7 @@ export const PatchOrganizationsSourcesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Source).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsSourcesRequest>;
 
@@ -8177,7 +8181,7 @@ export const GetOrganizationsSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsSourcesRequest>;
 
@@ -8214,7 +8218,7 @@ export const ListOrganizationsSourcesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/sources" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/sources" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSourcesRequest>;
 
@@ -8254,7 +8258,7 @@ export const SetIamPolicyOrganizationsSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -8292,7 +8296,7 @@ export const GroupOrganizationsSourcesFindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/findings:group",
+      path: "v1beta1/{+parent}/findings:group",
       hasBody: true,
     }),
     svc,
@@ -8343,7 +8347,7 @@ export const ListOrganizationsSourcesFindingsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/findings" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/findings" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsSourcesFindingsRequest>;
 
@@ -8381,7 +8385,7 @@ export const SetStateOrganizationsSourcesFindingsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SetFindingStateRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:setState", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:setState", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SetStateOrganizationsSourcesFindingsRequest>;
 
@@ -8421,7 +8425,7 @@ export const PatchOrganizationsSourcesFindingsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsSourcesFindingsRequest>;
 
@@ -8463,7 +8467,7 @@ export const CreateOrganizationsSourcesFindingsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/findings",
+      path: "v1beta1/{+parent}/findings",
       hasBody: true,
     }),
     svc,
@@ -8508,7 +8512,7 @@ export const UpdateSecurityMarksOrganizationsSourcesFindingsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSecurityMarksOrganizationsSourcesFindingsRequest>;
 

--- a/packages/gcp/src/services/securitycenter-v1beta2.ts
+++ b/packages/gcp/src/services/securitycenter-v1beta2.ts
@@ -7371,7 +7371,7 @@ export const GetSecurityCenterSettingsOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSecurityCenterSettingsOrganizationsRequest>;
 
@@ -7403,7 +7403,7 @@ export const GetContainerThreatDetectionSettingsOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetContainerThreatDetectionSettingsOrganizationsRequest>;
 
@@ -7436,7 +7436,7 @@ export const GetSecurityHealthAnalyticsSettingsOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSecurityHealthAnalyticsSettingsOrganizationsRequest>;
 
@@ -7475,7 +7475,7 @@ export const UpdateSecurityHealthAnalyticsSettingsOrganizationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SecurityHealthAnalyticsSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSecurityHealthAnalyticsSettingsOrganizationsRequest>;
 
@@ -7508,7 +7508,7 @@ export const GetRapidVulnerabilityDetectionSettingsOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetRapidVulnerabilityDetectionSettingsOrganizationsRequest>;
 
@@ -7549,7 +7549,7 @@ export const UpdateRapidVulnerabilityDetectionSettingsOrganizationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateRapidVulnerabilityDetectionSettingsOrganizationsRequest>;
 
@@ -7588,7 +7588,7 @@ export const UpdateContainerThreatDetectionSettingsOrganizationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ContainerThreatDetectionSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateContainerThreatDetectionSettingsOrganizationsRequest>;
 
@@ -7621,7 +7621,7 @@ export const GetEventThreatDetectionSettingsOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEventThreatDetectionSettingsOrganizationsRequest>;
 
@@ -7653,7 +7653,7 @@ export const GetWebSecurityScannerSettingsOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetWebSecurityScannerSettingsOrganizationsRequest>;
 
@@ -7685,7 +7685,7 @@ export const GetSubscriptionOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSubscriptionOrganizationsRequest>;
 
@@ -7724,7 +7724,7 @@ export const UpdateVirtualMachineThreatDetectionSettingsOrganizationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateVirtualMachineThreatDetectionSettingsOrganizationsRequest>;
 
@@ -7763,7 +7763,7 @@ export const UpdateEventThreatDetectionSettingsOrganizationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EventThreatDetectionSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateEventThreatDetectionSettingsOrganizationsRequest>;
 
@@ -7802,7 +7802,7 @@ export const UpdateWebSecurityScannerSettingsOrganizationsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(WebSecurityScannerSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateWebSecurityScannerSettingsOrganizationsRequest>;
 
@@ -7834,7 +7834,7 @@ export const GetVirtualMachineThreatDetectionSettingsOrganizationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVirtualMachineThreatDetectionSettingsOrganizationsRequest>;
 
@@ -7872,7 +7872,7 @@ export const CalculateOrganizationsVirtualMachineThreatDetectionSettingsRequest 
       T.HttpQuery("showEligibleModulesOnly"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateOrganizationsVirtualMachineThreatDetectionSettingsRequest>;
 
@@ -7910,7 +7910,7 @@ export const CalculateOrganizationsEventThreatDetectionSettingsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateOrganizationsEventThreatDetectionSettingsRequest>;
 
@@ -7943,7 +7943,7 @@ export const CalculateOrganizationsRapidVulnerabilityDetectionSettingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateOrganizationsRapidVulnerabilityDetectionSettingsRequest>;
 
@@ -7981,7 +7981,7 @@ export const CalculateOrganizationsWebSecurityScannerSettingsRequest =
       T.HttpQuery("showEligibleModulesOnly"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateOrganizationsWebSecurityScannerSettingsRequest>;
 
@@ -8019,7 +8019,7 @@ export const CalculateOrganizationsContainerThreatDetectionSettingsRequest =
       T.HttpQuery("showEligibleModulesOnly"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateOrganizationsContainerThreatDetectionSettingsRequest>;
 
@@ -8057,7 +8057,7 @@ export const CalculateOrganizationsSecurityHealthAnalyticsSettingsRequest =
       T.HttpQuery("showEligibleModulesOnly"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateOrganizationsSecurityHealthAnalyticsSettingsRequest>;
 
@@ -8096,7 +8096,7 @@ export const UpdateEventThreatDetectionSettingsFoldersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(EventThreatDetectionSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateEventThreatDetectionSettingsFoldersRequest>;
 
@@ -8136,7 +8136,7 @@ export const UpdateVirtualMachineThreatDetectionSettingsFoldersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateVirtualMachineThreatDetectionSettingsFoldersRequest>;
 
@@ -8169,7 +8169,7 @@ export const GetWebSecurityScannerSettingsFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetWebSecurityScannerSettingsFoldersRequest>;
 
@@ -8201,7 +8201,7 @@ export const GetEventThreatDetectionSettingsFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEventThreatDetectionSettingsFoldersRequest>;
 
@@ -8239,7 +8239,7 @@ export const UpdateContainerThreatDetectionSettingsFoldersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ContainerThreatDetectionSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateContainerThreatDetectionSettingsFoldersRequest>;
 
@@ -8271,7 +8271,7 @@ export const GetVirtualMachineThreatDetectionSettingsFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVirtualMachineThreatDetectionSettingsFoldersRequest>;
 
@@ -8310,7 +8310,7 @@ export const UpdateWebSecurityScannerSettingsFoldersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(WebSecurityScannerSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateWebSecurityScannerSettingsFoldersRequest>;
 
@@ -8342,7 +8342,7 @@ export const GetContainerThreatDetectionSettingsFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetContainerThreatDetectionSettingsFoldersRequest>;
 
@@ -8374,7 +8374,7 @@ export const GetSecurityHealthAnalyticsSettingsFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSecurityHealthAnalyticsSettingsFoldersRequest>;
 
@@ -8406,7 +8406,7 @@ export const GetSecurityCenterSettingsFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSecurityCenterSettingsFoldersRequest>;
 
@@ -8437,7 +8437,7 @@ export const GetRapidVulnerabilityDetectionSettingsFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetRapidVulnerabilityDetectionSettingsFoldersRequest>;
 
@@ -8477,7 +8477,7 @@ export const UpdateRapidVulnerabilityDetectionSettingsFoldersRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateRapidVulnerabilityDetectionSettingsFoldersRequest>;
 
@@ -8516,7 +8516,7 @@ export const UpdateSecurityHealthAnalyticsSettingsFoldersRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(SecurityHealthAnalyticsSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSecurityHealthAnalyticsSettingsFoldersRequest>;
 
@@ -8553,7 +8553,7 @@ export const CalculateFoldersEventThreatDetectionSettingsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateFoldersEventThreatDetectionSettingsRequest>;
 
@@ -8590,7 +8590,7 @@ export const CalculateFoldersVirtualMachineThreatDetectionSettingsRequest =
       T.HttpQuery("showEligibleModulesOnly"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateFoldersVirtualMachineThreatDetectionSettingsRequest>;
 
@@ -8628,7 +8628,7 @@ export const CalculateFoldersContainerThreatDetectionSettingsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateFoldersContainerThreatDetectionSettingsRequest>;
 
@@ -8666,7 +8666,7 @@ export const CalculateFoldersSecurityHealthAnalyticsSettingsRequest =
       T.HttpQuery("showEligibleModulesOnly"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateFoldersSecurityHealthAnalyticsSettingsRequest>;
 
@@ -8699,7 +8699,7 @@ export const CalculateFoldersRapidVulnerabilityDetectionSettingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateFoldersRapidVulnerabilityDetectionSettingsRequest>;
 
@@ -8737,7 +8737,7 @@ export const CalculateFoldersWebSecurityScannerSettingsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateFoldersWebSecurityScannerSettingsRequest>;
 
@@ -8775,7 +8775,7 @@ export const UpdateSecurityHealthAnalyticsSettingsProjectsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(SecurityHealthAnalyticsSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateSecurityHealthAnalyticsSettingsProjectsRequest>;
 
@@ -8807,7 +8807,7 @@ export const GetRapidVulnerabilityDetectionSettingsProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetRapidVulnerabilityDetectionSettingsProjectsRequest>;
 
@@ -8847,7 +8847,7 @@ export const UpdateRapidVulnerabilityDetectionSettingsProjectsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateRapidVulnerabilityDetectionSettingsProjectsRequest>;
 
@@ -8880,7 +8880,7 @@ export const GetSecurityCenterSettingsProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSecurityCenterSettingsProjectsRequest>;
 
@@ -8911,7 +8911,7 @@ export const GetContainerThreatDetectionSettingsProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetContainerThreatDetectionSettingsProjectsRequest>;
 
@@ -8943,7 +8943,7 @@ export const GetSecurityHealthAnalyticsSettingsProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSecurityHealthAnalyticsSettingsProjectsRequest>;
 
@@ -8981,7 +8981,7 @@ export const UpdateWebSecurityScannerSettingsProjectsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(WebSecurityScannerSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateWebSecurityScannerSettingsProjectsRequest>;
 
@@ -9013,7 +9013,7 @@ export const GetVirtualMachineThreatDetectionSettingsProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetVirtualMachineThreatDetectionSettingsProjectsRequest>;
 
@@ -9052,7 +9052,7 @@ export const UpdateContainerThreatDetectionSettingsProjectsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ContainerThreatDetectionSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateContainerThreatDetectionSettingsProjectsRequest>;
 
@@ -9084,7 +9084,7 @@ export const GetEventThreatDetectionSettingsProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEventThreatDetectionSettingsProjectsRequest>;
 
@@ -9124,7 +9124,7 @@ export const UpdateVirtualMachineThreatDetectionSettingsProjectsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateVirtualMachineThreatDetectionSettingsProjectsRequest>;
 
@@ -9157,7 +9157,7 @@ export const GetWebSecurityScannerSettingsProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetWebSecurityScannerSettingsProjectsRequest>;
 
@@ -9195,7 +9195,7 @@ export const UpdateEventThreatDetectionSettingsProjectsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(EventThreatDetectionSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateEventThreatDetectionSettingsProjectsRequest>;
 
@@ -9227,7 +9227,7 @@ export const GetContainerThreatDetectionSettingsProjectsLocationsClustersRequest
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetContainerThreatDetectionSettingsProjectsLocationsClustersRequest>;
 
@@ -9266,7 +9266,7 @@ export const UpdateContainerThreatDetectionSettingsProjectsLocationsClustersRequ
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ContainerThreatDetectionSettings).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateContainerThreatDetectionSettingsProjectsLocationsClustersRequest>;
 
@@ -9305,7 +9305,7 @@ export const CalculateProjectsLocationsClustersContainerThreatDetectionSettingsR
       T.HttpQuery("showEligibleModulesOnly"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateProjectsLocationsClustersContainerThreatDetectionSettingsRequest>;
 
@@ -9345,7 +9345,7 @@ export const CalculateProjectsContainerThreatDetectionSettingsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateProjectsContainerThreatDetectionSettingsRequest>;
 
@@ -9383,7 +9383,7 @@ export const CalculateProjectsSecurityHealthAnalyticsSettingsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateProjectsSecurityHealthAnalyticsSettingsRequest>;
 
@@ -9416,7 +9416,7 @@ export const CalculateProjectsRapidVulnerabilityDetectionSettingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateProjectsRapidVulnerabilityDetectionSettingsRequest>;
 
@@ -9454,7 +9454,7 @@ export const CalculateProjectsWebSecurityScannerSettingsRequest =
       T.HttpQuery("showEligibleModulesOnly"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateProjectsWebSecurityScannerSettingsRequest>;
 
@@ -9491,7 +9491,7 @@ export const CalculateProjectsEventThreatDetectionSettingsRequest =
       T.HttpQuery("showEligibleModulesOnly"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateProjectsEventThreatDetectionSettingsRequest>;
 
@@ -9528,7 +9528,7 @@ export const CalculateProjectsVirtualMachineThreatDetectionSettingsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta2/{name}:calculate" }),
+    T.Http({ method: "GET", path: "v1beta2/{+name}:calculate" }),
     svc,
   ) as unknown as Schema.Schema<CalculateProjectsVirtualMachineThreatDetectionSettingsRequest>;
 

--- a/packages/gcp/src/services/securityposture-v1.ts
+++ b/packages/gcp/src/services/securityposture-v1.ts
@@ -828,7 +828,7 @@ export const PatchOrganizationsLocationsPostureDeploymentsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(PostureDeployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsPostureDeploymentsRequest>;
 
@@ -862,7 +862,7 @@ export const DeleteOrganizationsLocationsPostureDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsPostureDeploymentsRequest>;
 
@@ -893,7 +893,7 @@ export const GetOrganizationsLocationsPostureDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsPostureDeploymentsRequest>;
 
@@ -934,7 +934,7 @@ export const ListOrganizationsLocationsPostureDeploymentsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/postureDeployments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/postureDeployments" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsPostureDeploymentsRequest>;
 
@@ -980,7 +980,7 @@ export const CreateOrganizationsLocationsPostureDeploymentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/postureDeployments",
+      path: "v1/{+parent}/postureDeployments",
       hasBody: true,
     }),
     svc,
@@ -1022,7 +1022,7 @@ export const ListOrganizationsLocationsPostureTemplatesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/postureTemplates" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/postureTemplates" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsPostureTemplatesRequest>;
 
@@ -1061,7 +1061,7 @@ export const GetOrganizationsLocationsPostureTemplatesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     revisionId: Schema.optional(Schema.String).pipe(T.HttpQuery("revisionId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsPostureTemplatesRequest>;
 
@@ -1092,7 +1092,7 @@ export const GetOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsOperationsRequest>;
 
@@ -1126,7 +1126,7 @@ export const CancelOrganizationsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOrganizationsLocationsOperationsRequest>;
 
@@ -1171,7 +1171,7 @@ export const ListOrganizationsLocationsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsOperationsRequest>;
 
@@ -1207,7 +1207,7 @@ export const DeleteOrganizationsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsOperationsRequest>;
 
@@ -1247,7 +1247,7 @@ export const ListOrganizationsLocationsReportsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/reports" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/reports" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsReportsRequest>;
 
@@ -1282,7 +1282,7 @@ export const GetOrganizationsLocationsReportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsReportsRequest>;
 
@@ -1318,7 +1318,7 @@ export const CreateIaCValidationReportOrganizationsLocationsReportsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/reports:createIaCValidationReport",
+      path: "v1/{+parent}/reports:createIaCValidationReport",
       hasBody: true,
     }),
     svc,
@@ -1358,7 +1358,7 @@ export const ExtractOrganizationsLocationsPosturesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/postures:extract",
+      path: "v1/{+parent}/postures:extract",
       hasBody: true,
     }),
     svc,
@@ -1397,7 +1397,7 @@ export const CreateOrganizationsLocationsPosturesRequest =
     postureId: Schema.optional(Schema.String).pipe(T.HttpQuery("postureId")),
     body: Schema.optional(Posture).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/postures", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/postures", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateOrganizationsLocationsPosturesRequest>;
 
@@ -1437,7 +1437,7 @@ export const ListOrganizationsLocationsPosturesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/postures" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/postures" }),
     svc,
   ) as unknown as Schema.Schema<ListOrganizationsLocationsPosturesRequest>;
 
@@ -1478,7 +1478,7 @@ export const ListRevisionsOrganizationsLocationsPosturesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:listRevisions" }),
+    T.Http({ method: "GET", path: "v1/{+name}:listRevisions" }),
     svc,
   ) as unknown as Schema.Schema<ListRevisionsOrganizationsLocationsPosturesRequest>;
 
@@ -1517,7 +1517,7 @@ export const GetOrganizationsLocationsPosturesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     revisionId: Schema.optional(Schema.String).pipe(T.HttpQuery("revisionId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOrganizationsLocationsPosturesRequest>;
 
@@ -1551,7 +1551,7 @@ export const DeleteOrganizationsLocationsPosturesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOrganizationsLocationsPosturesRequest>;
 
@@ -1591,7 +1591,7 @@ export const PatchOrganizationsLocationsPosturesRequest =
     revisionId: Schema.optional(Schema.String).pipe(T.HttpQuery("revisionId")),
     body: Schema.optional(Posture).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchOrganizationsLocationsPosturesRequest>;
 
@@ -1636,7 +1636,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1671,7 +1671,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 

--- a/packages/gcp/src/services/serviceconsumermanagement-v1.ts
+++ b/packages/gcp/src/services/serviceconsumermanagement-v1.ts
@@ -2041,7 +2041,7 @@ export const CancelOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOperationsRequest>;
 
@@ -2071,7 +2071,7 @@ export const DeleteOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOperationsRequest>;
 
@@ -2114,7 +2114,7 @@ export const ListOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("returnPartialSuccess"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<ListOperationsRequest>;
 
@@ -2148,7 +2148,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -2186,7 +2186,7 @@ export const SearchServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{parent}:search" }),
+  T.Http({ method: "GET", path: "v1/{+parent}:search" }),
   svc,
 ) as unknown as Schema.Schema<SearchServicesRequest>;
 
@@ -2224,7 +2224,7 @@ export const DeleteProjectServicesTenancyUnitsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DeleteTenantProjectRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:deleteProject", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:deleteProject", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectServicesTenancyUnitsRequest>;
 
@@ -2260,7 +2260,7 @@ export const ApplyProjectConfigServicesTenancyUnitsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:applyProjectConfig",
+      path: "v1/{+name}:applyProjectConfig",
       hasBody: true,
     }),
     svc,
@@ -2296,7 +2296,7 @@ export const AttachProjectServicesTenancyUnitsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AttachTenantProjectRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:attachProject", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:attachProject", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AttachProjectServicesTenancyUnitsRequest>;
 
@@ -2327,7 +2327,7 @@ export const DeleteServicesTenancyUnitsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteServicesTenancyUnitsRequest>;
 
@@ -2361,7 +2361,11 @@ export const CreateServicesTenancyUnitsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateTenancyUnitRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/tenancyUnits", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/tenancyUnits",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateServicesTenancyUnitsRequest>;
 
@@ -2395,7 +2399,7 @@ export const AddProjectServicesTenancyUnitsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(AddTenantProjectRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:addProject", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}:addProject", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AddProjectServicesTenancyUnitsRequest>;
 
@@ -2429,7 +2433,7 @@ export const RemoveProjectServicesTenancyUnitsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RemoveTenantProjectRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:removeProject", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:removeProject", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RemoveProjectServicesTenancyUnitsRequest>;
 
@@ -2465,7 +2469,7 @@ export const UndeleteProjectServicesTenancyUnitsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:undeleteProject",
+      path: "v1/{+name}:undeleteProject",
       hasBody: true,
     }),
     svc,
@@ -2507,7 +2511,7 @@ export const ListServicesTenancyUnitsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/tenancyUnits" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/tenancyUnits" }),
     svc,
   ) as unknown as Schema.Schema<ListServicesTenancyUnitsRequest>;
 

--- a/packages/gcp/src/services/serviceconsumermanagement-v1beta1.ts
+++ b/packages/gcp/src/services/serviceconsumermanagement-v1beta1.ts
@@ -2000,7 +2000,7 @@ export const GetServicesConsumerQuotaMetricsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetServicesConsumerQuotaMetricsRequest>;
 
@@ -2039,7 +2039,7 @@ export const ImportProducerOverridesServicesConsumerQuotaMetricsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/consumerQuotaMetrics:importProducerOverrides",
+      path: "v1beta1/{+parent}/consumerQuotaMetrics:importProducerOverrides",
       hasBody: true,
     }),
     svc,
@@ -2083,7 +2083,7 @@ export const ListServicesConsumerQuotaMetricsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/consumerQuotaMetrics" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/consumerQuotaMetrics" }),
     svc,
   ) as unknown as Schema.Schema<ListServicesConsumerQuotaMetricsRequest>;
 
@@ -2126,7 +2126,7 @@ export const ImportProducerQuotaPoliciesServicesConsumerQuotaMetricsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/consumerQuotaMetrics:importProducerQuotaPolicies",
+      path: "v1beta1/{+parent}/consumerQuotaMetrics:importProducerQuotaPolicies",
       hasBody: true,
     }),
     svc,
@@ -2164,7 +2164,7 @@ export const GetServicesConsumerQuotaMetricsLimitsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetServicesConsumerQuotaMetricsLimitsRequest>;
 
@@ -2218,7 +2218,7 @@ export const CreateServicesConsumerQuotaMetricsLimitsProducerOverridesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/producerOverrides",
+      path: "v1beta1/{+parent}/producerOverrides",
       hasBody: true,
     }),
     svc,
@@ -2270,7 +2270,7 @@ export const DeleteServicesConsumerQuotaMetricsLimitsProducerOverridesRequest =
       T.HttpQuery("forceJustification"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteServicesConsumerQuotaMetricsLimitsProducerOverridesRequest>;
 
@@ -2326,7 +2326,7 @@ export const PatchServicesConsumerQuotaMetricsLimitsProducerOverridesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(V1Beta1QuotaOverride).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchServicesConsumerQuotaMetricsLimitsProducerOverridesRequest>;
 
@@ -2365,7 +2365,7 @@ export const ListServicesConsumerQuotaMetricsLimitsProducerOverridesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/producerOverrides" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/producerOverrides" }),
     svc,
   ) as unknown as Schema.Schema<ListServicesConsumerQuotaMetricsLimitsProducerOverridesRequest>;
 
@@ -2420,7 +2420,7 @@ export const CreateServicesConsumerQuotaMetricsLimitsProducerQuotaPoliciesReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/producerQuotaPolicies",
+      path: "v1beta1/{+parent}/producerQuotaPolicies",
       hasBody: true,
     }),
     svc,
@@ -2468,7 +2468,7 @@ export const DeleteServicesConsumerQuotaMetricsLimitsProducerQuotaPoliciesReques
       T.HttpQuery("forceJustification"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteServicesConsumerQuotaMetricsLimitsProducerQuotaPoliciesRequest>;
 
@@ -2520,7 +2520,7 @@ export const PatchServicesConsumerQuotaMetricsLimitsProducerQuotaPoliciesRequest
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     body: Schema.optional(V1Beta1ProducerQuotaPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchServicesConsumerQuotaMetricsLimitsProducerQuotaPoliciesRequest>;
 
@@ -2559,7 +2559,7 @@ export const ListServicesConsumerQuotaMetricsLimitsProducerQuotaPoliciesRequest 
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/producerQuotaPolicies" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/producerQuotaPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListServicesConsumerQuotaMetricsLimitsProducerQuotaPoliciesRequest>;
 
@@ -2595,7 +2595,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta1/{name}" }),
+  T.Http({ method: "GET", path: "v1beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 

--- a/packages/gcp/src/services/servicedirectory-v1.ts
+++ b/packages/gcp/src/services/servicedirectory-v1.ts
@@ -300,7 +300,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -335,7 +335,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -366,7 +366,7 @@ export const GetProjectsLocationsNamespacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNamespacesRequest>;
 
@@ -403,7 +403,7 @@ export const PatchProjectsLocationsNamespacesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Namespace).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsNamespacesRequest>;
 
@@ -446,7 +446,7 @@ export const ListProjectsLocationsNamespacesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/namespaces" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/namespaces" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNamespacesRequest>;
 
@@ -481,7 +481,7 @@ export const DeleteProjectsLocationsNamespacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNamespacesRequest>;
 
@@ -517,7 +517,7 @@ export const GetIamPolicyProjectsLocationsNamespacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -558,7 +558,7 @@ export const CreateProjectsLocationsNamespacesRequest =
     ),
     body: Schema.optional(Namespace).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/namespaces", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/namespaces", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsNamespacesRequest>;
 
@@ -594,7 +594,7 @@ export const SetIamPolicyProjectsLocationsNamespacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -632,7 +632,7 @@ export const TestIamPermissionsProjectsLocationsNamespacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -672,7 +672,7 @@ export const CreateProjectsLocationsNamespacesServicesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/services", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/services", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsNamespacesServicesRequest>;
 
@@ -708,7 +708,7 @@ export const SetIamPolicyProjectsLocationsNamespacesServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -747,7 +747,7 @@ export const TestIamPermissionsProjectsLocationsNamespacesServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -794,7 +794,7 @@ export const ListProjectsLocationsNamespacesServicesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/services" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/services" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNamespacesServicesRequest>;
 
@@ -835,7 +835,7 @@ export const GetIamPolicyProjectsLocationsNamespacesServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -869,7 +869,7 @@ export const DeleteProjectsLocationsNamespacesServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNamespacesServicesRequest>;
 
@@ -906,7 +906,7 @@ export const PatchProjectsLocationsNamespacesServicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsNamespacesServicesRequest>;
 
@@ -940,7 +940,7 @@ export const ResolveProjectsLocationsNamespacesServicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResolveServiceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:resolve", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:resolve", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResolveProjectsLocationsNamespacesServicesRequest>;
 
@@ -972,7 +972,7 @@ export const GetProjectsLocationsNamespacesServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNamespacesServicesRequest>;
 
@@ -1003,7 +1003,7 @@ export const GetProjectsLocationsNamespacesServicesEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNamespacesServicesEndpointsRequest>;
 
@@ -1047,7 +1047,7 @@ export const ListProjectsLocationsNamespacesServicesEndpointsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/endpoints" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/endpoints" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNamespacesServicesEndpointsRequest>;
 
@@ -1090,7 +1090,7 @@ export const PatchProjectsLocationsNamespacesServicesEndpointsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Endpoint).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsNamespacesServicesEndpointsRequest>;
 
@@ -1123,7 +1123,7 @@ export const DeleteProjectsLocationsNamespacesServicesEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNamespacesServicesEndpointsRequest>;
 
@@ -1161,7 +1161,7 @@ export const CreateProjectsLocationsNamespacesServicesEndpointsRequest =
     endpointId: Schema.optional(Schema.String).pipe(T.HttpQuery("endpointId")),
     body: Schema.optional(Endpoint).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/endpoints", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/endpoints", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsNamespacesServicesEndpointsRequest>;
 

--- a/packages/gcp/src/services/servicedirectory-v1beta1.ts
+++ b/packages/gcp/src/services/servicedirectory-v1beta1.ts
@@ -318,7 +318,7 @@ export const ListProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -353,7 +353,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -384,7 +384,7 @@ export const GetProjectsLocationsNamespacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNamespacesRequest>;
 
@@ -425,7 +425,7 @@ export const CreateProjectsLocationsNamespacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/namespaces",
+      path: "v1beta1/{+parent}/namespaces",
       hasBody: true,
     }),
     svc,
@@ -464,7 +464,7 @@ export const PatchProjectsLocationsNamespacesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Namespace).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsNamespacesRequest>;
 
@@ -500,7 +500,7 @@ export const SetIamPolicyProjectsLocationsNamespacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -545,7 +545,7 @@ export const ListProjectsLocationsNamespacesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/namespaces" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/namespaces" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNamespacesRequest>;
 
@@ -580,7 +580,7 @@ export const DeleteProjectsLocationsNamespacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNamespacesRequest>;
 
@@ -616,7 +616,7 @@ export const TestIamPermissionsProjectsLocationsNamespacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -655,7 +655,7 @@ export const GetIamPolicyProjectsLocationsNamespacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -693,7 +693,7 @@ export const GetIamPolicyProjectsLocationsNamespacesWorkloadsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -732,7 +732,7 @@ export const TestIamPermissionsProjectsLocationsNamespacesWorkloadsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -772,7 +772,7 @@ export const SetIamPolicyProjectsLocationsNamespacesWorkloadsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -806,7 +806,7 @@ export const DeleteProjectsLocationsNamespacesServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNamespacesServicesRequest>;
 
@@ -842,7 +842,7 @@ export const TestIamPermissionsProjectsLocationsNamespacesServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:testIamPermissions",
+      path: "v1beta1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -882,7 +882,7 @@ export const SetIamPolicyProjectsLocationsNamespacesServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:setIamPolicy",
+      path: "v1beta1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -919,7 +919,7 @@ export const ResolveProjectsLocationsNamespacesServicesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResolveServiceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta1/{name}:resolve", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta1/{+name}:resolve", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResolveProjectsLocationsNamespacesServicesRequest>;
 
@@ -956,7 +956,7 @@ export const GetIamPolicyProjectsLocationsNamespacesServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{resource}:getIamPolicy",
+      path: "v1beta1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1002,7 +1002,7 @@ export const ListProjectsLocationsNamespacesServicesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/services" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/services" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNamespacesServicesRequest>;
 
@@ -1044,7 +1044,7 @@ export const PatchProjectsLocationsNamespacesServicesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Service).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsNamespacesServicesRequest>;
 
@@ -1083,7 +1083,7 @@ export const CreateProjectsLocationsNamespacesServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/services",
+      path: "v1beta1/{+parent}/services",
       hasBody: true,
     }),
     svc,
@@ -1116,7 +1116,7 @@ export const GetProjectsLocationsNamespacesServicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNamespacesServicesRequest>;
 
@@ -1147,7 +1147,7 @@ export const GetProjectsLocationsNamespacesServicesEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNamespacesServicesEndpointsRequest>;
 
@@ -1187,7 +1187,7 @@ export const CreateProjectsLocationsNamespacesServicesEndpointsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/endpoints",
+      path: "v1beta1/{+parent}/endpoints",
       hasBody: true,
     }),
     svc,
@@ -1228,7 +1228,7 @@ export const PatchProjectsLocationsNamespacesServicesEndpointsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Endpoint).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsNamespacesServicesEndpointsRequest>;
 
@@ -1273,7 +1273,7 @@ export const ListProjectsLocationsNamespacesServicesEndpointsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/endpoints" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/endpoints" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNamespacesServicesEndpointsRequest>;
 
@@ -1310,7 +1310,7 @@ export const DeleteProjectsLocationsNamespacesServicesEndpointsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNamespacesServicesEndpointsRequest>;
 

--- a/packages/gcp/src/services/servicemanagement-v1.ts
+++ b/packages/gcp/src/services/servicemanagement-v1.ts
@@ -2086,7 +2086,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -2358,7 +2358,7 @@ export const SetIamPolicyServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2395,7 +2395,7 @@ export const GetIamPolicyServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2432,7 +2432,7 @@ export const TestIamPermissionsServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2744,7 +2744,7 @@ export const SetIamPolicyServicesConsumersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2782,7 +2782,7 @@ export const GetIamPolicyServicesConsumersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2820,7 +2820,7 @@ export const TestIamPermissionsServicesConsumersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/servicenetworking-v1.ts
+++ b/packages/gcp/src/services/servicenetworking-v1.ts
@@ -2340,7 +2340,7 @@ export const ListOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("returnPartialSuccess"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<ListOperationsRequest>;
 
@@ -2374,7 +2374,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -2404,7 +2404,7 @@ export const DeleteOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOperationsRequest>;
 
@@ -2437,7 +2437,7 @@ export const CancelOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOperationsRequest>;
 
@@ -2472,7 +2472,7 @@ export const DisableVpcServiceControlsServicesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1/{parent}:disableVpcServiceControls",
+      path: "v1/{+parent}:disableVpcServiceControls",
       hasBody: true,
     }),
     svc,
@@ -2510,7 +2510,7 @@ export const EnableVpcServiceControlsServicesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1/{parent}:enableVpcServiceControls",
+      path: "v1/{+parent}:enableVpcServiceControls",
       hasBody: true,
     }),
     svc,
@@ -2548,7 +2548,7 @@ export const AddSubnetworkServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:addSubnetwork",
+      path: "v1/{+parent}:addSubnetwork",
       hasBody: true,
     }),
     svc,
@@ -2584,7 +2584,7 @@ export const SearchRangeServicesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(SearchRangeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:searchRange", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}:searchRange", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<SearchRangeServicesRequest>;
 
@@ -2618,7 +2618,7 @@ export const ValidateServicesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(ValidateConsumerConfigRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}:validate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}:validate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ValidateServicesRequest>;
 
@@ -2652,7 +2652,7 @@ export const ListServicesConnectionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     network: Schema.optional(Schema.String).pipe(T.HttpQuery("network")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/connections" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/connections" }),
     svc,
   ) as unknown as Schema.Schema<ListServicesConnectionsRequest>;
 
@@ -2686,7 +2686,7 @@ export const CreateServicesConnectionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Connection).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/connections", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/connections", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateServicesConnectionsRequest>;
 
@@ -2720,7 +2720,7 @@ export const DeleteConnectionServicesConnectionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(DeleteConnectionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DeleteConnectionServicesConnectionsRequest>;
 
@@ -2760,7 +2760,7 @@ export const PatchServicesConnectionsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     body: Schema.optional(Connection).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchServicesConnectionsRequest>;
 
@@ -2791,7 +2791,7 @@ export const GetVpcServiceControlsServicesProjectsGlobalNetworksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/vpcServiceControls" }),
+    T.Http({ method: "GET", path: "v1/{+name}/vpcServiceControls" }),
     svc,
   ) as unknown as Schema.Schema<GetVpcServiceControlsServicesProjectsGlobalNetworksRequest>;
 
@@ -2829,7 +2829,7 @@ export const UpdateConsumerConfigServicesProjectsGlobalNetworksRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1/{parent}:updateConsumerConfig",
+      path: "v1/{+parent}:updateConsumerConfig",
       hasBody: true,
     }),
     svc,
@@ -2869,7 +2869,7 @@ export const GetServicesProjectsGlobalNetworksRequest =
       T.HttpQuery("includeUsedIpRanges"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetServicesProjectsGlobalNetworksRequest>;
 
@@ -2900,7 +2900,7 @@ export const ListServicesProjectsGlobalNetworksDnsZonesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dnsZones:list" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dnsZones:list" }),
     svc,
   ) as unknown as Schema.Schema<ListServicesProjectsGlobalNetworksDnsZonesRequest>;
 
@@ -2932,7 +2932,7 @@ export const GetServicesProjectsGlobalNetworksDnsZonesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetServicesProjectsGlobalNetworksDnsZonesRequest>;
 
@@ -2969,7 +2969,7 @@ export const CreateServicesProjectsGlobalNetworksPeeredDnsDomainsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/peeredDnsDomains",
+      path: "v1/{+parent}/peeredDnsDomains",
       hasBody: true,
     }),
     svc,
@@ -3004,7 +3004,7 @@ export const DeleteServicesProjectsGlobalNetworksPeeredDnsDomainsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteServicesProjectsGlobalNetworksPeeredDnsDomainsRequest>;
 
@@ -3037,7 +3037,7 @@ export const ListServicesProjectsGlobalNetworksPeeredDnsDomainsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/peeredDnsDomains" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/peeredDnsDomains" }),
     svc,
   ) as unknown as Schema.Schema<ListServicesProjectsGlobalNetworksPeeredDnsDomainsRequest>;
 
@@ -3073,7 +3073,7 @@ export const AddServicesRolesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(AddRolesRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/roles:add", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/roles:add", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AddServicesRolesRequest>;
 
@@ -3106,7 +3106,11 @@ export const AddServicesDnsZonesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(AddDnsZoneRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/dnsZones:add", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/dnsZones:add",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<AddServicesDnsZonesRequest>;
 
@@ -3142,7 +3146,7 @@ export const RemoveServicesDnsZonesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/dnsZones:remove",
+      path: "v1/{+parent}/dnsZones:remove",
       hasBody: true,
     }),
     svc,
@@ -3180,7 +3184,7 @@ export const AddServicesDnsRecordSetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/dnsRecordSets:add",
+      path: "v1/{+parent}/dnsRecordSets:add",
       hasBody: true,
     }),
     svc,
@@ -3218,7 +3222,7 @@ export const RemoveServicesDnsRecordSetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/dnsRecordSets:remove",
+      path: "v1/{+parent}/dnsRecordSets:remove",
       hasBody: true,
     }),
     svc,
@@ -3256,7 +3260,7 @@ export const UpdateServicesDnsRecordSetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/dnsRecordSets:update",
+      path: "v1/{+parent}/dnsRecordSets:update",
       hasBody: true,
     }),
     svc,
@@ -3303,7 +3307,7 @@ export const GetServicesDnsRecordSetsRequest =
     domain: Schema.optional(Schema.String).pipe(T.HttpQuery("domain")),
     type: Schema.optional(Schema.String).pipe(T.HttpQuery("type")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dnsRecordSets:get" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dnsRecordSets:get" }),
     svc,
   ) as unknown as Schema.Schema<GetServicesDnsRecordSetsRequest>;
 
@@ -3342,7 +3346,7 @@ export const ListServicesDnsRecordSetsRequest =
     ),
     zone: Schema.optional(Schema.String).pipe(T.HttpQuery("zone")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/dnsRecordSets:list" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/dnsRecordSets:list" }),
     svc,
   ) as unknown as Schema.Schema<ListServicesDnsRecordSetsRequest>;
 

--- a/packages/gcp/src/services/servicenetworking-v1beta.ts
+++ b/packages/gcp/src/services/servicenetworking-v1beta.ts
@@ -1979,7 +1979,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta/{name}" }),
+  T.Http({ method: "GET", path: "v1beta/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -2022,7 +2022,7 @@ export const UpdateConnectionsServicesRequest =
   }).pipe(
     T.Http({
       method: "PATCH",
-      path: "v1beta/{name}/connections",
+      path: "v1beta/{+name}/connections",
       hasBody: true,
     }),
     svc,
@@ -2060,7 +2060,7 @@ export const AddSubnetworkServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}:addSubnetwork",
+      path: "v1beta/{+parent}:addSubnetwork",
       hasBody: true,
     }),
     svc,
@@ -2098,7 +2098,7 @@ export const SearchRangeServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}:searchRange",
+      path: "v1beta/{+parent}:searchRange",
       hasBody: true,
     }),
     svc,
@@ -2134,7 +2134,7 @@ export const ListServicesConnectionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     network: Schema.optional(Schema.String).pipe(T.HttpQuery("network")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/connections" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/connections" }),
     svc,
   ) as unknown as Schema.Schema<ListServicesConnectionsRequest>;
 
@@ -2172,7 +2172,7 @@ export const CreateServicesConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/connections",
+      path: "v1beta/{+parent}/connections",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/serviceusage-v1.ts
+++ b/packages/gcp/src/services/serviceusage-v1.ts
@@ -22,12 +22,11 @@ const svc = T.Service({
 // Schemas
 // ==========================================================================
 
-export interface GoogleApiServiceusageV2betaAnalyzeConsumerPolicyMetadata {}
+export interface GoogleApiServiceusageV2betaAnalyzeConsumerPolicyMetadata {
+}
 
-export const GoogleApiServiceusageV2betaAnalyzeConsumerPolicyMetadata =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).annotate({
-    identifier: "GoogleApiServiceusageV2betaAnalyzeConsumerPolicyMetadata",
-  });
+export const GoogleApiServiceusageV2betaAnalyzeConsumerPolicyMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "GoogleApiServiceusageV2betaAnalyzeConsumerPolicyMetadata" });
 
 export interface SourceInfo {
   /** All files used during config generation. */
@@ -35,9 +34,7 @@ export interface SourceInfo {
 }
 
 export const SourceInfo = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  sourceFiles: Schema.optional(
-    Schema.Array(Schema.Record(Schema.String, Schema.Unknown)),
-  ),
+  sourceFiles: Schema.optional(Schema.Array(Schema.Record(Schema.String, Schema.Unknown))),
 }).annotate({ identifier: "SourceInfo" });
 
 export interface GoogleApiServiceusageV1OperationMetadata {
@@ -45,10 +42,9 @@ export interface GoogleApiServiceusageV1OperationMetadata {
   resourceNames?: ReadonlyArray<string>;
 }
 
-export const GoogleApiServiceusageV1OperationMetadata =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    resourceNames: Schema.optional(Schema.Array(Schema.String)),
-  }).annotate({ identifier: "GoogleApiServiceusageV1OperationMetadata" });
+export const GoogleApiServiceusageV1OperationMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  resourceNames: Schema.optional(Schema.Array(Schema.String)),
+}).annotate({ identifier: "GoogleApiServiceusageV1OperationMetadata" });
 
 export interface CustomHttpPattern {
   /** The name of this custom HTTP verb. */
@@ -85,31 +81,24 @@ export interface HttpRule {
   custom?: CustomHttpPattern;
 }
 
-export const HttpRule: Schema.Schema<HttpRule> =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.suspend(() =>
-    Schema.Struct({
-      patch: Schema.optional(Schema.String),
-      responseBody: Schema.optional(Schema.String),
-      body: Schema.optional(Schema.String),
-      get: Schema.optional(Schema.String),
-      delete: Schema.optional(Schema.String),
-      additionalBindings: Schema.optional(Schema.Array(HttpRule)),
-      post: Schema.optional(Schema.String),
-      selector: Schema.optional(Schema.String),
-      put: Schema.optional(Schema.String),
-      custom: Schema.optional(CustomHttpPattern),
-    }),
-  ).annotate({ identifier: "HttpRule" }) as any as Schema.Schema<HttpRule>;
+export const HttpRule: Schema.Schema<HttpRule> = /*@__PURE__*/ /*#__PURE__*/ Schema.suspend(() => Schema.Struct({
+  patch: Schema.optional(Schema.String),
+  responseBody: Schema.optional(Schema.String),
+  body: Schema.optional(Schema.String),
+  get: Schema.optional(Schema.String),
+  delete: Schema.optional(Schema.String),
+  additionalBindings: Schema.optional(Schema.Array(HttpRule)),
+  post: Schema.optional(Schema.String),
+  selector: Schema.optional(Schema.String),
+  put: Schema.optional(Schema.String),
+  custom: Schema.optional(CustomHttpPattern),
+})).annotate({ identifier: "HttpRule" }) as any as Schema.Schema<HttpRule>;
 
 export interface Impact {
   /** The parent resource that the analysis is based on and the service name that the analysis is for. Example: `projects/100/services/compute.googleapis.com`, folders/101/services/compute.googleapis.com` and `organizations/102/services/compute.googleapis.com`. Usually, the parent resource here is same as the parent resource of the analyzed policy. However, for some analysis types, the parent can be different. For example, for resource existence analysis, if the parent resource of the analyzed policy is a folder or an organization, the parent resource here can still be the project that contains the resources. */
   parent?: string;
   /** Output only. The type of impact. */
-  impactType?:
-    | "IMPACT_TYPE_UNSPECIFIED"
-    | "DEPENDENCY_MISSING_DEPENDENCIES"
-    | "RESOURCE_EXISTENCE_PROJECT"
-    | (string & {});
+  impactType?: "IMPACT_TYPE_UNSPECIFIED" | "DEPENDENCY_MISSING_DEPENDENCIES" | "RESOURCE_EXISTENCE_PROJECT" | (string & {});
   /** Output only. User friendly impact detail in a free form message. */
   detail?: string;
 }
@@ -134,12 +123,7 @@ export const AnalysisResult = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export interface Analysis {
   /** Output only. The type of analysis. */
-  analysisType?:
-    | "ANALYSIS_TYPE_UNSPECIFIED"
-    | "ANALYSIS_TYPE_DEPENDENCY"
-    | "ANALYSIS_TYPE_RESOURCE_USAGE"
-    | "ANALYSIS_TYPE_RESOURCE_EXISTENCE"
-    | (string & {});
+  analysisType?: "ANALYSIS_TYPE_UNSPECIFIED" | "ANALYSIS_TYPE_DEPENDENCY" | "ANALYSIS_TYPE_RESOURCE_USAGE" | "ANALYSIS_TYPE_RESOURCE_EXISTENCE" | (string & {});
   /** Output only. The user friendly display name of the analysis type. E.g. service dependency analysis, service resource usage analysis, etc. */
   displayName?: string;
   /** Output only. Analysis result of updating a policy. */
@@ -160,27 +144,24 @@ export interface AnalyzeConsumerPolicyResponse {
   analysis?: ReadonlyArray<Analysis>;
 }
 
-export const AnalyzeConsumerPolicyResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    analysis: Schema.optional(Schema.Array(Analysis)),
-  }).annotate({ identifier: "AnalyzeConsumerPolicyResponse" });
+export const AnalyzeConsumerPolicyResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  analysis: Schema.optional(Schema.Array(Analysis)),
+}).annotate({ identifier: "AnalyzeConsumerPolicyResponse" });
 
-export interface UpdateConsumerPolicyMetadata {}
+export interface UpdateConsumerPolicyMetadata {
+}
 
-export const UpdateConsumerPolicyMetadata =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).annotate({
-    identifier: "UpdateConsumerPolicyMetadata",
-  });
+export const UpdateConsumerPolicyMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "UpdateConsumerPolicyMetadata" });
 
 export interface GoogleApiServiceusageV2betaEnableRule {
   /** The names of the services that are enabled. Example: `services/storage.googleapis.com`. */
   services?: ReadonlyArray<string>;
 }
 
-export const GoogleApiServiceusageV2betaEnableRule =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    services: Schema.optional(Schema.Array(Schema.String)),
-  }).annotate({ identifier: "GoogleApiServiceusageV2betaEnableRule" });
+export const GoogleApiServiceusageV2betaEnableRule = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  services: Schema.optional(Schema.Array(Schema.String)),
+}).annotate({ identifier: "GoogleApiServiceusageV2betaEnableRule" });
 
 export interface GoogleApiServiceusageV2betaConsumerPolicy {
   /** An opaque tag indicating the current version of the policy, used for concurrency control. */
@@ -195,16 +176,13 @@ export interface GoogleApiServiceusageV2betaConsumerPolicy {
   createTime?: string;
 }
 
-export const GoogleApiServiceusageV2betaConsumerPolicy =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    etag: Schema.optional(Schema.String),
-    name: Schema.optional(Schema.String),
-    enableRules: Schema.optional(
-      Schema.Array(GoogleApiServiceusageV2betaEnableRule),
-    ),
-    updateTime: Schema.optional(Schema.String),
-    createTime: Schema.optional(Schema.String),
-  }).annotate({ identifier: "GoogleApiServiceusageV2betaConsumerPolicy" });
+export const GoogleApiServiceusageV2betaConsumerPolicy = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  etag: Schema.optional(Schema.String),
+  name: Schema.optional(Schema.String),
+  enableRules: Schema.optional(Schema.Array(GoogleApiServiceusageV2betaEnableRule)),
+  updateTime: Schema.optional(Schema.String),
+  createTime: Schema.optional(Schema.String),
+}).annotate({ identifier: "GoogleApiServiceusageV2betaConsumerPolicy" });
 
 export interface AspectRule {
   /** Required. Selects the RPC methods to which this rule applies. Refer to selector for syntax details. */
@@ -225,11 +203,10 @@ export interface SelectiveGapicGeneration {
   methods?: ReadonlyArray<string>;
 }
 
-export const SelectiveGapicGeneration =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    generateOmittedAsInternal: Schema.optional(Schema.Boolean),
-    methods: Schema.optional(Schema.Array(Schema.String)),
-  }).annotate({ identifier: "SelectiveGapicGeneration" });
+export const SelectiveGapicGeneration = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  generateOmittedAsInternal: Schema.optional(Schema.Boolean),
+  methods: Schema.optional(Schema.Array(Schema.String)),
+}).annotate({ identifier: "SelectiveGapicGeneration" });
 
 export interface CommonLanguageSettings {
   /** Link to automatically generated reference documentation. Example: https://cloud.google.com/nodejs/docs/reference/asset/latest */
@@ -237,21 +214,14 @@ export interface CommonLanguageSettings {
   /** Configuration for which RPCs should be generated in the GAPIC client. Note: This field should not be used in most cases. */
   selectiveGapicGeneration?: SelectiveGapicGeneration;
   /** The destination where API teams want this client library to be published. */
-  destinations?: ReadonlyArray<
-    | "CLIENT_LIBRARY_DESTINATION_UNSPECIFIED"
-    | "GITHUB"
-    | "PACKAGE_MANAGER"
-    | (string & {})
-  >;
+  destinations?: ReadonlyArray<"CLIENT_LIBRARY_DESTINATION_UNSPECIFIED" | "GITHUB" | "PACKAGE_MANAGER" | (string & {})>;
 }
 
-export const CommonLanguageSettings = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {
-    referenceDocsUri: Schema.optional(Schema.String),
-    selectiveGapicGeneration: Schema.optional(SelectiveGapicGeneration),
-    destinations: Schema.optional(Schema.Array(Schema.String)),
-  },
-).annotate({ identifier: "CommonLanguageSettings" });
+export const CommonLanguageSettings = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  referenceDocsUri: Schema.optional(Schema.String),
+  selectiveGapicGeneration: Schema.optional(SelectiveGapicGeneration),
+  destinations: Schema.optional(Schema.Array(Schema.String)),
+}).annotate({ identifier: "CommonLanguageSettings" });
 
 export interface NodeSettings {
   /** Some settings. */
@@ -285,22 +255,18 @@ export interface GoogleApiServiceusageV2betaMcpService {
   service?: string;
 }
 
-export const GoogleApiServiceusageV2betaMcpService =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    service: Schema.optional(Schema.String),
-  }).annotate({ identifier: "GoogleApiServiceusageV2betaMcpService" });
+export const GoogleApiServiceusageV2betaMcpService = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  service: Schema.optional(Schema.String),
+}).annotate({ identifier: "GoogleApiServiceusageV2betaMcpService" });
 
 export interface GoogleApiServiceusageV2betaMcpEnableRule {
   /** List of enabled MCP services. */
   mcpServices?: ReadonlyArray<GoogleApiServiceusageV2betaMcpService>;
 }
 
-export const GoogleApiServiceusageV2betaMcpEnableRule =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    mcpServices: Schema.optional(
-      Schema.Array(GoogleApiServiceusageV2betaMcpService),
-    ),
-  }).annotate({ identifier: "GoogleApiServiceusageV2betaMcpEnableRule" });
+export const GoogleApiServiceusageV2betaMcpEnableRule = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  mcpServices: Schema.optional(Schema.Array(GoogleApiServiceusageV2betaMcpService)),
+}).annotate({ identifier: "GoogleApiServiceusageV2betaMcpEnableRule" });
 
 export interface GoogleApiServiceusageV2betaMcpPolicy {
   /** Output only. The time the policy was created. For singleton policies (such as the `default` policy), this is the first touch of the policy. */
@@ -315,35 +281,28 @@ export interface GoogleApiServiceusageV2betaMcpPolicy {
   etag?: string;
 }
 
-export const GoogleApiServiceusageV2betaMcpPolicy =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    createTime: Schema.optional(Schema.String),
-    updateTime: Schema.optional(Schema.String),
-    mcpEnableRules: Schema.optional(
-      Schema.Array(GoogleApiServiceusageV2betaMcpEnableRule),
-    ),
-    name: Schema.optional(Schema.String),
-    etag: Schema.optional(Schema.String),
-  }).annotate({ identifier: "GoogleApiServiceusageV2betaMcpPolicy" });
+export const GoogleApiServiceusageV2betaMcpPolicy = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  createTime: Schema.optional(Schema.String),
+  updateTime: Schema.optional(Schema.String),
+  mcpEnableRules: Schema.optional(Schema.Array(GoogleApiServiceusageV2betaMcpEnableRule)),
+  name: Schema.optional(Schema.String),
+  etag: Schema.optional(Schema.String),
+}).annotate({ identifier: "GoogleApiServiceusageV2betaMcpPolicy" });
 
 export interface GoogleApiServiceusageV2betaImpact {
   /** Output only. The type of impact. */
-  impactType?:
-    | "IMPACT_TYPE_UNSPECIFIED"
-    | "DEPENDENCY_MISSING_DEPENDENCIES"
-    | (string & {});
+  impactType?: "IMPACT_TYPE_UNSPECIFIED" | "DEPENDENCY_MISSING_DEPENDENCIES" | (string & {});
   /** Output only. User friendly impact detail in a free form message. */
   detail?: string;
   /** Output only. This field will be populated only for the `DEPENDENCY_MISSING_DEPENDENCIES` impact type. Example: `services/compute.googleapis.com`. Impact.detail will be in format : `missing service dependency: {missing_dependency}.` */
   missingDependency?: string;
 }
 
-export const GoogleApiServiceusageV2betaImpact =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    impactType: Schema.optional(Schema.String),
-    detail: Schema.optional(Schema.String),
-    missingDependency: Schema.optional(Schema.String),
-  }).annotate({ identifier: "GoogleApiServiceusageV2betaImpact" });
+export const GoogleApiServiceusageV2betaImpact = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  impactType: Schema.optional(Schema.String),
+  detail: Schema.optional(Schema.String),
+  missingDependency: Schema.optional(Schema.String),
+}).annotate({ identifier: "GoogleApiServiceusageV2betaImpact" });
 
 export interface GoogleApiServiceusageV2betaAnalysisResult {
   /** Blocking information that would prevent the policy changes at runtime. */
@@ -352,11 +311,10 @@ export interface GoogleApiServiceusageV2betaAnalysisResult {
   warnings?: ReadonlyArray<GoogleApiServiceusageV2betaImpact>;
 }
 
-export const GoogleApiServiceusageV2betaAnalysisResult =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    blockers: Schema.optional(Schema.Array(GoogleApiServiceusageV2betaImpact)),
-    warnings: Schema.optional(Schema.Array(GoogleApiServiceusageV2betaImpact)),
-  }).annotate({ identifier: "GoogleApiServiceusageV2betaAnalysisResult" });
+export const GoogleApiServiceusageV2betaAnalysisResult = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  blockers: Schema.optional(Schema.Array(GoogleApiServiceusageV2betaImpact)),
+  warnings: Schema.optional(Schema.Array(GoogleApiServiceusageV2betaImpact)),
+}).annotate({ identifier: "GoogleApiServiceusageV2betaAnalysisResult" });
 
 export interface BatchingDescriptorProto {
   /** Optional. When present, indicates the field in the response message to be used to demultiplex the response into multiple response messages, in correspondence with the multiple request messages originally batched together. */
@@ -367,12 +325,11 @@ export interface BatchingDescriptorProto {
   batchedField?: string;
 }
 
-export const BatchingDescriptorProto =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    subresponseField: Schema.optional(Schema.String),
-    discriminatorFields: Schema.optional(Schema.Array(Schema.String)),
-    batchedField: Schema.optional(Schema.String),
-  }).annotate({ identifier: "BatchingDescriptorProto" });
+export const BatchingDescriptorProto = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  subresponseField: Schema.optional(Schema.String),
+  discriminatorFields: Schema.optional(Schema.Array(Schema.String)),
+  batchedField: Schema.optional(Schema.String),
+}).annotate({ identifier: "BatchingDescriptorProto" });
 
 export interface CppSettings {
   /** Some settings. */
@@ -401,11 +358,7 @@ export interface Method {
   /** If true, the response is streamed. */
   responseStreaming?: boolean;
   /** The source syntax of this method. This field should be ignored, instead the syntax should be inherited from Api. This is similar to Field and EnumValue. */
-  syntax?:
-    | "SYNTAX_PROTO2"
-    | "SYNTAX_PROTO3"
-    | "SYNTAX_EDITIONS"
-    | (string & {});
+  syntax?: "SYNTAX_PROTO2" | "SYNTAX_PROTO3" | "SYNTAX_EDITIONS" | (string & {});
   /** The simple name of this method. */
   name?: string;
   /** The URL of the output message type. */
@@ -434,10 +387,9 @@ export interface BatchEnableServicesRequest {
   serviceIds?: ReadonlyArray<string>;
 }
 
-export const BatchEnableServicesRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    serviceIds: Schema.optional(Schema.Array(Schema.String)),
-  }).annotate({ identifier: "BatchEnableServicesRequest" });
+export const BatchEnableServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  serviceIds: Schema.optional(Schema.Array(Schema.String)),
+}).annotate({ identifier: "BatchEnableServicesRequest" });
 
 export interface AdminQuotaPolicy {
   /** The name of the metric to which this policy applies. An example name would be: `compute.googleapis.com/cpus` */
@@ -468,10 +420,9 @@ export interface ContentSecurityProvider {
   name?: string;
 }
 
-export const ContentSecurityProvider =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    name: Schema.optional(Schema.String),
-  }).annotate({ identifier: "ContentSecurityProvider" });
+export const ContentSecurityProvider = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  name: Schema.optional(Schema.String),
+}).annotate({ identifier: "ContentSecurityProvider" });
 
 export interface ContentSecurity {
   /** List of content security providers that are enabled for content scanning. */
@@ -479,9 +430,7 @@ export interface ContentSecurity {
 }
 
 export const ContentSecurity = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  contentSecurityProviders: Schema.optional(
-    Schema.Array(ContentSecurityProvider),
-  ),
+  contentSecurityProviders: Schema.optional(Schema.Array(ContentSecurityProvider)),
 }).annotate({ identifier: "ContentSecurity" });
 
 export interface ContentSecurityPolicy {
@@ -515,11 +464,10 @@ export interface GoogleApiServiceusageV1beta1ServiceIdentity {
   uniqueId?: string;
 }
 
-export const GoogleApiServiceusageV1beta1ServiceIdentity =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    email: Schema.optional(Schema.String),
-    uniqueId: Schema.optional(Schema.String),
-  }).annotate({ identifier: "GoogleApiServiceusageV1beta1ServiceIdentity" });
+export const GoogleApiServiceusageV1beta1ServiceIdentity = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  email: Schema.optional(Schema.String),
+  uniqueId: Schema.optional(Schema.String),
+}).annotate({ identifier: "GoogleApiServiceusageV1beta1ServiceIdentity" });
 
 export interface GoogleApiServiceusageV1beta1GetServiceIdentityResponse {
   /** Service identity that service producer can use to access consumer resources. If exists is true, it contains email and unique_id. If exists is false, it contains pre-constructed email and empty unique_id. */
@@ -528,13 +476,10 @@ export interface GoogleApiServiceusageV1beta1GetServiceIdentityResponse {
   state?: "IDENTITY_STATE_UNSPECIFIED" | "ACTIVE" | (string & {});
 }
 
-export const GoogleApiServiceusageV1beta1GetServiceIdentityResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    identity: Schema.optional(GoogleApiServiceusageV1beta1ServiceIdentity),
-    state: Schema.optional(Schema.String),
-  }).annotate({
-    identifier: "GoogleApiServiceusageV1beta1GetServiceIdentityResponse",
-  });
+export const GoogleApiServiceusageV1beta1GetServiceIdentityResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  identity: Schema.optional(GoogleApiServiceusageV1beta1ServiceIdentity),
+  state: Schema.optional(Schema.String),
+}).annotate({ identifier: "GoogleApiServiceusageV1beta1GetServiceIdentityResponse" });
 
 export interface AuthRequirement {
   /** id from authentication provider. Example: provider_id: bookstore_auth */
@@ -595,10 +540,9 @@ export interface BatchCreateConsumerOverridesResponse {
   overrides?: ReadonlyArray<QuotaOverride>;
 }
 
-export const BatchCreateConsumerOverridesResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    overrides: Schema.optional(Schema.Array(QuotaOverride)),
-  }).annotate({ identifier: "BatchCreateConsumerOverridesResponse" });
+export const BatchCreateConsumerOverridesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  overrides: Schema.optional(Schema.Array(QuotaOverride)),
+}).annotate({ identifier: "BatchCreateConsumerOverridesResponse" });
 
 export interface Field {
   /** The field name. */
@@ -606,38 +550,13 @@ export interface Field {
   /** Whether to use alternative packed wire representation. */
   packed?: boolean;
   /** The field type. */
-  kind?:
-    | "TYPE_UNKNOWN"
-    | "TYPE_DOUBLE"
-    | "TYPE_FLOAT"
-    | "TYPE_INT64"
-    | "TYPE_UINT64"
-    | "TYPE_INT32"
-    | "TYPE_FIXED64"
-    | "TYPE_FIXED32"
-    | "TYPE_BOOL"
-    | "TYPE_STRING"
-    | "TYPE_GROUP"
-    | "TYPE_MESSAGE"
-    | "TYPE_BYTES"
-    | "TYPE_UINT32"
-    | "TYPE_ENUM"
-    | "TYPE_SFIXED32"
-    | "TYPE_SFIXED64"
-    | "TYPE_SINT32"
-    | "TYPE_SINT64"
-    | (string & {});
+  kind?: "TYPE_UNKNOWN" | "TYPE_DOUBLE" | "TYPE_FLOAT" | "TYPE_INT64" | "TYPE_UINT64" | "TYPE_INT32" | "TYPE_FIXED64" | "TYPE_FIXED32" | "TYPE_BOOL" | "TYPE_STRING" | "TYPE_GROUP" | "TYPE_MESSAGE" | "TYPE_BYTES" | "TYPE_UINT32" | "TYPE_ENUM" | "TYPE_SFIXED32" | "TYPE_SFIXED64" | "TYPE_SINT32" | "TYPE_SINT64" | (string & {});
   /** The index of the field type in `Type.oneofs`, for message or enumeration types. The first type has index 1; zero means the type is not in the list. */
   oneofIndex?: number;
   /** The field JSON name. */
   jsonName?: string;
   /** The field cardinality. */
-  cardinality?:
-    | "CARDINALITY_UNKNOWN"
-    | "CARDINALITY_OPTIONAL"
-    | "CARDINALITY_REQUIRED"
-    | "CARDINALITY_REPEATED"
-    | (string & {});
+  cardinality?: "CARDINALITY_UNKNOWN" | "CARDINALITY_OPTIONAL" | "CARDINALITY_REQUIRED" | "CARDINALITY_REPEATED" | (string & {});
   /** The field number. */
   number?: number;
   /** The field type URL, without the scheme, for message or enumeration types. Example: `"type.googleapis.com/google.protobuf.Timestamp"`. */
@@ -709,35 +628,17 @@ export interface MetricDescriptorMetadata {
   /** The delay of data points caused by ingestion. Data points older than this age are guaranteed to be ingested and available to be read, excluding data loss due to errors. */
   ingestDelay?: string;
   /** Deprecated. Must use the MetricDescriptor.launch_stage instead. */
-  launchStage?:
-    | "LAUNCH_STAGE_UNSPECIFIED"
-    | "UNIMPLEMENTED"
-    | "PRELAUNCH"
-    | "EARLY_ACCESS"
-    | "ALPHA"
-    | "BETA"
-    | "GA"
-    | "DEPRECATED"
-    | (string & {});
+  launchStage?: "LAUNCH_STAGE_UNSPECIFIED" | "UNIMPLEMENTED" | "PRELAUNCH" | "EARLY_ACCESS" | "ALPHA" | "BETA" | "GA" | "DEPRECATED" | (string & {});
   /** The scope of the timeseries data of the metric. */
-  timeSeriesResourceHierarchyLevel?: ReadonlyArray<
-    | "TIME_SERIES_RESOURCE_HIERARCHY_LEVEL_UNSPECIFIED"
-    | "PROJECT"
-    | "ORGANIZATION"
-    | "FOLDER"
-    | (string & {})
-  >;
+  timeSeriesResourceHierarchyLevel?: ReadonlyArray<"TIME_SERIES_RESOURCE_HIERARCHY_LEVEL_UNSPECIFIED" | "PROJECT" | "ORGANIZATION" | "FOLDER" | (string & {})>;
 }
 
-export const MetricDescriptorMetadata =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    samplePeriod: Schema.optional(Schema.String),
-    ingestDelay: Schema.optional(Schema.String),
-    launchStage: Schema.optional(Schema.String),
-    timeSeriesResourceHierarchyLevel: Schema.optional(
-      Schema.Array(Schema.String),
-    ),
-  }).annotate({ identifier: "MetricDescriptorMetadata" });
+export const MetricDescriptorMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  samplePeriod: Schema.optional(Schema.String),
+  ingestDelay: Schema.optional(Schema.String),
+  launchStage: Schema.optional(Schema.String),
+  timeSeriesResourceHierarchyLevel: Schema.optional(Schema.Array(Schema.String)),
+}).annotate({ identifier: "MetricDescriptorMetadata" });
 
 export interface MetricDescriptor {
   /** The units in which the metric value is reported. It is only applicable if the `value_type` is `INT64`, `DOUBLE`, or `DISTRIBUTION`. The `unit` defines the representation of the stored metric values. Different systems might scale the values to be more easily displayed (so a value of `0.02kBy` _might_ be displayed as `20By`, and a value of `3523kBy` _might_ be displayed as `3.5MBy`). However, if the `unit` is `kBy`, then the value of the metric is always in thousands of bytes, no matter how it might be displayed. If you want a custom metric to record the exact number of CPU-seconds used by a job, you can create an `INT64 CUMULATIVE` metric whose `unit` is `s{CPU}` (or equivalently `1s{CPU}` or just `s`). If the job uses 12,005 CPU-seconds, then the value is written as `12005`. Alternatively, if you want a custom metric to record data in a more granular way, you can create a `DOUBLE CUMULATIVE` metric whose `unit` is `ks{CPU}`, and then write the value `12.005` (which is `12005/1000`), or use `Kis{CPU}` and write `11.723` (which is `12005/1024`). The supported units are a subset of [The Unified Code for Units of Measure](https://unitsofmeasure.org/ucum.html) standard: **Basic units (UNIT)** * `bit` bit * `By` byte * `s` second * `min` minute * `h` hour * `d` day * `1` dimensionless **Prefixes (PREFIX)** * `k` kilo (10^3) * `M` mega (10^6) * `G` giga (10^9) * `T` tera (10^12) * `P` peta (10^15) * `E` exa (10^18) * `Z` zetta (10^21) * `Y` yotta (10^24) * `m` milli (10^-3) * `u` micro (10^-6) * `n` nano (10^-9) * `p` pico (10^-12) * `f` femto (10^-15) * `a` atto (10^-18) * `z` zepto (10^-21) * `y` yocto (10^-24) * `Ki` kibi (2^10) * `Mi` mebi (2^20) * `Gi` gibi (2^30) * `Ti` tebi (2^40) * `Pi` pebi (2^50) **Grammar** The grammar also includes these connectors: * `/` division or ratio (as an infix operator). For examples, `kBy/{email}` or `MiBy/10ms` (although you should almost never have `/s` in a metric `unit`; rates should always be computed at query time from the underlying cumulative or delta value). * `.` multiplication or composition (as an infix operator). For examples, `GBy.d` or `k{watt}.h`. The grammar for a unit is as follows: Expression = Component { "." Component } { "/" Component } ; Component = ( [ PREFIX ] UNIT | "%" ) [ Annotation ] | Annotation | "1" ; Annotation = "{" NAME "}" ; Notes: * `Annotation` is just a comment if it follows a `UNIT`. If the annotation is used alone, then the unit is equivalent to `1`. For examples, `{request}/s == 1/s`, `By{transmitted}/s == By/s`. * `NAME` is a sequence of non-blank printable ASCII characters not containing `{` or `}`. * `1` represents a unitary [dimensionless unit](https://en.wikipedia.org/wiki/Dimensionless_quantity) of 1, such as in `1/s`. It is typically used when none of the basic units are appropriate. For example, "new users per day" can be represented as `1/d` or `{new-users}/d` (and a metric value `5` would mean "5 new users). Alternatively, "thousands of page views per day" would be represented as `1000/d` or `k1/d` or `k{page_views}/d` (and a metric value of `5.3` would mean "5300 page views per day"). * `%` represents dimensionless value of 1/100, and annotates values giving a percentage (so the metric values are typically in the range of 0..100, and a metric value `3` means "3 percent"). * `10^2.%` indicates a metric contains a ratio, typically in the range 0..1, that will be multiplied by 100 and displayed as a percentage (so a metric value `0.03` means "3 percent"). */
@@ -747,39 +648,17 @@ export interface MetricDescriptor {
   /** The resource name of the metric descriptor. */
   name?: string;
   /** Whether the measurement is an integer, a floating-point number, etc. Some combinations of `metric_kind` and `value_type` might not be supported. */
-  valueType?:
-    | "VALUE_TYPE_UNSPECIFIED"
-    | "BOOL"
-    | "INT64"
-    | "DOUBLE"
-    | "STRING"
-    | "DISTRIBUTION"
-    | "MONEY"
-    | (string & {});
+  valueType?: "VALUE_TYPE_UNSPECIFIED" | "BOOL" | "INT64" | "DOUBLE" | "STRING" | "DISTRIBUTION" | "MONEY" | (string & {});
   /** The metric type, including its DNS name prefix. The type is not URL-encoded. All user-defined metric types have the DNS name `custom.googleapis.com` or `external.googleapis.com`. Metric types should use a natural hierarchical grouping. For example: "custom.googleapis.com/invoice/paid/amount" "external.googleapis.com/prometheus/up" "appengine.googleapis.com/http/server/response_latencies" */
   type?: string;
   /** The set of labels that can be used to describe a specific instance of this metric type. For example, the `appengine.googleapis.com/http/server/response_latencies` metric type has a label for the HTTP response code, `response_code`, so you can look at latencies for successful responses or just for responses that failed. */
   labels?: ReadonlyArray<LabelDescriptor>;
   /** Optional. The launch stage of the metric definition. */
-  launchStage?:
-    | "LAUNCH_STAGE_UNSPECIFIED"
-    | "UNIMPLEMENTED"
-    | "PRELAUNCH"
-    | "EARLY_ACCESS"
-    | "ALPHA"
-    | "BETA"
-    | "GA"
-    | "DEPRECATED"
-    | (string & {});
+  launchStage?: "LAUNCH_STAGE_UNSPECIFIED" | "UNIMPLEMENTED" | "PRELAUNCH" | "EARLY_ACCESS" | "ALPHA" | "BETA" | "GA" | "DEPRECATED" | (string & {});
   /** A concise name for the metric, which can be displayed in user interfaces. Use sentence case without an ending period, for example "Request count". This field is optional but it is recommended to be set for any metrics associated with user-visible concepts, such as Quota. */
   displayName?: string;
   /** Whether the metric records instantaneous values, changes to a value, etc. Some combinations of `metric_kind` and `value_type` might not be supported. */
-  metricKind?:
-    | "METRIC_KIND_UNSPECIFIED"
-    | "GAUGE"
-    | "DELTA"
-    | "CUMULATIVE"
-    | (string & {});
+  metricKind?: "METRIC_KIND_UNSPECIFIED" | "GAUGE" | "DELTA" | "CUMULATIVE" | (string & {});
   /** Optional. Metadata which can be used to guide usage of the metric. */
   metadata?: MetricDescriptorMetadata;
   /** A detailed description of the metric, which can be used in documentation. */
@@ -819,11 +698,7 @@ export interface Api {
   /** The methods of this interface, in unspecified order. */
   methods?: ReadonlyArray<Method>;
   /** The source syntax of the service. */
-  syntax?:
-    | "SYNTAX_PROTO2"
-    | "SYNTAX_PROTO3"
-    | "SYNTAX_EDITIONS"
-    | (string & {});
+  syntax?: "SYNTAX_PROTO2" | "SYNTAX_PROTO3" | "SYNTAX_EDITIONS" | (string & {});
   /** Source context for the protocol buffer service represented by this message. */
   sourceContext?: SourceContext;
   /** A version string for this interface. If specified, must have the form `major-version.minor-version`, as in `1.10`. If the minor version is omitted, it defaults to zero. If the entire version field is empty, the major version is derived from the package name, as outlined below. If the field is not empty, the version in the package name will be verified to be consistent with what is provided here. The versioning schema uses [semantic versioning](http://semver.org) where the major version number indicates a breaking change and the minor version an additive, non-breaking change. Both version numbers are signals to users what to expect from different versions, and should be carefully chosen based on the product plan. The major version is also reflected in the package name of the interface, which must end in `v`, as in `google.feature.v1`. For major versions 0 and 1, the suffix can be omitted. Zero major versions must only be used for experimental, non-GA interfaces. */
@@ -1032,27 +907,17 @@ export interface MonitoredResourceDescriptor {
   /** Required. A set of labels used to describe instances of this monitored resource type. For example, an individual Google Cloud SQL database is identified by values for the labels `"database_id"` and `"zone"`. */
   labels?: ReadonlyArray<LabelDescriptor>;
   /** Optional. The launch stage of the monitored resource definition. */
-  launchStage?:
-    | "LAUNCH_STAGE_UNSPECIFIED"
-    | "UNIMPLEMENTED"
-    | "PRELAUNCH"
-    | "EARLY_ACCESS"
-    | "ALPHA"
-    | "BETA"
-    | "GA"
-    | "DEPRECATED"
-    | (string & {});
+  launchStage?: "LAUNCH_STAGE_UNSPECIFIED" | "UNIMPLEMENTED" | "PRELAUNCH" | "EARLY_ACCESS" | "ALPHA" | "BETA" | "GA" | "DEPRECATED" | (string & {});
 }
 
-export const MonitoredResourceDescriptor =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    displayName: Schema.optional(Schema.String),
-    name: Schema.optional(Schema.String),
-    type: Schema.optional(Schema.String),
-    description: Schema.optional(Schema.String),
-    labels: Schema.optional(Schema.Array(LabelDescriptor)),
-    launchStage: Schema.optional(Schema.String),
-  }).annotate({ identifier: "MonitoredResourceDescriptor" });
+export const MonitoredResourceDescriptor = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  displayName: Schema.optional(Schema.String),
+  name: Schema.optional(Schema.String),
+  type: Schema.optional(Schema.String),
+  description: Schema.optional(Schema.String),
+  labels: Schema.optional(Schema.Array(LabelDescriptor)),
+  launchStage: Schema.optional(Schema.String),
+}).annotate({ identifier: "MonitoredResourceDescriptor" });
 
 export interface Endpoint {
   /** The canonical name of this endpoint. */
@@ -1099,14 +964,11 @@ export interface Page {
   name?: string;
 }
 
-export const Page: Schema.Schema<Page> =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.suspend(() =>
-    Schema.Struct({
-      subpages: Schema.optional(Schema.Array(Page)),
-      content: Schema.optional(Schema.String),
-      name: Schema.optional(Schema.String),
-    }),
-  ).annotate({ identifier: "Page" }) as any as Schema.Schema<Page>;
+export const Page: Schema.Schema<Page> = /*@__PURE__*/ /*#__PURE__*/ Schema.suspend(() => Schema.Struct({
+  subpages: Schema.optional(Schema.Array(Page)),
+  content: Schema.optional(Schema.String),
+  name: Schema.optional(Schema.String),
+})).annotate({ identifier: "Page" }) as any as Schema.Schema<Page>;
 
 export interface Documentation {
   /** A short description of what the service does. The summary must be plain text. It becomes the overview of the service displayed in Google Cloud Console. NOTE: This field is equivalent to the standard field `description`. */
@@ -1161,21 +1023,18 @@ export interface GoogleApiServiceusageV1ServiceConfig {
   documentation?: Documentation;
 }
 
-export const GoogleApiServiceusageV1ServiceConfig =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    name: Schema.optional(Schema.String),
-    apis: Schema.optional(Schema.Array(Api)),
-    title: Schema.optional(Schema.String),
-    monitoring: Schema.optional(Monitoring),
-    authentication: Schema.optional(Authentication),
-    usage: Schema.optional(Usage),
-    quota: Schema.optional(Quota),
-    monitoredResources: Schema.optional(
-      Schema.Array(MonitoredResourceDescriptor),
-    ),
-    endpoints: Schema.optional(Schema.Array(Endpoint)),
-    documentation: Schema.optional(Documentation),
-  }).annotate({ identifier: "GoogleApiServiceusageV1ServiceConfig" });
+export const GoogleApiServiceusageV1ServiceConfig = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  name: Schema.optional(Schema.String),
+  apis: Schema.optional(Schema.Array(Api)),
+  title: Schema.optional(Schema.String),
+  monitoring: Schema.optional(Monitoring),
+  authentication: Schema.optional(Authentication),
+  usage: Schema.optional(Usage),
+  quota: Schema.optional(Quota),
+  monitoredResources: Schema.optional(Schema.Array(MonitoredResourceDescriptor)),
+  endpoints: Schema.optional(Schema.Array(Endpoint)),
+  documentation: Schema.optional(Documentation),
+}).annotate({ identifier: "GoogleApiServiceusageV1ServiceConfig" });
 
 export interface GoogleApiServiceusageV1Service {
   /** The resource name of the consumer and service. A valid name would be: - projects/123/services/serviceusage.googleapis.com */
@@ -1188,13 +1047,12 @@ export interface GoogleApiServiceusageV1Service {
   state?: "STATE_UNSPECIFIED" | "DISABLED" | "ENABLED" | (string & {});
 }
 
-export const GoogleApiServiceusageV1Service =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    name: Schema.optional(Schema.String),
-    config: Schema.optional(GoogleApiServiceusageV1ServiceConfig),
-    parent: Schema.optional(Schema.String),
-    state: Schema.optional(Schema.String),
-  }).annotate({ identifier: "GoogleApiServiceusageV1Service" });
+export const GoogleApiServiceusageV1Service = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  name: Schema.optional(Schema.String),
+  config: Schema.optional(GoogleApiServiceusageV1ServiceConfig),
+  parent: Schema.optional(Schema.String),
+  state: Schema.optional(Schema.String),
+}).annotate({ identifier: "GoogleApiServiceusageV1Service" });
 
 export interface EnableFailure {
   /** An error message describing why the service could not be enabled. */
@@ -1215,11 +1073,10 @@ export interface BatchEnableServicesResponse {
   failures?: ReadonlyArray<EnableFailure>;
 }
 
-export const BatchEnableServicesResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    services: Schema.optional(Schema.Array(GoogleApiServiceusageV1Service)),
-    failures: Schema.optional(Schema.Array(EnableFailure)),
-  }).annotate({ identifier: "BatchEnableServicesResponse" });
+export const BatchEnableServicesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  services: Schema.optional(Schema.Array(GoogleApiServiceusageV1Service)),
+  failures: Schema.optional(Schema.Array(EnableFailure)),
+}).annotate({ identifier: "BatchEnableServicesResponse" });
 
 export interface ContextRule {
   /** A list of full type names of requested contexts, only the requested context will be made available to the backend. */
@@ -1281,20 +1138,15 @@ export const Control = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   environment: Schema.optional(Schema.String),
 }).annotate({ identifier: "Control" });
 
-export interface CreateAdminQuotaPolicyMetadata {}
+export interface CreateAdminQuotaPolicyMetadata {
+}
 
-export const CreateAdminQuotaPolicyMetadata =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).annotate({
-    identifier: "CreateAdminQuotaPolicyMetadata",
-  });
+export const CreateAdminQuotaPolicyMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "CreateAdminQuotaPolicyMetadata" });
 
 export interface GoogleApiServiceusageV2betaAnalysis {
   /** Output only. The type of analysis. */
-  analysisType?:
-    | "ANALYSIS_TYPE_UNSPECIFIED"
-    | "ANALYSIS_TYPE_DEPENDENCY"
-    | "ANALYSIS_TYPE_RESOURCE_USAGE"
-    | (string & {});
+  analysisType?: "ANALYSIS_TYPE_UNSPECIFIED" | "ANALYSIS_TYPE_DEPENDENCY" | "ANALYSIS_TYPE_RESOURCE_USAGE" | (string & {});
   /** Output only. The user friendly display name of the analysis type. E.g. service dependency analysis, service resource usage analysis, etc. */
   displayName?: string;
   /** The names of the service that has analysis result of warnings or blockers. Example: `services/storage.googleapis.com`. */
@@ -1303,27 +1155,21 @@ export interface GoogleApiServiceusageV2betaAnalysis {
   analysisResult?: GoogleApiServiceusageV2betaAnalysisResult;
 }
 
-export const GoogleApiServiceusageV2betaAnalysis =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    analysisType: Schema.optional(Schema.String),
-    displayName: Schema.optional(Schema.String),
-    service: Schema.optional(Schema.String),
-    analysisResult: Schema.optional(GoogleApiServiceusageV2betaAnalysisResult),
-  }).annotate({ identifier: "GoogleApiServiceusageV2betaAnalysis" });
+export const GoogleApiServiceusageV2betaAnalysis = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  analysisType: Schema.optional(Schema.String),
+  displayName: Schema.optional(Schema.String),
+  service: Schema.optional(Schema.String),
+  analysisResult: Schema.optional(GoogleApiServiceusageV2betaAnalysisResult),
+}).annotate({ identifier: "GoogleApiServiceusageV2betaAnalysis" });
 
 export interface GoogleApiServiceusageV2betaAnalyzeConsumerPolicyResponse {
   /** The list of analyses returned from performing the intended policy update analysis. The analysis is grouped by service name and different analysis types. The empty analysis list means that the consumer policy can be updated without any warnings or blockers. */
   analysis?: ReadonlyArray<GoogleApiServiceusageV2betaAnalysis>;
 }
 
-export const GoogleApiServiceusageV2betaAnalyzeConsumerPolicyResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    analysis: Schema.optional(
-      Schema.Array(GoogleApiServiceusageV2betaAnalysis),
-    ),
-  }).annotate({
-    identifier: "GoogleApiServiceusageV2betaAnalyzeConsumerPolicyResponse",
-  });
+export const GoogleApiServiceusageV2betaAnalyzeConsumerPolicyResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  analysis: Schema.optional(Schema.Array(GoogleApiServiceusageV2betaAnalysis)),
+}).annotate({ identifier: "GoogleApiServiceusageV2betaAnalyzeConsumerPolicyResponse" });
 
 export interface LogDescriptor {
   /** A human-readable description of this log. This information appears in the documentation and can contain details. */
@@ -1353,12 +1199,7 @@ export interface BatchingSettingsProto {
   /** The number of elements of a field collected into a batch which, if exceeded, causes the batch to be sent. */
   elementCountThreshold?: number;
   /** The behavior to take when the flow control limit is exceeded. */
-  flowControlLimitExceededBehavior?:
-    | "UNSET_BEHAVIOR"
-    | "THROW_EXCEPTION"
-    | "BLOCK"
-    | "IGNORE"
-    | (string & {});
+  flowControlLimitExceededBehavior?: "UNSET_BEHAVIOR" | "THROW_EXCEPTION" | "BLOCK" | "IGNORE" | (string & {});
   /** The duration after which a batch should be sent, starting from the addition of the first message to that batch. */
   delayThreshold?: string;
   /** The maximum size of the request that could be accepted by server. */
@@ -1432,11 +1273,7 @@ export interface Type {
   /** The source context. */
   sourceContext?: SourceContext;
   /** The source syntax. */
-  syntax?:
-    | "SYNTAX_PROTO2"
-    | "SYNTAX_PROTO3"
-    | "SYNTAX_EDITIONS"
-    | (string & {});
+  syntax?: "SYNTAX_PROTO2" | "SYNTAX_PROTO3" | "SYNTAX_EDITIONS" | (string & {});
   /** The list of types appearing in `oneof` definitions in this type. */
   oneofs?: ReadonlyArray<string>;
   /** The protocol buffer options. */
@@ -1462,17 +1299,15 @@ export interface ImportAdminQuotaPoliciesResponse {
   policies?: ReadonlyArray<AdminQuotaPolicy>;
 }
 
-export const ImportAdminQuotaPoliciesResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    policies: Schema.optional(Schema.Array(AdminQuotaPolicy)),
-  }).annotate({ identifier: "ImportAdminQuotaPoliciesResponse" });
+export const ImportAdminQuotaPoliciesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  policies: Schema.optional(Schema.Array(AdminQuotaPolicy)),
+}).annotate({ identifier: "ImportAdminQuotaPoliciesResponse" });
 
-export interface GetServiceIdentityMetadata {}
+export interface GetServiceIdentityMetadata {
+}
 
-export const GetServiceIdentityMetadata =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).annotate({
-    identifier: "GetServiceIdentityMetadata",
-  });
+export const GetServiceIdentityMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "GetServiceIdentityMetadata" });
 
 export interface BackendRule {
   /** The JWT audience is used when generating a JWT ID token for the backend. This ID token will be added in the HTTP "authorization" header, and sent to the backend. */
@@ -1484,11 +1319,7 @@ export interface BackendRule {
   /** The number of seconds to wait for the completion of a long running operation. The default is no deadline. */
   operationDeadline?: number;
   /** Path translation specifies how to combine the backend address with the request path in order to produce the appropriate forwarding URL for the request. See PathTranslation for more details. */
-  pathTranslation?:
-    | "PATH_TRANSLATION_UNSPECIFIED"
-    | "CONSTANT_ADDRESS"
-    | "APPEND_PATH_TO_ADDRESS"
-    | (string & {});
+  pathTranslation?: "PATH_TRANSLATION_UNSPECIFIED" | "CONSTANT_ADDRESS" | "APPEND_PATH_TO_ADDRESS" | (string & {});
   /** When disable_auth is true, a JWT ID token won't be generated and the original "Authorization" HTTP header will be preserved. If the header is used to carry the original token and is expected by the backend, this field must be set to true to preserve the header. */
   disableAuth?: boolean;
   /** The number of seconds to wait for a response from a request. The default varies based on the request protocol and deployment environment. */
@@ -1503,26 +1334,19 @@ export interface BackendRule {
   minDeadline?: number;
 }
 
-export const BackendRule: Schema.Schema<BackendRule> =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.suspend(() =>
-    Schema.Struct({
-      jwtAudience: Schema.optional(Schema.String),
-      protocol: Schema.optional(Schema.String),
-      loadBalancingPolicy: Schema.optional(Schema.String),
-      operationDeadline: Schema.optional(Schema.Number),
-      pathTranslation: Schema.optional(Schema.String),
-      disableAuth: Schema.optional(Schema.Boolean),
-      deadline: Schema.optional(Schema.Number),
-      address: Schema.optional(Schema.String),
-      overridesByRequestProtocol: Schema.optional(
-        Schema.Record(Schema.String, BackendRule),
-      ),
-      selector: Schema.optional(Schema.String),
-      minDeadline: Schema.optional(Schema.Number),
-    }),
-  ).annotate({
-    identifier: "BackendRule",
-  }) as any as Schema.Schema<BackendRule>;
+export const BackendRule: Schema.Schema<BackendRule> = /*@__PURE__*/ /*#__PURE__*/ Schema.suspend(() => Schema.Struct({
+  jwtAudience: Schema.optional(Schema.String),
+  protocol: Schema.optional(Schema.String),
+  loadBalancingPolicy: Schema.optional(Schema.String),
+  operationDeadline: Schema.optional(Schema.Number),
+  pathTranslation: Schema.optional(Schema.String),
+  disableAuth: Schema.optional(Schema.Boolean),
+  deadline: Schema.optional(Schema.Number),
+  address: Schema.optional(Schema.String),
+  overridesByRequestProtocol: Schema.optional(Schema.Record(Schema.String, BackendRule)),
+  selector: Schema.optional(Schema.String),
+  minDeadline: Schema.optional(Schema.Number),
+})).annotate({ identifier: "BackendRule" }) as any as Schema.Schema<BackendRule>;
 
 export interface SystemParameter {
   /** Define the name of the parameter, such as "api_key" . It is case sensitive. */
@@ -1561,9 +1385,7 @@ export interface JavaSettings {
 }
 
 export const JavaSettings = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  serviceClassNames: Schema.optional(
-    Schema.Record(Schema.String, Schema.String),
-  ),
+  serviceClassNames: Schema.optional(Schema.Record(Schema.String, Schema.String)),
   common: Schema.optional(CommonLanguageSettings),
   libraryPackage: Schema.optional(Schema.String),
 }).annotate({ identifier: "JavaSettings" });
@@ -1607,9 +1429,7 @@ export interface DotnetSettings {
 export const DotnetSettings = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   handwrittenSignatures: Schema.optional(Schema.Array(Schema.String)),
   common: Schema.optional(CommonLanguageSettings),
-  renamedResources: Schema.optional(
-    Schema.Record(Schema.String, Schema.String),
-  ),
+  renamedResources: Schema.optional(Schema.Record(Schema.String, Schema.String)),
   renamedServices: Schema.optional(Schema.Record(Schema.String, Schema.String)),
   ignoredResources: Schema.optional(Schema.Array(Schema.String)),
   forcedNamespaceAliases: Schema.optional(Schema.Array(Schema.String)),
@@ -1653,16 +1473,7 @@ export interface ClientLibrarySettings {
   /** Settings for .NET client libraries. */
   dotnetSettings?: DotnetSettings;
   /** Launch stage of this version of the API. */
-  launchStage?:
-    | "LAUNCH_STAGE_UNSPECIFIED"
-    | "UNIMPLEMENTED"
-    | "PRELAUNCH"
-    | "EARLY_ACCESS"
-    | "ALPHA"
-    | "BETA"
-    | "GA"
-    | "DEPRECATED"
-    | (string & {});
+  launchStage?: "LAUNCH_STAGE_UNSPECIFIED" | "UNIMPLEMENTED" | "PRELAUNCH" | "EARLY_ACCESS" | "ALPHA" | "BETA" | "GA" | "DEPRECATED" | (string & {});
   /** Settings for Go client libraries. */
   goSettings?: GoSettings;
   /** Settings for PHP client libraries. */
@@ -1717,16 +1528,7 @@ export interface Publishing {
   /** A prefix used in sample code when demarking regions to be included in documentation. */
   docTagPrefix?: string;
   /** For whom the client library is being published. */
-  organization?:
-    | "CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED"
-    | "CLOUD"
-    | "ADS"
-    | "PHOTOS"
-    | "STREET_VIEW"
-    | "SHOPPING"
-    | "GEO"
-    | "GENERATIVE_AI"
-    | (string & {});
+  organization?: "CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED" | "CLOUD" | "ADS" | "PHOTOS" | "STREET_VIEW" | "SHOPPING" | "GEO" | "GENERATIVE_AI" | (string & {});
   /** Link to a *public* URI where users can report issues. Example: https://issuetracker.google.com/issues/new?component=190865&template=1161103 */
   newIssueUri?: string;
   /** Optional link to proto reference documentation. Example: https://cloud.google.com/pubsub/lite/docs/reference/rpc */
@@ -1753,12 +1555,11 @@ export const Publishing = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   documentationUri: Schema.optional(Schema.String),
 }).annotate({ identifier: "Publishing" });
 
-export interface DeleteAdminQuotaPolicyMetadata {}
+export interface DeleteAdminQuotaPolicyMetadata {
+}
 
-export const DeleteAdminQuotaPolicyMetadata =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).annotate({
-    identifier: "DeleteAdminQuotaPolicyMetadata",
-  });
+export const DeleteAdminQuotaPolicyMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "DeleteAdminQuotaPolicyMetadata" });
 
 export interface ListServicesResponse {
   /** Token that can be passed to `ListServices` to resume a paginated query. */
@@ -1772,22 +1573,17 @@ export const ListServicesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   services: Schema.optional(Schema.Array(GoogleApiServiceusageV1Service)),
 }).annotate({ identifier: "ListServicesResponse" });
 
-export interface GoogleApiServiceusageV2betaUpdateMcpPolicyMetadata {}
+export interface GoogleApiServiceusageV2betaUpdateMcpPolicyMetadata {
+}
 
-export const GoogleApiServiceusageV2betaUpdateMcpPolicyMetadata =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).annotate({
-    identifier: "GoogleApiServiceusageV2betaUpdateMcpPolicyMetadata",
-  });
+export const GoogleApiServiceusageV2betaUpdateMcpPolicyMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "GoogleApiServiceusageV2betaUpdateMcpPolicyMetadata" });
 
 export interface DisableServiceRequest {
   /** Indicates if services that are enabled and which depend on this service should also be disabled. If not set, an error will be generated if any enabled services depend on the service to be disabled. When set, the service, and any enabled services that depend on it, will be disabled together. */
   disableDependentServices?: boolean;
   /** Defines the behavior for checking service usage when disabling a service. */
-  checkIfServiceHasUsage?:
-    | "CHECK_IF_SERVICE_HAS_USAGE_UNSPECIFIED"
-    | "SKIP"
-    | "CHECK"
-    | (string & {});
+  checkIfServiceHasUsage?: "CHECK_IF_SERVICE_HAS_USAGE_UNSPECIFIED" | "SKIP" | "CHECK" | (string & {});
 }
 
 export const DisableServiceRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -1800,10 +1596,9 @@ export interface GoogleApiServiceusageV2alphaEnableRule {
   services?: ReadonlyArray<string>;
 }
 
-export const GoogleApiServiceusageV2alphaEnableRule =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    services: Schema.optional(Schema.Array(Schema.String)),
-  }).annotate({ identifier: "GoogleApiServiceusageV2alphaEnableRule" });
+export const GoogleApiServiceusageV2alphaEnableRule = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  services: Schema.optional(Schema.Array(Schema.String)),
+}).annotate({ identifier: "GoogleApiServiceusageV2alphaEnableRule" });
 
 export interface GoogleApiServiceusageV2alphaConsumerPolicy {
   /** Output only. The resource name of the policy. Only the `default` policy is supported: `projects/12345/consumerPolicies/default`, `folders/12345/consumerPolicies/default`, `organizations/12345/consumerPolicies/default`. */
@@ -1820,27 +1615,23 @@ export interface GoogleApiServiceusageV2alphaConsumerPolicy {
   createTime?: string;
 }
 
-export const GoogleApiServiceusageV2alphaConsumerPolicy =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    name: Schema.optional(Schema.String),
-    enableRules: Schema.optional(
-      Schema.Array(GoogleApiServiceusageV2alphaEnableRule),
-    ),
-    etag: Schema.optional(Schema.String),
-    updateTime: Schema.optional(Schema.String),
-    annotations: Schema.optional(Schema.Record(Schema.String, Schema.String)),
-    createTime: Schema.optional(Schema.String),
-  }).annotate({ identifier: "GoogleApiServiceusageV2alphaConsumerPolicy" });
+export const GoogleApiServiceusageV2alphaConsumerPolicy = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  name: Schema.optional(Schema.String),
+  enableRules: Schema.optional(Schema.Array(GoogleApiServiceusageV2alphaEnableRule)),
+  etag: Schema.optional(Schema.String),
+  updateTime: Schema.optional(Schema.String),
+  annotations: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  createTime: Schema.optional(Schema.String),
+}).annotate({ identifier: "GoogleApiServiceusageV2alphaConsumerPolicy" });
 
 export interface ImportConsumerOverridesResponse {
   /** The overrides that were created from the imported data. */
   overrides?: ReadonlyArray<QuotaOverride>;
 }
 
-export const ImportConsumerOverridesResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    overrides: Schema.optional(Schema.Array(QuotaOverride)),
-  }).annotate({ identifier: "ImportConsumerOverridesResponse" });
+export const ImportConsumerOverridesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  overrides: Schema.optional(Schema.Array(QuotaOverride)),
+}).annotate({ identifier: "ImportConsumerOverridesResponse" });
 
 export interface SystemParameterRule {
   /** Selects the methods to which this rule applies. Use '*' to indicate all methods in all APIs. Refer to selector for syntax details. */
@@ -1872,30 +1663,24 @@ export const Backend = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   rules: Schema.optional(Schema.Array(BackendRule)),
 }).annotate({ identifier: "Backend" });
 
-export interface GoogleApiServiceusageV2alphaUpdateConsumerPolicyMetadata {}
+export interface GoogleApiServiceusageV2alphaUpdateConsumerPolicyMetadata {
+}
 
-export const GoogleApiServiceusageV2alphaUpdateConsumerPolicyMetadata =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).annotate({
-    identifier: "GoogleApiServiceusageV2alphaUpdateConsumerPolicyMetadata",
-  });
+export const GoogleApiServiceusageV2alphaUpdateConsumerPolicyMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "GoogleApiServiceusageV2alphaUpdateConsumerPolicyMetadata" });
 
 export interface BatchCreateAdminOverridesResponse {
   /** The overrides that were created. */
   overrides?: ReadonlyArray<QuotaOverride>;
 }
 
-export const BatchCreateAdminOverridesResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    overrides: Schema.optional(Schema.Array(QuotaOverride)),
-  }).annotate({ identifier: "BatchCreateAdminOverridesResponse" });
+export const BatchCreateAdminOverridesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  overrides: Schema.optional(Schema.Array(QuotaOverride)),
+}).annotate({ identifier: "BatchCreateAdminOverridesResponse" });
 
 export interface Enum {
   /** The source syntax. */
-  syntax?:
-    | "SYNTAX_PROTO2"
-    | "SYNTAX_PROTO3"
-    | "SYNTAX_EDITIONS"
-    | (string & {});
+  syntax?: "SYNTAX_PROTO2" | "SYNTAX_PROTO3" | "SYNTAX_EDITIONS" | (string & {});
   /** The source context. */
   sourceContext?: SourceContext;
   /** Enum type name. */
@@ -2086,42 +1871,37 @@ export const GoogleApiService = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   backend: Schema.optional(Backend),
   sourceInfo: Schema.optional(SourceInfo),
   logs: Schema.optional(Schema.Array(LogDescriptor)),
-  monitoredResources: Schema.optional(
-    Schema.Array(MonitoredResourceDescriptor),
-  ),
+  monitoredResources: Schema.optional(Schema.Array(MonitoredResourceDescriptor)),
   aspects: Schema.optional(Schema.Array(Aspect)),
   systemTypes: Schema.optional(Schema.Array(Type)),
 }).annotate({ identifier: "GoogleApiService" });
 
-export interface ImportAdminQuotaPoliciesMetadata {}
+export interface ImportAdminQuotaPoliciesMetadata {
+}
 
-export const ImportAdminQuotaPoliciesMetadata =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).annotate({
-    identifier: "ImportAdminQuotaPoliciesMetadata",
-  });
+export const ImportAdminQuotaPoliciesMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "ImportAdminQuotaPoliciesMetadata" });
 
-export interface ImportAdminOverridesMetadata {}
+export interface ImportAdminOverridesMetadata {
+}
 
-export const ImportAdminOverridesMetadata =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).annotate({
-    identifier: "ImportAdminOverridesMetadata",
-  });
+export const ImportAdminOverridesMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "ImportAdminOverridesMetadata" });
 
-export interface CancelOperationRequest {}
+export interface CancelOperationRequest {
+}
 
-export const CancelOperationRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {},
-).annotate({ identifier: "CancelOperationRequest" });
+export const CancelOperationRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "CancelOperationRequest" });
 
 export interface BatchGetServicesResponse {
   /** The requested Service states. */
   services?: ReadonlyArray<GoogleApiServiceusageV1Service>;
 }
 
-export const BatchGetServicesResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    services: Schema.optional(Schema.Array(GoogleApiServiceusageV1Service)),
-  }).annotate({ identifier: "BatchGetServicesResponse" });
+export const BatchGetServicesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  services: Schema.optional(Schema.Array(GoogleApiServiceusageV1Service)),
+}).annotate({ identifier: "BatchGetServicesResponse" });
 
 export interface EnableRule {
   /** The names of the services or service groups that are enabled. Example: `services/storage.googleapis.com`, `groups/googleServices`, `groups/allServices`. */
@@ -2129,12 +1909,7 @@ export interface EnableRule {
   /** DEPRECATED: Please use field `values`. Service should have prefix `services/`. The names of the services that are enabled. Example: `storage.googleapis.com`. */
   services?: ReadonlyArray<string>;
   /** Client and resource project enable type. */
-  enableType?:
-    | "ENABLE_TYPE_UNSPECIFIED"
-    | "CLIENT"
-    | "RESOURCE"
-    | "V1_COMPATIBLE"
-    | (string & {});
+  enableType?: "ENABLE_TYPE_UNSPECIFIED" | "CLIENT" | "RESOURCE" | "V1_COMPATIBLE" | (string & {});
   /** DEPRECATED: Please use field `values`. Service group should have prefix `groups/`. The names of the service groups that are enabled (Not Implemented). Example: `groups/googleServices`. */
   groups?: ReadonlyArray<string>;
 }
@@ -2172,10 +1947,9 @@ export interface ImportAdminOverridesResponse {
   overrides?: ReadonlyArray<QuotaOverride>;
 }
 
-export const ImportAdminOverridesResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    overrides: Schema.optional(Schema.Array(QuotaOverride)),
-  }).annotate({ identifier: "ImportAdminOverridesResponse" });
+export const ImportAdminOverridesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  overrides: Schema.optional(Schema.Array(QuotaOverride)),
+}).annotate({ identifier: "ImportAdminOverridesResponse" });
 
 export interface Status {
   /** A list of messages that carry the error details. There is a common set of message types for APIs to use. */
@@ -2187,9 +1961,7 @@ export interface Status {
 }
 
 export const Status = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  details: Schema.optional(
-    Schema.Array(Schema.Record(Schema.String, Schema.Unknown)),
-  ),
+  details: Schema.optional(Schema.Array(Schema.Record(Schema.String, Schema.Unknown))),
   message: Schema.optional(Schema.String),
   code: Schema.optional(Schema.Number),
 }).annotate({ identifier: "Status" });
@@ -2201,19 +1973,16 @@ export interface AddEnableRulesResponse {
   addedValues?: ReadonlyArray<string>;
 }
 
-export const AddEnableRulesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {
-    parent: Schema.optional(Schema.String),
-    addedValues: Schema.optional(Schema.Array(Schema.String)),
-  },
-).annotate({ identifier: "AddEnableRulesResponse" });
+export const AddEnableRulesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  parent: Schema.optional(Schema.String),
+  addedValues: Schema.optional(Schema.Array(Schema.String)),
+}).annotate({ identifier: "AddEnableRulesResponse" });
 
-export interface RemoveEnableRulesMetadata {}
+export interface RemoveEnableRulesMetadata {
+}
 
-export const RemoveEnableRulesMetadata =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).annotate({
-    identifier: "RemoveEnableRulesMetadata",
-  });
+export const RemoveEnableRulesMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "RemoveEnableRulesMetadata" });
 
 export interface Operation {
   /** Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any. */
@@ -2245,45 +2014,41 @@ export interface ListOperationsResponse {
   unreachable?: ReadonlyArray<string>;
 }
 
-export const ListOperationsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {
-    nextPageToken: Schema.optional(Schema.String),
-    operations: Schema.optional(Schema.Array(Operation)),
-    unreachable: Schema.optional(Schema.Array(Schema.String)),
-  },
-).annotate({ identifier: "ListOperationsResponse" });
+export const ListOperationsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  nextPageToken: Schema.optional(Schema.String),
+  operations: Schema.optional(Schema.Array(Operation)),
+  unreachable: Schema.optional(Schema.Array(Schema.String)),
+}).annotate({ identifier: "ListOperationsResponse" });
 
-export interface ImportConsumerOverridesMetadata {}
+export interface ImportConsumerOverridesMetadata {
+}
 
-export const ImportConsumerOverridesMetadata =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).annotate({
-    identifier: "ImportConsumerOverridesMetadata",
-  });
+export const ImportConsumerOverridesMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "ImportConsumerOverridesMetadata" });
 
-export interface AddEnableRulesMetadata {}
+export interface AddEnableRulesMetadata {
+}
 
-export const AddEnableRulesMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {},
-).annotate({ identifier: "AddEnableRulesMetadata" });
+export const AddEnableRulesMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "AddEnableRulesMetadata" });
 
-export interface EnableServiceRequest {}
+export interface EnableServiceRequest {
+}
 
-export const EnableServiceRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {},
-).annotate({ identifier: "EnableServiceRequest" });
+export const EnableServiceRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "EnableServiceRequest" });
 
-export interface GoogleApiServiceusageV2betaUpdateConsumerPolicyMetadata {}
+export interface GoogleApiServiceusageV2betaUpdateConsumerPolicyMetadata {
+}
 
-export const GoogleApiServiceusageV2betaUpdateConsumerPolicyMetadata =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).annotate({
-    identifier: "GoogleApiServiceusageV2betaUpdateConsumerPolicyMetadata",
-  });
+export const GoogleApiServiceusageV2betaUpdateConsumerPolicyMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "GoogleApiServiceusageV2betaUpdateConsumerPolicyMetadata" });
 
-export interface Empty {}
+export interface Empty {
+}
 
-export const Empty = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).annotate({
-  identifier: "Empty",
-});
+export const Empty = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "Empty" });
 
 export interface GetServiceIdentityResponse {
   /** Service identity that service producer can use to access consumer resources. If exists is true, it contains email and unique_id. If exists is false, it contains pre-constructed email and empty unique_id. */
@@ -2292,36 +2057,31 @@ export interface GetServiceIdentityResponse {
   state?: "IDENTITY_STATE_UNSPECIFIED" | "ACTIVE" | (string & {});
 }
 
-export const GetServiceIdentityResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    identity: Schema.optional(ServiceIdentity),
-    state: Schema.optional(Schema.String),
-  }).annotate({ identifier: "GetServiceIdentityResponse" });
+export const GetServiceIdentityResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  identity: Schema.optional(ServiceIdentity),
+  state: Schema.optional(Schema.String),
+}).annotate({ identifier: "GetServiceIdentityResponse" });
 
 export interface DisableServiceResponse {
   /** The new state of the service after disabling. */
   service?: GoogleApiServiceusageV1Service;
 }
 
-export const DisableServiceResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {
-    service: Schema.optional(GoogleApiServiceusageV1Service),
-  },
-).annotate({ identifier: "DisableServiceResponse" });
+export const DisableServiceResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  service: Schema.optional(GoogleApiServiceusageV1Service),
+}).annotate({ identifier: "DisableServiceResponse" });
 
-export interface UpdateContentSecurityPolicyMetadata {}
+export interface UpdateContentSecurityPolicyMetadata {
+}
 
-export const UpdateContentSecurityPolicyMetadata =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).annotate({
-    identifier: "UpdateContentSecurityPolicyMetadata",
-  });
+export const UpdateContentSecurityPolicyMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "UpdateContentSecurityPolicyMetadata" });
 
-export interface AnalyzeConsumerPolicyMetadata {}
+export interface AnalyzeConsumerPolicyMetadata {
+}
 
-export const AnalyzeConsumerPolicyMetadata =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).annotate({
-    identifier: "AnalyzeConsumerPolicyMetadata",
-  });
+export const AnalyzeConsumerPolicyMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "AnalyzeConsumerPolicyMetadata" });
 
 export interface RemoveEnableRulesResponse {
   /** The values removed from the parent consumer policy. */
@@ -2330,11 +2090,10 @@ export interface RemoveEnableRulesResponse {
   parent?: string;
 }
 
-export const RemoveEnableRulesResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    removedValues: Schema.optional(Schema.Array(Schema.String)),
-    parent: Schema.optional(Schema.String),
-  }).annotate({ identifier: "RemoveEnableRulesResponse" });
+export const RemoveEnableRulesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  removedValues: Schema.optional(Schema.Array(Schema.String)),
+  parent: Schema.optional(Schema.String),
+}).annotate({ identifier: "RemoveEnableRulesResponse" });
 
 export interface OperationMetadata {
   /** The full name of the resources that this operation is directly associated with. */
@@ -2345,12 +2104,63 @@ export const OperationMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   resourceNames: Schema.optional(Schema.Array(Schema.String)),
 }).annotate({ identifier: "OperationMetadata" });
 
-export interface UpdateAdminQuotaPolicyMetadata {}
+export interface UpdateAdminQuotaPolicyMetadata {
+}
 
-export const UpdateAdminQuotaPolicyMetadata =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).annotate({
-    identifier: "UpdateAdminQuotaPolicyMetadata",
-  });
+export const UpdateAdminQuotaPolicyMetadata = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+}).annotate({ identifier: "UpdateAdminQuotaPolicyMetadata" });
+
+// ==========================================================================
+// Errors
+// ==========================================================================
+
+export class NotFound extends Schema.TaggedErrorClass<NotFound>()(
+  "NotFound",
+  {
+    code: Schema.optional(Schema.Number),
+    message: Schema.String,
+    status: Schema.optional(Schema.String),
+    reason: Schema.optional(Schema.String),
+    domain: Schema.optional(Schema.String),
+  },
+) {}
+T.applyErrorMatchers(NotFound, [{"httpStatus":404}]);
+
+export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
+  "BadRequest",
+  {
+    code: Schema.optional(Schema.Number),
+    message: Schema.String,
+    status: Schema.optional(Schema.String),
+    reason: Schema.optional(Schema.String),
+    domain: Schema.optional(Schema.String),
+  },
+) {}
+T.applyErrorMatchers(BadRequest, [{"httpStatus":400}]);
+
+export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
+  "Forbidden",
+  {
+    code: Schema.optional(Schema.Number),
+    message: Schema.String,
+    status: Schema.optional(Schema.String),
+    reason: Schema.optional(Schema.String),
+    domain: Schema.optional(Schema.String),
+  },
+) {}
+T.applyErrorMatchers(Forbidden, [{"httpStatus":403}]);
+
+export class Conflict extends Schema.TaggedErrorClass<Conflict>()(
+  "Conflict",
+  {
+    code: Schema.optional(Schema.Number),
+    message: Schema.String,
+    status: Schema.optional(Schema.String),
+    reason: Schema.optional(Schema.String),
+    domain: Schema.optional(Schema.String),
+  },
+) {}
+T.applyErrorMatchers(Conflict, [{"httpStatus":409}]);
 
 // ==========================================================================
 // Operations
@@ -2370,9 +2180,7 @@ export interface ListOperationsRequest {
 }
 
 export const ListOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  returnPartialSuccess: Schema.optional(Schema.Boolean).pipe(
-    T.HttpQuery("returnPartialSuccess"),
-  ),
+  returnPartialSuccess: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("returnPartialSuccess")),
   filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   name: Schema.optional(Schema.String).pipe(T.HttpQuery("name")),
@@ -2383,18 +2191,12 @@ export const ListOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 ) as unknown as Schema.Schema<ListOperationsRequest>;
 
 export type ListOperationsResponse_Op = ListOperationsResponse;
-export const ListOperationsResponse_Op =
-  /*@__PURE__*/ /*#__PURE__*/ ListOperationsResponse;
+export const ListOperationsResponse_Op = /*@__PURE__*/ /*#__PURE__*/ ListOperationsResponse;
 
 export type ListOperationsError = DefaultErrors;
 
 /** Lists operations that match the specified filter in the request. If the server doesn't support this method, it returns `UNIMPLEMENTED`. */
-export const listOperations: API.PaginatedOperationMethod<
-  ListOperationsRequest,
-  ListOperationsResponse_Op,
-  ListOperationsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+export const listOperations: API.PaginatedOperationMethod<ListOperationsRequest, ListOperationsResponse_Op, ListOperationsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
   input: ListOperationsRequest,
   output: ListOperationsResponse_Op,
   errors: [],
@@ -2411,14 +2213,13 @@ export interface CancelOperationsRequest {
   body?: CancelOperationRequest;
 }
 
-export const CancelOperationsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    name: Schema.String.pipe(T.HttpPath("name")),
-    body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
-  }).pipe(
-    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
-    svc,
-  ) as unknown as Schema.Schema<CancelOperationsRequest>;
+export const CancelOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  name: Schema.String.pipe(T.HttpPath("name")),
+  body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
+}).pipe(
+  T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
+  svc,
+) as unknown as Schema.Schema<CancelOperationsRequest>;
 
 export type CancelOperationsResponse = Empty;
 export const CancelOperationsResponse = /*@__PURE__*/ /*#__PURE__*/ Empty;
@@ -2426,12 +2227,7 @@ export const CancelOperationsResponse = /*@__PURE__*/ /*#__PURE__*/ Empty;
 export type CancelOperationsError = DefaultErrors;
 
 /** Starts asynchronous cancellation on a long-running operation. The server makes a best effort to cancel the operation, but success is not guaranteed. If the server doesn't support this method, it returns `google.rpc.Code.UNIMPLEMENTED`. Clients can use Operations.GetOperation or other methods to check whether the cancellation succeeded or whether the operation completed despite cancellation. On successful cancellation, the operation is not deleted; instead, it becomes an operation with an Operation.error value with a google.rpc.Status.code of `1`, corresponding to `Code.CANCELLED`. */
-export const cancelOperations: API.OperationMethod<
-  CancelOperationsRequest,
-  CancelOperationsResponse,
-  CancelOperationsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const cancelOperations: API.OperationMethod<CancelOperationsRequest, CancelOperationsResponse, CancelOperationsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: CancelOperationsRequest,
   output: CancelOperationsResponse,
   errors: [],
@@ -2452,18 +2248,13 @@ export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 export type GetOperationsResponse = Operation;
 export const GetOperationsResponse = /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type GetOperationsError = DefaultErrors;
+export type GetOperationsError = DefaultErrors | NotFound | Forbidden;
 
 /** Gets the latest state of a long-running operation. Clients can use this method to poll the operation result at intervals as recommended by the API service. */
-export const getOperations: API.OperationMethod<
-  GetOperationsRequest,
-  GetOperationsResponse,
-  GetOperationsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const getOperations: API.OperationMethod<GetOperationsRequest, GetOperationsResponse, GetOperationsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetOperationsRequest,
   output: GetOperationsResponse,
-  errors: [],
+  errors: [NotFound, Forbidden],
 }));
 
 export interface DeleteOperationsRequest {
@@ -2471,13 +2262,12 @@ export interface DeleteOperationsRequest {
   name: string;
 }
 
-export const DeleteOperationsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    name: Schema.String.pipe(T.HttpPath("name")),
-  }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{+name}" }),
-    svc,
-  ) as unknown as Schema.Schema<DeleteOperationsRequest>;
+export const DeleteOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  name: Schema.String.pipe(T.HttpPath("name")),
+}).pipe(
+  T.Http({ method: "DELETE", path: "v1/{+name}" }),
+  svc,
+) as unknown as Schema.Schema<DeleteOperationsRequest>;
 
 export type DeleteOperationsResponse = Empty;
 export const DeleteOperationsResponse = /*@__PURE__*/ /*#__PURE__*/ Empty;
@@ -2485,12 +2275,7 @@ export const DeleteOperationsResponse = /*@__PURE__*/ /*#__PURE__*/ Empty;
 export type DeleteOperationsError = DefaultErrors;
 
 /** Deletes a long-running operation. This method indicates that the client is no longer interested in the operation result. It does not cancel the operation. If the server doesn't support this method, it returns `google.rpc.Code.UNIMPLEMENTED`. */
-export const deleteOperations: API.OperationMethod<
-  DeleteOperationsRequest,
-  DeleteOperationsResponse,
-  DeleteOperationsError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const deleteOperations: API.OperationMethod<DeleteOperationsRequest, DeleteOperationsResponse, DeleteOperationsError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: DeleteOperationsRequest,
   output: DeleteOperationsResponse,
   errors: [],
@@ -2503,12 +2288,10 @@ export interface DisableServicesRequest {
   body?: DisableServiceRequest;
 }
 
-export const DisableServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {
-    name: Schema.String.pipe(T.HttpPath("name")),
-    body: Schema.optional(DisableServiceRequest).pipe(T.HttpBody()),
-  },
-).pipe(
+export const DisableServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  name: Schema.String.pipe(T.HttpPath("name")),
+  body: Schema.optional(DisableServiceRequest).pipe(T.HttpBody()),
+}).pipe(
   T.Http({ method: "POST", path: "v1/{+name}:disable", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<DisableServicesRequest>;
@@ -2516,18 +2299,13 @@ export const DisableServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 export type DisableServicesResponse = Operation;
 export const DisableServicesResponse = /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type DisableServicesError = DefaultErrors;
+export type DisableServicesError = DefaultErrors | NotFound | BadRequest | Forbidden | Conflict;
 
 /** Disable a service so that it can no longer be used with a project. This prevents unintended usage that may cause unexpected billing charges or security leaks. It is not valid to call the disable method on a service that is not currently enabled. Callers will receive a `FAILED_PRECONDITION` status if the target service is not currently enabled. */
-export const disableServices: API.OperationMethod<
-  DisableServicesRequest,
-  DisableServicesResponse,
-  DisableServicesError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const disableServices: API.OperationMethod<DisableServicesRequest, DisableServicesResponse, DisableServicesError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: DisableServicesRequest,
   output: DisableServicesResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface BatchEnableServicesRequest_Op {
@@ -2537,32 +2315,21 @@ export interface BatchEnableServicesRequest_Op {
   body?: BatchEnableServicesRequest;
 }
 
-export const BatchEnableServicesRequest_Op =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    parent: Schema.String.pipe(T.HttpPath("parent")),
-    body: Schema.optional(BatchEnableServicesRequest).pipe(T.HttpBody()),
-  }).pipe(
-    T.Http({
-      method: "POST",
-      path: "v1/{+parent}/services:batchEnable",
-      hasBody: true,
-    }),
-    svc,
-  ) as unknown as Schema.Schema<BatchEnableServicesRequest_Op>;
+export const BatchEnableServicesRequest_Op = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  parent: Schema.String.pipe(T.HttpPath("parent")),
+  body: Schema.optional(BatchEnableServicesRequest).pipe(T.HttpBody()),
+}).pipe(
+  T.Http({ method: "POST", path: "v1/{+parent}/services:batchEnable", hasBody: true }),
+  svc,
+) as unknown as Schema.Schema<BatchEnableServicesRequest_Op>;
 
 export type BatchEnableServicesResponse_Op = Operation;
-export const BatchEnableServicesResponse_Op =
-  /*@__PURE__*/ /*#__PURE__*/ Operation;
+export const BatchEnableServicesResponse_Op = /*@__PURE__*/ /*#__PURE__*/ Operation;
 
 export type BatchEnableServicesError = DefaultErrors;
 
 /** Enable multiple services on a project. The operation is atomic: if enabling any service fails, then the entire batch fails, and no state changes occur. To enable a single service, use the `EnableService` method instead. */
-export const batchEnableServices: API.OperationMethod<
-  BatchEnableServicesRequest_Op,
-  BatchEnableServicesResponse_Op,
-  BatchEnableServicesError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const batchEnableServices: API.OperationMethod<BatchEnableServicesRequest_Op, BatchEnableServicesResponse_Op, BatchEnableServicesError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: BatchEnableServicesRequest_Op,
   output: BatchEnableServicesResponse_Op,
   errors: [],
@@ -2575,30 +2342,21 @@ export interface BatchGetServicesRequest {
   parent: string;
 }
 
-export const BatchGetServicesRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    names: Schema.optional(Schema.Array(Schema.String)).pipe(
-      T.HttpQuery("names"),
-    ),
-    parent: Schema.String.pipe(T.HttpPath("parent")),
-  }).pipe(
-    T.Http({ method: "GET", path: "v1/{+parent}/services:batchGet" }),
-    svc,
-  ) as unknown as Schema.Schema<BatchGetServicesRequest>;
+export const BatchGetServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  names: Schema.optional(Schema.Array(Schema.String)).pipe(T.HttpQuery("names")),
+  parent: Schema.String.pipe(T.HttpPath("parent")),
+}).pipe(
+  T.Http({ method: "GET", path: "v1/{+parent}/services:batchGet" }),
+  svc,
+) as unknown as Schema.Schema<BatchGetServicesRequest>;
 
 export type BatchGetServicesResponse_Op = BatchGetServicesResponse;
-export const BatchGetServicesResponse_Op =
-  /*@__PURE__*/ /*#__PURE__*/ BatchGetServicesResponse;
+export const BatchGetServicesResponse_Op = /*@__PURE__*/ /*#__PURE__*/ BatchGetServicesResponse;
 
 export type BatchGetServicesError = DefaultErrors;
 
 /** Returns the service configurations and enabled states for a given list of services. */
-export const batchGetServices: API.OperationMethod<
-  BatchGetServicesRequest,
-  BatchGetServicesResponse_Op,
-  BatchGetServicesError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const batchGetServices: API.OperationMethod<BatchGetServicesRequest, BatchGetServicesResponse_Op, BatchGetServicesError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: BatchGetServicesRequest,
   output: BatchGetServicesResponse_Op,
   errors: [],
@@ -2622,18 +2380,13 @@ export const EnableServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 export type EnableServicesResponse = Operation;
 export const EnableServicesResponse = /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type EnableServicesError = DefaultErrors;
+export type EnableServicesError = DefaultErrors | NotFound | BadRequest | Forbidden | Conflict;
 
 /** Enable a service so that it can be used with a project. */
-export const enableServices: API.OperationMethod<
-  EnableServicesRequest,
-  EnableServicesResponse,
-  EnableServicesError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const enableServices: API.OperationMethod<EnableServicesRequest, EnableServicesResponse, EnableServicesError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: EnableServicesRequest,
   output: EnableServicesResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface ListServicesRequest {
@@ -2658,18 +2411,12 @@ export const ListServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 ) as unknown as Schema.Schema<ListServicesRequest>;
 
 export type ListServicesResponse_Op = ListServicesResponse;
-export const ListServicesResponse_Op =
-  /*@__PURE__*/ /*#__PURE__*/ ListServicesResponse;
+export const ListServicesResponse_Op = /*@__PURE__*/ /*#__PURE__*/ ListServicesResponse;
 
 export type ListServicesError = DefaultErrors;
 
 /** List all services available to the specified project, and the current state of those services with respect to the project. The list includes all public services, all services for which the calling user has the `servicemanagement.services.bind` permission, and all services that have already been enabled on the project. The list can be filtered to only include services in a specific state, for example to only include services enabled on the project. WARNING: If you need to query enabled services frequently or across an organization, you should use [Cloud Asset Inventory API](https://cloud.google.com/asset-inventory/docs/apis), which provides higher throughput and richer filtering capability. */
-export const listServices: API.PaginatedOperationMethod<
-  ListServicesRequest,
-  ListServicesResponse_Op,
-  ListServicesError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+export const listServices: API.PaginatedOperationMethod<ListServicesRequest, ListServicesResponse_Op, ListServicesError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
   input: ListServicesRequest,
   output: ListServicesResponse_Op,
   errors: [],
@@ -2692,19 +2439,14 @@ export const GetServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 ) as unknown as Schema.Schema<GetServicesRequest>;
 
 export type GetServicesResponse = GoogleApiServiceusageV1Service;
-export const GetServicesResponse =
-  /*@__PURE__*/ /*#__PURE__*/ GoogleApiServiceusageV1Service;
+export const GetServicesResponse = /*@__PURE__*/ /*#__PURE__*/ GoogleApiServiceusageV1Service;
 
-export type GetServicesError = DefaultErrors;
+export type GetServicesError = DefaultErrors | NotFound | Forbidden;
 
 /** Returns the service configuration and enabled state for a given service. */
-export const getServices: API.OperationMethod<
-  GetServicesRequest,
-  GetServicesResponse,
-  GetServicesError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const getServices: API.OperationMethod<GetServicesRequest, GetServicesResponse, GetServicesError, Credentials | HttpClient.HttpClient> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetServicesRequest,
   output: GetServicesResponse,
-  errors: [],
+  errors: [NotFound, Forbidden],
 }));
+

--- a/packages/gcp/src/services/serviceusage-v1.ts
+++ b/packages/gcp/src/services/serviceusage-v1.ts
@@ -2416,7 +2416,7 @@ export const CancelOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOperationsRequest>;
 
@@ -2445,7 +2445,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -2475,7 +2475,7 @@ export const DeleteOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOperationsRequest>;
 
@@ -2509,7 +2509,7 @@ export const DisableServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     body: Schema.optional(DisableServiceRequest).pipe(T.HttpBody()),
   },
 ).pipe(
-  T.Http({ method: "POST", path: "v1/{name}:disable", hasBody: true }),
+  T.Http({ method: "POST", path: "v1/{+name}:disable", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<DisableServicesRequest>;
 
@@ -2544,7 +2544,7 @@ export const BatchEnableServicesRequest_Op =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/services:batchEnable",
+      path: "v1/{+parent}/services:batchEnable",
       hasBody: true,
     }),
     svc,
@@ -2582,7 +2582,7 @@ export const BatchGetServicesRequest =
     ),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/services:batchGet" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/services:batchGet" }),
     svc,
   ) as unknown as Schema.Schema<BatchGetServicesRequest>;
 
@@ -2615,7 +2615,7 @@ export const EnableServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(EnableServiceRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v1/{name}:enable", hasBody: true }),
+  T.Http({ method: "POST", path: "v1/{+name}:enable", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<EnableServicesRequest>;
 
@@ -2653,7 +2653,7 @@ export const ListServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{parent}/services" }),
+  T.Http({ method: "GET", path: "v1/{+parent}/services" }),
   svc,
 ) as unknown as Schema.Schema<ListServicesRequest>;
 
@@ -2687,7 +2687,7 @@ export interface GetServicesRequest {
 export const GetServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetServicesRequest>;
 

--- a/packages/gcp/src/services/serviceusage-v1beta1.ts
+++ b/packages/gcp/src/services/serviceusage-v1beta1.ts
@@ -2600,7 +2600,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta1/{name}" }),
+  T.Http({ method: "GET", path: "v1beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -2682,7 +2682,7 @@ export const DisableServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     body: Schema.optional(DisableServiceRequest).pipe(T.HttpBody()),
   },
 ).pipe(
-  T.Http({ method: "POST", path: "v1beta1/{name}:disable", hasBody: true }),
+  T.Http({ method: "POST", path: "v1beta1/{+name}:disable", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<DisableServicesRequest>;
 
@@ -2714,7 +2714,7 @@ export const EnableServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(EnableServiceRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v1beta1/{name}:enable", hasBody: true }),
+  T.Http({ method: "POST", path: "v1beta1/{+name}:enable", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<EnableServicesRequest>;
 
@@ -2746,7 +2746,7 @@ export const GenerateServiceIdentityServicesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:generateServiceIdentity",
+      path: "v1beta1/{+parent}:generateServiceIdentity",
       hasBody: true,
     }),
     svc,
@@ -2778,7 +2778,7 @@ export interface GetServicesRequest {
 export const GetServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta1/{name}" }),
+  T.Http({ method: "GET", path: "v1beta1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetServicesRequest>;
 
@@ -2816,7 +2816,7 @@ export const ListServicesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1beta1/{parent}/services" }),
+  T.Http({ method: "GET", path: "v1beta1/{+parent}/services" }),
   svc,
 ) as unknown as Schema.Schema<ListServicesRequest>;
 
@@ -2856,7 +2856,7 @@ export const BatchEnableServicesRequest_Op =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/services:batchEnable",
+      path: "v1beta1/{+parent}/services:batchEnable",
       hasBody: true,
     }),
     svc,
@@ -2898,7 +2898,7 @@ export const ListServicesConsumerQuotaMetricsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/consumerQuotaMetrics" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/consumerQuotaMetrics" }),
     svc,
   ) as unknown as Schema.Schema<ListServicesConsumerQuotaMetricsRequest>;
 
@@ -2937,7 +2937,7 @@ export const GetServicesConsumerQuotaMetricsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetServicesConsumerQuotaMetricsRequest>;
 
@@ -2973,7 +2973,7 @@ export const ImportAdminOverridesServicesConsumerQuotaMetricsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/consumerQuotaMetrics:importAdminOverrides",
+      path: "v1beta1/{+parent}/consumerQuotaMetrics:importAdminOverrides",
       hasBody: true,
     }),
     svc,
@@ -3013,7 +3013,7 @@ export const ImportConsumerOverridesServicesConsumerQuotaMetricsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/consumerQuotaMetrics:importConsumerOverrides",
+      path: "v1beta1/{+parent}/consumerQuotaMetrics:importConsumerOverrides",
       hasBody: true,
     }),
     svc,
@@ -3051,7 +3051,7 @@ export const GetServicesConsumerQuotaMetricsLimitsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetServicesConsumerQuotaMetricsLimitsRequest>;
 
@@ -3099,7 +3099,7 @@ export const CreateServicesConsumerQuotaMetricsLimitsAdminOverridesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/adminOverrides",
+      path: "v1beta1/{+parent}/adminOverrides",
       hasBody: true,
     }),
     svc,
@@ -3140,7 +3140,7 @@ export const ListServicesConsumerQuotaMetricsLimitsAdminOverridesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/adminOverrides" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/adminOverrides" }),
     svc,
   ) as unknown as Schema.Schema<ListServicesConsumerQuotaMetricsLimitsAdminOverridesRequest>;
 
@@ -3189,7 +3189,7 @@ export const DeleteServicesConsumerQuotaMetricsLimitsAdminOverridesRequest =
     ),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteServicesConsumerQuotaMetricsLimitsAdminOverridesRequest>;
 
@@ -3240,7 +3240,7 @@ export const PatchServicesConsumerQuotaMetricsLimitsAdminOverridesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(QuotaOverride).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchServicesConsumerQuotaMetricsLimitsAdminOverridesRequest>;
 
@@ -3291,7 +3291,7 @@ export const PatchServicesConsumerQuotaMetricsLimitsConsumerOverridesRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     body: Schema.optional(QuotaOverride).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchServicesConsumerQuotaMetricsLimitsConsumerOverridesRequest>;
 
@@ -3336,7 +3336,7 @@ export const DeleteServicesConsumerQuotaMetricsLimitsConsumerOverridesRequest =
     ),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteServicesConsumerQuotaMetricsLimitsConsumerOverridesRequest>;
 
@@ -3386,7 +3386,7 @@ export const CreateServicesConsumerQuotaMetricsLimitsConsumerOverridesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/consumerOverrides",
+      path: "v1beta1/{+parent}/consumerOverrides",
       hasBody: true,
     }),
     svc,
@@ -3427,7 +3427,7 @@ export const ListServicesConsumerQuotaMetricsLimitsConsumerOverridesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/consumerOverrides" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/consumerOverrides" }),
     svc,
   ) as unknown as Schema.Schema<ListServicesConsumerQuotaMetricsLimitsConsumerOverridesRequest>;
 

--- a/packages/gcp/src/services/slides-v1.ts
+++ b/packages/gcp/src/services/slides-v1.ts
@@ -2884,7 +2884,7 @@ export const GetPresentationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     presentationId: Schema.String.pipe(T.HttpPath("presentationId")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/presentations/{presentationId}" }),
+    T.Http({ method: "GET", path: "v1/presentations/{+presentationId}" }),
     svc,
   ) as unknown as Schema.Schema<GetPresentationsRequest>;
 

--- a/packages/gcp/src/services/smartdevicemanagement-v1.ts
+++ b/packages/gcp/src/services/smartdevicemanagement-v1.ts
@@ -165,7 +165,7 @@ export const GetEnterprisesStructuresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEnterprisesStructuresRequest>;
 
@@ -200,7 +200,7 @@ export const ListEnterprisesStructuresRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/structures" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/structures" }),
     svc,
   ) as unknown as Schema.Schema<ListEnterprisesStructuresRequest>;
 
@@ -232,7 +232,7 @@ export const GetEnterprisesStructuresRoomsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEnterprisesStructuresRoomsRequest>;
 
@@ -264,7 +264,7 @@ export const ListEnterprisesStructuresRoomsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/rooms" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/rooms" }),
     svc,
   ) as unknown as Schema.Schema<ListEnterprisesStructuresRoomsRequest>;
 
@@ -299,7 +299,7 @@ export const ListEnterprisesDevicesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/devices" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/devices" }),
     svc,
   ) as unknown as Schema.Schema<ListEnterprisesDevicesRequest>;
 
@@ -331,7 +331,7 @@ export const GetEnterprisesDevicesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetEnterprisesDevicesRequest>;
 
@@ -367,7 +367,11 @@ export const ExecuteCommandEnterprisesDevicesRequest =
       GoogleHomeEnterpriseSdmV1ExecuteDeviceCommandRequest,
     ).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:executeCommand", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+name}:executeCommand",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<ExecuteCommandEnterprisesDevicesRequest>;
 

--- a/packages/gcp/src/services/spanner-v1.ts
+++ b/packages/gcp/src/services/spanner-v1.ts
@@ -3198,7 +3198,7 @@ export const ListScansRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{parent}" }),
+  T.Http({ method: "GET", path: "v1/{+parent}" }),
   svc,
 ) as unknown as Schema.Schema<ListScansRequest>;
 
@@ -3239,7 +3239,7 @@ export const ListProjectsInstanceConfigsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/instanceConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/instanceConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstanceConfigsRequest>;
 
@@ -3274,7 +3274,7 @@ export const GetProjectsInstanceConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstanceConfigsRequest>;
 
@@ -3310,7 +3310,7 @@ export const CreateProjectsInstanceConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/instanceConfigs",
+      path: "v1/{+parent}/instanceConfigs",
       hasBody: true,
     }),
     svc,
@@ -3351,7 +3351,7 @@ export const DeleteProjectsInstanceConfigsRequest =
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstanceConfigsRequest>;
 
@@ -3385,7 +3385,7 @@ export const PatchProjectsInstanceConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateInstanceConfigRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsInstanceConfigsRequest>;
 
@@ -3430,7 +3430,7 @@ export const ListProjectsInstanceConfigsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstanceConfigsOperationsRequest>;
 
@@ -3466,7 +3466,7 @@ export const GetProjectsInstanceConfigsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstanceConfigsOperationsRequest>;
 
@@ -3497,7 +3497,7 @@ export const DeleteProjectsInstanceConfigsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstanceConfigsOperationsRequest>;
 
@@ -3528,7 +3528,7 @@ export const CancelProjectsInstanceConfigsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsInstanceConfigsOperationsRequest>;
 
@@ -3573,7 +3573,7 @@ export const ListProjectsInstanceConfigsSsdCachesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstanceConfigsSsdCachesOperationsRequest>;
 
@@ -3609,7 +3609,7 @@ export const GetProjectsInstanceConfigsSsdCachesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstanceConfigsSsdCachesOperationsRequest>;
 
@@ -3640,7 +3640,7 @@ export const DeleteProjectsInstanceConfigsSsdCachesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstanceConfigsSsdCachesOperationsRequest>;
 
@@ -3672,7 +3672,7 @@ export const CancelProjectsInstanceConfigsSsdCachesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsInstanceConfigsSsdCachesOperationsRequest>;
 
@@ -3713,7 +3713,7 @@ export const ListProjectsInstanceConfigOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/instanceConfigOperations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/instanceConfigOperations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstanceConfigOperationsRequest>;
 
@@ -3763,7 +3763,7 @@ export const ListProjectsInstancesRequest =
       T.HttpQuery("instanceDeadline"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/instances" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/instances" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesRequest>;
 
@@ -3801,7 +3801,7 @@ export const GetProjectsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     fieldMask: Schema.optional(Schema.String).pipe(T.HttpQuery("fieldMask")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesRequest>;
 
@@ -3835,7 +3835,7 @@ export const CreateProjectsInstancesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/instances", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/instances", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsInstancesRequest>;
 
@@ -3869,7 +3869,7 @@ export const PatchProjectsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsInstancesRequest>;
 
@@ -3903,7 +3903,7 @@ export const MoveProjectsInstancesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MoveInstanceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:move", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:move", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<MoveProjectsInstancesRequest>;
 
@@ -3939,7 +3939,7 @@ export const TestIamPermissionsProjectsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3973,7 +3973,7 @@ export const DeleteProjectsInstancesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstancesRequest>;
 
@@ -4009,7 +4009,7 @@ export const SetIamPolicyProjectsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4047,7 +4047,7 @@ export const GetIamPolicyProjectsInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4086,7 +4086,7 @@ export const PatchProjectsInstancesBackupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsInstancesBackupsRequest>;
 
@@ -4120,7 +4120,11 @@ export const CopyProjectsInstancesBackupsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CopyBackupRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/backups:copy", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/backups:copy",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CopyProjectsInstancesBackupsRequest>;
 
@@ -4156,7 +4160,7 @@ export const TestIamPermissionsProjectsInstancesBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4190,7 +4194,7 @@ export const GetProjectsInstancesBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesBackupsRequest>;
 
@@ -4230,7 +4234,7 @@ export const ListProjectsInstancesBackupsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesBackupsRequest>;
 
@@ -4291,7 +4295,7 @@ export const CreateProjectsInstancesBackupsRequest =
     ),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/backups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/backups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsInstancesBackupsRequest>;
 
@@ -4327,7 +4331,7 @@ export const SetIamPolicyProjectsInstancesBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4365,7 +4369,7 @@ export const GetIamPolicyProjectsInstancesBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -4398,7 +4402,7 @@ export const DeleteProjectsInstancesBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstancesBackupsRequest>;
 
@@ -4429,7 +4433,7 @@ export const DeleteProjectsInstancesBackupsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstancesBackupsOperationsRequest>;
 
@@ -4460,7 +4464,7 @@ export const CancelProjectsInstancesBackupsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsInstancesBackupsOperationsRequest>;
 
@@ -4505,7 +4509,7 @@ export const ListProjectsInstancesBackupsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesBackupsOperationsRequest>;
 
@@ -4541,7 +4545,7 @@ export const GetProjectsInstancesBackupsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesBackupsOperationsRequest>;
 
@@ -4581,7 +4585,7 @@ export const ListProjectsInstancesBackupOperationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backupOperations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backupOperations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesBackupOperationsRequest>;
 
@@ -4628,7 +4632,7 @@ export const ListProjectsInstancesInstancePartitionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/instancePartitions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/instancePartitions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesInstancePartitionsRequest>;
 
@@ -4664,7 +4668,7 @@ export const GetProjectsInstancesInstancePartitionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesInstancePartitionsRequest>;
 
@@ -4700,7 +4704,7 @@ export const CreateProjectsInstancesInstancePartitionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/instancePartitions",
+      path: "v1/{+parent}/instancePartitions",
       hasBody: true,
     }),
     svc,
@@ -4736,7 +4740,7 @@ export const DeleteProjectsInstancesInstancePartitionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstancesInstancePartitionsRequest>;
 
@@ -4770,7 +4774,7 @@ export const PatchProjectsInstancesInstancePartitionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UpdateInstancePartitionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsInstancesInstancePartitionsRequest>;
 
@@ -4815,7 +4819,7 @@ export const ListProjectsInstancesInstancePartitionsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesInstancePartitionsOperationsRequest>;
 
@@ -4852,7 +4856,7 @@ export const GetProjectsInstancesInstancePartitionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesInstancePartitionsOperationsRequest>;
 
@@ -4885,7 +4889,7 @@ export const DeleteProjectsInstancesInstancePartitionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstancesInstancePartitionsOperationsRequest>;
 
@@ -4917,7 +4921,7 @@ export const CancelProjectsInstancesInstancePartitionsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsInstancesInstancePartitionsOperationsRequest>;
 
@@ -4958,7 +4962,7 @@ export const ListProjectsInstancesDatabaseOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/databaseOperations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/databaseOperations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesDatabaseOperationsRequest>;
 
@@ -4997,7 +5001,7 @@ export const CreateProjectsInstancesDatabasesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreateDatabaseRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/databases", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/databases", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsInstancesDatabasesRequest>;
 
@@ -5034,7 +5038,7 @@ export const ListProjectsInstancesDatabasesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/databases" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/databases" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesDatabasesRequest>;
 
@@ -5069,7 +5073,7 @@ export const GetProjectsInstancesDatabasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesDatabasesRequest>;
 
@@ -5105,7 +5109,7 @@ export const TestIamPermissionsProjectsInstancesDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5142,7 +5146,7 @@ export const UpdateDdlProjectsInstancesDatabasesRequest =
     database: Schema.String.pipe(T.HttpPath("database")),
     body: Schema.optional(UpdateDatabaseDdlRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{database}/ddl", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+database}/ddl", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateDdlProjectsInstancesDatabasesRequest>;
 
@@ -5178,7 +5182,7 @@ export const RestoreProjectsInstancesDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/databases:restore",
+      path: "v1/{+parent}/databases:restore",
       hasBody: true,
     }),
     svc,
@@ -5214,7 +5218,7 @@ export const ChangequorumProjectsInstancesDatabasesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ChangeQuorumRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:changequorum", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:changequorum", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ChangequorumProjectsInstancesDatabasesRequest>;
 
@@ -5254,7 +5258,7 @@ export const GetScansProjectsInstancesDatabasesRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     endTime: Schema.optional(Schema.String).pipe(T.HttpQuery("endTime")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/scans" }),
+    T.Http({ method: "GET", path: "v1/{+name}/scans" }),
     svc,
   ) as unknown as Schema.Schema<GetScansProjectsInstancesDatabasesRequest>;
 
@@ -5285,7 +5289,7 @@ export const GetDdlProjectsInstancesDatabasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     database: Schema.String.pipe(T.HttpPath("database")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{database}/ddl" }),
+    T.Http({ method: "GET", path: "v1/{+database}/ddl" }),
     svc,
   ) as unknown as Schema.Schema<GetDdlProjectsInstancesDatabasesRequest>;
 
@@ -5322,7 +5326,7 @@ export const PatchProjectsInstancesDatabasesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Database).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsInstancesDatabasesRequest>;
 
@@ -5358,7 +5362,7 @@ export const SetIamPolicyProjectsInstancesDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5396,7 +5400,7 @@ export const GetIamPolicyProjectsInstancesDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -5434,7 +5438,7 @@ export const AddSplitPointsProjectsInstancesDatabasesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{database}:addSplitPoints",
+      path: "v1/{+database}:addSplitPoints",
       hasBody: true,
     }),
     svc,
@@ -5468,7 +5472,7 @@ export const DropDatabaseProjectsInstancesDatabasesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     database: Schema.String.pipe(T.HttpPath("database")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{database}" }),
+    T.Http({ method: "DELETE", path: "v1/{+database}" }),
     svc,
   ) as unknown as Schema.Schema<DropDatabaseProjectsInstancesDatabasesRequest>;
 
@@ -5504,7 +5508,7 @@ export const TestIamPermissionsProjectsInstancesDatabasesDatabaseRolesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -5545,7 +5549,7 @@ export const ListProjectsInstancesDatabasesDatabaseRolesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/databaseRoles" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/databaseRoles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesDatabasesDatabaseRolesRequest>;
 
@@ -5595,7 +5599,7 @@ export const ListProjectsInstancesDatabasesOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesDatabasesOperationsRequest>;
 
@@ -5631,7 +5635,7 @@ export const GetProjectsInstancesDatabasesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesDatabasesOperationsRequest>;
 
@@ -5662,7 +5666,7 @@ export const DeleteProjectsInstancesDatabasesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstancesDatabasesOperationsRequest>;
 
@@ -5693,7 +5697,7 @@ export const CancelProjectsInstancesDatabasesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsInstancesDatabasesOperationsRequest>;
 
@@ -5729,7 +5733,7 @@ export const BeginTransactionProjectsInstancesDatabasesSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{session}:beginTransaction",
+      path: "v1/{+session}:beginTransaction",
       hasBody: true,
     }),
     svc,
@@ -5769,7 +5773,7 @@ export const PartitionReadProjectsInstancesDatabasesSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{session}:partitionRead",
+      path: "v1/{+session}:partitionRead",
       hasBody: true,
     }),
     svc,
@@ -5807,7 +5811,7 @@ export const RollbackProjectsInstancesDatabasesSessionsRequest =
     session: Schema.String.pipe(T.HttpPath("session")),
     body: Schema.optional(RollbackRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{session}:rollback", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+session}:rollback", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RollbackProjectsInstancesDatabasesSessionsRequest>;
 
@@ -5841,7 +5845,7 @@ export const BatchWriteProjectsInstancesDatabasesSessionsRequest =
     session: Schema.String.pipe(T.HttpPath("session")),
     body: Schema.optional(BatchWriteRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{session}:batchWrite", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+session}:batchWrite", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<BatchWriteProjectsInstancesDatabasesSessionsRequest>;
 
@@ -5878,7 +5882,7 @@ export const BatchCreateProjectsInstancesDatabasesSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{database}/sessions:batchCreate",
+      path: "v1/{+database}/sessions:batchCreate",
       hasBody: true,
     }),
     svc,
@@ -5915,7 +5919,7 @@ export const CommitProjectsInstancesDatabasesSessionsRequest =
     session: Schema.String.pipe(T.HttpPath("session")),
     body: Schema.optional(CommitRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{session}:commit", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+session}:commit", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CommitProjectsInstancesDatabasesSessionsRequest>;
 
@@ -5949,7 +5953,7 @@ export const AdaptMessageProjectsInstancesDatabasesSessionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AdaptMessageRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:adaptMessage", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:adaptMessage", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AdaptMessageProjectsInstancesDatabasesSessionsRequest>;
 
@@ -5986,7 +5990,7 @@ export const PartitionQueryProjectsInstancesDatabasesSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{session}:partitionQuery",
+      path: "v1/{+session}:partitionQuery",
       hasBody: true,
     }),
     svc,
@@ -6026,7 +6030,7 @@ export const ExecuteBatchDmlProjectsInstancesDatabasesSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{session}:executeBatchDml",
+      path: "v1/{+session}:executeBatchDml",
       hasBody: true,
     }),
     svc,
@@ -6064,7 +6068,7 @@ export const ExecuteSqlProjectsInstancesDatabasesSessionsRequest =
     session: Schema.String.pipe(T.HttpPath("session")),
     body: Schema.optional(ExecuteSqlRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{session}:executeSql", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+session}:executeSql", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExecuteSqlProjectsInstancesDatabasesSessionsRequest>;
 
@@ -6098,7 +6102,7 @@ export const ReadProjectsInstancesDatabasesSessionsRequest =
     session: Schema.String.pipe(T.HttpPath("session")),
     body: Schema.optional(ReadRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{session}:read", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+session}:read", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReadProjectsInstancesDatabasesSessionsRequest>;
 
@@ -6132,7 +6136,7 @@ export const CreateProjectsInstancesDatabasesSessionsRequest =
     database: Schema.String.pipe(T.HttpPath("database")),
     body: Schema.optional(CreateSessionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{database}/sessions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+database}/sessions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsInstancesDatabasesSessionsRequest>;
 
@@ -6168,7 +6172,7 @@ export const StreamingReadProjectsInstancesDatabasesSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{session}:streamingRead",
+      path: "v1/{+session}:streamingRead",
       hasBody: true,
     }),
     svc,
@@ -6208,7 +6212,7 @@ export const AdapterProjectsInstancesDatabasesSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/sessions:adapter",
+      path: "v1/{+parent}/sessions:adapter",
       hasBody: true,
     }),
     svc,
@@ -6241,7 +6245,7 @@ export const GetProjectsInstancesDatabasesSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesDatabasesSessionsRequest>;
 
@@ -6281,7 +6285,7 @@ export const ListProjectsInstancesDatabasesSessionsRequest =
     database: Schema.String.pipe(T.HttpPath("database")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{database}/sessions" }),
+    T.Http({ method: "GET", path: "v1/{+database}/sessions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesDatabasesSessionsRequest>;
 
@@ -6317,7 +6321,7 @@ export const DeleteProjectsInstancesDatabasesSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstancesDatabasesSessionsRequest>;
 
@@ -6353,7 +6357,7 @@ export const ExecuteStreamingSqlProjectsInstancesDatabasesSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{session}:executeStreamingSql",
+      path: "v1/{+session}:executeStreamingSql",
       hasBody: true,
     }),
     svc,
@@ -6398,7 +6402,7 @@ export const CreateProjectsInstancesDatabasesBackupSchedulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/backupSchedules",
+      path: "v1/{+parent}/backupSchedules",
       hasBody: true,
     }),
     svc,
@@ -6438,7 +6442,7 @@ export const SetIamPolicyProjectsInstancesDatabasesBackupSchedulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -6478,7 +6482,7 @@ export const GetIamPolicyProjectsInstancesDatabasesBackupSchedulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:getIamPolicy",
+      path: "v1/{+resource}:getIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -6513,7 +6517,7 @@ export const DeleteProjectsInstancesDatabasesBackupSchedulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstancesDatabasesBackupSchedulesRequest>;
 
@@ -6545,7 +6549,7 @@ export const GetProjectsInstancesDatabasesBackupSchedulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesDatabasesBackupSchedulesRequest>;
 
@@ -6583,7 +6587,7 @@ export const ListProjectsInstancesDatabasesBackupSchedulesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backupSchedules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backupSchedules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesDatabasesBackupSchedulesRequest>;
 
@@ -6624,7 +6628,7 @@ export const TestIamPermissionsProjectsInstancesDatabasesBackupSchedulesRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -6665,7 +6669,7 @@ export const PatchProjectsInstancesDatabasesBackupSchedulesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(BackupSchedule).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsInstancesDatabasesBackupSchedulesRequest>;
 
@@ -6711,7 +6715,7 @@ export const ListProjectsInstancesInstancePartitionOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/instancePartitionOperations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/instancePartitionOperations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesInstancePartitionOperationsRequest>;
 
@@ -6748,7 +6752,7 @@ export const DeleteProjectsInstancesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsInstancesOperationsRequest>;
 
@@ -6779,7 +6783,7 @@ export const CancelProjectsInstancesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsInstancesOperationsRequest>;
 
@@ -6824,7 +6828,7 @@ export const ListProjectsInstancesOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsInstancesOperationsRequest>;
 
@@ -6859,7 +6863,7 @@ export const GetProjectsInstancesOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsInstancesOperationsRequest>;
 

--- a/packages/gcp/src/services/speech-v1.ts
+++ b/packages/gcp/src/services/speech-v1.ts
@@ -731,7 +731,7 @@ export const DeleteProjectsLocationsPhraseSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPhraseSetsRequest>;
 
@@ -768,7 +768,7 @@ export const PatchProjectsLocationsPhraseSetsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PhraseSet).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPhraseSetsRequest>;
 
@@ -802,7 +802,7 @@ export const CreateProjectsLocationsPhraseSetsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CreatePhraseSetRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/phraseSets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/phraseSets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsPhraseSetsRequest>;
 
@@ -833,7 +833,7 @@ export const GetProjectsLocationsPhraseSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPhraseSetsRequest>;
 
@@ -870,7 +870,7 @@ export const ListProjectsLocationsPhraseSetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/phraseSets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/phraseSets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPhraseSetsRequest>;
 
@@ -905,7 +905,7 @@ export const DeleteProjectsLocationsCustomClassesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCustomClassesRequest>;
 
@@ -942,7 +942,7 @@ export const PatchProjectsLocationsCustomClassesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CustomClass).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCustomClassesRequest>;
 
@@ -978,7 +978,7 @@ export const CreateProjectsLocationsCustomClassesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/customClasses",
+      path: "v1/{+parent}/customClasses",
       hasBody: true,
     }),
     svc,
@@ -1011,7 +1011,7 @@ export const GetProjectsLocationsCustomClassesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCustomClassesRequest>;
 
@@ -1048,7 +1048,7 @@ export const ListProjectsLocationsCustomClassesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/customClasses" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/customClasses" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCustomClassesRequest>;
 
@@ -1131,7 +1131,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/operations/{name}" }),
+  T.Http({ method: "GET", path: "v1/operations/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 

--- a/packages/gcp/src/services/speech-v1p1beta1.ts
+++ b/packages/gcp/src/services/speech-v1p1beta1.ts
@@ -723,7 +723,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1p1beta1/operations/{name}" }),
+  T.Http({ method: "GET", path: "v1p1beta1/operations/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -759,7 +759,7 @@ export const ListProjectsLocationsPhraseSetsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1p1beta1/{parent}/phraseSets" }),
+    T.Http({ method: "GET", path: "v1p1beta1/{+parent}/phraseSets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPhraseSetsRequest>;
 
@@ -794,7 +794,7 @@ export const GetProjectsLocationsPhraseSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1p1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1p1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPhraseSetsRequest>;
 
@@ -825,7 +825,7 @@ export const DeleteProjectsLocationsPhraseSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1p1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1p1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPhraseSetsRequest>;
 
@@ -861,7 +861,7 @@ export const CreateProjectsLocationsPhraseSetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p1beta1/{parent}/phraseSets",
+      path: "v1p1beta1/{+parent}/phraseSets",
       hasBody: true,
     }),
     svc,
@@ -900,7 +900,7 @@ export const PatchProjectsLocationsPhraseSetsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(PhraseSet).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1p1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1p1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPhraseSetsRequest>;
 
@@ -937,7 +937,7 @@ export const ListProjectsLocationsCustomClassesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1p1beta1/{parent}/customClasses" }),
+    T.Http({ method: "GET", path: "v1p1beta1/{+parent}/customClasses" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsCustomClassesRequest>;
 
@@ -973,7 +973,7 @@ export const GetProjectsLocationsCustomClassesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1p1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1p1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsCustomClassesRequest>;
 
@@ -1004,7 +1004,7 @@ export const DeleteProjectsLocationsCustomClassesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1p1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1p1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsCustomClassesRequest>;
 
@@ -1040,7 +1040,7 @@ export const CreateProjectsLocationsCustomClassesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p1beta1/{parent}/customClasses",
+      path: "v1p1beta1/{+parent}/customClasses",
       hasBody: true,
     }),
     svc,
@@ -1079,7 +1079,7 @@ export const PatchProjectsLocationsCustomClassesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(CustomClass).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1p1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1p1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsCustomClassesRequest>;
 

--- a/packages/gcp/src/services/sqladmin-v1.ts
+++ b/packages/gcp/src/services/sqladmin-v1.ts
@@ -5111,7 +5111,7 @@ export const PointInTimeRestoreInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:pointInTimeRestore",
+      path: "v1/{+parent}:pointInTimeRestore",
       hasBody: true,
     }),
     svc,
@@ -5799,7 +5799,7 @@ export const CreateBackupBackupsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/backups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/backups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateBackupBackupsRequest>;
 
@@ -5830,7 +5830,7 @@ export const GetBackupBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBackupBackupsRequest>;
 
@@ -5869,7 +5869,7 @@ export const ListBackupsBackupsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/backups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListBackupsBackupsRequest>;
 
@@ -5910,7 +5910,7 @@ export const UpdateBackupBackupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateBackupBackupsRequest>;
 
@@ -5941,7 +5941,7 @@ export const DeleteBackupBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteBackupBackupsRequest>;
 

--- a/packages/gcp/src/services/sqladmin-v1beta4.ts
+++ b/packages/gcp/src/services/sqladmin-v1beta4.ts
@@ -5558,7 +5558,7 @@ export const PointInTimeRestoreInstancesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "sql/v1beta4/{parent}:pointInTimeRestore",
+      path: "sql/v1beta4/{+parent}:pointInTimeRestore",
       hasBody: true,
     }),
     svc,
@@ -6200,7 +6200,7 @@ export const CreateBackupBackupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "sql/v1beta4/{parent}/backups",
+      path: "sql/v1beta4/{+parent}/backups",
       hasBody: true,
     }),
     svc,
@@ -6233,7 +6233,7 @@ export const GetBackupBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "sql/v1beta4/{name}" }),
+    T.Http({ method: "GET", path: "sql/v1beta4/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetBackupBackupsRequest>;
 
@@ -6272,7 +6272,7 @@ export const ListBackupsBackupsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "sql/v1beta4/{parent}/backups" }),
+    T.Http({ method: "GET", path: "sql/v1beta4/{+parent}/backups" }),
     svc,
   ) as unknown as Schema.Schema<ListBackupsBackupsRequest>;
 
@@ -6313,7 +6313,7 @@ export const UpdateBackupBackupsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Backup).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "sql/v1beta4/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "sql/v1beta4/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateBackupBackupsRequest>;
 
@@ -6344,7 +6344,7 @@ export const DeleteBackupBackupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "sql/v1beta4/{name}" }),
+    T.Http({ method: "DELETE", path: "sql/v1beta4/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteBackupBackupsRequest>;
 

--- a/packages/gcp/src/services/storagebatchoperations-v1.ts
+++ b/packages/gcp/src/services/storagebatchoperations-v1.ts
@@ -584,7 +584,7 @@ export const ListProjectsLocationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -619,7 +619,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -664,7 +664,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -699,7 +699,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -730,7 +730,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -764,7 +764,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -804,7 +804,7 @@ export const CreateProjectsLocationsJobsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Job).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/jobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/jobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsJobsRequest>;
 
@@ -838,7 +838,7 @@ export const CancelProjectsLocationsJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsJobsRequest>;
 
@@ -869,7 +869,7 @@ export const GetProjectsLocationsJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsJobsRequest>;
 
@@ -911,7 +911,7 @@ export const ListProjectsLocationsJobsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/jobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/jobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsJobsRequest>;
 
@@ -952,7 +952,7 @@ export const DeleteProjectsLocationsJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsJobsRequest>;
 
@@ -995,7 +995,7 @@ export const ListProjectsLocationsJobsBucketOperationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/bucketOperations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/bucketOperations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsJobsBucketOperationsRequest>;
 
@@ -1031,7 +1031,7 @@ export const GetProjectsLocationsJobsBucketOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsJobsBucketOperationsRequest>;
 

--- a/packages/gcp/src/services/storagetransfer-v1.ts
+++ b/packages/gcp/src/services/storagetransfer-v1.ts
@@ -947,7 +947,7 @@ export const ListTransferOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<ListTransferOperationsRequest>;
 
@@ -982,7 +982,7 @@ export const GetTransferOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTransferOperationsRequest>;
 
@@ -1016,7 +1016,7 @@ export const CancelTransferOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelTransferOperationsRequest>;
 
@@ -1050,7 +1050,7 @@ export const PauseTransferOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(PauseTransferOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:pause", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:pause", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PauseTransferOperationsRequest>;
 
@@ -1084,7 +1084,7 @@ export const ResumeTransferOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResumeTransferOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:resume", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:resume", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResumeTransferOperationsRequest>;
 
@@ -1180,7 +1180,7 @@ export const PatchTransferJobsRequest =
     jobName: Schema.String.pipe(T.HttpPath("jobName")),
     body: Schema.optional(UpdateTransferJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{jobName}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+jobName}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchTransferJobsRequest>;
 
@@ -1215,7 +1215,7 @@ export const GetTransferJobsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     projectId: Schema.String.pipe(T.HttpQuery("projectId")),
   },
 ).pipe(
-  T.Http({ method: "GET", path: "v1/{jobName}" }),
+  T.Http({ method: "GET", path: "v1/{+jobName}" }),
   svc,
 ) as unknown as Schema.Schema<GetTransferJobsRequest>;
 
@@ -1290,7 +1290,7 @@ export const RunTransferJobsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     body: Schema.optional(RunTransferJobRequest).pipe(T.HttpBody()),
   },
 ).pipe(
-  T.Http({ method: "POST", path: "v1/{jobName}:run", hasBody: true }),
+  T.Http({ method: "POST", path: "v1/{+jobName}:run", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<RunTransferJobsRequest>;
 
@@ -1323,7 +1323,7 @@ export const DeleteTransferJobsRequest =
     jobName: Schema.String.pipe(T.HttpPath("jobName")),
     projectId: Schema.String.pipe(T.HttpQuery("projectId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{jobName}" }),
+    T.Http({ method: "DELETE", path: "v1/{+jobName}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteTransferJobsRequest>;
 
@@ -1363,7 +1363,7 @@ export const CreateProjectsAgentPoolsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/projects/{projectId}/agentPools",
+      path: "v1/projects/{+projectId}/agentPools",
       hasBody: true,
     }),
     svc,
@@ -1402,7 +1402,7 @@ export const PatchProjectsAgentPoolsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(AgentPool).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsAgentPoolsRequest>;
 
@@ -1433,7 +1433,7 @@ export const GetProjectsAgentPoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAgentPoolsRequest>;
 
@@ -1473,7 +1473,7 @@ export const ListProjectsAgentPoolsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/projects/{projectId}/agentPools" }),
+    T.Http({ method: "GET", path: "v1/projects/{+projectId}/agentPools" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAgentPoolsRequest>;
 
@@ -1508,7 +1508,7 @@ export const DeleteProjectsAgentPoolsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsAgentPoolsRequest>;
 

--- a/packages/gcp/src/services/tagmanager-v2.ts
+++ b/packages/gcp/src/services/tagmanager-v2.ts
@@ -1863,7 +1863,7 @@ export interface GetAccountsRequest {
 export const GetAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   path: Schema.String.pipe(T.HttpPath("path")),
 }).pipe(
-  T.Http({ method: "GET", path: "tagmanager/v2/{path}" }),
+  T.Http({ method: "GET", path: "tagmanager/v2/{+path}" }),
   svc,
 ) as unknown as Schema.Schema<GetAccountsRequest>;
 
@@ -1898,7 +1898,7 @@ export const UpdateAccountsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   fingerprint: Schema.optional(Schema.String).pipe(T.HttpQuery("fingerprint")),
   body: Schema.optional(Account).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "PUT", path: "tagmanager/v2/{path}", hasBody: true }),
+  T.Http({ method: "PUT", path: "tagmanager/v2/{+path}", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<UpdateAccountsRequest>;
 
@@ -1931,7 +1931,7 @@ export const ListAccountsUser_permissionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{parent}/user_permissions" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+parent}/user_permissions" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsUser_permissionsRequest>;
 
@@ -1966,7 +1966,7 @@ export const GetAccountsUser_permissionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsUser_permissionsRequest>;
 
@@ -1997,7 +1997,7 @@ export const DeleteAccountsUser_permissionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "DELETE", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsUser_permissionsRequest>;
 
@@ -2035,7 +2035,7 @@ export const CreateAccountsUser_permissionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{parent}/user_permissions",
+      path: "tagmanager/v2/{+parent}/user_permissions",
       hasBody: true,
     }),
     svc,
@@ -2071,7 +2071,7 @@ export const UpdateAccountsUser_permissionsRequest =
     path: Schema.String.pipe(T.HttpPath("path")),
     body: Schema.optional(UserPermission).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "tagmanager/v2/{path}", hasBody: true }),
+    T.Http({ method: "PUT", path: "tagmanager/v2/{+path}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAccountsUser_permissionsRequest>;
 
@@ -2123,7 +2123,7 @@ export const CombineAccountsContainersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:combine",
+      path: "tagmanager/v2/{+path}:combine",
       hasBody: true,
     }),
     svc,
@@ -2182,7 +2182,7 @@ export const Move_tag_idAccountsContainersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:move_tag_id",
+      path: "tagmanager/v2/{+path}:move_tag_id",
       hasBody: true,
     }),
     svc,
@@ -2215,7 +2215,7 @@ export const GetAccountsContainersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsContainersRequest>;
 
@@ -2251,7 +2251,7 @@ export const CreateAccountsContainersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{parent}/containers",
+      path: "tagmanager/v2/{+parent}/containers",
       hasBody: true,
     }),
     svc,
@@ -2292,7 +2292,7 @@ export const UpdateAccountsContainersRequest =
     ),
     body: Schema.optional(Container).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "tagmanager/v2/{path}", hasBody: true }),
+    T.Http({ method: "PUT", path: "tagmanager/v2/{+path}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAccountsContainersRequest>;
 
@@ -2359,7 +2359,7 @@ export const SnippetAccountsContainersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{path}:snippet" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+path}:snippet" }),
     svc,
   ) as unknown as Schema.Schema<SnippetAccountsContainersRequest>;
 
@@ -2390,7 +2390,7 @@ export const DeleteAccountsContainersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "DELETE", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsContainersRequest>;
 
@@ -2426,7 +2426,7 @@ export const ListAccountsContainersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{parent}/containers" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+parent}/containers" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsContainersRequest>;
 
@@ -2463,7 +2463,7 @@ export const Set_latestAccountsContainersVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:set_latest",
+      path: "tagmanager/v2/{+path}:set_latest",
       hasBody: true,
     }),
     svc,
@@ -2496,7 +2496,7 @@ export const LiveAccountsContainersVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{parent}/versions:live" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+parent}/versions:live" }),
     svc,
   ) as unknown as Schema.Schema<LiveAccountsContainersVersionsRequest>;
 
@@ -2535,7 +2535,7 @@ export const UpdateAccountsContainersVersionsRequest =
     ),
     body: Schema.optional(ContainerVersion).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "tagmanager/v2/{path}", hasBody: true }),
+    T.Http({ method: "PUT", path: "tagmanager/v2/{+path}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAccountsContainersVersionsRequest>;
 
@@ -2573,7 +2573,7 @@ export const PublishAccountsContainersVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:publish",
+      path: "tagmanager/v2/{+path}:publish",
       hasBody: true,
     }),
     svc,
@@ -2609,7 +2609,7 @@ export const UndeleteAccountsContainersVersionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:undelete",
+      path: "tagmanager/v2/{+path}:undelete",
       hasBody: true,
     }),
     svc,
@@ -2647,7 +2647,7 @@ export const GetAccountsContainersVersionsRequest =
     ),
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsContainersVersionsRequest>;
 
@@ -2678,7 +2678,7 @@ export const DeleteAccountsContainersVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "DELETE", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsContainersVersionsRequest>;
 
@@ -2719,7 +2719,7 @@ export const ListAccountsContainersVersion_headersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{parent}/version_headers" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+parent}/version_headers" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsContainersVersion_headersRequest>;
 
@@ -2757,7 +2757,7 @@ export const LatestAccountsContainersVersion_headersRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "tagmanager/v2/{parent}/version_headers:latest",
+      path: "tagmanager/v2/{+parent}/version_headers:latest",
     }),
     svc,
   ) as unknown as Schema.Schema<LatestAccountsContainersVersion_headersRequest>;
@@ -2795,7 +2795,7 @@ export const ReauthorizeAccountsContainersEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:reauthorize",
+      path: "tagmanager/v2/{+path}:reauthorize",
       hasBody: true,
     }),
     svc,
@@ -2833,7 +2833,7 @@ export const CreateAccountsContainersEnvironmentsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{parent}/environments",
+      path: "tagmanager/v2/{+parent}/environments",
       hasBody: true,
     }),
     svc,
@@ -2874,7 +2874,7 @@ export const UpdateAccountsContainersEnvironmentsRequest =
     ),
     body: Schema.optional(Environment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "tagmanager/v2/{path}", hasBody: true }),
+    T.Http({ method: "PUT", path: "tagmanager/v2/{+path}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAccountsContainersEnvironmentsRequest>;
 
@@ -2908,7 +2908,7 @@ export const ListAccountsContainersEnvironmentsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{parent}/environments" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+parent}/environments" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsContainersEnvironmentsRequest>;
 
@@ -2944,7 +2944,7 @@ export const GetAccountsContainersEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsContainersEnvironmentsRequest>;
 
@@ -2975,7 +2975,7 @@ export const DeleteAccountsContainersEnvironmentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "DELETE", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsContainersEnvironmentsRequest>;
 
@@ -3010,7 +3010,7 @@ export const Quick_previewAccountsContainersWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:quick_preview",
+      path: "tagmanager/v2/{+path}:quick_preview",
       hasBody: true,
     }),
     svc,
@@ -3044,7 +3044,7 @@ export const GetStatusAccountsContainersWorkspacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{path}/status" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+path}/status" }),
     svc,
   ) as unknown as Schema.Schema<GetStatusAccountsContainersWorkspacesRequest>;
 
@@ -3081,7 +3081,7 @@ export const CreateAccountsContainersWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{parent}/workspaces",
+      path: "tagmanager/v2/{+parent}/workspaces",
       hasBody: true,
     }),
     svc,
@@ -3122,7 +3122,7 @@ export const UpdateAccountsContainersWorkspacesRequest =
     ),
     body: Schema.optional(Workspace).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "tagmanager/v2/{path}", hasBody: true }),
+    T.Http({ method: "PUT", path: "tagmanager/v2/{+path}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAccountsContainersWorkspacesRequest>;
 
@@ -3156,7 +3156,7 @@ export const ListAccountsContainersWorkspacesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{parent}/workspaces" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+parent}/workspaces" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsContainersWorkspacesRequest>;
 
@@ -3191,7 +3191,7 @@ export const DeleteAccountsContainersWorkspacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "DELETE", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsContainersWorkspacesRequest>;
 
@@ -3234,7 +3234,7 @@ export const Resolve_conflictAccountsContainersWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:resolve_conflict",
+      path: "tagmanager/v2/{+path}:resolve_conflict",
       hasBody: true,
     }),
     svc,
@@ -3276,7 +3276,7 @@ export const Create_versionAccountsContainersWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:create_version",
+      path: "tagmanager/v2/{+path}:create_version",
       hasBody: true,
     }),
     svc,
@@ -3312,7 +3312,7 @@ export const SyncAccountsContainersWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:sync",
+      path: "tagmanager/v2/{+path}:sync",
       hasBody: true,
     }),
     svc,
@@ -3350,7 +3350,7 @@ export const Bulk_updateAccountsContainersWorkspacesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}/bulk_update",
+      path: "tagmanager/v2/{+path}/bulk_update",
       hasBody: true,
     }),
     svc,
@@ -3384,7 +3384,7 @@ export const GetAccountsContainersWorkspacesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsContainersWorkspacesRequest>;
 
@@ -3420,7 +3420,7 @@ export const CreateAccountsContainersWorkspacesZonesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{parent}/zones",
+      path: "tagmanager/v2/{+parent}/zones",
       hasBody: true,
     }),
     svc,
@@ -3461,7 +3461,7 @@ export const UpdateAccountsContainersWorkspacesZonesRequest =
     ),
     body: Schema.optional(Zone).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "tagmanager/v2/{path}", hasBody: true }),
+    T.Http({ method: "PUT", path: "tagmanager/v2/{+path}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAccountsContainersWorkspacesZonesRequest>;
 
@@ -3495,7 +3495,7 @@ export const ListAccountsContainersWorkspacesZonesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{parent}/zones" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+parent}/zones" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsContainersWorkspacesZonesRequest>;
 
@@ -3530,7 +3530,7 @@ export const GetAccountsContainersWorkspacesZonesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsContainersWorkspacesZonesRequest>;
 
@@ -3561,7 +3561,7 @@ export const DeleteAccountsContainersWorkspacesZonesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "DELETE", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsContainersWorkspacesZonesRequest>;
 
@@ -3601,7 +3601,7 @@ export const RevertAccountsContainersWorkspacesZonesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:revert",
+      path: "tagmanager/v2/{+path}:revert",
       hasBody: true,
     }),
     svc,
@@ -3640,7 +3640,7 @@ export const CreateAccountsContainersWorkspacesClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{parent}/clients",
+      path: "tagmanager/v2/{+parent}/clients",
       hasBody: true,
     }),
     svc,
@@ -3681,7 +3681,7 @@ export const UpdateAccountsContainersWorkspacesClientsRequest =
     ),
     body: Schema.optional(Client).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "tagmanager/v2/{path}", hasBody: true }),
+    T.Http({ method: "PUT", path: "tagmanager/v2/{+path}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAccountsContainersWorkspacesClientsRequest>;
 
@@ -3712,7 +3712,7 @@ export const GetAccountsContainersWorkspacesClientsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsContainersWorkspacesClientsRequest>;
 
@@ -3743,7 +3743,7 @@ export const DeleteAccountsContainersWorkspacesClientsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "DELETE", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsContainersWorkspacesClientsRequest>;
 
@@ -3783,7 +3783,7 @@ export const RevertAccountsContainersWorkspacesClientsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:revert",
+      path: "tagmanager/v2/{+path}:revert",
       hasBody: true,
     }),
     svc,
@@ -3820,7 +3820,7 @@ export const ListAccountsContainersWorkspacesClientsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{parent}/clients" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+parent}/clients" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsContainersWorkspacesClientsRequest>;
 
@@ -3861,7 +3861,7 @@ export const CreateAccountsContainersWorkspacesTransformationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{parent}/transformations",
+      path: "tagmanager/v2/{+parent}/transformations",
       hasBody: true,
     }),
     svc,
@@ -3904,7 +3904,7 @@ export const UpdateAccountsContainersWorkspacesTransformationsRequest =
     ),
     body: Schema.optional(Transformation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "tagmanager/v2/{path}", hasBody: true }),
+    T.Http({ method: "PUT", path: "tagmanager/v2/{+path}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAccountsContainersWorkspacesTransformationsRequest>;
 
@@ -3937,7 +3937,7 @@ export const GetAccountsContainersWorkspacesTransformationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsContainersWorkspacesTransformationsRequest>;
 
@@ -3969,7 +3969,7 @@ export const DeleteAccountsContainersWorkspacesTransformationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "DELETE", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsContainersWorkspacesTransformationsRequest>;
 
@@ -4010,7 +4010,7 @@ export const RevertAccountsContainersWorkspacesTransformationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:revert",
+      path: "tagmanager/v2/{+path}:revert",
       hasBody: true,
     }),
     svc,
@@ -4048,7 +4048,7 @@ export const ListAccountsContainersWorkspacesTransformationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{parent}/transformations" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+parent}/transformations" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsContainersWorkspacesTransformationsRequest>;
 
@@ -4090,7 +4090,7 @@ export const CreateAccountsContainersWorkspacesTagsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{parent}/tags",
+      path: "tagmanager/v2/{+parent}/tags",
       hasBody: true,
     }),
     svc,
@@ -4131,7 +4131,7 @@ export const UpdateAccountsContainersWorkspacesTagsRequest =
     ),
     body: Schema.optional(Tag).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "tagmanager/v2/{path}", hasBody: true }),
+    T.Http({ method: "PUT", path: "tagmanager/v2/{+path}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAccountsContainersWorkspacesTagsRequest>;
 
@@ -4165,7 +4165,7 @@ export const ListAccountsContainersWorkspacesTagsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{parent}/tags" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+parent}/tags" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsContainersWorkspacesTagsRequest>;
 
@@ -4200,7 +4200,7 @@ export const GetAccountsContainersWorkspacesTagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsContainersWorkspacesTagsRequest>;
 
@@ -4231,7 +4231,7 @@ export const DeleteAccountsContainersWorkspacesTagsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "DELETE", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsContainersWorkspacesTagsRequest>;
 
@@ -4271,7 +4271,7 @@ export const RevertAccountsContainersWorkspacesTagsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:revert",
+      path: "tagmanager/v2/{+path}:revert",
       hasBody: true,
     }),
     svc,
@@ -4304,7 +4304,7 @@ export const GetAccountsContainersWorkspacesGtag_configRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsContainersWorkspacesGtag_configRequest>;
 
@@ -4335,7 +4335,7 @@ export const DeleteAccountsContainersWorkspacesGtag_configRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "DELETE", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsContainersWorkspacesGtag_configRequest>;
 
@@ -4371,7 +4371,7 @@ export const ListAccountsContainersWorkspacesGtag_configRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{parent}/gtag_config" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+parent}/gtag_config" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsContainersWorkspacesGtag_configRequest>;
 
@@ -4412,7 +4412,7 @@ export const CreateAccountsContainersWorkspacesGtag_configRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{parent}/gtag_config",
+      path: "tagmanager/v2/{+parent}/gtag_config",
       hasBody: true,
     }),
     svc,
@@ -4453,7 +4453,7 @@ export const UpdateAccountsContainersWorkspacesGtag_configRequest =
     ),
     body: Schema.optional(GtagConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "tagmanager/v2/{path}", hasBody: true }),
+    T.Http({ method: "PUT", path: "tagmanager/v2/{+path}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAccountsContainersWorkspacesGtag_configRequest>;
 
@@ -4489,7 +4489,7 @@ export const ListAccountsContainersWorkspacesBuilt_in_variablesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "tagmanager/v2/{parent}/built_in_variables",
+      path: "tagmanager/v2/{+parent}/built_in_variables",
     }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsContainersWorkspacesBuilt_in_variablesRequest>;
@@ -4650,7 +4650,7 @@ export const DeleteAccountsContainersWorkspacesBuilt_in_variablesRequest =
     ),
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "DELETE", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsContainersWorkspacesBuilt_in_variablesRequest>;
 
@@ -4807,7 +4807,7 @@ export const RevertAccountsContainersWorkspacesBuilt_in_variablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}/built_in_variables:revert",
+      path: "tagmanager/v2/{+path}/built_in_variables:revert",
       hasBody: true,
     }),
     svc,
@@ -4967,7 +4967,7 @@ export const CreateAccountsContainersWorkspacesBuilt_in_variablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{parent}/built_in_variables",
+      path: "tagmanager/v2/{+parent}/built_in_variables",
       hasBody: true,
     }),
     svc,
@@ -5007,7 +5007,7 @@ export const CreateAccountsContainersWorkspacesFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{parent}/folders",
+      path: "tagmanager/v2/{+parent}/folders",
       hasBody: true,
     }),
     svc,
@@ -5048,7 +5048,7 @@ export const UpdateAccountsContainersWorkspacesFoldersRequest =
     ),
     body: Schema.optional(Folder).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "tagmanager/v2/{path}", hasBody: true }),
+    T.Http({ method: "PUT", path: "tagmanager/v2/{+path}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAccountsContainersWorkspacesFoldersRequest>;
 
@@ -5084,7 +5084,7 @@ export const EntitiesAccountsContainersWorkspacesFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:entities",
+      path: "tagmanager/v2/{+path}:entities",
       hasBody: true,
     }),
     svc,
@@ -5142,7 +5142,7 @@ export const Move_entities_to_folderAccountsContainersWorkspacesFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:move_entities_to_folder",
+      path: "tagmanager/v2/{+path}:move_entities_to_folder",
       hasBody: true,
     }),
     svc,
@@ -5178,7 +5178,7 @@ export const GetAccountsContainersWorkspacesFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsContainersWorkspacesFoldersRequest>;
 
@@ -5209,7 +5209,7 @@ export const DeleteAccountsContainersWorkspacesFoldersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "DELETE", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsContainersWorkspacesFoldersRequest>;
 
@@ -5249,7 +5249,7 @@ export const RevertAccountsContainersWorkspacesFoldersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:revert",
+      path: "tagmanager/v2/{+path}:revert",
       hasBody: true,
     }),
     svc,
@@ -5286,7 +5286,7 @@ export const ListAccountsContainersWorkspacesFoldersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{parent}/folders" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+parent}/folders" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsContainersWorkspacesFoldersRequest>;
 
@@ -5325,7 +5325,7 @@ export const ListAccountsContainersWorkspacesTemplatesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{parent}/templates" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+parent}/templates" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsContainersWorkspacesTemplatesRequest>;
 
@@ -5361,7 +5361,7 @@ export const GetAccountsContainersWorkspacesTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsContainersWorkspacesTemplatesRequest>;
 
@@ -5392,7 +5392,7 @@ export const DeleteAccountsContainersWorkspacesTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "DELETE", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsContainersWorkspacesTemplatesRequest>;
 
@@ -5432,7 +5432,7 @@ export const RevertAccountsContainersWorkspacesTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:revert",
+      path: "tagmanager/v2/{+path}:revert",
       hasBody: true,
     }),
     svc,
@@ -5486,7 +5486,7 @@ export const Import_from_galleryAccountsContainersWorkspacesTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{parent}/templates:import_from_gallery",
+      path: "tagmanager/v2/{+parent}/templates:import_from_gallery",
       hasBody: true,
     }),
     svc,
@@ -5526,7 +5526,7 @@ export const CreateAccountsContainersWorkspacesTemplatesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{parent}/templates",
+      path: "tagmanager/v2/{+parent}/templates",
       hasBody: true,
     }),
     svc,
@@ -5568,7 +5568,7 @@ export const UpdateAccountsContainersWorkspacesTemplatesRequest =
     ),
     body: Schema.optional(CustomTemplate).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "tagmanager/v2/{path}", hasBody: true }),
+    T.Http({ method: "PUT", path: "tagmanager/v2/{+path}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAccountsContainersWorkspacesTemplatesRequest>;
 
@@ -5600,7 +5600,7 @@ export const GetAccountsContainersWorkspacesVariablesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsContainersWorkspacesVariablesRequest>;
 
@@ -5631,7 +5631,7 @@ export const DeleteAccountsContainersWorkspacesVariablesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "DELETE", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsContainersWorkspacesVariablesRequest>;
 
@@ -5671,7 +5671,7 @@ export const RevertAccountsContainersWorkspacesVariablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:revert",
+      path: "tagmanager/v2/{+path}:revert",
       hasBody: true,
     }),
     svc,
@@ -5708,7 +5708,7 @@ export const ListAccountsContainersWorkspacesVariablesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{parent}/variables" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+parent}/variables" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsContainersWorkspacesVariablesRequest>;
 
@@ -5749,7 +5749,7 @@ export const CreateAccountsContainersWorkspacesVariablesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{parent}/variables",
+      path: "tagmanager/v2/{+parent}/variables",
       hasBody: true,
     }),
     svc,
@@ -5790,7 +5790,7 @@ export const UpdateAccountsContainersWorkspacesVariablesRequest =
     ),
     body: Schema.optional(Variable).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "tagmanager/v2/{path}", hasBody: true }),
+    T.Http({ method: "PUT", path: "tagmanager/v2/{+path}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAccountsContainersWorkspacesVariablesRequest>;
 
@@ -5826,7 +5826,7 @@ export const CreateAccountsContainersWorkspacesTriggersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{parent}/triggers",
+      path: "tagmanager/v2/{+parent}/triggers",
       hasBody: true,
     }),
     svc,
@@ -5867,7 +5867,7 @@ export const UpdateAccountsContainersWorkspacesTriggersRequest =
     ),
     body: Schema.optional(Trigger).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PUT", path: "tagmanager/v2/{path}", hasBody: true }),
+    T.Http({ method: "PUT", path: "tagmanager/v2/{+path}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateAccountsContainersWorkspacesTriggersRequest>;
 
@@ -5901,7 +5901,7 @@ export const ListAccountsContainersWorkspacesTriggersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{parent}/triggers" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+parent}/triggers" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsContainersWorkspacesTriggersRequest>;
 
@@ -5937,7 +5937,7 @@ export const GetAccountsContainersWorkspacesTriggersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsContainersWorkspacesTriggersRequest>;
 
@@ -5968,7 +5968,7 @@ export const DeleteAccountsContainersWorkspacesTriggersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "DELETE", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteAccountsContainersWorkspacesTriggersRequest>;
 
@@ -6008,7 +6008,7 @@ export const RevertAccountsContainersWorkspacesTriggersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{path}:revert",
+      path: "tagmanager/v2/{+path}:revert",
       hasBody: true,
     }),
     svc,
@@ -6042,7 +6042,7 @@ export const GetAccountsContainersDestinationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     path: Schema.String.pipe(T.HttpPath("path")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{path}" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+path}" }),
     svc,
   ) as unknown as Schema.Schema<GetAccountsContainersDestinationsRequest>;
 
@@ -6085,7 +6085,7 @@ export const LinkAccountsContainersDestinationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "tagmanager/v2/{parent}/destinations:link",
+      path: "tagmanager/v2/{+parent}/destinations:link",
       hasBody: true,
     }),
     svc,
@@ -6118,7 +6118,7 @@ export const ListAccountsContainersDestinationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "tagmanager/v2/{parent}/destinations" }),
+    T.Http({ method: "GET", path: "tagmanager/v2/{+parent}/destinations" }),
     svc,
   ) as unknown as Schema.Schema<ListAccountsContainersDestinationsRequest>;
 

--- a/packages/gcp/src/services/testing-v1.ts
+++ b/packages/gcp/src/services/testing-v1.ts
@@ -1845,7 +1845,7 @@ export const ListProjectsDeviceSessionsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deviceSessions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deviceSessions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsDeviceSessionsRequest>;
 
@@ -1880,7 +1880,7 @@ export const GetProjectsDeviceSessionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsDeviceSessionsRequest>;
 
@@ -1914,7 +1914,7 @@ export const CancelProjectsDeviceSessionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelDeviceSessionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsDeviceSessionsRequest>;
 
@@ -1951,7 +1951,7 @@ export const PatchProjectsDeviceSessionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(DeviceSession).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsDeviceSessionsRequest>;
 
@@ -1987,7 +1987,7 @@ export const CreateProjectsDeviceSessionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/deviceSessions",
+      path: "v1/{+parent}/deviceSessions",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/texttospeech-v1.ts
+++ b/packages/gcp/src/services/texttospeech-v1.ts
@@ -494,7 +494,7 @@ export const SynthesizeLongAudioProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}:synthesizeLongAudio",
+      path: "v1/{+parent}:synthesizeLongAudio",
       hasBody: true,
     }),
     svc,
@@ -541,7 +541,7 @@ export const ListProjectsLocationsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -576,7 +576,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -639,7 +639,7 @@ export const DeleteOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOperationsRequest>;
 
@@ -672,7 +672,7 @@ export const CancelOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOperationsRequest>;
 

--- a/packages/gcp/src/services/texttospeech-v1beta1.ts
+++ b/packages/gcp/src/services/texttospeech-v1beta1.ts
@@ -506,7 +506,7 @@ export const SynthesizeLongAudioProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}:synthesizeLongAudio",
+      path: "v1beta1/{+parent}:synthesizeLongAudio",
       hasBody: true,
     }),
     svc,
@@ -539,7 +539,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -584,7 +584,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/threatintelligence-v1beta.ts
+++ b/packages/gcp/src/services/threatintelligence-v1beta.ts
@@ -1012,7 +1012,7 @@ export const GenerateOrgProfileProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{name}:generateOrgProfile",
+      path: "v1beta/{+name}:generateOrgProfile",
       hasBody: true,
     }),
     svc,
@@ -1057,7 +1057,7 @@ export const ListProjectsAlertsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/alerts" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/alerts" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsAlertsRequest>;
 
@@ -1095,7 +1095,7 @@ export const ReadProjectsAlertsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MarkAlertAsReadRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:read", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:read", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReadProjectsAlertsRequest>;
 
@@ -1128,7 +1128,7 @@ export const EscalateProjectsAlertsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MarkAlertAsEscalatedRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:escalate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:escalate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<EscalateProjectsAlertsRequest>;
 
@@ -1163,7 +1163,7 @@ export const NotActionableProjectsAlertsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{name}:notActionable",
+      path: "v1beta/{+name}:notActionable",
       hasBody: true,
     }),
     svc,
@@ -1199,7 +1199,7 @@ export const DuplicateProjectsAlertsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MarkAlertAsDuplicateRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:duplicate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:duplicate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<DuplicateProjectsAlertsRequest>;
 
@@ -1230,7 +1230,7 @@ export const GetProjectsAlertsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAlertsRequest>;
 
@@ -1263,7 +1263,7 @@ export const EnumerateFacetsProjectsAlertsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/alerts:enumerateFacets" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/alerts:enumerateFacets" }),
     svc,
   ) as unknown as Schema.Schema<EnumerateFacetsProjectsAlertsRequest>;
 
@@ -1298,7 +1298,7 @@ export const TriageProjectsAlertsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MarkAlertAsTriagedRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:triage", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:triage", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<TriageProjectsAlertsRequest>;
 
@@ -1335,7 +1335,7 @@ export const TrackExternallyProjectsAlertsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{name}:trackExternally",
+      path: "v1beta/{+name}:trackExternally",
       hasBody: true,
     }),
     svc,
@@ -1373,7 +1373,7 @@ export const FalsePositiveProjectsAlertsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{name}:falsePositive",
+      path: "v1beta/{+name}:falsePositive",
       hasBody: true,
     }),
     svc,
@@ -1409,7 +1409,7 @@ export const ResolveProjectsAlertsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MarkAlertAsResolvedRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:resolve", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:resolve", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResolveProjectsAlertsRequest>;
 
@@ -1442,7 +1442,7 @@ export const BenignProjectsAlertsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MarkAlertAsBenignRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:benign", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:benign", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<BenignProjectsAlertsRequest>;
 
@@ -1472,7 +1472,7 @@ export const GetProjectsAlertsDocumentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsAlertsDocumentsRequest>;
 
@@ -1515,7 +1515,7 @@ export const ListProjectsFindingsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/findings" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/findings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsFindingsRequest>;
 
@@ -1562,7 +1562,7 @@ export const SearchProjectsFindingsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/findings:search" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/findings:search" }),
     svc,
   ) as unknown as Schema.Schema<SearchProjectsFindingsRequest>;
 
@@ -1597,7 +1597,7 @@ export const GetProjectsFindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsFindingsRequest>;
 
@@ -1639,7 +1639,7 @@ export const ListProjectsConfigurationsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/configurations" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/configurations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsConfigurationsRequest>;
 
@@ -1674,7 +1674,7 @@ export const GetProjectsConfigurationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsConfigurationsRequest>;
 
@@ -1715,7 +1715,7 @@ export const UpsertProjectsConfigurationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/configurations:upsert",
+      path: "v1beta/{+parent}/configurations:upsert",
       hasBody: true,
     }),
     svc,
@@ -1760,7 +1760,7 @@ export const ListProjectsConfigurationsRevisionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/revisions" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/revisions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsConfigurationsRevisionsRequest>;
 

--- a/packages/gcp/src/services/toolresults-v1beta3.ts
+++ b/packages/gcp/src/services/toolresults-v1beta3.ts
@@ -2185,7 +2185,7 @@ export const AccessibilityClustersProjectsHistoriesExecutionsStepsRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "toolresults/v1beta3/{name}:accessibilityClusters",
+      path: "toolresults/v1beta3/{+name}:accessibilityClusters",
     }),
     svc,
   ) as unknown as Schema.Schema<AccessibilityClustersProjectsHistoriesExecutionsStepsRequest>;

--- a/packages/gcp/src/services/tpu-v1.ts
+++ b/packages/gcp/src/services/tpu-v1.ts
@@ -404,7 +404,7 @@ export const ListProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -439,7 +439,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -476,7 +476,7 @@ export const ListProjectsLocationsNodesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/nodes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/nodes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNodesRequest>;
 
@@ -511,7 +511,7 @@ export const DeleteProjectsLocationsNodesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNodesRequest>;
 
@@ -545,7 +545,7 @@ export const StartProjectsLocationsNodesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StartNodeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsLocationsNodesRequest>;
 
@@ -576,7 +576,7 @@ export const GetProjectsLocationsNodesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNodesRequest>;
 
@@ -613,7 +613,7 @@ export const CreateProjectsLocationsNodesRequest =
     nodeId: Schema.optional(Schema.String).pipe(T.HttpQuery("nodeId")),
     body: Schema.optional(Node).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/nodes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/nodes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsNodesRequest>;
 
@@ -647,7 +647,7 @@ export const ReimageProjectsLocationsNodesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ReimageNodeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:reimage", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:reimage", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReimageProjectsLocationsNodesRequest>;
 
@@ -681,7 +681,7 @@ export const StopProjectsLocationsNodesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopNodeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsNodesRequest>;
 
@@ -712,7 +712,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -757,7 +757,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -792,7 +792,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -823,7 +823,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -854,7 +854,7 @@ export const GetProjectsLocationsTensorflowVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTensorflowVersionsRequest>;
 
@@ -897,7 +897,7 @@ export const ListProjectsLocationsTensorflowVersionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/tensorflowVersions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/tensorflowVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTensorflowVersionsRequest>;
 
@@ -945,7 +945,7 @@ export const ListProjectsLocationsAcceleratorTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/acceleratorTypes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/acceleratorTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAcceleratorTypesRequest>;
 
@@ -981,7 +981,7 @@ export const GetProjectsLocationsAcceleratorTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAcceleratorTypesRequest>;
 

--- a/packages/gcp/src/services/tpu-v1alpha1.ts
+++ b/packages/gcp/src/services/tpu-v1alpha1.ts
@@ -404,7 +404,7 @@ export const ListProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -439,7 +439,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -482,7 +482,7 @@ export const ListProjectsLocationsAcceleratorTypesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/acceleratorTypes" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/acceleratorTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAcceleratorTypesRequest>;
 
@@ -518,7 +518,7 @@ export const GetProjectsLocationsAcceleratorTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAcceleratorTypesRequest>;
 
@@ -552,7 +552,7 @@ export const StartProjectsLocationsNodesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StartNodeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsLocationsNodesRequest>;
 
@@ -589,7 +589,7 @@ export const ListProjectsLocationsNodesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/nodes" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/nodes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNodesRequest>;
 
@@ -624,7 +624,7 @@ export const GetProjectsLocationsNodesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNodesRequest>;
 
@@ -658,7 +658,7 @@ export const ReimageProjectsLocationsNodesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ReimageNodeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:reimage", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:reimage", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReimageProjectsLocationsNodesRequest>;
 
@@ -692,7 +692,7 @@ export const StopProjectsLocationsNodesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopNodeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsNodesRequest>;
 
@@ -726,7 +726,7 @@ export const DeleteProjectsLocationsNodesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNodesRequest>;
 
@@ -766,7 +766,7 @@ export const CreateProjectsLocationsNodesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Node).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{parent}/nodes", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+parent}/nodes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsNodesRequest>;
 
@@ -809,7 +809,7 @@ export const ListProjectsLocationsTensorflowVersionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/tensorflowVersions" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/tensorflowVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTensorflowVersionsRequest>;
 
@@ -845,7 +845,7 @@ export const GetProjectsLocationsTensorflowVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTensorflowVersionsRequest>;
 
@@ -876,7 +876,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -907,7 +907,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -952,7 +952,7 @@ export const ListProjectsLocationsOperationsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -987,7 +987,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/tpu-v2.ts
+++ b/packages/gcp/src/services/tpu-v2.ts
@@ -882,7 +882,7 @@ export const ListProjectsLocationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -922,7 +922,7 @@ export const GenerateServiceIdentityProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}:generateServiceIdentity",
+      path: "v2/{+parent}:generateServiceIdentity",
       hasBody: true,
     }),
     svc,
@@ -956,7 +956,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -999,7 +999,7 @@ export const ListProjectsLocationsRuntimeVersionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/runtimeVersions" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/runtimeVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRuntimeVersionsRequest>;
 
@@ -1035,7 +1035,7 @@ export const GetProjectsLocationsRuntimeVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRuntimeVersionsRequest>;
 
@@ -1069,7 +1069,7 @@ export const StopProjectsLocationsNodesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopNodeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsNodesRequest>;
 
@@ -1103,7 +1103,7 @@ export const StartProjectsLocationsNodesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StartNodeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsLocationsNodesRequest>;
 
@@ -1140,7 +1140,7 @@ export const ListProjectsLocationsNodesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/nodes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/nodes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNodesRequest>;
 
@@ -1175,7 +1175,7 @@ export const GetProjectsLocationsNodesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNodesRequest>;
 
@@ -1206,7 +1206,7 @@ export const DeleteProjectsLocationsNodesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNodesRequest>;
 
@@ -1242,7 +1242,7 @@ export const GetGuestAttributesProjectsLocationsNodesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{name}:getGuestAttributes",
+      path: "v2/{+name}:getGuestAttributes",
       hasBody: true,
     }),
     svc,
@@ -1282,7 +1282,7 @@ export const PatchProjectsLocationsNodesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Node).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsNodesRequest>;
 
@@ -1319,7 +1319,7 @@ export const CreateProjectsLocationsNodesRequest =
     nodeId: Schema.optional(Schema.String).pipe(T.HttpQuery("nodeId")),
     body: Schema.optional(Node).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{parent}/nodes", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+parent}/nodes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsNodesRequest>;
 
@@ -1363,7 +1363,7 @@ export const CreateProjectsLocationsQueuedResourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2/{parent}/queuedResources",
+      path: "v2/{+parent}/queuedResources",
       hasBody: true,
     }),
     svc,
@@ -1402,7 +1402,7 @@ export const DeleteProjectsLocationsQueuedResourcesRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsQueuedResourcesRequest>;
 
@@ -1436,7 +1436,7 @@ export const ResetProjectsLocationsQueuedResourcesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResetQueuedResourceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:reset", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:reset", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResetProjectsLocationsQueuedResourcesRequest>;
 
@@ -1467,7 +1467,7 @@ export const GetProjectsLocationsQueuedResourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsQueuedResourcesRequest>;
 
@@ -1504,7 +1504,7 @@ export const ListProjectsLocationsQueuedResourcesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/queuedResources" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/queuedResources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsQueuedResourcesRequest>;
 
@@ -1554,7 +1554,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1589,7 +1589,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2/{name}" }),
+    T.Http({ method: "DELETE", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1620,7 +1620,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v2/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1651,7 +1651,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1694,7 +1694,7 @@ export const ListProjectsLocationsAcceleratorTypesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{parent}/acceleratorTypes" }),
+    T.Http({ method: "GET", path: "v2/{+parent}/acceleratorTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAcceleratorTypesRequest>;
 
@@ -1730,7 +1730,7 @@ export const GetProjectsLocationsAcceleratorTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2/{name}" }),
+    T.Http({ method: "GET", path: "v2/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAcceleratorTypesRequest>;
 

--- a/packages/gcp/src/services/tpu-v2alpha1.ts
+++ b/packages/gcp/src/services/tpu-v2alpha1.ts
@@ -1087,7 +1087,7 @@ export const ListProjectsLocationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v2alpha1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1127,7 +1127,7 @@ export const GenerateServiceIdentityProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha1/{parent}:generateServiceIdentity",
+      path: "v2alpha1/{+parent}:generateServiceIdentity",
       hasBody: true,
     }),
     svc,
@@ -1161,7 +1161,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1192,7 +1192,7 @@ export const GetProjectsLocationsQueuedResourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsQueuedResourcesRequest>;
 
@@ -1236,7 +1236,7 @@ export const CreateProjectsLocationsQueuedResourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha1/{parent}/queuedResources",
+      path: "v2alpha1/{+parent}/queuedResources",
       hasBody: true,
     }),
     svc,
@@ -1275,7 +1275,7 @@ export const ListProjectsLocationsQueuedResourcesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha1/{parent}/queuedResources" }),
+    T.Http({ method: "GET", path: "v2alpha1/{+parent}/queuedResources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsQueuedResourcesRequest>;
 
@@ -1317,7 +1317,7 @@ export const DeleteProjectsLocationsQueuedResourcesRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsQueuedResourcesRequest>;
 
@@ -1355,7 +1355,7 @@ export const PerformMaintenanceQueuedResourceProjectsLocationsQueuedResourcesReq
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha1/{name}:performMaintenanceQueuedResource",
+      path: "v2alpha1/{+name}:performMaintenanceQueuedResource",
       hasBody: true,
     }),
     svc,
@@ -1395,7 +1395,7 @@ export const ResetProjectsLocationsQueuedResourcesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ResetQueuedResourceRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2alpha1/{name}:reset", hasBody: true }),
+    T.Http({ method: "POST", path: "v2alpha1/{+name}:reset", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ResetProjectsLocationsQueuedResourcesRequest>;
 
@@ -1426,7 +1426,7 @@ export const GetMaintenanceInfoProjectsLocationsQueuedResourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha1/{name}:getMaintenanceInfo" }),
+    T.Http({ method: "GET", path: "v2alpha1/{+name}:getMaintenanceInfo" }),
     svc,
   ) as unknown as Schema.Schema<GetMaintenanceInfoProjectsLocationsQueuedResourcesRequest>;
 
@@ -1468,7 +1468,7 @@ export const CreateProjectsLocationsNodesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Node).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2alpha1/{parent}/nodes", hasBody: true }),
+    T.Http({ method: "POST", path: "v2alpha1/{+parent}/nodes", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsNodesRequest>;
 
@@ -1505,7 +1505,7 @@ export const ListProjectsLocationsNodesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha1/{parent}/nodes" }),
+    T.Http({ method: "GET", path: "v2alpha1/{+parent}/nodes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNodesRequest>;
 
@@ -1543,7 +1543,7 @@ export const DeleteProjectsLocationsNodesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNodesRequest>;
 
@@ -1579,7 +1579,7 @@ export const GetGuestAttributesProjectsLocationsNodesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha1/{name}:getGuestAttributes",
+      path: "v2alpha1/{+name}:getGuestAttributes",
       hasBody: true,
     }),
     svc,
@@ -1619,7 +1619,7 @@ export const PatchProjectsLocationsNodesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Node).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v2alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v2alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsNodesRequest>;
 
@@ -1650,7 +1650,7 @@ export const GetProjectsLocationsNodesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNodesRequest>;
 
@@ -1686,7 +1686,7 @@ export const SimulateMaintenanceEventProjectsLocationsNodesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha1/{name}:simulateMaintenanceEvent",
+      path: "v2alpha1/{+name}:simulateMaintenanceEvent",
       hasBody: true,
     }),
     svc,
@@ -1722,7 +1722,7 @@ export const StartProjectsLocationsNodesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StartNodeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2alpha1/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v2alpha1/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsLocationsNodesRequest>;
 
@@ -1756,7 +1756,7 @@ export const StopProjectsLocationsNodesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopNodeRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v2alpha1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v2alpha1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsNodesRequest>;
 
@@ -1792,7 +1792,7 @@ export const PerformMaintenanceProjectsLocationsNodesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v2alpha1/{name}:performMaintenance",
+      path: "v2alpha1/{+name}:performMaintenance",
       hasBody: true,
     }),
     svc,
@@ -1825,7 +1825,7 @@ export const CancelProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "POST", path: "v2alpha1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v2alpha1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1870,7 +1870,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v2alpha1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1905,7 +1905,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v2alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v2alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1936,7 +1936,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1979,7 +1979,7 @@ export const ListProjectsLocationsRuntimeVersionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha1/{parent}/runtimeVersions" }),
+    T.Http({ method: "GET", path: "v2alpha1/{+parent}/runtimeVersions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRuntimeVersionsRequest>;
 
@@ -2015,7 +2015,7 @@ export const GetProjectsLocationsRuntimeVersionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRuntimeVersionsRequest>;
 
@@ -2052,7 +2052,7 @@ export const ListProjectsLocationsReservationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha1/{parent}/reservations" }),
+    T.Http({ method: "GET", path: "v2alpha1/{+parent}/reservations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsReservationsRequest>;
 
@@ -2100,7 +2100,7 @@ export const ListProjectsLocationsAcceleratorTypesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha1/{parent}/acceleratorTypes" }),
+    T.Http({ method: "GET", path: "v2alpha1/{+parent}/acceleratorTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAcceleratorTypesRequest>;
 
@@ -2136,7 +2136,7 @@ export const GetProjectsLocationsAcceleratorTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v2alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v2alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAcceleratorTypesRequest>;
 

--- a/packages/gcp/src/services/transcoder-v1.ts
+++ b/packages/gcp/src/services/transcoder-v1.ts
@@ -1151,7 +1151,7 @@ export const ListProjectsLocationsJobTemplatesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/jobTemplates" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/jobTemplates" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsJobTemplatesRequest>;
 
@@ -1195,7 +1195,11 @@ export const CreateProjectsLocationsJobTemplatesRequest =
     ),
     body: Schema.optional(JobTemplate).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/jobTemplates", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/jobTemplates",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsJobTemplatesRequest>;
 
@@ -1226,7 +1230,7 @@ export const GetProjectsLocationsJobTemplatesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsJobTemplatesRequest>;
 
@@ -1262,7 +1266,7 @@ export const DeleteProjectsLocationsJobTemplatesRequest =
       T.HttpQuery("allowMissing"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsJobTemplatesRequest>;
 
@@ -1298,7 +1302,7 @@ export const DeleteProjectsLocationsJobsRequest =
       T.HttpQuery("allowMissing"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsJobsRequest>;
 
@@ -1332,7 +1336,7 @@ export const CreateProjectsLocationsJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Job).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/jobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/jobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsJobsRequest>;
 
@@ -1363,7 +1367,7 @@ export const GetProjectsLocationsJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsJobsRequest>;
 
@@ -1405,7 +1409,7 @@ export const ListProjectsLocationsJobsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/jobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/jobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsJobsRequest>;
 

--- a/packages/gcp/src/services/translate-v3.ts
+++ b/packages/gcp/src/services/translate-v3.ts
@@ -1185,7 +1185,7 @@ export const TranslateTextProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}:translateText",
+      path: "v3/{+parent}:translateText",
       hasBody: true,
     }),
     svc,
@@ -1221,7 +1221,11 @@ export const RomanizeTextProjectsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(RomanizeTextRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}:romanizeText", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v3/{+parent}:romanizeText",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<RomanizeTextProjectsRequest>;
 
@@ -1257,7 +1261,7 @@ export const DetectLanguageProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}:detectLanguage",
+      path: "v3/{+parent}:detectLanguage",
       hasBody: true,
     }),
     svc,
@@ -1298,7 +1302,7 @@ export const GetSupportedLanguagesProjectsRequest =
       T.HttpQuery("displayLanguageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/supportedLanguages" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/supportedLanguages" }),
     svc,
   ) as unknown as Schema.Schema<GetSupportedLanguagesProjectsRequest>;
 
@@ -1334,7 +1338,7 @@ export const AdaptiveMtTranslateProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}:adaptiveMtTranslate",
+      path: "v3/{+parent}:adaptiveMtTranslate",
       hasBody: true,
     }),
     svc,
@@ -1368,7 +1372,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1404,7 +1408,7 @@ export const BatchTranslateTextProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}:batchTranslateText",
+      path: "v3/{+parent}:batchTranslateText",
       hasBody: true,
     }),
     svc,
@@ -1442,7 +1446,7 @@ export const TranslateDocumentProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}:translateDocument",
+      path: "v3/{+parent}:translateDocument",
       hasBody: true,
     }),
     svc,
@@ -1481,7 +1485,7 @@ export const DetectLanguageProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}:detectLanguage",
+      path: "v3/{+parent}:detectLanguage",
       hasBody: true,
     }),
     svc,
@@ -1522,7 +1526,7 @@ export const GetSupportedLanguagesProjectsLocationsRequest =
       T.HttpQuery("displayLanguageCode"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/supportedLanguages" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/supportedLanguages" }),
     svc,
   ) as unknown as Schema.Schema<GetSupportedLanguagesProjectsLocationsRequest>;
 
@@ -1558,7 +1562,7 @@ export const BatchTranslateDocumentProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}:batchTranslateDocument",
+      path: "v3/{+parent}:batchTranslateDocument",
       hasBody: true,
     }),
     svc,
@@ -1596,7 +1600,7 @@ export const TranslateTextProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}:translateText",
+      path: "v3/{+parent}:translateText",
       hasBody: true,
     }),
     svc,
@@ -1643,7 +1647,7 @@ export const ListProjectsLocationsRequest =
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}/locations" }),
+    T.Http({ method: "GET", path: "v3/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1681,7 +1685,7 @@ export const RefineTextProjectsLocationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(RefineTextRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}:refineText", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}:refineText", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RefineTextProjectsLocationsRequest>;
 
@@ -1715,7 +1719,11 @@ export const RomanizeTextProjectsLocationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(RomanizeTextRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}:romanizeText", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v3/{+parent}:romanizeText",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<RomanizeTextProjectsLocationsRequest>;
 
@@ -1751,7 +1759,7 @@ export const ImportAdaptiveMtFileProjectsLocationsAdaptiveMtDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}:importAdaptiveMtFile",
+      path: "v3/{+parent}:importAdaptiveMtFile",
       hasBody: true,
     }),
     svc,
@@ -1786,7 +1794,7 @@ export const DeleteProjectsLocationsAdaptiveMtDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAdaptiveMtDatasetsRequest>;
 
@@ -1817,7 +1825,7 @@ export const GetProjectsLocationsAdaptiveMtDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAdaptiveMtDatasetsRequest>;
 
@@ -1853,7 +1861,7 @@ export const CreateProjectsLocationsAdaptiveMtDatasetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}/adaptiveMtDatasets",
+      path: "v3/{+parent}/adaptiveMtDatasets",
       hasBody: true,
     }),
     svc,
@@ -1896,7 +1904,7 @@ export const ListProjectsLocationsAdaptiveMtDatasetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/adaptiveMtDatasets" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/adaptiveMtDatasets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAdaptiveMtDatasetsRequest>;
 
@@ -1938,7 +1946,7 @@ export const ListProjectsLocationsAdaptiveMtDatasetsAdaptiveMtFilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/adaptiveMtFiles" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/adaptiveMtFiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAdaptiveMtDatasetsAdaptiveMtFilesRequest>;
 
@@ -1975,7 +1983,7 @@ export const GetProjectsLocationsAdaptiveMtDatasetsAdaptiveMtFilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAdaptiveMtDatasetsAdaptiveMtFilesRequest>;
 
@@ -2008,7 +2016,7 @@ export const DeleteProjectsLocationsAdaptiveMtDatasetsAdaptiveMtFilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsAdaptiveMtDatasetsAdaptiveMtFilesRequest>;
 
@@ -2046,7 +2054,7 @@ export const ListProjectsLocationsAdaptiveMtDatasetsAdaptiveMtFilesAdaptiveMtSen
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/adaptiveMtSentences" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/adaptiveMtSentences" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAdaptiveMtDatasetsAdaptiveMtFilesAdaptiveMtSentencesRequest>;
 
@@ -2090,7 +2098,7 @@ export const ListProjectsLocationsAdaptiveMtDatasetsAdaptiveMtSentencesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/adaptiveMtSentences" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/adaptiveMtSentences" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAdaptiveMtDatasetsAdaptiveMtSentencesRequest>;
 
@@ -2133,7 +2141,7 @@ export const PatchProjectsLocationsGlossariesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Glossary).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlossariesRequest>;
 
@@ -2173,7 +2181,7 @@ export const ListProjectsLocationsGlossariesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/glossaries" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/glossaries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlossariesRequest>;
 
@@ -2208,7 +2216,7 @@ export const GetProjectsLocationsGlossariesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlossariesRequest>;
 
@@ -2239,7 +2247,7 @@ export const DeleteProjectsLocationsGlossariesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlossariesRequest>;
 
@@ -2273,7 +2281,7 @@ export const CreateProjectsLocationsGlossariesRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Glossary).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/glossaries", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/glossaries", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGlossariesRequest>;
 
@@ -2307,7 +2315,7 @@ export const PatchProjectsLocationsGlossariesGlossaryEntriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GlossaryEntry).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v3/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v3/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGlossariesGlossaryEntriesRequest>;
 
@@ -2346,7 +2354,7 @@ export const ListProjectsLocationsGlossariesGlossaryEntriesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/glossaryEntries" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/glossaryEntries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlossariesGlossaryEntriesRequest>;
 
@@ -2382,7 +2390,7 @@ export const GetProjectsLocationsGlossariesGlossaryEntriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlossariesGlossaryEntriesRequest>;
 
@@ -2414,7 +2422,7 @@ export const DeleteProjectsLocationsGlossariesGlossaryEntriesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlossariesGlossaryEntriesRequest>;
 
@@ -2451,7 +2459,7 @@ export const CreateProjectsLocationsGlossariesGlossaryEntriesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3/{parent}/glossaryEntries",
+      path: "v3/{+parent}/glossaryEntries",
       hasBody: true,
     }),
     svc,
@@ -2489,7 +2497,7 @@ export const CreateProjectsLocationsDatasetsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Dataset).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/datasets", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/datasets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDatasetsRequest>;
 
@@ -2523,7 +2531,7 @@ export const ImportDataProjectsLocationsDatasetsRequest =
     dataset: Schema.String.pipe(T.HttpPath("dataset")),
     body: Schema.optional(ImportDataRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{dataset}:importData", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+dataset}:importData", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ImportDataProjectsLocationsDatasetsRequest>;
 
@@ -2554,7 +2562,7 @@ export const GetProjectsLocationsDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatasetsRequest>;
 
@@ -2585,7 +2593,7 @@ export const DeleteProjectsLocationsDatasetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatasetsRequest>;
 
@@ -2619,7 +2627,7 @@ export const ExportDataProjectsLocationsDatasetsRequest =
     dataset: Schema.String.pipe(T.HttpPath("dataset")),
     body: Schema.optional(ExportDataRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{dataset}:exportData", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+dataset}:exportData", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ExportDataProjectsLocationsDatasetsRequest>;
 
@@ -2656,7 +2664,7 @@ export const ListProjectsLocationsDatasetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/datasets" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/datasets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsRequest>;
 
@@ -2700,7 +2708,7 @@ export const ListProjectsLocationsDatasetsExamplesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/examples" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/examples" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatasetsExamplesRequest>;
 
@@ -2736,7 +2744,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2767,7 +2775,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2801,7 +2809,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2846,7 +2854,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}/operations" }),
+    T.Http({ method: "GET", path: "v3/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2884,7 +2892,7 @@ export const WaitProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(WaitOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsOperationsRequest>;
 
@@ -2918,7 +2926,7 @@ export const CreateProjectsLocationsModelsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Model).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3/{parent}/models", hasBody: true }),
+    T.Http({ method: "POST", path: "v3/{+parent}/models", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsModelsRequest>;
 
@@ -2949,7 +2957,7 @@ export const GetProjectsLocationsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{name}" }),
+    T.Http({ method: "GET", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsModelsRequest>;
 
@@ -2980,7 +2988,7 @@ export const DeleteProjectsLocationsModelsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3/{name}" }),
+    T.Http({ method: "DELETE", path: "v3/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsModelsRequest>;
 
@@ -3020,7 +3028,7 @@ export const ListProjectsLocationsModelsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3/{parent}/models" }),
+    T.Http({ method: "GET", path: "v3/{+parent}/models" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsModelsRequest>;
 

--- a/packages/gcp/src/services/translate-v3beta1.ts
+++ b/packages/gcp/src/services/translate-v3beta1.ts
@@ -631,7 +631,7 @@ export const TranslateTextProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}:translateText",
+      path: "v3beta1/{+parent}:translateText",
       hasBody: true,
     }),
     svc,
@@ -669,7 +669,7 @@ export const DetectLanguageProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}:detectLanguage",
+      path: "v3beta1/{+parent}:detectLanguage",
       hasBody: true,
     }),
     svc,
@@ -710,7 +710,7 @@ export const GetSupportedLanguagesProjectsRequest =
     ),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/supportedLanguages" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/supportedLanguages" }),
     svc,
   ) as unknown as Schema.Schema<GetSupportedLanguagesProjectsRequest>;
 
@@ -741,7 +741,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -777,7 +777,7 @@ export const BatchTranslateTextProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}:batchTranslateText",
+      path: "v3beta1/{+parent}:batchTranslateText",
       hasBody: true,
     }),
     svc,
@@ -815,7 +815,7 @@ export const TranslateDocumentProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}:translateDocument",
+      path: "v3beta1/{+parent}:translateDocument",
       hasBody: true,
     }),
     svc,
@@ -854,7 +854,7 @@ export const DetectLanguageProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}:detectLanguage",
+      path: "v3beta1/{+parent}:detectLanguage",
       hasBody: true,
     }),
     svc,
@@ -895,7 +895,7 @@ export const GetSupportedLanguagesProjectsLocationsRequest =
     model: Schema.optional(Schema.String).pipe(T.HttpQuery("model")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/supportedLanguages" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/supportedLanguages" }),
     svc,
   ) as unknown as Schema.Schema<GetSupportedLanguagesProjectsLocationsRequest>;
 
@@ -931,7 +931,7 @@ export const BatchTranslateDocumentProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}:batchTranslateDocument",
+      path: "v3beta1/{+parent}:batchTranslateDocument",
       hasBody: true,
     }),
     svc,
@@ -978,7 +978,7 @@ export const ListProjectsLocationsRequest =
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1018,7 +1018,7 @@ export const RefineTextProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}:refineText",
+      path: "v3beta1/{+parent}:refineText",
       hasBody: true,
     }),
     svc,
@@ -1056,7 +1056,7 @@ export const TranslateTextProjectsLocationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}:translateText",
+      path: "v3beta1/{+parent}:translateText",
       hasBody: true,
     }),
     svc,
@@ -1089,7 +1089,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1120,7 +1120,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1154,7 +1154,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1199,7 +1199,7 @@ export const ListProjectsLocationsOperationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1237,7 +1237,7 @@ export const WaitProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(WaitOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v3beta1/{name}:wait", hasBody: true }),
+    T.Http({ method: "POST", path: "v3beta1/{+name}:wait", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<WaitProjectsLocationsOperationsRequest>;
 
@@ -1277,7 +1277,7 @@ export const ListProjectsLocationsGlossariesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{parent}/glossaries" }),
+    T.Http({ method: "GET", path: "v3beta1/{+parent}/glossaries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGlossariesRequest>;
 
@@ -1312,7 +1312,7 @@ export const GetProjectsLocationsGlossariesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v3beta1/{name}" }),
+    T.Http({ method: "GET", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGlossariesRequest>;
 
@@ -1343,7 +1343,7 @@ export const DeleteProjectsLocationsGlossariesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v3beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v3beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGlossariesRequest>;
 
@@ -1379,7 +1379,7 @@ export const CreateProjectsLocationsGlossariesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v3beta1/{parent}/glossaries",
+      path: "v3beta1/{+parent}/glossaries",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/vault-v1.ts
+++ b/packages/gcp/src/services/vault-v1.ts
@@ -1168,7 +1168,7 @@ export const ListOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("returnPartialSuccess"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<ListOperationsRequest>;
 
@@ -1202,7 +1202,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -1232,7 +1232,7 @@ export const DeleteOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOperationsRequest>;
 
@@ -1265,7 +1265,7 @@ export const CancelOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOperationsRequest>;
 

--- a/packages/gcp/src/services/versionhistory-v1.ts
+++ b/packages/gcp/src/services/versionhistory-v1.ts
@@ -203,7 +203,7 @@ export const ListPlatformsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{parent}/platforms" }),
+  T.Http({ method: "GET", path: "v1/{+parent}/platforms" }),
   svc,
 ) as unknown as Schema.Schema<ListPlatformsRequest>;
 
@@ -244,7 +244,7 @@ export const ListPlatformsChannelsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/channels" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/channels" }),
     svc,
   ) as unknown as Schema.Schema<ListPlatformsChannelsRequest>;
 
@@ -291,7 +291,7 @@ export const ListPlatformsChannelsVersionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/versions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/versions" }),
     svc,
   ) as unknown as Schema.Schema<ListPlatformsChannelsVersionsRequest>;
 
@@ -338,7 +338,7 @@ export const ListPlatformsChannelsVersionsReleasesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/releases" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/releases" }),
     svc,
   ) as unknown as Schema.Schema<ListPlatformsChannelsVersionsReleasesRequest>;
 

--- a/packages/gcp/src/services/videointelligence-v1.ts
+++ b/packages/gcp/src/services/videointelligence-v1.ts
@@ -4182,7 +4182,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -4218,7 +4218,7 @@ export const CancelProjectsLocationsOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -4263,7 +4263,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -4299,7 +4299,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -4331,7 +4331,7 @@ export const GetOperationsProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/operations/{name}" }),
+    T.Http({ method: "GET", path: "v1/operations/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetOperationsProjectsLocationsOperationsRequest>;
 
@@ -4363,7 +4363,7 @@ export const DeleteOperationsProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/operations/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/operations/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOperationsProjectsLocationsOperationsRequest>;
 
@@ -4397,7 +4397,7 @@ export const CancelOperationsProjectsLocationsOperationsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/operations/{name}:cancel",
+      path: "v1/operations/{+name}:cancel",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/vision-v1.ts
+++ b/packages/gcp/src/services/vision-v1.ts
@@ -5904,7 +5904,7 @@ export const ListOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("returnPartialSuccess"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<ListOperationsRequest>;
 
@@ -5938,7 +5938,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 
@@ -5968,7 +5968,7 @@ export const DeleteOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteOperationsRequest>;
 
@@ -6001,7 +6001,7 @@ export const CancelOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelOperationsRequest>;
 
@@ -6031,7 +6031,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 
@@ -6062,7 +6062,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -6101,7 +6101,7 @@ export const CreateProjectsLocationsProductSetsRequest =
     ),
     body: Schema.optional(ProductSet).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/productSets", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/productSets", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsProductSetsRequest>;
 
@@ -6138,7 +6138,7 @@ export const ListProjectsLocationsProductSetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/productSets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/productSets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProductSetsRequest>;
 
@@ -6173,7 +6173,7 @@ export const GetProjectsLocationsProductSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProductSetsRequest>;
 
@@ -6210,7 +6210,7 @@ export const PatchProjectsLocationsProductSetsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ProductSet).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsProductSetsRequest>;
 
@@ -6241,7 +6241,7 @@ export const DeleteProjectsLocationsProductSetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsProductSetsRequest>;
 
@@ -6275,7 +6275,7 @@ export const AddProductProjectsLocationsProductSetsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(AddProductToProductSetRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:addProduct", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:addProduct", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<AddProductProjectsLocationsProductSetsRequest>;
 
@@ -6311,7 +6311,7 @@ export const RemoveProductProjectsLocationsProductSetsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:removeProduct", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:removeProduct", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RemoveProductProjectsLocationsProductSetsRequest>;
 
@@ -6347,7 +6347,7 @@ export const ImportProjectsLocationsProductSetsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/productSets:import",
+      path: "v1/{+parent}/productSets:import",
       hasBody: true,
     }),
     svc,
@@ -6386,7 +6386,7 @@ export const ListProjectsLocationsProductSetsProductsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/products" }),
+    T.Http({ method: "GET", path: "v1/{+name}/products" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProductSetsProductsRequest>;
 
@@ -6428,7 +6428,7 @@ export const CreateProjectsLocationsProductsRequest =
     productId: Schema.optional(Schema.String).pipe(T.HttpQuery("productId")),
     body: Schema.optional(Product).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/products", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/products", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsProductsRequest>;
 
@@ -6465,7 +6465,7 @@ export const ListProjectsLocationsProductsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/products" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/products" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProductsRequest>;
 
@@ -6500,7 +6500,7 @@ export const GetProjectsLocationsProductsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProductsRequest>;
 
@@ -6537,7 +6537,7 @@ export const PatchProjectsLocationsProductsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Product).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsProductsRequest>;
 
@@ -6568,7 +6568,7 @@ export const DeleteProjectsLocationsProductsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsProductsRequest>;
 
@@ -6604,7 +6604,7 @@ export const PurgeProjectsLocationsProductsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/products:purge",
+      path: "v1/{+parent}/products:purge",
       hasBody: true,
     }),
     svc,
@@ -6647,7 +6647,7 @@ export const CreateProjectsLocationsProductsReferenceImagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/referenceImages",
+      path: "v1/{+parent}/referenceImages",
       hasBody: true,
     }),
     svc,
@@ -6681,7 +6681,7 @@ export const DeleteProjectsLocationsProductsReferenceImagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsProductsReferenceImagesRequest>;
 
@@ -6718,7 +6718,7 @@ export const ListProjectsLocationsProductsReferenceImagesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/referenceImages" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/referenceImages" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsProductsReferenceImagesRequest>;
 
@@ -6754,7 +6754,7 @@ export const GetProjectsLocationsProductsReferenceImagesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsProductsReferenceImagesRequest>;
 
@@ -6791,7 +6791,7 @@ export const AnnotateProjectsLocationsImagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/images:annotate",
+      path: "v1/{+parent}/images:annotate",
       hasBody: true,
     }),
     svc,
@@ -6830,7 +6830,7 @@ export const AsyncBatchAnnotateProjectsLocationsImagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/images:asyncBatchAnnotate",
+      path: "v1/{+parent}/images:asyncBatchAnnotate",
       hasBody: true,
     }),
     svc,
@@ -6868,7 +6868,7 @@ export const AnnotateProjectsLocationsFilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/files:annotate",
+      path: "v1/{+parent}/files:annotate",
       hasBody: true,
     }),
     svc,
@@ -6906,7 +6906,7 @@ export const AsyncBatchAnnotateProjectsLocationsFilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/files:asyncBatchAnnotate",
+      path: "v1/{+parent}/files:asyncBatchAnnotate",
       hasBody: true,
     }),
     svc,
@@ -6944,7 +6944,7 @@ export const AnnotateProjectsImagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/images:annotate",
+      path: "v1/{+parent}/images:annotate",
       hasBody: true,
     }),
     svc,
@@ -6982,7 +6982,7 @@ export const AsyncBatchAnnotateProjectsImagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/images:asyncBatchAnnotate",
+      path: "v1/{+parent}/images:asyncBatchAnnotate",
       hasBody: true,
     }),
     svc,
@@ -7020,7 +7020,7 @@ export const AnnotateProjectsFilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/files:annotate",
+      path: "v1/{+parent}/files:annotate",
       hasBody: true,
     }),
     svc,
@@ -7058,7 +7058,7 @@ export const AsyncBatchAnnotateProjectsFilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/files:asyncBatchAnnotate",
+      path: "v1/{+parent}/files:asyncBatchAnnotate",
       hasBody: true,
     }),
     svc,
@@ -7091,7 +7091,7 @@ export const GetLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/vision-v1p1beta1.ts
+++ b/packages/gcp/src/services/vision-v1p1beta1.ts
@@ -5846,7 +5846,7 @@ export const AnnotateProjectsLocationsImagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p1beta1/{parent}/images:annotate",
+      path: "v1p1beta1/{+parent}/images:annotate",
       hasBody: true,
     }),
     svc,
@@ -5887,7 +5887,7 @@ export const AsyncBatchAnnotateProjectsLocationsImagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p1beta1/{parent}/images:asyncBatchAnnotate",
+      path: "v1p1beta1/{+parent}/images:asyncBatchAnnotate",
       hasBody: true,
     }),
     svc,
@@ -5927,7 +5927,7 @@ export const AnnotateProjectsLocationsFilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p1beta1/{parent}/files:annotate",
+      path: "v1p1beta1/{+parent}/files:annotate",
       hasBody: true,
     }),
     svc,
@@ -5968,7 +5968,7 @@ export const AsyncBatchAnnotateProjectsLocationsFilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p1beta1/{parent}/files:asyncBatchAnnotate",
+      path: "v1p1beta1/{+parent}/files:asyncBatchAnnotate",
       hasBody: true,
     }),
     svc,
@@ -6008,7 +6008,7 @@ export const AnnotateProjectsImagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p1beta1/{parent}/images:annotate",
+      path: "v1p1beta1/{+parent}/images:annotate",
       hasBody: true,
     }),
     svc,
@@ -6049,7 +6049,7 @@ export const AsyncBatchAnnotateProjectsImagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p1beta1/{parent}/images:asyncBatchAnnotate",
+      path: "v1p1beta1/{+parent}/images:asyncBatchAnnotate",
       hasBody: true,
     }),
     svc,
@@ -6089,7 +6089,7 @@ export const AnnotateProjectsFilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p1beta1/{parent}/files:annotate",
+      path: "v1p1beta1/{+parent}/files:annotate",
       hasBody: true,
     }),
     svc,
@@ -6130,7 +6130,7 @@ export const AsyncBatchAnnotateProjectsFilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p1beta1/{parent}/files:asyncBatchAnnotate",
+      path: "v1p1beta1/{+parent}/files:asyncBatchAnnotate",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/vision-v1p2beta1.ts
+++ b/packages/gcp/src/services/vision-v1p2beta1.ts
@@ -5846,7 +5846,7 @@ export const AnnotateProjectsLocationsImagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p2beta1/{parent}/images:annotate",
+      path: "v1p2beta1/{+parent}/images:annotate",
       hasBody: true,
     }),
     svc,
@@ -5887,7 +5887,7 @@ export const AsyncBatchAnnotateProjectsLocationsImagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p2beta1/{parent}/images:asyncBatchAnnotate",
+      path: "v1p2beta1/{+parent}/images:asyncBatchAnnotate",
       hasBody: true,
     }),
     svc,
@@ -5927,7 +5927,7 @@ export const AnnotateProjectsLocationsFilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p2beta1/{parent}/files:annotate",
+      path: "v1p2beta1/{+parent}/files:annotate",
       hasBody: true,
     }),
     svc,
@@ -5968,7 +5968,7 @@ export const AsyncBatchAnnotateProjectsLocationsFilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p2beta1/{parent}/files:asyncBatchAnnotate",
+      path: "v1p2beta1/{+parent}/files:asyncBatchAnnotate",
       hasBody: true,
     }),
     svc,
@@ -6008,7 +6008,7 @@ export const AnnotateProjectsImagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p2beta1/{parent}/images:annotate",
+      path: "v1p2beta1/{+parent}/images:annotate",
       hasBody: true,
     }),
     svc,
@@ -6049,7 +6049,7 @@ export const AsyncBatchAnnotateProjectsImagesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p2beta1/{parent}/images:asyncBatchAnnotate",
+      path: "v1p2beta1/{+parent}/images:asyncBatchAnnotate",
       hasBody: true,
     }),
     svc,
@@ -6089,7 +6089,7 @@ export const AnnotateProjectsFilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p2beta1/{parent}/files:annotate",
+      path: "v1p2beta1/{+parent}/files:annotate",
       hasBody: true,
     }),
     svc,
@@ -6130,7 +6130,7 @@ export const AsyncBatchAnnotateProjectsFilesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1p2beta1/{parent}/files:asyncBatchAnnotate",
+      path: "v1p2beta1/{+parent}/files:asyncBatchAnnotate",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/vmmigration-v1.ts
+++ b/packages/gcp/src/services/vmmigration-v1.ts
@@ -2768,7 +2768,7 @@ export const ListProjectsLocationsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2803,7 +2803,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2834,7 +2834,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2879,7 +2879,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2917,7 +2917,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2948,7 +2948,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2984,7 +2984,7 @@ export const RemoveGroupMigrationProjectsLocationsGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{group}:removeGroupMigration",
+      path: "v1/{+group}:removeGroupMigration",
       hasBody: true,
     }),
     svc,
@@ -3026,7 +3026,7 @@ export const PatchProjectsLocationsGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Group).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGroupsRequest>;
 
@@ -3057,7 +3057,7 @@ export const GetProjectsLocationsGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGroupsRequest>;
 
@@ -3097,7 +3097,7 @@ export const CreateProjectsLocationsGroupsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Group).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/groups", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/groups", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGroupsRequest>;
 
@@ -3133,7 +3133,7 @@ export const AddGroupMigrationProjectsLocationsGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{group}:addGroupMigration",
+      path: "v1/{+group}:addGroupMigration",
       hasBody: true,
     }),
     svc,
@@ -3169,7 +3169,7 @@ export const DeleteProjectsLocationsGroupsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGroupsRequest>;
 
@@ -3212,7 +3212,7 @@ export const ListProjectsLocationsGroupsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/groups" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/groups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGroupsRequest>;
 
@@ -3258,7 +3258,11 @@ export const CreateProjectsLocationsImageImportsRequest =
     ),
     body: Schema.optional(ImageImport).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/imageImports", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/imageImports",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsImageImportsRequest>;
 
@@ -3301,7 +3305,7 @@ export const ListProjectsLocationsImageImportsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/imageImports" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/imageImports" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsImageImportsRequest>;
 
@@ -3340,7 +3344,7 @@ export const DeleteProjectsLocationsImageImportsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsImageImportsRequest>;
 
@@ -3371,7 +3375,7 @@ export const GetProjectsLocationsImageImportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsImageImportsRequest>;
 
@@ -3414,7 +3418,7 @@ export const ListProjectsLocationsImageImportsImageImportJobsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/imageImportJobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/imageImportJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsImageImportsImageImportJobsRequest>;
 
@@ -3451,7 +3455,7 @@ export const GetProjectsLocationsImageImportsImageImportJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsImageImportsImageImportJobsRequest>;
 
@@ -3487,7 +3491,7 @@ export const CancelProjectsLocationsImageImportsImageImportJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelImageImportJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsImageImportsImageImportJobsRequest>;
 
@@ -3523,7 +3527,7 @@ export const DeleteProjectsLocationsTargetProjectsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTargetProjectsRequest>;
 
@@ -3563,7 +3567,7 @@ export const PatchProjectsLocationsTargetProjectsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(TargetProject).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTargetProjectsRequest>;
 
@@ -3594,7 +3598,7 @@ export const GetProjectsLocationsTargetProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTargetProjectsRequest>;
 
@@ -3638,7 +3642,7 @@ export const CreateProjectsLocationsTargetProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/targetProjects",
+      path: "v1/{+parent}/targetProjects",
       hasBody: true,
     }),
     svc,
@@ -3683,7 +3687,7 @@ export const ListProjectsLocationsTargetProjectsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/targetProjects" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/targetProjects" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTargetProjectsRequest>;
 
@@ -3733,7 +3737,7 @@ export const FetchStorageInventoryProjectsLocationsSourcesRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{source}:fetchStorageInventory" }),
+    T.Http({ method: "GET", path: "v1/{+source}:fetchStorageInventory" }),
     svc,
   ) as unknown as Schema.Schema<FetchStorageInventoryProjectsLocationsSourcesRequest>;
 
@@ -3778,7 +3782,7 @@ export const CreateProjectsLocationsSourcesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Source).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/sources", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/sources", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSourcesRequest>;
 
@@ -3809,7 +3813,7 @@ export const GetProjectsLocationsSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesRequest>;
 
@@ -3843,7 +3847,7 @@ export const DeleteProjectsLocationsSourcesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSourcesRequest>;
 
@@ -3885,7 +3889,7 @@ export const FetchInventoryProjectsLocationsSourcesRequest =
       T.HttpQuery("forceRefresh"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{source}:fetchInventory" }),
+    T.Http({ method: "GET", path: "v1/{+source}:fetchInventory" }),
     svc,
   ) as unknown as Schema.Schema<FetchInventoryProjectsLocationsSourcesRequest>;
 
@@ -3933,7 +3937,7 @@ export const ListProjectsLocationsSourcesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/sources" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/sources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesRequest>;
 
@@ -3977,7 +3981,7 @@ export const PatchProjectsLocationsSourcesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Source).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSourcesRequest>;
 
@@ -4008,7 +4012,7 @@ export const GetProjectsLocationsSourcesDatacenterConnectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesDatacenterConnectorsRequest>;
 
@@ -4044,7 +4048,7 @@ export const DeleteProjectsLocationsSourcesDatacenterConnectorsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSourcesDatacenterConnectorsRequest>;
 
@@ -4082,7 +4086,7 @@ export const UpgradeApplianceProjectsLocationsSourcesDatacenterConnectorsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{datacenterConnector}:upgradeAppliance",
+      path: "v1/{+datacenterConnector}:upgradeAppliance",
       hasBody: true,
     }),
     svc,
@@ -4130,7 +4134,7 @@ export const CreateProjectsLocationsSourcesDatacenterConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/datacenterConnectors",
+      path: "v1/{+parent}/datacenterConnectors",
       hasBody: true,
     }),
     svc,
@@ -4177,7 +4181,7 @@ export const ListProjectsLocationsSourcesDatacenterConnectorsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/datacenterConnectors" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/datacenterConnectors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesDatacenterConnectorsRequest>;
 
@@ -4227,7 +4231,7 @@ export const CreateProjectsLocationsSourcesDiskMigrationJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/diskMigrationJobs",
+      path: "v1/{+parent}/diskMigrationJobs",
       hasBody: true,
     }),
     svc,
@@ -4273,7 +4277,7 @@ export const ListProjectsLocationsSourcesDiskMigrationJobsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/diskMigrationJobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/diskMigrationJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesDiskMigrationJobsRequest>;
 
@@ -4318,7 +4322,7 @@ export const PatchProjectsLocationsSourcesDiskMigrationJobsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(DiskMigrationJob).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSourcesDiskMigrationJobsRequest>;
 
@@ -4352,7 +4356,7 @@ export const CancelProjectsLocationsSourcesDiskMigrationJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelDiskMigrationJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsSourcesDiskMigrationJobsRequest>;
 
@@ -4384,7 +4388,7 @@ export const GetProjectsLocationsSourcesDiskMigrationJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesDiskMigrationJobsRequest>;
 
@@ -4419,7 +4423,7 @@ export const RunProjectsLocationsSourcesDiskMigrationJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RunDiskMigrationJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsSourcesDiskMigrationJobsRequest>;
 
@@ -4450,7 +4454,7 @@ export const DeleteProjectsLocationsSourcesDiskMigrationJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSourcesDiskMigrationJobsRequest>;
 
@@ -4501,7 +4505,7 @@ export const ListProjectsLocationsSourcesUtilizationReportsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/utilizationReports" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/utilizationReports" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesUtilizationReportsRequest>;
 
@@ -4544,7 +4548,7 @@ export const GetProjectsLocationsSourcesUtilizationReportsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesUtilizationReportsRequest>;
 
@@ -4589,7 +4593,7 @@ export const CreateProjectsLocationsSourcesUtilizationReportsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/utilizationReports",
+      path: "v1/{+parent}/utilizationReports",
       hasBody: true,
     }),
     svc,
@@ -4627,7 +4631,7 @@ export const DeleteProjectsLocationsSourcesUtilizationReportsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSourcesUtilizationReportsRequest>;
 
@@ -4660,7 +4664,7 @@ export const DeleteProjectsLocationsSourcesMigratingVmsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSourcesMigratingVmsRequest>;
 
@@ -4696,7 +4700,7 @@ export const StartMigrationProjectsLocationsSourcesMigratingVmsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{migratingVm}:startMigration",
+      path: "v1/{+migratingVm}:startMigration",
       hasBody: true,
     }),
     svc,
@@ -4742,7 +4746,11 @@ export const CreateProjectsLocationsSourcesMigratingVmsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(MigratingVm).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/migratingVms", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/migratingVms",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSourcesMigratingVmsRequest>;
 
@@ -4792,7 +4800,7 @@ export const ListProjectsLocationsSourcesMigratingVmsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/migratingVms" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/migratingVms" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesMigratingVmsRequest>;
 
@@ -4833,7 +4841,7 @@ export const ExtendMigrationProjectsLocationsSourcesMigratingVmsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{migratingVm}:extendMigration",
+      path: "v1/{+migratingVm}:extendMigration",
       hasBody: true,
     }),
     svc,
@@ -4873,7 +4881,7 @@ export const ResumeMigrationProjectsLocationsSourcesMigratingVmsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{migratingVm}:resumeMigration",
+      path: "v1/{+migratingVm}:resumeMigration",
       hasBody: true,
     }),
     svc,
@@ -4915,7 +4923,7 @@ export const GetProjectsLocationsSourcesMigratingVmsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesMigratingVmsRequest>;
 
@@ -4951,7 +4959,7 @@ export const PauseMigrationProjectsLocationsSourcesMigratingVmsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{migratingVm}:pauseMigration",
+      path: "v1/{+migratingVm}:pauseMigration",
       hasBody: true,
     }),
     svc,
@@ -4995,7 +5003,7 @@ export const PatchProjectsLocationsSourcesMigratingVmsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(MigratingVm).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSourcesMigratingVmsRequest>;
 
@@ -5031,7 +5039,7 @@ export const FinalizeMigrationProjectsLocationsSourcesMigratingVmsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{migratingVm}:finalizeMigration",
+      path: "v1/{+migratingVm}:finalizeMigration",
       hasBody: true,
     }),
     svc,
@@ -5066,7 +5074,7 @@ export const GetProjectsLocationsSourcesMigratingVmsCutoverJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesMigratingVmsCutoverJobsRequest>;
 
@@ -5102,7 +5110,7 @@ export const CancelProjectsLocationsSourcesMigratingVmsCutoverJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelCutoverJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsSourcesMigratingVmsCutoverJobsRequest>;
 
@@ -5147,7 +5155,7 @@ export const ListProjectsLocationsSourcesMigratingVmsCutoverJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/cutoverJobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/cutoverJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesMigratingVmsCutoverJobsRequest>;
 
@@ -5195,7 +5203,7 @@ export const CreateProjectsLocationsSourcesMigratingVmsCutoverJobsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(CutoverJob).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/cutoverJobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/cutoverJobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSourcesMigratingVmsCutoverJobsRequest>;
 
@@ -5231,7 +5239,7 @@ export const CancelProjectsLocationsSourcesMigratingVmsCloneJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelCloneJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsSourcesMigratingVmsCloneJobsRequest>;
 
@@ -5276,7 +5284,7 @@ export const ListProjectsLocationsSourcesMigratingVmsCloneJobsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/cloneJobs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/cloneJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesMigratingVmsCloneJobsRequest>;
 
@@ -5313,7 +5321,7 @@ export const GetProjectsLocationsSourcesMigratingVmsCloneJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesMigratingVmsCloneJobsRequest>;
 
@@ -5354,7 +5362,7 @@ export const CreateProjectsLocationsSourcesMigratingVmsCloneJobsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(CloneJob).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/cloneJobs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/cloneJobs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsSourcesMigratingVmsCloneJobsRequest>;
 
@@ -5399,7 +5407,7 @@ export const ListProjectsLocationsSourcesMigratingVmsReplicationCyclesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/replicationCycles" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/replicationCycles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesMigratingVmsReplicationCyclesRequest>;
 
@@ -5436,7 +5444,7 @@ export const GetProjectsLocationsSourcesMigratingVmsReplicationCyclesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesMigratingVmsReplicationCyclesRequest>;
 

--- a/packages/gcp/src/services/vmmigration-v1alpha1.ts
+++ b/packages/gcp/src/services/vmmigration-v1alpha1.ts
@@ -2903,7 +2903,7 @@ export const ListProjectsLocationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2938,7 +2938,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2972,7 +2972,7 @@ export const DeleteProjectsLocationsTargetProjectsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsTargetProjectsRequest>;
 
@@ -3016,7 +3016,7 @@ export const CreateProjectsLocationsTargetProjectsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/targetProjects",
+      path: "v1alpha1/{+parent}/targetProjects",
       hasBody: true,
     }),
     svc,
@@ -3061,7 +3061,7 @@ export const ListProjectsLocationsTargetProjectsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/targetProjects" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/targetProjects" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsTargetProjectsRequest>;
 
@@ -3106,7 +3106,7 @@ export const PatchProjectsLocationsTargetProjectsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(TargetProject).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsTargetProjectsRequest>;
 
@@ -3137,7 +3137,7 @@ export const GetProjectsLocationsTargetProjectsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsTargetProjectsRequest>;
 
@@ -3179,7 +3179,7 @@ export const CreateProjectsLocationsSourcesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/sources",
+      path: "v1alpha1/{+parent}/sources",
       hasBody: true,
     }),
     svc,
@@ -3215,7 +3215,7 @@ export const DeleteProjectsLocationsSourcesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSourcesRequest>;
 
@@ -3257,7 +3257,7 @@ export const FetchInventoryProjectsLocationsSourcesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     source: Schema.String.pipe(T.HttpPath("source")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{source}:fetchInventory" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+source}:fetchInventory" }),
     svc,
   ) as unknown as Schema.Schema<FetchInventoryProjectsLocationsSourcesRequest>;
 
@@ -3307,7 +3307,7 @@ export const FetchStorageInventoryProjectsLocationsSourcesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     type: Schema.optional(Schema.String).pipe(T.HttpQuery("type")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{source}:fetchStorageInventory" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+source}:fetchStorageInventory" }),
     svc,
   ) as unknown as Schema.Schema<FetchStorageInventoryProjectsLocationsSourcesRequest>;
 
@@ -3352,7 +3352,7 @@ export const PatchProjectsLocationsSourcesRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Source).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSourcesRequest>;
 
@@ -3395,7 +3395,7 @@ export const ListProjectsLocationsSourcesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/sources" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/sources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesRequest>;
 
@@ -3430,7 +3430,7 @@ export const GetProjectsLocationsSourcesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesRequest>;
 
@@ -3473,7 +3473,7 @@ export const ListProjectsLocationsSourcesDatacenterConnectorsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/datacenterConnectors" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/datacenterConnectors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesDatacenterConnectorsRequest>;
 
@@ -3513,7 +3513,7 @@ export const DeleteProjectsLocationsSourcesDatacenterConnectorsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSourcesDatacenterConnectorsRequest>;
 
@@ -3559,7 +3559,7 @@ export const CreateProjectsLocationsSourcesDatacenterConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/datacenterConnectors",
+      path: "v1alpha1/{+parent}/datacenterConnectors",
       hasBody: true,
     }),
     svc,
@@ -3599,7 +3599,7 @@ export const UpgradeApplianceProjectsLocationsSourcesDatacenterConnectorsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{datacenterConnector}:upgradeAppliance",
+      path: "v1alpha1/{+datacenterConnector}:upgradeAppliance",
       hasBody: true,
     }),
     svc,
@@ -3634,7 +3634,7 @@ export const GetProjectsLocationsSourcesDatacenterConnectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesDatacenterConnectorsRequest>;
 
@@ -3686,7 +3686,7 @@ export const ListProjectsLocationsSourcesUtilizationReportsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/utilizationReports" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/utilizationReports" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesUtilizationReportsRequest>;
 
@@ -3729,7 +3729,7 @@ export const GetProjectsLocationsSourcesUtilizationReportsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesUtilizationReportsRequest>;
 
@@ -3764,7 +3764,7 @@ export const DeleteProjectsLocationsSourcesUtilizationReportsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSourcesUtilizationReportsRequest>;
 
@@ -3810,7 +3810,7 @@ export const CreateProjectsLocationsSourcesUtilizationReportsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/utilizationReports",
+      path: "v1alpha1/{+parent}/utilizationReports",
       hasBody: true,
     }),
     svc,
@@ -3845,7 +3845,7 @@ export const DeleteProjectsLocationsSourcesDiskMigrationJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSourcesDiskMigrationJobsRequest>;
 
@@ -3880,7 +3880,7 @@ export const RunProjectsLocationsSourcesDiskMigrationJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RunDiskMigrationJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:run", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:run", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsSourcesDiskMigrationJobsRequest>;
 
@@ -3923,7 +3923,7 @@ export const ListProjectsLocationsSourcesDiskMigrationJobsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/diskMigrationJobs" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/diskMigrationJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesDiskMigrationJobsRequest>;
 
@@ -3968,7 +3968,7 @@ export const PatchProjectsLocationsSourcesDiskMigrationJobsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(DiskMigrationJob).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSourcesDiskMigrationJobsRequest>;
 
@@ -4012,7 +4012,7 @@ export const CreateProjectsLocationsSourcesDiskMigrationJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/diskMigrationJobs",
+      path: "v1alpha1/{+parent}/diskMigrationJobs",
       hasBody: true,
     }),
     svc,
@@ -4049,7 +4049,7 @@ export const CancelProjectsLocationsSourcesDiskMigrationJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelDiskMigrationJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsSourcesDiskMigrationJobsRequest>;
 
@@ -4081,7 +4081,7 @@ export const GetProjectsLocationsSourcesDiskMigrationJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesDiskMigrationJobsRequest>;
 
@@ -4118,7 +4118,7 @@ export const ExtendMigrationProjectsLocationsSourcesMigratingVmsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{migratingVm}:extendMigration",
+      path: "v1alpha1/{+migratingVm}:extendMigration",
       hasBody: true,
     }),
     svc,
@@ -4158,7 +4158,7 @@ export const FinalizeMigrationProjectsLocationsSourcesMigratingVmsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{migratingVm}:finalizeMigration",
+      path: "v1alpha1/{+migratingVm}:finalizeMigration",
       hasBody: true,
     }),
     svc,
@@ -4198,7 +4198,7 @@ export const ResumeMigrationProjectsLocationsSourcesMigratingVmsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{migratingVm}:resumeMigration",
+      path: "v1alpha1/{+migratingVm}:resumeMigration",
       hasBody: true,
     }),
     svc,
@@ -4240,7 +4240,7 @@ export const GetProjectsLocationsSourcesMigratingVmsRequest =
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesMigratingVmsRequest>;
 
@@ -4276,7 +4276,7 @@ export const PauseMigrationProjectsLocationsSourcesMigratingVmsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{migratingVm}:pauseMigration",
+      path: "v1alpha1/{+migratingVm}:pauseMigration",
       hasBody: true,
     }),
     svc,
@@ -4311,7 +4311,7 @@ export const DeleteProjectsLocationsSourcesMigratingVmsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsSourcesMigratingVmsRequest>;
 
@@ -4347,7 +4347,7 @@ export const StartMigrationProjectsLocationsSourcesMigratingVmsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{migratingVm}:startMigration",
+      path: "v1alpha1/{+migratingVm}:startMigration",
       hasBody: true,
     }),
     svc,
@@ -4395,7 +4395,7 @@ export const CreateProjectsLocationsSourcesMigratingVmsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/migratingVms",
+      path: "v1alpha1/{+parent}/migratingVms",
       hasBody: true,
     }),
     svc,
@@ -4437,7 +4437,7 @@ export const PatchProjectsLocationsSourcesMigratingVmsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(MigratingVm).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsSourcesMigratingVmsRequest>;
 
@@ -4487,7 +4487,7 @@ export const ListProjectsLocationsSourcesMigratingVmsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/migratingVms" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/migratingVms" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesMigratingVmsRequest>;
 
@@ -4535,7 +4535,7 @@ export const ListProjectsLocationsSourcesMigratingVmsReplicationCyclesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/replicationCycles" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/replicationCycles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesMigratingVmsReplicationCyclesRequest>;
 
@@ -4572,7 +4572,7 @@ export const GetProjectsLocationsSourcesMigratingVmsReplicationCyclesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesMigratingVmsReplicationCyclesRequest>;
 
@@ -4617,7 +4617,7 @@ export const ListProjectsLocationsSourcesMigratingVmsCutoverJobsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/cutoverJobs" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/cutoverJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesMigratingVmsCutoverJobsRequest>;
 
@@ -4654,7 +4654,7 @@ export const GetProjectsLocationsSourcesMigratingVmsCutoverJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesMigratingVmsCutoverJobsRequest>;
 
@@ -4690,7 +4690,7 @@ export const CancelProjectsLocationsSourcesMigratingVmsCutoverJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelCutoverJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsSourcesMigratingVmsCutoverJobsRequest>;
 
@@ -4736,7 +4736,7 @@ export const CreateProjectsLocationsSourcesMigratingVmsCutoverJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/cutoverJobs",
+      path: "v1alpha1/{+parent}/cutoverJobs",
       hasBody: true,
     }),
     svc,
@@ -4774,7 +4774,7 @@ export const CancelProjectsLocationsSourcesMigratingVmsCloneJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelCloneJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsSourcesMigratingVmsCloneJobsRequest>;
 
@@ -4819,7 +4819,7 @@ export const ListProjectsLocationsSourcesMigratingVmsCloneJobsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/cloneJobs" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/cloneJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsSourcesMigratingVmsCloneJobsRequest>;
 
@@ -4867,7 +4867,7 @@ export const CreateProjectsLocationsSourcesMigratingVmsCloneJobsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/cloneJobs",
+      path: "v1alpha1/{+parent}/cloneJobs",
       hasBody: true,
     }),
     svc,
@@ -4902,7 +4902,7 @@ export const GetProjectsLocationsSourcesMigratingVmsCloneJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsSourcesMigratingVmsCloneJobsRequest>;
 
@@ -4947,7 +4947,7 @@ export const CreateProjectsLocationsImageImportsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{parent}/imageImports",
+      path: "v1alpha1/{+parent}/imageImports",
       hasBody: true,
     }),
     svc,
@@ -4992,7 +4992,7 @@ export const ListProjectsLocationsImageImportsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/imageImports" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/imageImports" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsImageImportsRequest>;
 
@@ -5031,7 +5031,7 @@ export const DeleteProjectsLocationsImageImportsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsImageImportsRequest>;
 
@@ -5062,7 +5062,7 @@ export const GetProjectsLocationsImageImportsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsImageImportsRequest>;
 
@@ -5093,7 +5093,7 @@ export const GetProjectsLocationsImageImportsImageImportJobsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsImageImportsImageImportJobsRequest>;
 
@@ -5129,7 +5129,7 @@ export const CancelProjectsLocationsImageImportsImageImportJobsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelImageImportJobRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsImageImportsImageImportJobsRequest>;
 
@@ -5174,7 +5174,7 @@ export const ListProjectsLocationsImageImportsImageImportJobsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/imageImportJobs" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/imageImportJobs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsImageImportsImageImportJobsRequest>;
 
@@ -5214,7 +5214,7 @@ export const DeleteProjectsLocationsGroupsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsGroupsRequest>;
 
@@ -5257,7 +5257,7 @@ export const ListProjectsLocationsGroupsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{parent}/groups" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+parent}/groups" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsGroupsRequest>;
 
@@ -5292,7 +5292,7 @@ export const GetProjectsLocationsGroupsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsGroupsRequest>;
 
@@ -5328,7 +5328,7 @@ export const RemoveGroupMigrationProjectsLocationsGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{group}:removeGroupMigration",
+      path: "v1alpha1/{+group}:removeGroupMigration",
       hasBody: true,
     }),
     svc,
@@ -5366,7 +5366,7 @@ export const AddGroupMigrationProjectsLocationsGroupsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha1/{group}:addGroupMigration",
+      path: "v1alpha1/{+group}:addGroupMigration",
       hasBody: true,
     }),
     svc,
@@ -5408,7 +5408,7 @@ export const PatchProjectsLocationsGroupsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Group).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsGroupsRequest>;
 
@@ -5448,7 +5448,11 @@ export const CreateProjectsLocationsGroupsRequest =
     groupId: Schema.optional(Schema.String).pipe(T.HttpQuery("groupId")),
     body: Schema.optional(Group).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{parent}/groups", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1alpha1/{+parent}/groups",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsGroupsRequest>;
 
@@ -5482,7 +5486,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -5513,7 +5517,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -5558,7 +5562,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -5593,7 +5597,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha1/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/vmwareengine-v1.ts
+++ b/packages/gcp/src/services/vmwareengine-v1.ts
@@ -2048,7 +2048,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2079,7 +2079,7 @@ export const GetDnsBindPermissionProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDnsBindPermissionProjectsLocationsRequest>;
 
@@ -2124,7 +2124,7 @@ export const ListProjectsLocationsRequest =
     ),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2177,7 +2177,7 @@ export const CreateProjectsLocationsVmwareEngineNetworksRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/vmwareEngineNetworks",
+      path: "v1/{+parent}/vmwareEngineNetworks",
       hasBody: true,
     }),
     svc,
@@ -2216,7 +2216,7 @@ export const DeleteProjectsLocationsVmwareEngineNetworksRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsVmwareEngineNetworksRequest>;
 
@@ -2247,7 +2247,7 @@ export const GetProjectsLocationsVmwareEngineNetworksRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsVmwareEngineNetworksRequest>;
 
@@ -2293,7 +2293,7 @@ export const PatchProjectsLocationsVmwareEngineNetworksRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(VmwareEngineNetwork).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsVmwareEngineNetworksRequest>;
 
@@ -2336,7 +2336,7 @@ export const ListProjectsLocationsVmwareEngineNetworksRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/vmwareEngineNetworks" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/vmwareEngineNetworks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsVmwareEngineNetworksRequest>;
 
@@ -2375,7 +2375,7 @@ export const RevokeProjectsLocationsDnsBindPermissionRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RevokeDnsBindPermissionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:revoke", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:revoke", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RevokeProjectsLocationsDnsBindPermissionRequest>;
 
@@ -2409,7 +2409,7 @@ export const GrantProjectsLocationsDnsBindPermissionRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(GrantDnsBindPermissionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:grant", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:grant", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<GrantProjectsLocationsDnsBindPermissionRequest>;
 
@@ -2445,7 +2445,7 @@ export const ResetNsxCredentialsProjectsLocationsPrivateCloudsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{privateCloud}:resetNsxCredentials",
+      path: "v1/{+privateCloud}:resetNsxCredentials",
       hasBody: true,
     }),
     svc,
@@ -2483,7 +2483,10 @@ export const ShowVcenterCredentialsProjectsLocationsPrivateCloudsRequest =
     username: Schema.optional(Schema.String).pipe(T.HttpQuery("username")),
     privateCloud: Schema.String.pipe(T.HttpPath("privateCloud")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{privateCloud}:showVcenterCredentials" }),
+    T.Http({
+      method: "GET",
+      path: "v1/{+privateCloud}:showVcenterCredentials",
+    }),
     svc,
   ) as unknown as Schema.Schema<ShowVcenterCredentialsProjectsLocationsPrivateCloudsRequest>;
 
@@ -2516,7 +2519,7 @@ export const GetDnsForwardingProjectsLocationsPrivateCloudsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetDnsForwardingProjectsLocationsPrivateCloudsRequest>;
 
@@ -2548,7 +2551,7 @@ export const GetProjectsLocationsPrivateCloudsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPrivateCloudsRequest>;
 
@@ -2584,7 +2587,7 @@ export const ResetVcenterCredentialsProjectsLocationsPrivateCloudsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{privateCloud}:resetVcenterCredentials",
+      path: "v1/{+privateCloud}:resetVcenterCredentials",
       hasBody: true,
     }),
     svc,
@@ -2633,7 +2636,7 @@ export const PatchProjectsLocationsPrivateCloudsRequest =
     ),
     body: Schema.optional(PrivateCloud).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPrivateCloudsRequest>;
 
@@ -2682,7 +2685,7 @@ export const CreateProjectsLocationsPrivateCloudsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/privateClouds",
+      path: "v1/{+parent}/privateClouds",
       hasBody: true,
     }),
     svc,
@@ -2720,7 +2723,7 @@ export const SetIamPolicyProjectsLocationsPrivateCloudsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -2758,7 +2761,7 @@ export const GetIamPolicyProjectsLocationsPrivateCloudsRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsPrivateCloudsRequest>;
 
@@ -2796,7 +2799,7 @@ export const PrivateCloudDeletionNowProjectsLocationsPrivateCloudsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:privateCloudDeletionNow",
+      path: "v1/{+name}:privateCloudDeletionNow",
       hasBody: true,
     }),
     svc,
@@ -2843,7 +2846,7 @@ export const ListProjectsLocationsPrivateCloudsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/privateClouds" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/privateClouds" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPrivateCloudsRequest>;
 
@@ -2888,7 +2891,7 @@ export const DeleteProjectsLocationsPrivateCloudsRequest =
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
     delayHours: Schema.optional(Schema.Number).pipe(T.HttpQuery("delayHours")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPrivateCloudsRequest>;
 
@@ -2924,7 +2927,7 @@ export const TestIamPermissionsProjectsLocationsPrivateCloudsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2962,7 +2965,7 @@ export const UndeleteProjectsLocationsPrivateCloudsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(UndeletePrivateCloudRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:undelete", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:undelete", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UndeleteProjectsLocationsPrivateCloudsRequest>;
 
@@ -2993,7 +2996,7 @@ export const ShowNsxCredentialsProjectsLocationsPrivateCloudsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     privateCloud: Schema.String.pipe(T.HttpPath("privateCloud")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{privateCloud}:showNsxCredentials" }),
+    T.Http({ method: "GET", path: "v1/{+privateCloud}:showNsxCredentials" }),
     svc,
   ) as unknown as Schema.Schema<ShowNsxCredentialsProjectsLocationsPrivateCloudsRequest>;
 
@@ -3035,7 +3038,7 @@ export const UpdateDnsForwardingProjectsLocationsPrivateCloudsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(DnsForwarding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<UpdateDnsForwardingProjectsLocationsPrivateCloudsRequest>;
 
@@ -3081,7 +3084,7 @@ export const CreateProjectsLocationsPrivateCloudsLoggingServersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/loggingServers",
+      path: "v1/{+parent}/loggingServers",
       hasBody: true,
     }),
     svc,
@@ -3119,7 +3122,7 @@ export const DeleteProjectsLocationsPrivateCloudsLoggingServersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPrivateCloudsLoggingServersRequest>;
 
@@ -3152,7 +3155,7 @@ export const GetProjectsLocationsPrivateCloudsLoggingServersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPrivateCloudsLoggingServersRequest>;
 
@@ -3194,7 +3197,7 @@ export const PatchProjectsLocationsPrivateCloudsLoggingServersRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(LoggingServer).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPrivateCloudsLoggingServersRequest>;
 
@@ -3239,7 +3242,7 @@ export const ListProjectsLocationsPrivateCloudsLoggingServersRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/loggingServers" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/loggingServers" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPrivateCloudsLoggingServersRequest>;
 
@@ -3276,7 +3279,7 @@ export const GetProjectsLocationsPrivateCloudsUpgradesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPrivateCloudsUpgradesRequest>;
 
@@ -3319,7 +3322,7 @@ export const ListProjectsLocationsPrivateCloudsUpgradesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/upgrades" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/upgrades" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPrivateCloudsUpgradesRequest>;
 
@@ -3364,7 +3367,7 @@ export const PatchProjectsLocationsPrivateCloudsUpgradesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Upgrade).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPrivateCloudsUpgradesRequest>;
 
@@ -3409,7 +3412,7 @@ export const PatchProjectsLocationsPrivateCloudsClustersRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Cluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPrivateCloudsClustersRequest>;
 
@@ -3445,7 +3448,7 @@ export const UnmountDatastoreProjectsLocationsPrivateCloudsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:unmountDatastore",
+      path: "v1/{+name}:unmountDatastore",
       hasBody: true,
     }),
     svc,
@@ -3480,7 +3483,7 @@ export const GetProjectsLocationsPrivateCloudsClustersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPrivateCloudsClustersRequest>;
 
@@ -3516,7 +3519,7 @@ export const TestIamPermissionsProjectsLocationsPrivateCloudsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -3565,7 +3568,7 @@ export const CreateProjectsLocationsPrivateCloudsClustersRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Cluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/clusters", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/clusters", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsPrivateCloudsClustersRequest>;
 
@@ -3601,7 +3604,7 @@ export const SetIamPolicyProjectsLocationsPrivateCloudsClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3640,7 +3643,7 @@ export const GetIamPolicyProjectsLocationsPrivateCloudsClustersRequest =
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsPrivateCloudsClustersRequest>;
 
@@ -3684,7 +3687,7 @@ export const ListProjectsLocationsPrivateCloudsClustersRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/clusters" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/clusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPrivateCloudsClustersRequest>;
 
@@ -3723,7 +3726,7 @@ export const DeleteProjectsLocationsPrivateCloudsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPrivateCloudsClustersRequest>;
 
@@ -3757,7 +3760,11 @@ export const MountDatastoreProjectsLocationsPrivateCloudsClustersRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(MountDatastoreRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:mountDatastore", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+name}:mountDatastore",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<MountDatastoreProjectsLocationsPrivateCloudsClustersRequest>;
 
@@ -3790,7 +3797,7 @@ export const GetProjectsLocationsPrivateCloudsClustersNodesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPrivateCloudsClustersNodesRequest>;
 
@@ -3827,7 +3834,7 @@ export const ListProjectsLocationsPrivateCloudsClustersNodesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/nodes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/nodes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPrivateCloudsClustersNodesRequest>;
 
@@ -3877,7 +3884,7 @@ export const CreateProjectsLocationsPrivateCloudsHcxActivationKeysRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/hcxActivationKeys",
+      path: "v1/{+parent}/hcxActivationKeys",
       hasBody: true,
     }),
     svc,
@@ -3917,7 +3924,7 @@ export const SetIamPolicyProjectsLocationsPrivateCloudsHcxActivationKeysRequest 
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -3957,7 +3964,7 @@ export const GetIamPolicyProjectsLocationsPrivateCloudsHcxActivationKeysRequest 
       T.HttpQuery("options.requestedPolicyVersion"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsPrivateCloudsHcxActivationKeysRequest>;
 
@@ -3996,7 +4003,7 @@ export const ListProjectsLocationsPrivateCloudsHcxActivationKeysRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/hcxActivationKeys" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/hcxActivationKeys" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPrivateCloudsHcxActivationKeysRequest>;
 
@@ -4033,7 +4040,7 @@ export const GetProjectsLocationsPrivateCloudsHcxActivationKeysRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPrivateCloudsHcxActivationKeysRequest>;
 
@@ -4071,7 +4078,7 @@ export const TestIamPermissionsProjectsLocationsPrivateCloudsHcxActivationKeysRe
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -4117,7 +4124,7 @@ export const PatchProjectsLocationsPrivateCloudsManagementDnsZoneBindingsRequest
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(ManagementDnsZoneBinding).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPrivateCloudsManagementDnsZoneBindingsRequest>;
 
@@ -4162,7 +4169,7 @@ export const ListProjectsLocationsPrivateCloudsManagementDnsZoneBindingsRequest 
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/managementDnsZoneBindings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/managementDnsZoneBindings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPrivateCloudsManagementDnsZoneBindingsRequest>;
 
@@ -4199,7 +4206,7 @@ export const GetProjectsLocationsPrivateCloudsManagementDnsZoneBindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPrivateCloudsManagementDnsZoneBindingsRequest>;
 
@@ -4237,7 +4244,7 @@ export const RepairProjectsLocationsPrivateCloudsManagementDnsZoneBindingsReques
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:repair", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:repair", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<RepairProjectsLocationsPrivateCloudsManagementDnsZoneBindingsRequest>;
 
@@ -4273,7 +4280,7 @@ export const DeleteProjectsLocationsPrivateCloudsManagementDnsZoneBindingsReques
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPrivateCloudsManagementDnsZoneBindingsRequest>;
 
@@ -4319,7 +4326,7 @@ export const CreateProjectsLocationsPrivateCloudsManagementDnsZoneBindingsReques
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/managementDnsZoneBindings",
+      path: "v1/{+parent}/managementDnsZoneBindings",
       hasBody: true,
     }),
     svc,
@@ -4354,7 +4361,7 @@ export const GetProjectsLocationsPrivateCloudsSubnetsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPrivateCloudsSubnetsRequest>;
 
@@ -4391,7 +4398,7 @@ export const ListProjectsLocationsPrivateCloudsSubnetsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/subnets" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/subnets" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPrivateCloudsSubnetsRequest>;
 
@@ -4433,7 +4440,7 @@ export const PatchProjectsLocationsPrivateCloudsSubnetsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Subnet).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPrivateCloudsSubnetsRequest>;
 
@@ -4467,7 +4474,7 @@ export const DeleteProjectsLocationsPrivateCloudsExternalAddressesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPrivateCloudsExternalAddressesRequest>;
 
@@ -4518,7 +4525,7 @@ export const CreateProjectsLocationsPrivateCloudsExternalAddressesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/externalAddresses",
+      path: "v1/{+parent}/externalAddresses",
       hasBody: true,
     }),
     svc,
@@ -4567,7 +4574,7 @@ export const PatchProjectsLocationsPrivateCloudsExternalAddressesRequest =
     ),
     body: Schema.optional(ExternalAddress).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPrivateCloudsExternalAddressesRequest>;
 
@@ -4612,7 +4619,7 @@ export const ListProjectsLocationsPrivateCloudsExternalAddressesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/externalAddresses" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/externalAddresses" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPrivateCloudsExternalAddressesRequest>;
 
@@ -4649,7 +4656,7 @@ export const GetProjectsLocationsPrivateCloudsExternalAddressesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPrivateCloudsExternalAddressesRequest>;
 
@@ -4682,7 +4689,7 @@ export const GetProjectsLocationsAnnouncementsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsAnnouncementsRequest>;
 
@@ -4725,7 +4732,7 @@ export const ListProjectsLocationsAnnouncementsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/announcements" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/announcements" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsAnnouncementsRequest>;
 
@@ -4761,7 +4768,7 @@ export const GetProjectsLocationsDatastoresRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDatastoresRequest>;
 
@@ -4807,7 +4814,7 @@ export const ListProjectsLocationsDatastoresRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/datastores" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/datastores" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDatastoresRequest>;
 
@@ -4851,7 +4858,7 @@ export const PatchProjectsLocationsDatastoresRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Datastore).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsDatastoresRequest>;
 
@@ -4893,7 +4900,7 @@ export const CreateProjectsLocationsDatastoresRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(Datastore).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/datastores", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/datastores", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDatastoresRequest>;
 
@@ -4930,7 +4937,7 @@ export const DeleteProjectsLocationsDatastoresRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDatastoresRequest>;
 
@@ -4961,7 +4968,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -5006,7 +5013,7 @@ export const ListProjectsLocationsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -5041,7 +5048,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -5090,7 +5097,7 @@ export const CreateProjectsLocationsNetworkPeeringsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/networkPeerings",
+      path: "v1/{+parent}/networkPeerings",
       hasBody: true,
     }),
     svc,
@@ -5126,7 +5133,7 @@ export const DeleteProjectsLocationsNetworkPeeringsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNetworkPeeringsRequest>;
 
@@ -5157,7 +5164,7 @@ export const GetProjectsLocationsNetworkPeeringsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNetworkPeeringsRequest>;
 
@@ -5202,7 +5209,7 @@ export const PatchProjectsLocationsNetworkPeeringsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(NetworkPeering).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsNetworkPeeringsRequest>;
 
@@ -5245,7 +5252,7 @@ export const ListProjectsLocationsNetworkPeeringsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/networkPeerings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/networkPeerings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNetworkPeeringsRequest>;
 
@@ -5290,7 +5297,7 @@ export const ListProjectsLocationsNetworkPeeringsPeeringRoutesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/peeringRoutes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/peeringRoutes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNetworkPeeringsPeeringRoutesRequest>;
 
@@ -5345,7 +5352,7 @@ export const CreateProjectsLocationsPrivateConnectionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/privateConnections",
+      path: "v1/{+parent}/privateConnections",
       hasBody: true,
     }),
     svc,
@@ -5381,7 +5388,7 @@ export const DeleteProjectsLocationsPrivateConnectionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsPrivateConnectionsRequest>;
 
@@ -5412,7 +5419,7 @@ export const GetProjectsLocationsPrivateConnectionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsPrivateConnectionsRequest>;
 
@@ -5455,7 +5462,7 @@ export const ListProjectsLocationsPrivateConnectionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/privateConnections" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/privateConnections" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPrivateConnectionsRequest>;
 
@@ -5505,7 +5512,7 @@ export const PatchProjectsLocationsPrivateConnectionsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(PrivateConnection).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsPrivateConnectionsRequest>;
 
@@ -5542,7 +5549,7 @@ export const ListProjectsLocationsPrivateConnectionsPeeringRoutesRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/peeringRoutes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/peeringRoutes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsPrivateConnectionsPeeringRoutesRequest>;
 
@@ -5597,7 +5604,7 @@ export const CreateProjectsLocationsNetworkPoliciesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/networkPolicies",
+      path: "v1/{+parent}/networkPolicies",
       hasBody: true,
     }),
     svc,
@@ -5633,7 +5640,7 @@ export const DeleteProjectsLocationsNetworkPoliciesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNetworkPoliciesRequest>;
 
@@ -5672,7 +5679,7 @@ export const FetchExternalAddressesProjectsLocationsNetworkPoliciesRequest =
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{networkPolicy}:fetchExternalAddresses",
+      path: "v1/{+networkPolicy}:fetchExternalAddresses",
     }),
     svc,
   ) as unknown as Schema.Schema<FetchExternalAddressesProjectsLocationsNetworkPoliciesRequest>;
@@ -5710,7 +5717,7 @@ export const GetProjectsLocationsNetworkPoliciesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNetworkPoliciesRequest>;
 
@@ -5753,7 +5760,7 @@ export const ListProjectsLocationsNetworkPoliciesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/networkPolicies" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/networkPolicies" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNetworkPoliciesRequest>;
 
@@ -5803,7 +5810,7 @@ export const PatchProjectsLocationsNetworkPoliciesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(NetworkPolicy).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsNetworkPoliciesRequest>;
 
@@ -5837,7 +5844,7 @@ export const DeleteProjectsLocationsNetworkPoliciesExternalAccessRulesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsNetworkPoliciesExternalAccessRulesRequest>;
 
@@ -5888,7 +5895,7 @@ export const CreateProjectsLocationsNetworkPoliciesExternalAccessRulesRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/externalAccessRules",
+      path: "v1/{+parent}/externalAccessRules",
       hasBody: true,
     }),
     svc,
@@ -5937,7 +5944,7 @@ export const PatchProjectsLocationsNetworkPoliciesExternalAccessRulesRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     body: Schema.optional(ExternalAccessRule).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsNetworkPoliciesExternalAccessRulesRequest>;
 
@@ -5982,7 +5989,7 @@ export const ListProjectsLocationsNetworkPoliciesExternalAccessRulesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/externalAccessRules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/externalAccessRules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNetworkPoliciesExternalAccessRulesRequest>;
 
@@ -6019,7 +6026,7 @@ export const GetProjectsLocationsNetworkPoliciesExternalAccessRulesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNetworkPoliciesExternalAccessRulesRequest>;
 
@@ -6061,7 +6068,7 @@ export const ListProjectsLocationsNodeTypesRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/nodeTypes" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/nodeTypes" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsNodeTypesRequest>;
 
@@ -6096,7 +6103,7 @@ export const GetProjectsLocationsNodeTypesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsNodeTypesRequest>;
 

--- a/packages/gcp/src/services/vpcaccess-v1.ts
+++ b/packages/gcp/src/services/vpcaccess-v1.ts
@@ -265,7 +265,7 @@ export const ListProjectsLocationsRequest =
     ),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -308,7 +308,7 @@ export const CreateProjectsLocationsConnectorsRequest =
     ),
     body: Schema.optional(Connector).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/connectors", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/connectors", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsConnectorsRequest>;
 
@@ -345,7 +345,7 @@ export const ListProjectsLocationsConnectorsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/connectors" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/connectors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectorsRequest>;
 
@@ -386,7 +386,7 @@ export const PatchProjectsLocationsConnectorsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Connector).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectorsRequest>;
 
@@ -417,7 +417,7 @@ export const GetProjectsLocationsConnectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectorsRequest>;
 
@@ -448,7 +448,7 @@ export const DeleteProjectsLocationsConnectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectorsRequest>;
 
@@ -493,7 +493,7 @@ export const ListProjectsLocationsOperationsRequest =
     ),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -528,7 +528,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 

--- a/packages/gcp/src/services/vpcaccess-v1beta1.ts
+++ b/packages/gcp/src/services/vpcaccess-v1beta1.ts
@@ -271,7 +271,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -320,7 +320,7 @@ export const ListProjectsLocationsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -355,7 +355,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -386,7 +386,7 @@ export const GetProjectsLocationsConnectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{name}" }),
+    T.Http({ method: "GET", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsConnectorsRequest>;
 
@@ -423,7 +423,7 @@ export const ListProjectsLocationsConnectorsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta1/{parent}/connectors" }),
+    T.Http({ method: "GET", path: "v1beta1/{+parent}/connectors" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsConnectorsRequest>;
 
@@ -464,7 +464,7 @@ export const PatchProjectsLocationsConnectorsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Connector).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsConnectorsRequest>;
 
@@ -495,7 +495,7 @@ export const DeleteProjectsLocationsConnectorsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsConnectorsRequest>;
 
@@ -536,7 +536,7 @@ export const CreateProjectsLocationsConnectorsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta1/{parent}/connectors",
+      path: "v1beta1/{+parent}/connectors",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/webrisk-v1.ts
+++ b/packages/gcp/src/services/webrisk-v1.ts
@@ -349,7 +349,7 @@ export const ListProjectsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsOperationsRequest>;
 
@@ -385,7 +385,7 @@ export const DeleteProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsOperationsRequest>;
 
@@ -421,7 +421,7 @@ export const CancelProjectsOperationsRequest =
       T.HttpBody(),
     ),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsOperationsRequest>;
 
@@ -452,7 +452,7 @@ export const GetProjectsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsOperationsRequest>;
 
@@ -486,7 +486,7 @@ export const CreateProjectsSubmissionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(GoogleCloudWebriskV1Submission).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/submissions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/submissions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsSubmissionsRequest>;
 

--- a/packages/gcp/src/services/websecurityscanner-v1.ts
+++ b/packages/gcp/src/services/websecurityscanner-v1.ts
@@ -615,7 +615,7 @@ export const StartProjectsScanConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StartScanRunRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsScanConfigsRequest>;
 
@@ -646,7 +646,7 @@ export const DeleteProjectsScanConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsScanConfigsRequest>;
 
@@ -680,7 +680,7 @@ export const CreateProjectsScanConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(ScanConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/scanConfigs", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/scanConfigs", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsScanConfigsRequest>;
 
@@ -717,7 +717,7 @@ export const ListProjectsScanConfigsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/scanConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/scanConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsScanConfigsRequest>;
 
@@ -752,7 +752,7 @@ export const GetProjectsScanConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsScanConfigsRequest>;
 
@@ -789,7 +789,7 @@ export const PatchProjectsScanConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ScanConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsScanConfigsRequest>;
 
@@ -820,7 +820,7 @@ export const GetProjectsScanConfigsScanRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsScanConfigsScanRunsRequest>;
 
@@ -857,7 +857,7 @@ export const ListProjectsScanConfigsScanRunsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/scanRuns" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/scanRuns" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsScanConfigsScanRunsRequest>;
 
@@ -895,7 +895,7 @@ export const StopProjectsScanConfigsScanRunsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopScanRunRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsScanConfigsScanRunsRequest>;
 
@@ -926,7 +926,7 @@ export const ListProjectsScanConfigsScanRunsFindingTypeStatsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/findingTypeStats" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/findingTypeStats" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsScanConfigsScanRunsFindingTypeStatsRequest>;
 
@@ -968,7 +968,7 @@ export const ListProjectsScanConfigsScanRunsFindingsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/findings" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/findings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsScanConfigsScanRunsFindingsRequest>;
 
@@ -1004,7 +1004,7 @@ export const GetProjectsScanConfigsScanRunsFindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsScanConfigsScanRunsFindingsRequest>;
 
@@ -1041,7 +1041,7 @@ export const ListProjectsScanConfigsScanRunsCrawledUrlsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/crawledUrls" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/crawledUrls" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsScanConfigsScanRunsCrawledUrlsRequest>;
 

--- a/packages/gcp/src/services/websecurityscanner-v1alpha.ts
+++ b/packages/gcp/src/services/websecurityscanner-v1alpha.ts
@@ -440,7 +440,7 @@ export const StartProjectsScanConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StartScanRunRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsScanConfigsRequest>;
 
@@ -477,7 +477,7 @@ export const PatchProjectsScanConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ScanConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1alpha/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1alpha/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsScanConfigsRequest>;
 
@@ -508,7 +508,7 @@ export const DeleteProjectsScanConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1alpha/{name}" }),
+    T.Http({ method: "DELETE", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsScanConfigsRequest>;
 
@@ -539,7 +539,7 @@ export const GetProjectsScanConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsScanConfigsRequest>;
 
@@ -576,7 +576,7 @@ export const ListProjectsScanConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/scanConfigs" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/scanConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsScanConfigsRequest>;
 
@@ -616,7 +616,7 @@ export const CreateProjectsScanConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1alpha/{parent}/scanConfigs",
+      path: "v1alpha/{+parent}/scanConfigs",
       hasBody: true,
     }),
     svc,
@@ -649,7 +649,7 @@ export const GetProjectsScanConfigsScanRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsScanConfigsScanRunsRequest>;
 
@@ -683,7 +683,7 @@ export const StopProjectsScanConfigsScanRunsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopScanRunRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1alpha/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1alpha/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsScanConfigsScanRunsRequest>;
 
@@ -720,7 +720,7 @@ export const ListProjectsScanConfigsScanRunsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/scanRuns" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/scanRuns" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsScanConfigsScanRunsRequest>;
 
@@ -761,7 +761,7 @@ export const ListProjectsScanConfigsScanRunsCrawledUrlsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/crawledUrls" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/crawledUrls" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsScanConfigsScanRunsCrawledUrlsRequest>;
 
@@ -797,7 +797,7 @@ export const ListProjectsScanConfigsScanRunsFindingTypeStatsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/findingTypeStats" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/findingTypeStats" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsScanConfigsScanRunsFindingTypeStatsRequest>;
 
@@ -839,7 +839,7 @@ export const ListProjectsScanConfigsScanRunsFindingsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{parent}/findings" }),
+    T.Http({ method: "GET", path: "v1alpha/{+parent}/findings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsScanConfigsScanRunsFindingsRequest>;
 
@@ -875,7 +875,7 @@ export const GetProjectsScanConfigsScanRunsFindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1alpha/{name}" }),
+    T.Http({ method: "GET", path: "v1alpha/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsScanConfigsScanRunsFindingsRequest>;
 

--- a/packages/gcp/src/services/websecurityscanner-v1beta.ts
+++ b/packages/gcp/src/services/websecurityscanner-v1beta.ts
@@ -590,7 +590,7 @@ export const GetProjectsScanConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsScanConfigsRequest>;
 
@@ -626,7 +626,7 @@ export const CreateProjectsScanConfigsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/scanConfigs",
+      path: "v1beta/{+parent}/scanConfigs",
       hasBody: true,
     }),
     svc,
@@ -665,7 +665,7 @@ export const ListProjectsScanConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/scanConfigs" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/scanConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsScanConfigsRequest>;
 
@@ -700,7 +700,7 @@ export const DeleteProjectsScanConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsScanConfigsRequest>;
 
@@ -737,7 +737,7 @@ export const PatchProjectsScanConfigsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(ScanConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsScanConfigsRequest>;
 
@@ -771,7 +771,7 @@ export const StartProjectsScanConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StartScanRunRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsScanConfigsRequest>;
 
@@ -802,7 +802,7 @@ export const GetProjectsScanConfigsScanRunsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsScanConfigsScanRunsRequest>;
 
@@ -836,7 +836,7 @@ export const StopProjectsScanConfigsScanRunsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopScanRunRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsScanConfigsScanRunsRequest>;
 
@@ -873,7 +873,7 @@ export const ListProjectsScanConfigsScanRunsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/scanRuns" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/scanRuns" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsScanConfigsScanRunsRequest>;
 
@@ -908,7 +908,7 @@ export const GetProjectsScanConfigsScanRunsFindingsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsScanConfigsScanRunsFindingsRequest>;
 
@@ -948,7 +948,7 @@ export const ListProjectsScanConfigsScanRunsFindingsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/findings" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/findings" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsScanConfigsScanRunsFindingsRequest>;
 
@@ -984,7 +984,7 @@ export const ListProjectsScanConfigsScanRunsFindingTypeStatsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/findingTypeStats" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/findingTypeStats" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsScanConfigsScanRunsFindingTypeStatsRequest>;
 
@@ -1023,7 +1023,7 @@ export const ListProjectsScanConfigsScanRunsCrawledUrlsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/crawledUrls" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/crawledUrls" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsScanConfigsScanRunsCrawledUrlsRequest>;
 

--- a/packages/gcp/src/services/workflowexecutions-v1.ts
+++ b/packages/gcp/src/services/workflowexecutions-v1.ts
@@ -457,7 +457,7 @@ export const TriggerPubsubExecutionProjectsLocationsWorkflowsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{workflow}:triggerPubsubExecution",
+      path: "v1/{+workflow}:triggerPubsubExecution",
       hasBody: true,
     }),
     svc,
@@ -507,7 +507,7 @@ export const ListProjectsLocationsWorkflowsExecutionsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/executions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/executions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkflowsExecutionsRequest>;
 
@@ -546,7 +546,7 @@ export const CreateProjectsLocationsWorkflowsExecutionsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Execution).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/executions", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/executions", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsWorkflowsExecutionsRequest>;
 
@@ -580,7 +580,7 @@ export const GetProjectsLocationsWorkflowsExecutionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkflowsExecutionsRequest>;
 
@@ -614,7 +614,7 @@ export const CancelProjectsLocationsWorkflowsExecutionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelExecutionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsWorkflowsExecutionsRequest>;
 
@@ -645,7 +645,7 @@ export const ExportDataProjectsLocationsWorkflowsExecutionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:exportData" }),
+    T.Http({ method: "GET", path: "v1/{+name}:exportData" }),
     svc,
   ) as unknown as Schema.Schema<ExportDataProjectsLocationsWorkflowsExecutionsRequest>;
 
@@ -682,7 +682,7 @@ export const DeleteExecutionHistoryProjectsLocationsWorkflowsExecutionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{name}:deleteExecutionHistory",
+      path: "v1/{+name}:deleteExecutionHistory",
       hasBody: true,
     }),
     svc,
@@ -723,7 +723,7 @@ export const ListProjectsLocationsWorkflowsExecutionsCallbacksRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/callbacks" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/callbacks" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkflowsExecutionsCallbacksRequest>;
 
@@ -782,7 +782,7 @@ export const ListProjectsLocationsWorkflowsExecutionsStepEntriesRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/stepEntries" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/stepEntries" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkflowsExecutionsStepEntriesRequest>;
 
@@ -826,7 +826,7 @@ export const GetProjectsLocationsWorkflowsExecutionsStepEntriesRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkflowsExecutionsStepEntriesRequest>;
 

--- a/packages/gcp/src/services/workflowexecutions-v1beta.ts
+++ b/packages/gcp/src/services/workflowexecutions-v1beta.ts
@@ -188,7 +188,7 @@ export const ListProjectsLocationsWorkflowsExecutionsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/executions" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/executions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkflowsExecutionsRequest>;
 
@@ -229,7 +229,7 @@ export const CreateProjectsLocationsWorkflowsExecutionsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/executions",
+      path: "v1beta/{+parent}/executions",
       hasBody: true,
     }),
     svc,
@@ -265,7 +265,7 @@ export const GetProjectsLocationsWorkflowsExecutionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     view: Schema.optional(Schema.String).pipe(T.HttpQuery("view")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkflowsExecutionsRequest>;
 
@@ -299,7 +299,7 @@ export const CancelProjectsLocationsWorkflowsExecutionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelExecutionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsWorkflowsExecutionsRequest>;
 

--- a/packages/gcp/src/services/workflows-v1.ts
+++ b/packages/gcp/src/services/workflows-v1.ts
@@ -276,7 +276,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -311,7 +311,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -342,7 +342,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -373,7 +373,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -418,7 +418,7 @@ export const ListProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -459,7 +459,7 @@ export const ListRevisionsProjectsLocationsWorkflowsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}:listRevisions" }),
+    T.Http({ method: "GET", path: "v1/{+name}:listRevisions" }),
     svc,
   ) as unknown as Schema.Schema<ListRevisionsProjectsLocationsWorkflowsRequest>;
 
@@ -501,7 +501,7 @@ export const CreateProjectsLocationsWorkflowsRequest =
     workflowId: Schema.optional(Schema.String).pipe(T.HttpQuery("workflowId")),
     body: Schema.optional(Workflow).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/workflows", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/workflows", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsWorkflowsRequest>;
 
@@ -535,7 +535,7 @@ export const GetProjectsLocationsWorkflowsRequest =
     revisionId: Schema.optional(Schema.String).pipe(T.HttpQuery("revisionId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkflowsRequest>;
 
@@ -566,7 +566,7 @@ export const DeleteProjectsLocationsWorkflowsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWorkflowsRequest>;
 
@@ -603,7 +603,7 @@ export const PatchProjectsLocationsWorkflowsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Workflow).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsWorkflowsRequest>;
 
@@ -646,7 +646,7 @@ export const ListProjectsLocationsWorkflowsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/workflows" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/workflows" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkflowsRequest>;
 

--- a/packages/gcp/src/services/workflows-v1beta.ts
+++ b/packages/gcp/src/services/workflows-v1beta.ts
@@ -201,7 +201,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -246,7 +246,7 @@ export const ListProjectsLocationsRequest =
     ),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -281,7 +281,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -312,7 +312,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -357,7 +357,7 @@ export const ListProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -392,7 +392,7 @@ export const DeleteProjectsLocationsWorkflowsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWorkflowsRequest>;
 
@@ -435,7 +435,7 @@ export const ListProjectsLocationsWorkflowsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/workflows" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/workflows" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkflowsRequest>;
 
@@ -470,7 +470,7 @@ export const GetProjectsLocationsWorkflowsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkflowsRequest>;
 
@@ -509,7 +509,7 @@ export const CreateProjectsLocationsWorkflowsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/workflows",
+      path: "v1beta/{+parent}/workflows",
       hasBody: true,
     }),
     svc,
@@ -548,7 +548,7 @@ export const PatchProjectsLocationsWorkflowsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Workflow).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsWorkflowsRequest>;
 

--- a/packages/gcp/src/services/workloadmanager-v1.ts
+++ b/packages/gcp/src/services/workloadmanager-v1.ts
@@ -2363,7 +2363,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -2408,7 +2408,7 @@ export const ListProjectsLocationsRequest =
       T.HttpQuery("extraLocationTypes"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -2443,7 +2443,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -2474,7 +2474,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -2508,7 +2508,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -2553,7 +2553,7 @@ export const ListProjectsLocationsOperationsRequest =
       T.HttpQuery("returnPartialSuccess"),
     ),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -2593,7 +2593,7 @@ export const WriteInsightProjectsLocationsInsightsRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{location}/insights:writeInsight",
+      path: "v1/{+location}/insights:writeInsight",
       hasBody: true,
     }),
     svc,
@@ -2630,7 +2630,7 @@ export const DeleteProjectsLocationsInsightsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsInsightsRequest>;
 
@@ -2673,7 +2673,7 @@ export const ListProjectsLocationsDeploymentsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/deployments" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/deployments" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeploymentsRequest>;
 
@@ -2708,7 +2708,7 @@ export const GetProjectsLocationsDeploymentsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeploymentsRequest>;
 
@@ -2750,7 +2750,7 @@ export const CreateProjectsLocationsDeploymentsRequest =
     ),
     body: Schema.optional(Deployment).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/deployments", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/deployments", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDeploymentsRequest>;
 
@@ -2784,7 +2784,7 @@ export const DeleteProjectsLocationsDeploymentsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDeploymentsRequest>;
 
@@ -2815,7 +2815,7 @@ export const GetProjectsLocationsDeploymentsActuationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDeploymentsActuationsRequest>;
 
@@ -2852,7 +2852,7 @@ export const CreateProjectsLocationsDeploymentsActuationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Actuation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/actuations", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/actuations", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsDeploymentsActuationsRequest>;
 
@@ -2883,7 +2883,7 @@ export const DeleteProjectsLocationsDeploymentsActuationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsDeploymentsActuationsRequest>;
 
@@ -2926,7 +2926,7 @@ export const ListProjectsLocationsDeploymentsActuationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/actuations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/actuations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDeploymentsActuationsRequest>;
 
@@ -2962,7 +2962,7 @@ export const GetProjectsLocationsDiscoveredprofilesRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDiscoveredprofilesRequest>;
 
@@ -3002,7 +3002,7 @@ export const ListProjectsLocationsDiscoveredprofilesRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/discoveredprofiles" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/discoveredprofiles" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsDiscoveredprofilesRequest>;
 
@@ -3038,7 +3038,7 @@ export const GetProjectsLocationsDiscoveredprofilesHealthRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsDiscoveredprofilesHealthRequest>;
 
@@ -3079,7 +3079,7 @@ export const PatchProjectsLocationsEvaluationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(Evaluation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsEvaluationsRequest>;
 
@@ -3122,7 +3122,7 @@ export const ListProjectsLocationsEvaluationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/evaluations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/evaluations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEvaluationsRequest>;
 
@@ -3157,7 +3157,7 @@ export const GetProjectsLocationsEvaluationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEvaluationsRequest>;
 
@@ -3199,7 +3199,7 @@ export const CreateProjectsLocationsEvaluationsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(Evaluation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/evaluations", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}/evaluations", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsEvaluationsRequest>;
 
@@ -3236,7 +3236,7 @@ export const DeleteProjectsLocationsEvaluationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     force: Schema.optional(Schema.Boolean).pipe(T.HttpQuery("force")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEvaluationsRequest>;
 
@@ -3267,7 +3267,7 @@ export const GetProjectsLocationsEvaluationsExecutionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsEvaluationsExecutionsRequest>;
 
@@ -3301,7 +3301,7 @@ export const DeleteProjectsLocationsEvaluationsExecutionsRequest =
     requestId: Schema.optional(Schema.String).pipe(T.HttpQuery("requestId")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsEvaluationsExecutionsRequest>;
 
@@ -3344,7 +3344,7 @@ export const ListProjectsLocationsEvaluationsExecutionsRequest =
     orderBy: Schema.optional(Schema.String).pipe(T.HttpQuery("orderBy")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/executions" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/executions" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEvaluationsExecutionsRequest>;
 
@@ -3383,7 +3383,11 @@ export const RunProjectsLocationsEvaluationsExecutionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(RunEvaluationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}/executions:run", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+name}/executions:run",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<RunProjectsLocationsEvaluationsExecutionsRequest>;
 
@@ -3423,7 +3427,7 @@ export const ListProjectsLocationsEvaluationsExecutionsResultsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/results" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/results" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEvaluationsExecutionsResultsRequest>;
 
@@ -3475,7 +3479,7 @@ export const ListProjectsLocationsEvaluationsExecutionsScannedResourcesRequest =
     rule: Schema.optional(Schema.String).pipe(T.HttpQuery("rule")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/scannedResources" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/scannedResources" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsEvaluationsExecutionsScannedResourcesRequest>;
 
@@ -3536,7 +3540,7 @@ export const ListProjectsLocationsRulesRequest =
     ),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/rules" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/rules" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRulesRequest>;
 

--- a/packages/gcp/src/services/workspaceevents-v1.ts
+++ b/packages/gcp/src/services/workspaceevents-v1.ts
@@ -505,7 +505,7 @@ export const PatchSubscriptionsRequest =
     updateMask: Schema.optional(Schema.String).pipe(T.HttpQuery("updateMask")),
     body: Schema.optional(Subscription).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchSubscriptionsRequest>;
 
@@ -538,7 +538,7 @@ export const ReactivateSubscriptionsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(ReactivateSubscriptionRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:reactivate", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:reactivate", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<ReactivateSubscriptionsRequest>;
 
@@ -569,7 +569,7 @@ export const GetSubscriptionsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetSubscriptionsRequest>;
 
@@ -649,7 +649,7 @@ export const DeleteSubscriptionsRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteSubscriptionsRequest>;
 
@@ -757,7 +757,7 @@ export const GetTasksRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.HttpQuery("historyLength"),
   ),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetTasksRequest>;
 
@@ -789,7 +789,7 @@ export const CancelTasksRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
   body: Schema.optional(CancelTaskRequest).pipe(T.HttpBody()),
 }).pipe(
-  T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+  T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
   svc,
 ) as unknown as Schema.Schema<CancelTasksRequest>;
 
@@ -821,7 +821,7 @@ export const SubscribeTasksRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   tenant: Schema.optional(Schema.String).pipe(T.HttpQuery("tenant")),
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}:subscribe" }),
+  T.Http({ method: "GET", path: "v1/{+name}:subscribe" }),
   svc,
 ) as unknown as Schema.Schema<SubscribeTasksRequest>;
 
@@ -855,7 +855,7 @@ export const GetTasksPushNotificationConfigsRequest =
     tenant: Schema.optional(Schema.String).pipe(T.HttpQuery("tenant")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetTasksPushNotificationConfigsRequest>;
 
@@ -896,7 +896,7 @@ export const ListTasksPushNotificationConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/pushNotificationConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/pushNotificationConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListTasksPushNotificationConfigsRequest>;
 
@@ -941,7 +941,7 @@ export const CreateTasksPushNotificationConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     body: Schema.optional(TaskPushNotificationConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+parent}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CreateTasksPushNotificationConfigsRequest>;
 
@@ -976,7 +976,7 @@ export const DeleteTasksPushNotificationConfigsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     tenant: Schema.optional(Schema.String).pipe(T.HttpQuery("tenant")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteTasksPushNotificationConfigsRequest>;
 
@@ -1006,7 +1006,7 @@ export interface GetOperationsRequest {
 export const GetOperationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   name: Schema.String.pipe(T.HttpPath("name")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/{name}" }),
+  T.Http({ method: "GET", path: "v1/{+name}" }),
   svc,
 ) as unknown as Schema.Schema<GetOperationsRequest>;
 

--- a/packages/gcp/src/services/workstations-v1.ts
+++ b/packages/gcp/src/services/workstations-v1.ts
@@ -989,7 +989,7 @@ export const ListProjectsLocationsRequest =
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/locations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/locations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsRequest>;
 
@@ -1024,7 +1024,7 @@ export const GetProjectsLocationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsRequest>;
 
@@ -1055,7 +1055,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1086,7 +1086,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1131,7 +1131,7 @@ export const ListProjectsLocationsOperationsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1169,7 +1169,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1215,7 +1215,7 @@ export const CreateProjectsLocationsWorkstationClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/workstationClusters",
+      path: "v1/{+parent}/workstationClusters",
       hasBody: true,
     }),
     svc,
@@ -1259,7 +1259,7 @@ export const DeleteProjectsLocationsWorkstationClustersRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWorkstationClustersRequest>;
 
@@ -1299,7 +1299,7 @@ export const ListProjectsLocationsWorkstationClustersRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/workstationClusters" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/workstationClusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkstationClustersRequest>;
 
@@ -1335,7 +1335,7 @@ export const GetProjectsLocationsWorkstationClustersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkstationClustersRequest>;
 
@@ -1383,7 +1383,7 @@ export const PatchProjectsLocationsWorkstationClustersRequest =
     ),
     body: Schema.optional(WorkstationCluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsWorkstationClustersRequest>;
 
@@ -1414,7 +1414,7 @@ export const GetProjectsLocationsWorkstationClustersWorkstationConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkstationClustersWorkstationConfigsRequest>;
 
@@ -1455,7 +1455,7 @@ export const ListUsableProjectsLocationsWorkstationClustersWorkstationConfigsReq
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1/{parent}/workstationConfigs:listUsable",
+      path: "v1/{+parent}/workstationConfigs:listUsable",
     }),
     svc,
   ) as unknown as Schema.Schema<ListUsableProjectsLocationsWorkstationClustersWorkstationConfigsRequest>;
@@ -1510,7 +1510,7 @@ export const CreateProjectsLocationsWorkstationClustersWorkstationConfigsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{parent}/workstationConfigs",
+      path: "v1/{+parent}/workstationConfigs",
       hasBody: true,
     }),
     svc,
@@ -1561,7 +1561,7 @@ export const PatchProjectsLocationsWorkstationClustersWorkstationConfigsRequest 
     ),
     body: Schema.optional(WorkstationConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsWorkstationClustersWorkstationConfigsRequest>;
 
@@ -1603,7 +1603,7 @@ export const ListProjectsLocationsWorkstationClustersWorkstationConfigsRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/workstationConfigs" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/workstationConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkstationClustersWorkstationConfigsRequest>;
 
@@ -1645,7 +1645,7 @@ export const GetIamPolicyProjectsLocationsWorkstationClustersWorkstationConfigsR
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsWorkstationClustersWorkstationConfigsRequest>;
 
@@ -1691,7 +1691,7 @@ export const DeleteProjectsLocationsWorkstationClustersWorkstationConfigsRequest
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWorkstationClustersWorkstationConfigsRequest>;
 
@@ -1729,7 +1729,7 @@ export const SetIamPolicyProjectsLocationsWorkstationClustersWorkstationConfigsR
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1771,7 +1771,7 @@ export const TestIamPermissionsProjectsLocationsWorkstationClustersWorkstationCo
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1817,7 +1817,7 @@ export const ListProjectsLocationsWorkstationClustersWorkstationConfigsWorkstati
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/workstations" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/workstations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkstationClustersWorkstationConfigsWorkstationsRequest>;
 
@@ -1861,7 +1861,7 @@ export const GetIamPolicyProjectsLocationsWorkstationClustersWorkstationConfigsW
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsWorkstationClustersWorkstationConfigsWorkstationsRequest>;
 
@@ -1904,7 +1904,7 @@ export const DeleteProjectsLocationsWorkstationClustersWorkstationConfigsWorksta
     ),
     etag: Schema.optional(Schema.String).pipe(T.HttpQuery("etag")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1/{name}" }),
+    T.Http({ method: "DELETE", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWorkstationClustersWorkstationConfigsWorkstationsRequest>;
 
@@ -1944,7 +1944,7 @@ export const SetIamPolicyProjectsLocationsWorkstationClustersWorkstationConfigsW
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:setIamPolicy",
+      path: "v1/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1986,7 +1986,7 @@ export const GenerateAccessTokenProjectsLocationsWorkstationClustersWorkstationC
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{workstation}:generateAccessToken",
+      path: "v1/{+workstation}:generateAccessToken",
       hasBody: true,
     }),
     svc,
@@ -2028,7 +2028,7 @@ export const TestIamPermissionsProjectsLocationsWorkstationClustersWorkstationCo
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1/{resource}:testIamPermissions",
+      path: "v1/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -2068,7 +2068,7 @@ export const StartProjectsLocationsWorkstationClustersWorkstationConfigsWorkstat
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StartWorkstationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsLocationsWorkstationClustersWorkstationConfigsWorkstationsRequest>;
 
@@ -2103,7 +2103,7 @@ export const GetProjectsLocationsWorkstationClustersWorkstationConfigsWorkstatio
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{name}" }),
+    T.Http({ method: "GET", path: "v1/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkstationClustersWorkstationConfigsWorkstationsRequest>;
 
@@ -2141,7 +2141,7 @@ export const StopProjectsLocationsWorkstationClustersWorkstationConfigsWorkstati
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopWorkstationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsWorkstationClustersWorkstationConfigsWorkstationsRequest>;
 
@@ -2182,7 +2182,7 @@ export const ListUsableProjectsLocationsWorkstationClustersWorkstationConfigsWor
     parent: Schema.String.pipe(T.HttpPath("parent")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1/{parent}/workstations:listUsable" }),
+    T.Http({ method: "GET", path: "v1/{+parent}/workstations:listUsable" }),
     svc,
   ) as unknown as Schema.Schema<ListUsableProjectsLocationsWorkstationClustersWorkstationConfigsWorkstationsRequest>;
 
@@ -2234,7 +2234,11 @@ export const CreateProjectsLocationsWorkstationClustersWorkstationConfigsWorksta
     ),
     body: Schema.optional(Workstation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1/{parent}/workstations", hasBody: true }),
+    T.Http({
+      method: "POST",
+      path: "v1/{+parent}/workstations",
+      hasBody: true,
+    }),
     svc,
   ) as unknown as Schema.Schema<CreateProjectsLocationsWorkstationClustersWorkstationConfigsWorkstationsRequest>;
 
@@ -2285,7 +2289,7 @@ export const PatchProjectsLocationsWorkstationClustersWorkstationConfigsWorkstat
     ),
     body: Schema.optional(Workstation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsWorkstationClustersWorkstationConfigsWorkstationsRequest>;
 

--- a/packages/gcp/src/services/workstations-v1beta.ts
+++ b/packages/gcp/src/services/workstations-v1beta.ts
@@ -1027,7 +1027,7 @@ export const GetProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsOperationsRequest>;
 
@@ -1072,7 +1072,7 @@ export const ListProjectsLocationsOperationsRequest =
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}/operations" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}/operations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsOperationsRequest>;
 
@@ -1110,7 +1110,7 @@ export const CancelProjectsLocationsOperationsRequest =
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(CancelOperationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:cancel", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:cancel", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<CancelProjectsLocationsOperationsRequest>;
 
@@ -1141,7 +1141,7 @@ export const DeleteProjectsLocationsOperationsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsOperationsRequest>;
 
@@ -1188,7 +1188,7 @@ export const PatchProjectsLocationsWorkstationClustersRequest =
     ),
     body: Schema.optional(WorkstationCluster).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsWorkstationClustersRequest>;
 
@@ -1228,7 +1228,7 @@ export const ListProjectsLocationsWorkstationClustersRequest =
     parent: Schema.String.pipe(T.HttpPath("parent")),
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/workstationClusters" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/workstationClusters" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkstationClustersRequest>;
 
@@ -1279,7 +1279,7 @@ export const CreateProjectsLocationsWorkstationClustersRequest =
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/workstationClusters",
+      path: "v1beta/{+parent}/workstationClusters",
       hasBody: true,
     }),
     svc,
@@ -1323,7 +1323,7 @@ export const DeleteProjectsLocationsWorkstationClustersRequest =
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWorkstationClustersRequest>;
 
@@ -1354,7 +1354,7 @@ export const GetProjectsLocationsWorkstationClustersRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkstationClustersRequest>;
 
@@ -1395,7 +1395,7 @@ export const ListProjectsLocationsWorkstationClustersWorkstationConfigsRequest =
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/workstationConfigs" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/workstationConfigs" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkstationClustersWorkstationConfigsRequest>;
 
@@ -1437,7 +1437,7 @@ export const GetIamPolicyProjectsLocationsWorkstationClustersWorkstationConfigsR
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsWorkstationClustersWorkstationConfigsRequest>;
 
@@ -1483,7 +1483,7 @@ export const DeleteProjectsLocationsWorkstationClustersWorkstationConfigsRequest
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWorkstationClustersWorkstationConfigsRequest>;
 
@@ -1521,7 +1521,7 @@ export const SetIamPolicyProjectsLocationsWorkstationClustersWorkstationConfigsR
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:setIamPolicy",
+      path: "v1beta/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1563,7 +1563,7 @@ export const TestIamPermissionsProjectsLocationsWorkstationClustersWorkstationCo
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:testIamPermissions",
+      path: "v1beta/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1608,7 +1608,7 @@ export const ListUsableProjectsLocationsWorkstationClustersWorkstationConfigsReq
   }).pipe(
     T.Http({
       method: "GET",
-      path: "v1beta/{parent}/workstationConfigs:listUsable",
+      path: "v1beta/{+parent}/workstationConfigs:listUsable",
     }),
     svc,
   ) as unknown as Schema.Schema<ListUsableProjectsLocationsWorkstationClustersWorkstationConfigsRequest>;
@@ -1663,7 +1663,7 @@ export const CreateProjectsLocationsWorkstationClustersWorkstationConfigsRequest
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/workstationConfigs",
+      path: "v1beta/{+parent}/workstationConfigs",
       hasBody: true,
     }),
     svc,
@@ -1698,7 +1698,7 @@ export const GetProjectsLocationsWorkstationClustersWorkstationConfigsRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkstationClustersWorkstationConfigsRequest>;
 
@@ -1747,7 +1747,7 @@ export const PatchProjectsLocationsWorkstationClustersWorkstationConfigsRequest 
     ),
     body: Schema.optional(WorkstationConfig).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsWorkstationClustersWorkstationConfigsRequest>;
 
@@ -1785,7 +1785,7 @@ export const GenerateAccessTokenProjectsLocationsWorkstationClustersWorkstationC
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{workstation}:generateAccessToken",
+      path: "v1beta/{+workstation}:generateAccessToken",
       hasBody: true,
     }),
     svc,
@@ -1827,7 +1827,7 @@ export const TestIamPermissionsProjectsLocationsWorkstationClustersWorkstationCo
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:testIamPermissions",
+      path: "v1beta/{+resource}:testIamPermissions",
       hasBody: true,
     }),
     svc,
@@ -1867,7 +1867,7 @@ export const StartProjectsLocationsWorkstationClustersWorkstationConfigsWorkstat
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StartWorkstationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:start", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:start", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StartProjectsLocationsWorkstationClustersWorkstationConfigsWorkstationsRequest>;
 
@@ -1910,7 +1910,7 @@ export const DeleteProjectsLocationsWorkstationClustersWorkstationConfigsWorksta
       T.HttpQuery("validateOnly"),
     ),
   }).pipe(
-    T.Http({ method: "DELETE", path: "v1beta/{name}" }),
+    T.Http({ method: "DELETE", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<DeleteProjectsLocationsWorkstationClustersWorkstationConfigsWorkstationsRequest>;
 
@@ -1950,7 +1950,7 @@ export const SetIamPolicyProjectsLocationsWorkstationClustersWorkstationConfigsW
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{resource}:setIamPolicy",
+      path: "v1beta/{+resource}:setIamPolicy",
       hasBody: true,
     }),
     svc,
@@ -1996,7 +1996,7 @@ export const ListProjectsLocationsWorkstationClustersWorkstationConfigsWorkstati
     filter: Schema.optional(Schema.String).pipe(T.HttpQuery("filter")),
     pageToken: Schema.optional(Schema.String).pipe(T.HttpQuery("pageToken")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/workstations" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/workstations" }),
     svc,
   ) as unknown as Schema.Schema<ListProjectsLocationsWorkstationClustersWorkstationConfigsWorkstationsRequest>;
 
@@ -2040,7 +2040,7 @@ export const GetIamPolicyProjectsLocationsWorkstationClustersWorkstationConfigsW
     ),
     resource: Schema.String.pipe(T.HttpPath("resource")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{resource}:getIamPolicy" }),
+    T.Http({ method: "GET", path: "v1beta/{+resource}:getIamPolicy" }),
     svc,
   ) as unknown as Schema.Schema<GetIamPolicyProjectsLocationsWorkstationClustersWorkstationConfigsWorkstationsRequest>;
 
@@ -2091,7 +2091,7 @@ export const PatchProjectsLocationsWorkstationClustersWorkstationConfigsWorkstat
     ),
     body: Schema.optional(Workstation).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "PATCH", path: "v1beta/{name}", hasBody: true }),
+    T.Http({ method: "PATCH", path: "v1beta/{+name}", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<PatchProjectsLocationsWorkstationClustersWorkstationConfigsWorkstationsRequest>;
 
@@ -2126,7 +2126,7 @@ export const GetProjectsLocationsWorkstationClustersWorkstationConfigsWorkstatio
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     name: Schema.String.pipe(T.HttpPath("name")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{name}" }),
+    T.Http({ method: "GET", path: "v1beta/{+name}" }),
     svc,
   ) as unknown as Schema.Schema<GetProjectsLocationsWorkstationClustersWorkstationConfigsWorkstationsRequest>;
 
@@ -2164,7 +2164,7 @@ export const StopProjectsLocationsWorkstationClustersWorkstationConfigsWorkstati
     name: Schema.String.pipe(T.HttpPath("name")),
     body: Schema.optional(StopWorkstationRequest).pipe(T.HttpBody()),
   }).pipe(
-    T.Http({ method: "POST", path: "v1beta/{name}:stop", hasBody: true }),
+    T.Http({ method: "POST", path: "v1beta/{+name}:stop", hasBody: true }),
     svc,
   ) as unknown as Schema.Schema<StopProjectsLocationsWorkstationClustersWorkstationConfigsWorkstationsRequest>;
 
@@ -2205,7 +2205,7 @@ export const ListUsableProjectsLocationsWorkstationClustersWorkstationConfigsWor
     pageSize: Schema.optional(Schema.Number).pipe(T.HttpQuery("pageSize")),
     parent: Schema.String.pipe(T.HttpPath("parent")),
   }).pipe(
-    T.Http({ method: "GET", path: "v1beta/{parent}/workstations:listUsable" }),
+    T.Http({ method: "GET", path: "v1beta/{+parent}/workstations:listUsable" }),
     svc,
   ) as unknown as Schema.Schema<ListUsableProjectsLocationsWorkstationClustersWorkstationConfigsWorkstationsRequest>;
 
@@ -2259,7 +2259,7 @@ export const CreateProjectsLocationsWorkstationClustersWorkstationConfigsWorksta
   }).pipe(
     T.Http({
       method: "POST",
-      path: "v1beta/{parent}/workstations",
+      path: "v1beta/{+parent}/workstations",
       hasBody: true,
     }),
     svc,

--- a/packages/gcp/src/services/youtubereporting-v1.ts
+++ b/packages/gcp/src/services/youtubereporting-v1.ts
@@ -501,7 +501,7 @@ export interface DownloadMediaRequest {
 export const DownloadMediaRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   resourceName: Schema.String.pipe(T.HttpPath("resourceName")),
 }).pipe(
-  T.Http({ method: "GET", path: "v1/media/{resourceName}" }),
+  T.Http({ method: "GET", path: "v1/media/{+resourceName}" }),
   svc,
 ) as unknown as Schema.Schema<DownloadMediaRequest>;
 

--- a/packages/gcp/test/base-url.test.ts
+++ b/packages/gcp/test/base-url.test.ts
@@ -1,0 +1,77 @@
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+import { describe, expect, it } from "vitest";
+import { Credentials } from "../src/credentials.ts";
+import * as crm from "../src/services/cloudresourcemanager-v3.ts";
+
+// Asserts the per-service `rootUrl` fallback resolves the full
+// request URL, captured via a mock `HttpClient`.
+
+const fakeCredentials = Layer.succeed(Credentials, {
+  accessToken: Redacted.make("ya29.fake-test-token"),
+  project: "fake-test-project",
+});
+
+const captureUrl = (sink: {
+  url?: string;
+}): Layer.Layer<HttpClient.HttpClient> =>
+  Layer.succeed(
+    HttpClient.HttpClient,
+    HttpClient.make((request) => {
+      sink.url = request.url;
+      return Effect.succeed(
+        HttpClientResponse.fromWeb(
+          request,
+          new Response("{}", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        ),
+      );
+    }),
+  );
+
+describe("GCP base URL resolution", () => {
+  it("prepends Service.rootUrl to the resolved path on getProjects", async () => {
+    const sink: { url?: string } = {};
+
+    const program = Effect.gen(function* () {
+      const getProjects = yield* crm.getProjects;
+      yield* getProjects({ name: "projects/my-project" });
+    });
+
+    await Effect.runPromise(
+      program.pipe(
+        Effect.provide(captureUrl(sink)),
+        Effect.provide(fakeCredentials),
+      ),
+    );
+
+    expect(sink.url).toBe(
+      "https://cloudresourcemanager.googleapis.com/v3/projects/my-project",
+    );
+  });
+
+  it("prepends Service.rootUrl on deleteProjects too", async () => {
+    const sink: { url?: string } = {};
+
+    const program = Effect.gen(function* () {
+      const deleteProjects = yield* crm.deleteProjects;
+      yield* deleteProjects({ name: "projects/my-project" });
+    });
+
+    await Effect.runPromise(
+      program.pipe(
+        Effect.provide(captureUrl(sink)),
+        Effect.provide(fakeCredentials),
+      ),
+    );
+
+    expect(sink.url).toBe(
+      "https://cloudresourcemanager.googleapis.com/v3/projects/my-project",
+    );
+  });
+});

--- a/packages/gcp/test/path-substitution.test.ts
+++ b/packages/gcp/test/path-substitution.test.ts
@@ -1,60 +1,44 @@
+import { buildRequestParts, getHttpTrait } from "@distilled.cloud/core/traits";
 import { describe, expect, it } from "vitest";
 import {
-  buildRequestParts,
-  getHttpTrait,
-} from "@distilled.cloud/core/traits";
-import {
-  GetProjectsRequest,
   DeleteProjectsRequest,
+  GetProjectsRequest,
 } from "../src/services/cloudresourcemanager-v3.ts";
 
-/**
- * Regression tests for the `flatPath` vs `path` mismatch in the GCP
- * generator. Discovery Documents publish two URL forms per method —
- * `path` (with RFC 6570 reserved-expansion variables, e.g. `v3/{+name}`)
- * and `flatPath` (used purely for documentation, e.g.
- * `v3/projects/{projectsId}`). The generator must emit URL templates
- * whose variable names match the `T.HttpPath(<name>)` annotations on the
- * request schema, otherwise `buildRequestParts` cannot substitute the
- * placeholder and the request URL is left malformed.
- *
- * These tests assert path resolution at the trait level — no live HTTP.
- */
+// Pins `T.HttpPath` substitution on real generated GCP services. No
+// live HTTP — assertions are at the trait level.
 describe("GCP HTTP path template substitution", () => {
-  it("substitutes {name} for cloudresourcemanager.getProjects", () => {
+  it("getProjects: `/` inside `name` is preserved on the wire", () => {
     const ast = (GetProjectsRequest as unknown as { ast: any }).ast;
     const trait = getHttpTrait(ast);
     expect(trait).toBeDefined();
 
     const parts = buildRequestParts(ast, trait!, {
-      name: "projects/microagi-research",
+      name: "projects/my-project",
     });
 
-    // The resolved path must NOT still contain a `{...}` placeholder.
-    expect(parts.path).not.toMatch(/\{[^}]+\}/);
-
-    // GCP REST accepts `%2F` as equivalent to `/` in resource-name
-    // path segments — both forms are acceptable as long as the
-    // template variable was substituted.
-    expect([
-      "v3/projects/microagi-research",
-      "v3/projects%2Fmicroagi-research",
-    ]).toContain(parts.path);
+    expect(parts.path).toBe("v3/projects/my-project");
   });
 
-  it("substitutes {name} for cloudresourcemanager.deleteProjects", () => {
+  it("deleteProjects: `/` inside `name` is preserved on the wire", () => {
     const ast = (DeleteProjectsRequest as unknown as { ast: any }).ast;
     const trait = getHttpTrait(ast);
     expect(trait).toBeDefined();
 
     const parts = buildRequestParts(ast, trait!, {
-      name: "projects/microagi-research",
+      name: "projects/my-project",
     });
 
-    expect(parts.path).not.toMatch(/\{[^}]+\}/);
-    expect([
-      "v3/projects/microagi-research",
-      "v3/projects%2Fmicroagi-research",
-    ]).toContain(parts.path);
+    expect(parts.path).toBe("v3/projects/my-project");
+  });
+
+  it("non-reserved characters in `name` are still percent-encoded", () => {
+    const ast = (GetProjectsRequest as unknown as { ast: any }).ast;
+    const trait = getHttpTrait(ast);
+    const parts = buildRequestParts(ast, trait!, {
+      name: "projects/with space",
+    });
+
+    expect(parts.path).toBe("v3/projects/with%20space");
   });
 });


### PR DESCRIPTION
After #260 every read-by-name request from `@distilled.cloud/gcp` still fails — but with a different error than before. Two distinct gaps surface, and they share enough structure to fix as one PR.

```
error: InvalidUrl error (GET v3/projects%2Falchemy-test-rpilvq)
       _tag: "HttpClientError"
  request: { method: "GET", url: "v3/projects%2Falchemy-test-rpilvq", ... }
```

Both failure signatures are visible in that one URL: `v3/projects%2F...` (slash percent-encoded) and no `https://cloudresourcemanager.googleapis.com/` prefix.

### Gap 1 — `T.Service.rootUrl` is never applied

`packages/core/src/client.ts` only consulted `config.getBaseUrl(creds)`. GCP's `makeAPI` config returns `""` (hosts vary per service, not per credentials) and instead declares the host on the service trait:

```ts
// packages/gcp/src/services/cloudresourcemanager-v3.ts
const svc = T.Service({
  name: "cloudresourcemanager",
  version: "v3",
  rootUrl: "https://cloudresourcemanager.googleapis.com/",
  servicePath: "",
});
```

The trait shape (`packages/core/src/traits.ts:384`) and the accessor (`getServiceTrait`) already exist — `client.ts` just never read them. Result: the resolved URL was a bare relative path and `effect/unstable/http/HttpClient` rejected it as `ERR_INVALID_URL`.

### Gap 2 — `{+name}` reserved-expansion regressed to `{name}`

#260 fixed flatPath/path mismatches by stripping `{+name}` to `{name}` in the generator so a single `path.replace(\`{${name}}\`, encodeURIComponent(value))` call would substitute. But `encodeURIComponent` percent-encodes `/` — and GCP discovery documents use `{+name}` precisely because the value (`projects/foo`) contains `/` that must stay literal under RFC 6570 §3.2.3 reserved-expansion.

#260's regression test masked this:

```ts
expect([
  "v3/projects/microagi-research",
  "v3/projects%2Fmicroagi-research",
]).toContain(parts.path);
```

Either form passed; the implementation produced the second; nobody noticed.

### Why one PR

The two fixes compose: stop stripping `{+name}` (generator), recognise it (core), and prepend the per-service host (core). Each piece is no use without the other two on the GCP path.

### Changes

- `core/src/traits.ts`: `buildRequestParts` recognises `{+name}` and substitutes via a new `encodeReserved` helper that preserves RFC 3986 reserved + unreserved characters; falls back to `encodeURIComponent` for plain `{name}`. Pure addition — simple expansion is unchanged.
- `core/src/client.ts`: when `config.getBaseUrl(creds)` is empty, fall back to `Traits.getServiceTrait(inputSchema.ast).rootUrl + servicePath`. Single declaration; both the request-build site and the paginated branch share it.
- `gcp/scripts/generate.ts`: emit `method.path` verbatim. Drop `stripReservedExpansion`.
- `gcp/src/services/*.ts`: regenerated. Mechanical churn — every operation that addresses a resource by name moves from `path: "v3/{name}"` to `path: "v3/{+name}"` (~417 files).
- `gcp/src/client/api.ts`: tighten the misleading "via Http trait" comment ("via Service trait"). Behaviour unchanged.

```diff
-const baseUrl = config.getBaseUrl(creds as ResolvedCreds);
+let baseUrl = config.getBaseUrl(creds as ResolvedCreds);
+if (!baseUrl) {
+  const svcTrait = Traits.getServiceTrait(inputSchema.ast);
+  if (svcTrait?.rootUrl) {
+    baseUrl = svcTrait.rootUrl + (svcTrait.servicePath ?? "");
+  }
+}
```

### Tests

- `packages/core/test/build-request-parts.test.ts` (new): pins `{+name}` preserves `/`, `{name}` encodes `/`, `{+name}` still encodes whitespace, and a fully-reserved value round-trips literally. Synthetic schemas — no GCP dependency.
- `packages/gcp/test/path-substitution.test.ts` (rewritten): drops the permissive `expect([..., "%2F..."]).toContain(parts.path)` form. Asserts the literal-`/` form exactly on real `getProjects` / `deleteProjects`. Adds a whitespace case.
- `packages/gcp/test/base-url.test.ts` (new): mocks `HttpClient.HttpClient`, captures the outgoing request URL, and asserts `getProjects` / `deleteProjects` resolve to `https://cloudresourcemanager.googleapis.com/v3/projects/<name>`. End-to-end regression for both gaps without a network call.

### Why other distilled SDKs are unaffected

- AWS bypasses `core.makeAPI` entirely (per-region/per-service endpoint resolution via Smithy rules).
- Cloudflare's `getBaseUrl(creds)` returns `creds.apiBaseUrl` — non-empty — so the rootUrl fallback never runs. `{+name}` doesn't appear in Cloudflare's specs.
- Verified locally: typecheck clean for `aws`, `cloudflare`, `neon`, `planetscale`, `axiom`, `stripe`, `supabase`, `fly-io`, `coinbase` against the modified `core`.

### Verification

```
bun --filter '@distilled.cloud/core' run test  →  39 passed
bun --filter '@distilled.cloud/gcp'  run test  →   5 passed
bun --filter '@distilled.cloud/{core,gcp}' run check  →  clean
```

End-to-end against live GCP using a downstream consumer (`alchemy-v2-gcp`):

```
cd vendor/alchemy-v2-gcp && CI=1 bun test test/CloudResourceManager/Project.test.ts
```
