### PR TITLE
fix: make effect a peer dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,6 @@
         "@smithy/types": "catalog:",
         "@smithy/util-base64": "catalog:",
         "aws4fetch": "catalog:",
-        "effect": "catalog:",
         "fast-xml-parser": "catalog:",
       },
       "devDependencies": {
@@ -57,7 +56,6 @@
       "version": "0.16.9",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -74,7 +72,6 @@
       "version": "0.16.9",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -91,7 +88,6 @@
       "version": "0.16.9",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@effect/platform-node": "catalog:",
@@ -111,7 +107,6 @@
       "version": "0.16.9",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -127,9 +122,6 @@
     "packages/core": {
       "name": "@distilled.cloud/core",
       "version": "0.16.9",
-      "dependencies": {
-        "effect": "catalog:",
-      },
       "devDependencies": {
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
@@ -145,7 +137,6 @@
       "version": "0.16.9",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -162,7 +153,6 @@
       "version": "0.16.9",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -179,7 +169,6 @@
       "version": "0.16.9",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -196,7 +185,6 @@
       "version": "0.16.9",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -213,7 +201,6 @@
       "version": "0.16.9",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -230,7 +217,6 @@
       "version": "0.16.9",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -247,7 +233,6 @@
       "version": "0.16.9",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -264,7 +249,6 @@
       "version": "0.16.9",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@effect/platform-node": "catalog:",
@@ -283,7 +267,6 @@
       "version": "0.16.9",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -300,7 +283,6 @@
       "version": "0.16.9",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -317,7 +299,6 @@
       "version": "0.16.9",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -334,7 +315,6 @@
       "version": "0.16.9",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -351,7 +331,6 @@
       "version": "0.16.9",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -369,7 +348,6 @@
       "version": "0.16.9",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -87,7 +87,6 @@
     "@smithy/types": "catalog:",
     "@smithy/util-base64": "catalog:",
     "aws4fetch": "catalog:",
-    "effect": "catalog:",
     "fast-xml-parser": "catalog:"
   },
   "devDependencies": {

--- a/packages/axiom/package.json
+++ b/packages/axiom/package.json
@@ -78,8 +78,7 @@
     "specs:update": "git -C specs/docs fetch && git -C specs/docs checkout main && git -C specs/docs pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -73,8 +73,7 @@
     "specs:update": "git -C specs/azure-rest-api-specs fetch && git -C specs/azure-rest-api-specs checkout main && git -C specs/azure-rest-api-specs pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -63,8 +63,7 @@
     "specs:update": "git -C specs/cloudflare-typescript fetch && git -C specs/cloudflare-typescript checkout main && git -C specs/cloudflare-typescript pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@effect/platform-node": "catalog:",

--- a/packages/coinbase/package.json
+++ b/packages/coinbase/package.json
@@ -73,8 +73,7 @@
     "specs:update": "git -C specs/cdp-sdk fetch && git -C specs/cdp-sdk checkout main && git -C specs/cdp-sdk pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,9 +76,6 @@
     "test": "bunx vitest run test --exclude specs --passWithNoTests",
     "publish:npm": "bun run build && bun publish --access public"
   },
-  "dependencies": {
-    "effect": "catalog:"
-  },
   "devDependencies": {
     "@types/bun": "catalog:",
     "@types/node": "catalog:",

--- a/packages/expo-eas/package.json
+++ b/packages/expo-eas/package.json
@@ -73,8 +73,7 @@
     "specs:update": "git -C specs/eas-cli fetch && git -C specs/eas-cli checkout main && git -C specs/eas-cli pull && git -C specs/expo fetch && git -C specs/expo checkout main && git -C specs/expo pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/fly-io/package.json
+++ b/packages/fly-io/package.json
@@ -74,8 +74,7 @@
     "specs:update": "git -C specs/distilled-spec-fly-io fetch && git -C specs/distilled-spec-fly-io checkout main && git -C specs/distilled-spec-fly-io pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/gcp/package.json
+++ b/packages/gcp/package.json
@@ -62,8 +62,7 @@
     "specs:update": "git -C specs/distilled-spec-gcp fetch && git -C specs/distilled-spec-gcp checkout main && git -C specs/distilled-spec-gcp pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/kubernetes/package.json
+++ b/packages/kubernetes/package.json
@@ -74,8 +74,7 @@
     "specs:update": "git -C specs/kubernetes fetch && git -C specs/kubernetes checkout master && git -C specs/kubernetes pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/mongodb-atlas/package.json
+++ b/packages/mongodb-atlas/package.json
@@ -74,8 +74,7 @@
     "specs:update": "git -C specs/distilled-spec-mongodb-atlas fetch && git -C specs/distilled-spec-mongodb-atlas checkout main && git -C specs/distilled-spec-mongodb-atlas pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/neon/package.json
+++ b/packages/neon/package.json
@@ -74,8 +74,7 @@
     "specs:update": "git -C specs/distilled-spec-neon fetch && git -C specs/distilled-spec-neon checkout main && git -C specs/distilled-spec-neon pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/planetscale/package.json
+++ b/packages/planetscale/package.json
@@ -73,8 +73,7 @@
     "specs:update": "git -C specs/distilled-spec-planetscale fetch && git -C specs/distilled-spec-planetscale checkout main && git -C specs/distilled-spec-planetscale pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/posthog/package.json
+++ b/packages/posthog/package.json
@@ -73,8 +73,7 @@
     "specs:update": "git -C specs/distilled-spec-posthog fetch && git -C specs/distilled-spec-posthog checkout main && git -C specs/distilled-spec-posthog pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@effect/platform-node": "catalog:",

--- a/packages/prisma-postgres/package.json
+++ b/packages/prisma-postgres/package.json
@@ -74,8 +74,7 @@
     "specs:update": "git -C specs/distilled-spec-prisma-postgres fetch && git -C specs/distilled-spec-prisma-postgres checkout main && git -C specs/distilled-spec-prisma-postgres pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -74,8 +74,7 @@
     "specs:update": "git -C specs/stripe-openapi fetch && git -C specs/stripe-openapi checkout master && git -C specs/stripe-openapi pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -74,8 +74,7 @@
     "specs:update": "git -C specs/distilled-spec-supabase fetch && git -C specs/distilled-spec-supabase checkout main && git -C specs/distilled-spec-supabase pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/turso/package.json
+++ b/packages/turso/package.json
@@ -74,8 +74,7 @@
     "specs:update": "git -C specs/turso-docs fetch && git -C specs/turso-docs checkout main && git -C specs/turso-docs pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/typesense/package.json
+++ b/packages/typesense/package.json
@@ -73,8 +73,7 @@
     "specs:update": "git -C specs/typesense-api-spec fetch && git -C specs/typesense-api-spec checkout main && git -C specs/typesense-api-spec pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/workos/package.json
+++ b/packages/workos/package.json
@@ -73,8 +73,7 @@
     "specs:update": "git -C specs/openapi-spec fetch && git -C specs/openapi-spec checkout main && git -C specs/openapi-spec pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",


### PR DESCRIPTION
## Summary
- Remove direct `effect` dependencies from published `@distilled.cloud/*` packages while keeping their existing `peerDependencies.effect` declarations.
- Refresh `bun.lock` so consumers provide a single compatible `effect` version instead of receiving nested copies from Distilled packages.

## Validation
- `bun pm why effect`
- `bun run typecheck`