### PR TITLE
fix(gcp): typed 4xx errors for container v1 cluster + node pool operations

### DIFF
--- a/packages/gcp/patches/container/createProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/createProjectsLocationsClusters.json
@@ -1,0 +1,7 @@
+{
+  "errors": {
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/createProjectsLocationsClustersNodePools.json
+++ b/packages/gcp/patches/container/createProjectsLocationsClustersNodePools.json
@@ -1,0 +1,7 @@
+{
+  "errors": {
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/deleteProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/deleteProjectsLocationsClusters.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/deleteProjectsLocationsClustersNodePools.json
+++ b/packages/gcp/patches/container/deleteProjectsLocationsClustersNodePools.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/getProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/getProjectsLocationsClusters.json
@@ -1,0 +1,6 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "Forbidden": [{ "httpStatus": 403 }]
+  }
+}

--- a/packages/gcp/patches/container/getProjectsLocationsClustersNodePools.json
+++ b/packages/gcp/patches/container/getProjectsLocationsClustersNodePools.json
@@ -1,0 +1,6 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "Forbidden": [{ "httpStatus": 403 }]
+  }
+}

--- a/packages/gcp/patches/container/getProjectsLocationsOperations.json
+++ b/packages/gcp/patches/container/getProjectsLocationsOperations.json
@@ -1,0 +1,6 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "Forbidden": [{ "httpStatus": 403 }]
+  }
+}

--- a/packages/gcp/patches/container/setAddonsProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/setAddonsProjectsLocationsClusters.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/setAutoscalingProjectsLocationsClustersNodePools.json
+++ b/packages/gcp/patches/container/setAutoscalingProjectsLocationsClustersNodePools.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/setLegacyAbacProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/setLegacyAbacProjectsLocationsClusters.json
@@ -1,0 +1,7 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }]
+  }
+}

--- a/packages/gcp/patches/container/setLocationsProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/setLocationsProjectsLocationsClusters.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/setLoggingProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/setLoggingProjectsLocationsClusters.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/setMaintenancePolicyProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/setMaintenancePolicyProjectsLocationsClusters.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/setManagementProjectsLocationsClustersNodePools.json
+++ b/packages/gcp/patches/container/setManagementProjectsLocationsClustersNodePools.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/setMasterAuthProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/setMasterAuthProjectsLocationsClusters.json
@@ -1,0 +1,7 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }]
+  }
+}

--- a/packages/gcp/patches/container/setMonitoringProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/setMonitoringProjectsLocationsClusters.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/setNetworkPolicyProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/setNetworkPolicyProjectsLocationsClusters.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/setResourceLabelsProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/setResourceLabelsProjectsLocationsClusters.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/setSizeProjectsLocationsClustersNodePools.json
+++ b/packages/gcp/patches/container/setSizeProjectsLocationsClustersNodePools.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/updateProjectsLocationsClusters.json
+++ b/packages/gcp/patches/container/updateProjectsLocationsClusters.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/patches/container/updateProjectsLocationsClustersNodePools.json
+++ b/packages/gcp/patches/container/updateProjectsLocationsClustersNodePools.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "NotFound": [{ "httpStatus": 404 }],
+    "BadRequest": [{ "httpStatus": 400 }],
+    "Forbidden": [{ "httpStatus": 403 }],
+    "Conflict": [{ "httpStatus": 409 }]
+  }
+}

--- a/packages/gcp/src/services/container-v1.ts
+++ b/packages/gcp/src/services/container-v1.ts
@@ -5053,6 +5053,52 @@ export const SetMonitoringServiceRequest =
   }).annotate({ identifier: "SetMonitoringServiceRequest" });
 
 // ==========================================================================
+// Errors
+// ==========================================================================
+
+export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
+  code: Schema.optional(Schema.Number),
+  message: Schema.String,
+  status: Schema.optional(Schema.String),
+  reason: Schema.optional(Schema.String),
+  domain: Schema.optional(Schema.String),
+}) {}
+T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
+
+export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
+  "BadRequest",
+  {
+    code: Schema.optional(Schema.Number),
+    message: Schema.String,
+    status: Schema.optional(Schema.String),
+    reason: Schema.optional(Schema.String),
+    domain: Schema.optional(Schema.String),
+  },
+) {}
+T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
+
+export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
+  "Forbidden",
+  {
+    code: Schema.optional(Schema.Number),
+    message: Schema.String,
+    status: Schema.optional(Schema.String),
+    reason: Schema.optional(Schema.String),
+    domain: Schema.optional(Schema.String),
+  },
+) {}
+T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
+
+export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
+  code: Schema.optional(Schema.Number),
+  message: Schema.String,
+  status: Schema.optional(Schema.String),
+  reason: Schema.optional(Schema.String),
+  domain: Schema.optional(Schema.String),
+}) {}
+T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
+
+// ==========================================================================
 // Operations
 // ==========================================================================
 
@@ -5158,7 +5204,12 @@ export type SetAddonsProjectsLocationsClustersResponse = Operation;
 export const SetAddonsProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetAddonsProjectsLocationsClustersError = DefaultErrors;
+export type SetAddonsProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Sets the addons for a specific cluster. */
 export const setAddonsProjectsLocationsClusters: API.OperationMethod<
@@ -5169,7 +5220,7 @@ export const setAddonsProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetAddonsProjectsLocationsClustersRequest,
   output: SetAddonsProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface SetMasterAuthProjectsLocationsClustersRequest {
@@ -5192,7 +5243,11 @@ export type SetMasterAuthProjectsLocationsClustersResponse = Operation;
 export const SetMasterAuthProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetMasterAuthProjectsLocationsClustersError = DefaultErrors;
+export type SetMasterAuthProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden;
 
 /** Sets master auth materials. Currently supports changing the admin password or a specific cluster, either via password generation or explicitly setting the password. */
 export const setMasterAuthProjectsLocationsClusters: API.OperationMethod<
@@ -5203,7 +5258,7 @@ export const setMasterAuthProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetMasterAuthProjectsLocationsClustersRequest,
   output: SetMasterAuthProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden],
 }));
 
 export interface SetMonitoringProjectsLocationsClustersRequest {
@@ -5226,7 +5281,12 @@ export type SetMonitoringProjectsLocationsClustersResponse = Operation;
 export const SetMonitoringProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetMonitoringProjectsLocationsClustersError = DefaultErrors;
+export type SetMonitoringProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Sets the monitoring service for a specific cluster. */
 export const setMonitoringProjectsLocationsClusters: API.OperationMethod<
@@ -5237,7 +5297,7 @@ export const setMonitoringProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetMonitoringProjectsLocationsClustersRequest,
   output: SetMonitoringProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface SetResourceLabelsProjectsLocationsClustersRequest {
@@ -5264,7 +5324,12 @@ export type SetResourceLabelsProjectsLocationsClustersResponse = Operation;
 export const SetResourceLabelsProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetResourceLabelsProjectsLocationsClustersError = DefaultErrors;
+export type SetResourceLabelsProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Sets labels on a cluster. */
 export const setResourceLabelsProjectsLocationsClusters: API.OperationMethod<
@@ -5275,7 +5340,7 @@ export const setResourceLabelsProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetResourceLabelsProjectsLocationsClustersRequest,
   output: SetResourceLabelsProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface SetLocationsProjectsLocationsClustersRequest {
@@ -5298,7 +5363,12 @@ export type SetLocationsProjectsLocationsClustersResponse = Operation;
 export const SetLocationsProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetLocationsProjectsLocationsClustersError = DefaultErrors;
+export type SetLocationsProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Sets the locations for a specific cluster. Deprecated. Use [projects.locations.clusters.update](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters/update) instead. */
 export const setLocationsProjectsLocationsClusters: API.OperationMethod<
@@ -5309,7 +5379,7 @@ export const setLocationsProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetLocationsProjectsLocationsClustersRequest,
   output: SetLocationsProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface GetProjectsLocationsClustersRequest {
@@ -5338,7 +5408,10 @@ export type GetProjectsLocationsClustersResponse = Cluster;
 export const GetProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Cluster;
 
-export type GetProjectsLocationsClustersError = DefaultErrors;
+export type GetProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | Forbidden;
 
 /** Gets the details of a specific cluster. */
 export const getProjectsLocationsClusters: API.OperationMethod<
@@ -5349,7 +5422,7 @@ export const getProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetProjectsLocationsClustersRequest,
   output: GetProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, Forbidden],
 }));
 
 export interface FetchClusterUpgradeInfoProjectsLocationsClustersRequest {
@@ -5408,7 +5481,11 @@ export type CreateProjectsLocationsClustersResponse = Operation;
 export const CreateProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type CreateProjectsLocationsClustersError = DefaultErrors;
+export type CreateProjectsLocationsClustersError =
+  | DefaultErrors
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Creates a cluster, consisting of the specified number and type of Google Compute Engine instances. By default, the cluster is created in the project's [default network](https://cloud.google.com/compute/docs/networks-and-firewalls#networks). One firewall is added for the cluster. After cluster creation, the kubelet creates routes for each node to allow the containers on that node to communicate with all other instances in the cluster. Finally, an entry is added to the project's global metadata indicating which CIDR range the cluster is using. */
 export const createProjectsLocationsClusters: API.OperationMethod<
@@ -5419,7 +5496,7 @@ export const createProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: CreateProjectsLocationsClustersRequest,
   output: CreateProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [BadRequest, Forbidden, Conflict],
 }));
 
 export interface ListProjectsLocationsClustersRequest {
@@ -5485,7 +5562,12 @@ export type DeleteProjectsLocationsClustersResponse = Operation;
 export const DeleteProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type DeleteProjectsLocationsClustersError = DefaultErrors;
+export type DeleteProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Deletes the cluster, including the Kubernetes endpoint and all worker nodes. Firewalls and routes that were configured during cluster creation are also deleted. Other Google Compute Engine resources that might be in use by the cluster, such as load balancer resources, are not deleted if they weren't present when the cluster was initially created. */
 export const deleteProjectsLocationsClusters: API.OperationMethod<
@@ -5496,7 +5578,7 @@ export const deleteProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: DeleteProjectsLocationsClustersRequest,
   output: DeleteProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface CheckAutopilotCompatibilityProjectsLocationsClustersRequest {
@@ -5556,7 +5638,12 @@ export type SetNetworkPolicyProjectsLocationsClustersResponse = Operation;
 export const SetNetworkPolicyProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetNetworkPolicyProjectsLocationsClustersError = DefaultErrors;
+export type SetNetworkPolicyProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Enables or disables Network Policy for a cluster. */
 export const setNetworkPolicyProjectsLocationsClusters: API.OperationMethod<
@@ -5567,7 +5654,7 @@ export const setNetworkPolicyProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetNetworkPolicyProjectsLocationsClustersRequest,
   output: SetNetworkPolicyProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface CompleteIpRotationProjectsLocationsClustersRequest {
@@ -5628,7 +5715,12 @@ export type SetLoggingProjectsLocationsClustersResponse = Operation;
 export const SetLoggingProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetLoggingProjectsLocationsClustersError = DefaultErrors;
+export type SetLoggingProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Sets the logging service for a specific cluster. */
 export const setLoggingProjectsLocationsClusters: API.OperationMethod<
@@ -5639,7 +5731,7 @@ export const setLoggingProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetLoggingProjectsLocationsClustersRequest,
   output: SetLoggingProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface UpdateProjectsLocationsClustersRequest {
@@ -5662,7 +5754,12 @@ export type UpdateProjectsLocationsClustersResponse = Operation;
 export const UpdateProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type UpdateProjectsLocationsClustersError = DefaultErrors;
+export type UpdateProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Updates the settings of a specific cluster. */
 export const updateProjectsLocationsClusters: API.OperationMethod<
@@ -5673,7 +5770,7 @@ export const updateProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: UpdateProjectsLocationsClustersRequest,
   output: UpdateProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface GetJwksProjectsLocationsClustersRequest {
@@ -5765,7 +5862,12 @@ export type SetMaintenancePolicyProjectsLocationsClustersResponse = Operation;
 export const SetMaintenancePolicyProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetMaintenancePolicyProjectsLocationsClustersError = DefaultErrors;
+export type SetMaintenancePolicyProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Sets the maintenance policy for a cluster. */
 export const setMaintenancePolicyProjectsLocationsClusters: API.OperationMethod<
@@ -5776,7 +5878,7 @@ export const setMaintenancePolicyProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetMaintenancePolicyProjectsLocationsClustersRequest,
   output: SetMaintenancePolicyProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface StartIpRotationProjectsLocationsClustersRequest {
@@ -5837,7 +5939,11 @@ export type SetLegacyAbacProjectsLocationsClustersResponse = Operation;
 export const SetLegacyAbacProjectsLocationsClustersResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetLegacyAbacProjectsLocationsClustersError = DefaultErrors;
+export type SetLegacyAbacProjectsLocationsClustersError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden;
 
 /** Enables or disables the ABAC authorization mechanism on a cluster. */
 export const setLegacyAbacProjectsLocationsClusters: API.OperationMethod<
@@ -5848,7 +5954,7 @@ export const setLegacyAbacProjectsLocationsClusters: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetLegacyAbacProjectsLocationsClustersRequest,
   output: SetLegacyAbacProjectsLocationsClustersResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden],
 }));
 
 export interface GetProjectsLocationsClustersNodePoolsRequest {
@@ -5880,7 +5986,10 @@ export type GetProjectsLocationsClustersNodePoolsResponse = NodePool;
 export const GetProjectsLocationsClustersNodePoolsResponse =
   /*@__PURE__*/ /*#__PURE__*/ NodePool;
 
-export type GetProjectsLocationsClustersNodePoolsError = DefaultErrors;
+export type GetProjectsLocationsClustersNodePoolsError =
+  | DefaultErrors
+  | NotFound
+  | Forbidden;
 
 /** Retrieves the requested node pool. */
 export const getProjectsLocationsClustersNodePools: API.OperationMethod<
@@ -5891,7 +6000,7 @@ export const getProjectsLocationsClustersNodePools: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetProjectsLocationsClustersNodePoolsRequest,
   output: GetProjectsLocationsClustersNodePoolsResponse,
-  errors: [],
+  errors: [NotFound, Forbidden],
 }));
 
 export interface UpdateProjectsLocationsClustersNodePoolsRequest {
@@ -5914,7 +6023,12 @@ export type UpdateProjectsLocationsClustersNodePoolsResponse = Operation;
 export const UpdateProjectsLocationsClustersNodePoolsResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type UpdateProjectsLocationsClustersNodePoolsError = DefaultErrors;
+export type UpdateProjectsLocationsClustersNodePoolsError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Updates the version and/or image type for the specified node pool. */
 export const updateProjectsLocationsClustersNodePools: API.OperationMethod<
@@ -5925,7 +6039,7 @@ export const updateProjectsLocationsClustersNodePools: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: UpdateProjectsLocationsClustersNodePoolsRequest,
   output: UpdateProjectsLocationsClustersNodePoolsResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface CreateProjectsLocationsClustersNodePoolsRequest {
@@ -5948,7 +6062,11 @@ export type CreateProjectsLocationsClustersNodePoolsResponse = Operation;
 export const CreateProjectsLocationsClustersNodePoolsResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type CreateProjectsLocationsClustersNodePoolsError = DefaultErrors;
+export type CreateProjectsLocationsClustersNodePoolsError =
+  | DefaultErrors
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Creates a node pool for a cluster. */
 export const createProjectsLocationsClustersNodePools: API.OperationMethod<
@@ -5959,7 +6077,7 @@ export const createProjectsLocationsClustersNodePools: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: CreateProjectsLocationsClustersNodePoolsRequest,
   output: CreateProjectsLocationsClustersNodePoolsResponse,
-  errors: [],
+  errors: [BadRequest, Forbidden, Conflict],
 }));
 
 export interface SetManagementProjectsLocationsClustersNodePoolsRequest {
@@ -5983,7 +6101,11 @@ export const SetManagementProjectsLocationsClustersNodePoolsResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
 export type SetManagementProjectsLocationsClustersNodePoolsError =
-  DefaultErrors;
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Sets the NodeManagement options for a node pool. */
 export const setManagementProjectsLocationsClustersNodePools: API.OperationMethod<
@@ -5994,7 +6116,7 @@ export const setManagementProjectsLocationsClustersNodePools: API.OperationMetho
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetManagementProjectsLocationsClustersNodePoolsRequest,
   output: SetManagementProjectsLocationsClustersNodePoolsResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface ListProjectsLocationsClustersNodePoolsRequest {
@@ -6128,7 +6250,12 @@ export type SetSizeProjectsLocationsClustersNodePoolsResponse = Operation;
 export const SetSizeProjectsLocationsClustersNodePoolsResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type SetSizeProjectsLocationsClustersNodePoolsError = DefaultErrors;
+export type SetSizeProjectsLocationsClustersNodePoolsError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Sets the size for a specific node pool. The new size will be used for all replicas, including future replicas created by modifying NodePool.locations. */
 export const setSizeProjectsLocationsClustersNodePools: API.OperationMethod<
@@ -6139,7 +6266,7 @@ export const setSizeProjectsLocationsClustersNodePools: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetSizeProjectsLocationsClustersNodePoolsRequest,
   output: SetSizeProjectsLocationsClustersNodePoolsResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface DeleteProjectsLocationsClustersNodePoolsRequest {
@@ -6171,7 +6298,12 @@ export type DeleteProjectsLocationsClustersNodePoolsResponse = Operation;
 export const DeleteProjectsLocationsClustersNodePoolsResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type DeleteProjectsLocationsClustersNodePoolsError = DefaultErrors;
+export type DeleteProjectsLocationsClustersNodePoolsError =
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Deletes a node pool from a cluster. */
 export const deleteProjectsLocationsClustersNodePools: API.OperationMethod<
@@ -6182,7 +6314,7 @@ export const deleteProjectsLocationsClustersNodePools: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: DeleteProjectsLocationsClustersNodePoolsRequest,
   output: DeleteProjectsLocationsClustersNodePoolsResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface CompleteUpgradeProjectsLocationsClustersNodePoolsRequest {
@@ -6246,7 +6378,11 @@ export const SetAutoscalingProjectsLocationsClustersNodePoolsResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
 export type SetAutoscalingProjectsLocationsClustersNodePoolsError =
-  DefaultErrors;
+  | DefaultErrors
+  | NotFound
+  | BadRequest
+  | Forbidden
+  | Conflict;
 
 /** Sets the autoscaling settings for the specified node pool. */
 export const setAutoscalingProjectsLocationsClustersNodePools: API.OperationMethod<
@@ -6257,7 +6393,7 @@ export const setAutoscalingProjectsLocationsClustersNodePools: API.OperationMeth
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: SetAutoscalingProjectsLocationsClustersNodePoolsRequest,
   output: SetAutoscalingProjectsLocationsClustersNodePoolsResponse,
-  errors: [],
+  errors: [NotFound, BadRequest, Forbidden, Conflict],
 }));
 
 export interface GetOpenid_configurationProjectsLocationsClustersWell_knownRequest {
@@ -6395,7 +6531,10 @@ export type GetProjectsLocationsOperationsResponse = Operation;
 export const GetProjectsLocationsOperationsResponse =
   /*@__PURE__*/ /*#__PURE__*/ Operation;
 
-export type GetProjectsLocationsOperationsError = DefaultErrors;
+export type GetProjectsLocationsOperationsError =
+  | DefaultErrors
+  | NotFound
+  | Forbidden;
 
 /** Gets the specified operation. */
 export const getProjectsLocationsOperations: API.OperationMethod<
@@ -6406,7 +6545,7 @@ export const getProjectsLocationsOperations: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetProjectsLocationsOperationsRequest,
   output: GetProjectsLocationsOperationsResponse,
-  errors: [],
+  errors: [NotFound, Forbidden],
 }));
 
 export interface GetServerconfigProjectsZonesRequest {


### PR DESCRIPTION
Adds per-operation error patches for container v1, mirroring the cloudresourcemanager v3 work in #258 so GKE cluster + node-pool calls return typed 4xx errors instead of `UnknownError`.

Covers 21 endpoints: cluster get/create/update/delete, cluster setters (`setLocations`, `setMaintenancePolicy`, `setLegacyAbac`, `setMasterAuth`, `setNetworkPolicy`, `setAddons`, `setResourceLabels`, `setLogging`, `setMonitoring`), node-pool get/create/update/delete, node-pool setters (`setSize`, `setAutoscaling`, `setManagement`), and `getProjectsLocationsOperations`.

Status mappings:

- `404 → NotFound` on every operation that addresses a specific resource
- `400 → BadRequest` on every mutating operation (validation failures)
- `403 → Forbidden` everywhere
- `409 → Conflict` on mutating operations (concurrent modification, state transitions)

Reads are kept narrow (`NotFound` + `Forbidden`); creates omit `NotFound` since the parent project is the addressed resource (already typed via the `cloudresourcemanager` patches).

Caller-side example:

```diff
 yield* getProjectsLocationsClusters({ name }).pipe(
-  Effect.catch(() => Effect.succeed(undefined)),
+  Effect.catch("NotFound", () => Effect.succeed(undefined)),
+  Effect.catch("Forbidden", () => Effect.succeed(undefined)),
 );
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
