### PR TITLE
feat(gcp): surface gRPC status + details[] from the error envelope

### DIFF
--- a/packages/gcp/scripts/generate.ts
+++ b/packages/gcp/scripts/generate.ts
@@ -192,7 +192,9 @@ const versionFilter = args.includes("--version")
 
 async function main() {
   // Load manifest
-  const manifestPath = path.resolve("specs/distilled-spec-gcp/specs/_manifest.json");
+  const manifestPath = path.resolve(
+    "specs/distilled-spec-gcp/specs/_manifest.json",
+  );
   if (!fs.existsSync(manifestPath)) {
     console.error(
       "No manifest found. Run `git submodule update --init` first to fetch specs.",
@@ -234,10 +236,10 @@ async function main() {
   let generated = 0;
   for (const entry of entries) {
     try {
-      const specPath = path.resolve(`specs/distilled-spec-gcp/specs/${entry.filename}`);
-      const doc: DiscoveryDoc = JSON.parse(
-        fs.readFileSync(specPath, "utf-8"),
+      const specPath = path.resolve(
+        `specs/distilled-spec-gcp/specs/${entry.filename}`,
       );
+      const doc: DiscoveryDoc = JSON.parse(fs.readFileSync(specPath, "utf-8"));
 
       const outputName = `${entry.name}-${entry.version}`;
       const outputDir = entry.preferred ? STABLE_DIR : UNSTABLE_DIR;
@@ -261,11 +263,12 @@ async function main() {
 // Patch Loading
 // =============================================================================
 
-function loadPatches(
-  serviceName: string,
-  _outputName: string,
-): ServicePatch {
-  const result: ServicePatch = { operations: {}, errors: {}, errorCategories: {} };
+function loadPatches(serviceName: string, _outputName: string): ServicePatch {
+  const result: ServicePatch = {
+    operations: {},
+    errors: {},
+    errorCategories: {},
+  };
 
   // Try service-level patch: patches/{service}.json
   const servicePatchPath = path.resolve(`patches/${serviceName}.json`);
@@ -310,28 +313,53 @@ function loadPatches(
 
 // Names that conflict with imports or TypeScript keywords
 const RESERVED_SCHEMA_NAMES = new Set([
-  "Schema", "Effect", "API", "T", "C", "HttpClient",
-  "Credentials", "DefaultErrors",
+  "Schema",
+  "Effect",
+  "API",
+  "T",
+  "C",
+  "HttpClient",
+  "Credentials",
+  "DefaultErrors",
   // Standard 4xx error class names emitted via method-keyed defaults
   // (see `methodDefaultErrorTags`). Several Google APIs ship discovery
   // schemas literally named `BadRequest` / `NotFound` (e.g.
   // `datamigration-v1`'s `google.rpc.BadRequest`); rename those to
   // avoid colliding with the emitted error classes.
-  "NotFound", "Forbidden", "BadRequest", "Conflict",
+  "NotFound",
+  "Forbidden",
+  "BadRequest",
+  "Conflict",
   // TypeScript built-in global types
-  "Record", "Array", "Map", "Set", "Promise", "Error",
-  "Function", "Object", "String", "Number", "Boolean",
-  "Symbol", "Date", "RegExp", "JSON",
+  "Record",
+  "Array",
+  "Map",
+  "Set",
+  "Promise",
+  "Error",
+  "Function",
+  "Object",
+  "String",
+  "Number",
+  "Boolean",
+  "Symbol",
+  "Date",
+  "RegExp",
+  "JSON",
 ]);
 
 function generateService(doc: DiscoveryDoc, patches: ServicePatch): string {
   const lines: string[] = [];
 
   // Header
-  lines.push("// ==========================================================================");
+  lines.push(
+    "// ==========================================================================",
+  );
   lines.push(`// ${doc.title} (${doc.name} ${doc.version})`);
   lines.push("// DO NOT EDIT - Generated from GCP Discovery Document");
-  lines.push("// ==========================================================================");
+  lines.push(
+    "// ==========================================================================",
+  );
   lines.push("");
   lines.push('import * as Schema from "effect/Schema";');
   lines.push('import * as API from "../client/api.ts";');
@@ -340,7 +368,9 @@ function generateService(doc: DiscoveryDoc, patches: ServicePatch): string {
   lines.push("__DURATION_SCHEMA_IMPORT__");
   lines.push('import type { Credentials } from "../credentials.ts";');
   lines.push('import type { DefaultErrors } from "../errors.ts";');
-  lines.push('import type * as HttpClient from "effect/unstable/http/HttpClient";');
+  lines.push(
+    'import type * as HttpClient from "effect/unstable/http/HttpClient";',
+  );
   lines.push("");
 
   // Service trait
@@ -385,7 +415,13 @@ function generateService(doc: DiscoveryDoc, patches: ServicePatch): string {
 
     for (const [originalName, schema] of sortedSchemas) {
       const name = schemaRenames.get(originalName) ?? originalName;
-      const schemaLines = generateSchema(name, schema, doc.schemas, schemaRenames, recursiveSchemas.has(originalName));
+      const schemaLines = generateSchema(
+        name,
+        schema,
+        doc.schemas,
+        schemaRenames,
+        recursiveSchemas.has(originalName),
+      );
       lines.push(...schemaLines);
       lines.push("");
     }
@@ -475,10 +511,16 @@ function generateService(doc: DiscoveryDoc, patches: ServicePatch): string {
     lines.push("");
 
     for (const op of operations) {
-      const opPatch =
-        patches.operations?.[op.functionName] ?? {};
+      const opPatch = patches.operations?.[op.functionName] ?? {};
       lines.push(
-        ...generateOperation(op, doc.schemas ?? {}, opPatch, allErrors, schemaNames, schemaRenames),
+        ...generateOperation(
+          op,
+          doc.schemas ?? {},
+          opPatch,
+          allErrors,
+          schemaNames,
+          schemaRenames,
+        ),
       );
       lines.push("");
     }
@@ -487,7 +529,10 @@ function generateService(doc: DiscoveryDoc, patches: ServicePatch): string {
   let code = lines.join("\n") + "\n";
   // Only include the category import if it's actually used
   if (code.includes("C.with")) {
-    code = code.replace("__CATEGORY_IMPORT__", 'import * as C from "../category.ts";');
+    code = code.replace(
+      "__CATEGORY_IMPORT__",
+      'import * as C from "../category.ts";',
+    );
   } else {
     code = code.replace("__CATEGORY_IMPORT__\n", "");
   }
@@ -559,13 +604,15 @@ function generateSchema(
         `})).annotate({ identifier: ${JSON.stringify(name)} }) as any as Schema.Schema<${name}>;`,
       );
     } else {
-      lines.push(
-        `}).annotate({ identifier: ${JSON.stringify(name)} });`,
-      );
+      lines.push(`}).annotate({ identifier: ${JSON.stringify(name)} });`);
     }
   } else if (schema.type === "object" && schema.additionalProperties) {
     // Map type
-    const valType = propertyToTsType(schema.additionalProperties, allSchemas, renames);
+    const valType = propertyToTsType(
+      schema.additionalProperties,
+      allSchemas,
+      renames,
+    );
     const valSchema = propertyToSchemaExpr(
       schema.additionalProperties,
       allSchemas,
@@ -578,10 +625,10 @@ function generateSchema(
   } else if (schema.enum) {
     // Enum type - open union
     const literals = schema.enum.map((v) => JSON.stringify(v)).join(" | ");
+    lines.push(`export type ${name} = ${literals} | (string & {});`);
     lines.push(
-      `export type ${name} = ${literals} | (string & {});`,
+      `export const ${name} = /*@__PURE__*/ /*#__PURE__*/ Schema.String;`,
     );
-    lines.push(`export const ${name} = /*@__PURE__*/ /*#__PURE__*/ Schema.String;`);
   } else {
     // Simple type alias
     const tsType = schemaTypeToTs(schema);
@@ -606,7 +653,10 @@ function propertyToTsType(
   switch (prop.type) {
     case "string":
       if (prop.enum) {
-        return prop.enum.map((v) => JSON.stringify(v)).join(" | ") + " | (string & {})";
+        return (
+          prop.enum.map((v) => JSON.stringify(v)).join(" | ") +
+          " | (string & {})"
+        );
       }
       if (prop.format === "date-time") return "string";
       if (prop.format === "int64" || prop.format === "uint64") return "string";
@@ -816,6 +866,12 @@ function generateErrorClass(
   lines.push(`    status: Schema.optional(Schema.String),`);
   lines.push(`    reason: Schema.optional(Schema.String),`);
   lines.push(`    domain: Schema.optional(Schema.String),`);
+  // GCP's standard error envelope includes a `details[]` array of
+  // typed protobuf messages (QuotaFailure, ErrorInfo, etc.) keyed by
+  // an `@type` URL. The shared `matchError` populates this on the
+  // instance from the response body; declaring it here makes it
+  // typed at every catch site.
+  lines.push(`    details: Schema.optional(Schema.Array(Schema.Unknown)),`);
   if (isRetryable) {
     lines.push(`    retryAfter: Schema.optional(DurationSchema),`);
   }
@@ -823,9 +879,7 @@ function generateErrorClass(
   lines.push(`) {}`);
 
   // Apply error matchers
-  lines.push(
-    `T.applyErrorMatchers(${safeTag}, ${JSON.stringify(matchers)});`,
-  );
+  lines.push(`T.applyErrorMatchers(${safeTag}, ${JSON.stringify(matchers)});`);
 
   // Apply categories if any
   if (categories && categories.length > 0) {
@@ -853,7 +907,7 @@ function generateOperation(
   const fnName = op.functionName;
   let inputName = `${capitalize(fnName)}Request`;
   let outputName = `${capitalize(fnName)}Response`;
-  
+
   // Avoid name collisions with existing schemas
   if (existingSchemaNames.has(inputName)) {
     inputName = `${inputName}_Op`;
@@ -880,7 +934,9 @@ function generateOperation(
   // Check for pagination
   const hasPagination =
     op.parameters.pageToken !== undefined ||
-    Object.values(op.parameters).some((p) => p.type === "string" && /pageToken/i.test(p.description ?? ""));
+    Object.values(op.parameters).some(
+      (p) => p.type === "string" && /pageToken/i.test(p.description ?? ""),
+    );
   const responseSchema = op.responseRef
     ? allSchemas[op.responseRef]
     : undefined;
@@ -892,7 +948,20 @@ function generateOperation(
   // Collect operation parameters (excluding global params)
   const opParams = Object.entries(op.parameters).filter(
     ([name]) =>
-      !["alt", "fields", "key", "oauth_token", "prettyPrint", "quotaUser", "userIp", "uploadType", "upload_protocol", "$.xgafv", "callback", "access_token"].includes(name),
+      ![
+        "alt",
+        "fields",
+        "key",
+        "oauth_token",
+        "prettyPrint",
+        "quotaUser",
+        "userIp",
+        "uploadType",
+        "upload_protocol",
+        "$.xgafv",
+        "callback",
+        "access_token",
+      ].includes(name),
   );
 
   // Generate request interface (description goes on the operation, not the interface)
@@ -906,8 +975,12 @@ function generateOperation(
     lines.push(`  ${safePropName(paramName)}${opt}: ${tsType};`);
   }
   // Resolve $ref names through renames
-  const resolvedRequestRef = op.requestRef ? (schemaRenames.get(op.requestRef) ?? op.requestRef) : undefined;
-  const resolvedResponseRef = op.responseRef ? (schemaRenames.get(op.responseRef) ?? op.responseRef) : undefined;
+  const resolvedRequestRef = op.requestRef
+    ? (schemaRenames.get(op.requestRef) ?? op.requestRef)
+    : undefined;
+  const resolvedResponseRef = op.responseRef
+    ? (schemaRenames.get(op.responseRef) ?? op.responseRef)
+    : undefined;
 
   // If there's a request body, add it
   if (resolvedRequestRef) {
@@ -918,7 +991,9 @@ function generateOperation(
   lines.push("");
 
   // Generate request schema
-  lines.push(`export const ${inputName} = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({`);
+  lines.push(
+    `export const ${inputName} = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({`,
+  );
   for (const [paramName, param] of opParams) {
     const schemaExpr = paramTypeToSchemaExpr(param);
     const traitPipe =
@@ -935,22 +1010,24 @@ function generateOperation(
     }
   }
   if (resolvedRequestRef) {
-    lines.push(`  body: Schema.optional(${resolvedRequestRef}).pipe(T.HttpBody()),`);
+    lines.push(
+      `  body: Schema.optional(${resolvedRequestRef}).pipe(T.HttpBody()),`,
+    );
   }
   lines.push(`}).pipe(`);
   lines.push(
     `  T.Http({ method: ${JSON.stringify(op.httpMethod)}, path: ${JSON.stringify(op.path)}${resolvedRequestRef || op.httpMethod === "POST" || op.httpMethod === "PUT" || op.httpMethod === "PATCH" ? ", hasBody: true" : ""} }),`,
   );
   lines.push(`  svc,`);
-  lines.push(
-    `) as unknown as Schema.Schema<${inputName}>;`,
-  );
+  lines.push(`) as unknown as Schema.Schema<${inputName}>;`);
   lines.push("");
 
   // Generate response type and schema
   if (resolvedResponseRef) {
     lines.push(`export type ${outputName} = ${resolvedResponseRef};`);
-    lines.push(`export const ${outputName} = /*@__PURE__*/ /*#__PURE__*/ ${resolvedResponseRef};`);
+    lines.push(
+      `export const ${outputName} = /*@__PURE__*/ /*#__PURE__*/ ${resolvedResponseRef};`,
+    );
   } else {
     lines.push(`export interface ${outputName} {}`);
     lines.push(
@@ -1112,7 +1189,7 @@ function methodToOperation(
   const safeName = safeIdentifier(methodName);
   const resourcePart =
     resourcePath.length > 0
-      ? resourcePath.map(r => capitalize(safeIdentifier(r))).join("")
+      ? resourcePath.map((r) => capitalize(safeIdentifier(r))).join("")
       : "";
   const functionName = safeName + resourcePart;
 

--- a/packages/gcp/src/client/api.ts
+++ b/packages/gcp/src/client/api.ts
@@ -20,7 +20,84 @@ import { Retry } from "../retry.ts";
 export type { OperationMethod, PaginatedOperationMethod };
 
 /**
+ * Shape of GCP's standard error envelope as documented at
+ * <https://cloud.google.com/apis/design/errors>:
+ *
+ * ```json
+ * {
+ *   "error": {
+ *     "code": 400,
+ *     "message": "Precondition check failed.",
+ *     "status": "FAILED_PRECONDITION",
+ *     "details": [
+ *       {
+ *         "@type": "type.googleapis.com/google.rpc.QuotaFailure",
+ *         "violations": [{ "subject": "...", "description": "..." }]
+ *       }
+ *     ]
+ *   }
+ * }
+ * ```
+ *
+ * `code` mirrors the HTTP status (already encoded in the error class).
+ * `status` is the gRPC-style enum string — useful to disambiguate sub-cases
+ * sharing an HTTP status (e.g. `FAILED_PRECONDITION` vs `INVALID_ARGUMENT`,
+ * both HTTP 400). `details[]` is a list of typed protobuf messages
+ * discriminated by their `@type` URL — `QuotaFailure`, `ErrorInfo`,
+ * `BadRequest.FieldViolation`, etc. We surface all three on the typed
+ * error so user code can do, e.g.:
+ *
+ * ```typescript
+ * Effect.catchTag("BadRequest", (e) => {
+ *   const isQuota = e.status === "FAILED_PRECONDITION" &&
+ *     e.details?.some((d: any) => d["@type"]?.endsWith("QuotaFailure"));
+ *   …
+ * });
+ * ```
+ */
+const extractGCPErrorEnvelope = (
+  errorBody: unknown,
+): {
+  message: string | undefined;
+  status: string | undefined;
+  details: ReadonlyArray<unknown> | undefined;
+} => {
+  if (
+    typeof errorBody !== "object" ||
+    errorBody === null ||
+    !("error" in errorBody)
+  ) {
+    return { message: undefined, status: undefined, details: undefined };
+  }
+  const err = (errorBody as { error?: unknown }).error;
+  if (typeof err !== "object" || err === null) {
+    return { message: undefined, status: undefined, details: undefined };
+  }
+  const e = err as { message?: unknown; status?: unknown; details?: unknown };
+  return {
+    message: typeof e.message === "string" ? e.message : undefined,
+    status: typeof e.status === "string" ? e.status : undefined,
+    details: Array.isArray(e.details) ? e.details : undefined,
+  };
+};
+
+/**
  * Match a GCP API error response to the appropriate error class.
+ *
+ * `HTTP_STATUS_MAP` is core's table of (HTTP status → error class). Core
+ * classes declare only `message` (and `retryAfter` for retryable
+ * statuses). The per-service inline error classes generated under
+ * `services/*.ts` declare additional `code` / `status` / `reason` /
+ * `domain` / `details` fields — these describe the *shape callers
+ * narrow to* via `Effect.catch("BadRequest", e => …)`.
+ *
+ * Since `Effect.catch` matches by `_tag` (string) and the runtime
+ * instance built here shares a tag with the per-service class, we can
+ * surface the structured envelope fields by attaching them to the
+ * runtime instance after construction. The Schema-level field set on
+ * the core class is unchanged; the tacked-on properties become visible
+ * exclusively at the per-service narrowed type. This keeps core
+ * untouched while delivering the structured info to consumers.
  */
 const matchError = (
   status: number,
@@ -29,22 +106,42 @@ const matchError = (
   headers?: Record<string, string | undefined>,
 ): Effect.Effect<never, unknown> => {
   const ErrorClass = (HTTP_STATUS_MAP as any)[status];
-  const message =
-    typeof errorBody === "object" && errorBody !== null && "error" in errorBody
-      ? ((errorBody as any).error?.message ?? String(status))
-      : String(status);
+  const envelope = extractGCPErrorEnvelope(errorBody);
+  const message = envelope.message ?? String(status);
 
   if (ErrorClass) {
-    return Effect.fail(
-      new ErrorClass({
-        message,
-        retryAfter: parseRetryAfterForStatus(status, headers),
-      }),
-    );
+    const instance = new ErrorClass({
+      message,
+      retryAfter: parseRetryAfterForStatus(status, headers),
+    });
+    const tackOn = instance as unknown as EnvelopeAddenda;
+    if (envelope.status !== undefined) tackOn.status = envelope.status;
+    if (envelope.details !== undefined) tackOn.details = envelope.details;
+    return Effect.fail(instance);
   }
-  return Effect.fail(
-    new UnknownGCPError({ code: status, message, body: errorBody }),
-  );
+
+  // `UnknownGCPError`'s schema *does* declare `status` already, so we
+  // could pass it through the constructor — but routing all envelope
+  // fields through the same tack-on path keeps `matchError` uniform.
+  const unknownInstance = new UnknownGCPError({
+    code: status,
+    message,
+    body: errorBody,
+  });
+  const tackOnUnknown = unknownInstance as unknown as EnvelopeAddenda;
+  if (envelope.status !== undefined) tackOnUnknown.status = envelope.status;
+  return Effect.fail(unknownInstance);
+};
+
+/**
+ * The two envelope fields the per-service inline error classes declare
+ * but the core HTTP_STATUS_MAP classes don't. Used as the (narrow)
+ * mutable view through which `matchError` writes the tacked-on
+ * properties without `Record<string, unknown>` losing the field names.
+ */
+type EnvelopeAddenda = {
+  status?: string;
+  details?: ReadonlyArray<unknown>;
 };
 
 /**

--- a/packages/gcp/src/services/abusiveexperiencereport-v1.ts
+++ b/packages/gcp/src/services/abusiveexperiencereport-v1.ts
@@ -76,6 +76,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -87,6 +88,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/acceleratedmobilepageurl-v1.ts
+++ b/packages/gcp/src/services/acceleratedmobilepageurl-v1.ts
@@ -96,6 +96,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -107,6 +108,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -119,6 +121,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -129,6 +132,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/accessapproval-v1.ts
+++ b/packages/gcp/src/services/accessapproval-v1.ts
@@ -371,6 +371,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -382,6 +383,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -394,6 +396,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -404,6 +407,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/accesscontextmanager-v1.ts
+++ b/packages/gcp/src/services/accesscontextmanager-v1.ts
@@ -978,6 +978,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -989,6 +990,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1001,6 +1003,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1011,6 +1014,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/addressvalidation-v1.ts
+++ b/packages/gcp/src/services/addressvalidation-v1.ts
@@ -546,6 +546,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -557,6 +558,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -569,6 +571,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -579,6 +582,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/adexchangebuyer2-v2beta1.ts
+++ b/packages/gcp/src/services/adexchangebuyer2-v2beta1.ts
@@ -2252,6 +2252,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2263,6 +2264,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2275,6 +2277,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2285,6 +2288,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/adexperiencereport-v1.ts
+++ b/packages/gcp/src/services/adexperiencereport-v1.ts
@@ -98,6 +98,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -109,6 +110,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/admin-reports_v1.ts
+++ b/packages/gcp/src/services/admin-reports_v1.ts
@@ -625,6 +625,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -636,6 +637,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -648,6 +650,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -658,6 +661,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/admob-v1.ts
+++ b/packages/gcp/src/services/admob-v1.ts
@@ -616,6 +616,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -627,6 +628,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -639,6 +641,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -649,6 +652,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/adsense-v2.ts
+++ b/packages/gcp/src/services/adsense-v2.ts
@@ -625,6 +625,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -636,6 +637,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -648,6 +650,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -658,6 +661,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/adsenseplatform-v1.ts
+++ b/packages/gcp/src/services/adsenseplatform-v1.ts
@@ -222,6 +222,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -233,6 +234,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -245,6 +247,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -255,6 +258,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/advisorynotifications-v1.ts
+++ b/packages/gcp/src/services/advisorynotifications-v1.ts
@@ -218,6 +218,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -229,6 +230,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -241,6 +243,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -251,6 +254,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/agentregistry-v1alpha.ts
+++ b/packages/gcp/src/services/agentregistry-v1alpha.ts
@@ -640,6 +640,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -651,6 +652,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -663,6 +665,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -673,6 +676,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/aiplatform-v1.ts
+++ b/packages/gcp/src/services/aiplatform-v1.ts
@@ -27542,6 +27542,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -27553,6 +27554,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -27565,6 +27567,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -27575,6 +27578,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/airquality-v1.ts
+++ b/packages/gcp/src/services/airquality-v1.ts
@@ -435,6 +435,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -446,6 +447,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -458,6 +460,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -468,6 +471,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/alertcenter-v1beta1.ts
+++ b/packages/gcp/src/services/alertcenter-v1beta1.ts
@@ -1444,6 +1444,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1455,6 +1456,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1467,6 +1469,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1477,6 +1480,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/alloydb-v1.ts
+++ b/packages/gcp/src/services/alloydb-v1.ts
@@ -3209,6 +3209,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3220,6 +3221,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3232,6 +3234,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3242,6 +3245,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/analytics-v3.ts
+++ b/packages/gcp/src/services/analytics-v3.ts
@@ -2324,6 +2324,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2335,6 +2336,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2347,6 +2349,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2357,6 +2360,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/analyticsadmin-v1beta.ts
+++ b/packages/gcp/src/services/analyticsadmin-v1beta.ts
@@ -1419,6 +1419,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1430,6 +1431,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1442,6 +1444,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1452,6 +1455,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/analyticsdata-v1beta.ts
+++ b/packages/gcp/src/services/analyticsdata-v1beta.ts
@@ -1261,6 +1261,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1272,6 +1273,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1284,6 +1286,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1294,6 +1297,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/analyticshub-v1.ts
+++ b/packages/gcp/src/services/analyticshub-v1.ts
@@ -1257,6 +1257,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1268,6 +1269,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1280,6 +1282,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1290,6 +1293,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/androiddeviceprovisioning-v1.ts
+++ b/packages/gcp/src/services/androiddeviceprovisioning-v1.ts
@@ -798,6 +798,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -809,6 +810,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -821,6 +823,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -831,6 +834,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/androidenterprise-v1.ts
+++ b/packages/gcp/src/services/androidenterprise-v1.ts
@@ -1608,6 +1608,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1619,6 +1620,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1631,6 +1633,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1641,6 +1644,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/androidmanagement-v1.ts
+++ b/packages/gcp/src/services/androidmanagement-v1.ts
@@ -4373,6 +4373,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -4384,6 +4385,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -4396,6 +4398,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -4406,6 +4409,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/androidpublisher-v3.ts
+++ b/packages/gcp/src/services/androidpublisher-v3.ts
@@ -5463,6 +5463,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -5474,6 +5475,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -5486,6 +5488,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -5496,6 +5499,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/apigateway-v1.ts
+++ b/packages/gcp/src/services/apigateway-v1.ts
@@ -499,6 +499,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -510,6 +511,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -522,6 +524,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -532,6 +535,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/apigee-v1.ts
+++ b/packages/gcp/src/services/apigee-v1.ts
@@ -7126,6 +7126,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -7137,6 +7138,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -7149,6 +7151,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -7159,6 +7162,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/apigeeregistry-v1.ts
+++ b/packages/gcp/src/services/apigeeregistry-v1.ts
@@ -639,6 +639,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -650,6 +651,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -662,6 +664,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -672,6 +675,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/apihub-v1.ts
+++ b/packages/gcp/src/services/apihub-v1.ts
@@ -2910,6 +2910,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2921,6 +2922,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2933,6 +2935,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2943,6 +2946,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/apikeys-v2.ts
+++ b/packages/gcp/src/services/apikeys-v2.ts
@@ -234,6 +234,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -245,6 +246,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -257,6 +259,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -267,6 +270,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/apim-v1alpha.ts
+++ b/packages/gcp/src/services/apim-v1alpha.ts
@@ -574,6 +574,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -585,6 +586,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -597,6 +599,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -607,6 +610,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/appengine-v1.ts
+++ b/packages/gcp/src/services/appengine-v1.ts
@@ -1739,6 +1739,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1750,6 +1751,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1762,6 +1764,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1772,6 +1775,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/apphub-v1.ts
+++ b/packages/gcp/src/services/apphub-v1.ts
@@ -857,6 +857,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -868,6 +869,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -880,6 +882,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -890,6 +893,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/appsmarket-v2.ts
+++ b/packages/gcp/src/services/appsmarket-v2.ts
@@ -101,6 +101,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -112,6 +113,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/areainsights-v1.ts
+++ b/packages/gcp/src/services/areainsights-v1.ts
@@ -204,6 +204,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -215,6 +216,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -227,6 +229,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -237,6 +240,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/artifactregistry-v1.ts
+++ b/packages/gcp/src/services/artifactregistry-v1.ts
@@ -1798,6 +1798,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1809,6 +1810,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1821,6 +1823,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1831,6 +1834,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/assuredworkloads-v1.ts
+++ b/packages/gcp/src/services/assuredworkloads-v1.ts
@@ -1049,6 +1049,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1060,6 +1061,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1072,6 +1074,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1082,6 +1085,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/authorizedbuyersmarketplace-v1.ts
+++ b/packages/gcp/src/services/authorizedbuyersmarketplace-v1.ts
@@ -1254,6 +1254,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1265,6 +1266,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1277,6 +1279,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1287,6 +1290,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/backupdr-v1.ts
+++ b/packages/gcp/src/services/backupdr-v1.ts
@@ -2981,6 +2981,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2992,6 +2993,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3004,6 +3006,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3014,6 +3017,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/baremetalsolution-v2.ts
+++ b/packages/gcp/src/services/baremetalsolution-v2.ts
@@ -1444,6 +1444,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1455,6 +1456,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1467,6 +1469,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1477,6 +1480,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/batch-v1.ts
+++ b/packages/gcp/src/services/batch-v1.ts
@@ -1201,6 +1201,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1212,6 +1213,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1224,6 +1226,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1234,6 +1237,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/beyondcorp-v1.ts
+++ b/packages/gcp/src/services/beyondcorp-v1.ts
@@ -1722,6 +1722,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1733,6 +1734,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1745,6 +1747,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1755,6 +1758,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/biglake-v1.ts
+++ b/packages/gcp/src/services/biglake-v1.ts
@@ -321,6 +321,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -332,6 +333,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -344,6 +346,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -354,6 +357,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/bigquery-v2.ts
+++ b/packages/gcp/src/services/bigquery-v2.ts
@@ -5862,6 +5862,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -5873,6 +5874,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -5885,6 +5887,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -5895,6 +5898,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/bigqueryconnection-v1.ts
+++ b/packages/gcp/src/services/bigqueryconnection-v1.ts
@@ -508,6 +508,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -519,6 +520,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -531,6 +533,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -541,6 +544,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/bigquerydatapolicy-v2.ts
+++ b/packages/gcp/src/services/bigquerydatapolicy-v2.ts
@@ -284,6 +284,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -295,6 +296,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -307,6 +309,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -317,6 +320,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/bigquerydatatransfer-v1.ts
+++ b/packages/gcp/src/services/bigquerydatatransfer-v1.ts
@@ -787,6 +787,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -798,6 +799,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -810,6 +812,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -820,6 +823,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/bigqueryreservation-v1.ts
+++ b/packages/gcp/src/services/bigqueryreservation-v1.ts
@@ -560,6 +560,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -571,6 +572,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -583,6 +585,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -593,6 +596,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/bigtableadmin-v2.ts
+++ b/packages/gcp/src/services/bigtableadmin-v2.ts
@@ -2315,6 +2315,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2326,6 +2327,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2338,6 +2340,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2348,6 +2351,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/billingbudgets-v1.ts
+++ b/packages/gcp/src/services/billingbudgets-v1.ts
@@ -241,6 +241,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -252,6 +253,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -264,6 +266,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -274,6 +277,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/binaryauthorization-v1.ts
+++ b/packages/gcp/src/services/binaryauthorization-v1.ts
@@ -830,6 +830,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -841,6 +842,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -853,6 +855,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -863,6 +866,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/blockchainnodeengine-v1.ts
+++ b/packages/gcp/src/services/blockchainnodeengine-v1.ts
@@ -334,6 +334,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -345,6 +346,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -357,6 +359,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -367,6 +370,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/blogger-v3.ts
+++ b/packages/gcp/src/services/blogger-v3.ts
@@ -551,6 +551,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -562,6 +563,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -574,6 +576,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -584,6 +587,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/books-v1.ts
+++ b/packages/gcp/src/services/books-v1.ts
@@ -1644,6 +1644,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1655,6 +1656,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1667,6 +1669,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1677,6 +1680,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/businessprofileperformance-v1.ts
+++ b/packages/gcp/src/services/businessprofileperformance-v1.ts
@@ -205,6 +205,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -216,6 +217,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/calendar-v3.ts
+++ b/packages/gcp/src/services/calendar-v3.ts
@@ -979,6 +979,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -990,6 +991,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1002,6 +1004,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1012,6 +1015,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/certificatemanager-v1.ts
+++ b/packages/gcp/src/services/certificatemanager-v1.ts
@@ -755,6 +755,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -766,6 +767,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -778,6 +780,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -788,6 +791,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/ces-v1.ts
+++ b/packages/gcp/src/services/ces-v1.ts
@@ -3449,6 +3449,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3460,6 +3461,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3472,6 +3474,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3482,6 +3485,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/chat-v1.ts
+++ b/packages/gcp/src/services/chat-v1.ts
@@ -3183,6 +3183,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3194,6 +3195,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3206,6 +3208,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3216,6 +3219,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/checks-v1alpha.ts
+++ b/packages/gcp/src/services/checks-v1alpha.ts
@@ -1445,6 +1445,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1456,6 +1457,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1468,6 +1470,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1478,6 +1481,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/chromemanagement-v1.ts
+++ b/packages/gcp/src/services/chromemanagement-v1.ts
@@ -3480,6 +3480,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3491,6 +3492,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3503,6 +3505,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3513,6 +3516,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/chromepolicy-v1.ts
+++ b/packages/gcp/src/services/chromepolicy-v1.ts
@@ -1042,6 +1042,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1053,6 +1054,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1065,6 +1067,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1075,6 +1078,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/chromeuxreport-v1.ts
+++ b/packages/gcp/src/services/chromeuxreport-v1.ts
@@ -309,6 +309,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -320,6 +321,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -332,6 +334,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -342,6 +345,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/chromewebstore-v2.ts
+++ b/packages/gcp/src/services/chromewebstore-v2.ts
@@ -215,6 +215,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -226,6 +227,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -238,6 +240,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -248,6 +251,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/civicinfo-v2.ts
+++ b/packages/gcp/src/services/civicinfo-v2.ts
@@ -589,6 +589,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -600,6 +601,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/classroom-v1.ts
+++ b/packages/gcp/src/services/classroom-v1.ts
@@ -1582,6 +1582,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1593,6 +1594,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1605,6 +1607,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1615,6 +1618,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/cloudasset-v1.ts
+++ b/packages/gcp/src/services/cloudasset-v1.ts
@@ -2691,6 +2691,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2702,6 +2703,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2714,6 +2716,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2724,6 +2727,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/cloudbilling-v1.ts
+++ b/packages/gcp/src/services/cloudbilling-v1.ts
@@ -425,6 +425,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -436,6 +437,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -448,6 +450,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -458,6 +461,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/cloudbuild-v2.ts
+++ b/packages/gcp/src/services/cloudbuild-v2.ts
@@ -1528,6 +1528,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1539,6 +1540,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1551,6 +1553,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1561,6 +1564,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/cloudchannel-v1.ts
+++ b/packages/gcp/src/services/cloudchannel-v1.ts
@@ -2805,6 +2805,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2816,6 +2817,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2828,6 +2830,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2838,6 +2841,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/cloudcommerceprocurement-v1.ts
+++ b/packages/gcp/src/services/cloudcommerceprocurement-v1.ts
@@ -315,6 +315,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -326,6 +327,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -338,6 +340,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -348,6 +351,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/cloudcontrolspartner-v1.ts
+++ b/packages/gcp/src/services/cloudcontrolspartner-v1.ts
@@ -538,6 +538,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -549,6 +550,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -561,6 +563,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -571,6 +574,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/clouddeploy-v1.ts
+++ b/packages/gcp/src/services/clouddeploy-v1.ts
@@ -3591,6 +3591,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3602,6 +3603,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3614,6 +3616,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3624,6 +3627,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/clouderrorreporting-v1beta1.ts
+++ b/packages/gcp/src/services/clouderrorreporting-v1beta1.ts
@@ -278,6 +278,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -289,6 +290,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -301,6 +303,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -311,6 +314,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/cloudfunctions-v2.ts
+++ b/packages/gcp/src/services/cloudfunctions-v2.ts
@@ -1035,6 +1035,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1046,6 +1047,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1058,6 +1060,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1068,6 +1071,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/cloudidentity-v1.ts
+++ b/packages/gcp/src/services/cloudidentity-v1.ts
@@ -1880,6 +1880,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1891,6 +1892,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1903,6 +1905,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1913,6 +1916,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/cloudkms-v1.ts
+++ b/packages/gcp/src/services/cloudkms-v1.ts
@@ -1988,6 +1988,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1999,6 +2000,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2011,6 +2013,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2021,6 +2024,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/cloudlocationfinder-v1.ts
+++ b/packages/gcp/src/services/cloudlocationfinder-v1.ts
@@ -130,6 +130,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -141,6 +142,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/cloudprofiler-v2.ts
+++ b/packages/gcp/src/services/cloudprofiler-v2.ts
@@ -120,6 +120,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -131,6 +132,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -143,6 +145,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -153,6 +156,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/cloudresourcemanager-v3.ts
+++ b/packages/gcp/src/services/cloudresourcemanager-v3.ts
@@ -949,6 +949,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -960,6 +961,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -972,6 +974,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -982,6 +985,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/cloudscheduler-v1.ts
+++ b/packages/gcp/src/services/cloudscheduler-v1.ts
@@ -420,6 +420,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -431,6 +432,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -443,6 +445,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -453,6 +456,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/cloudsearch-v1.ts
+++ b/packages/gcp/src/services/cloudsearch-v1.ts
@@ -4116,6 +4116,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -4127,6 +4128,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -4139,6 +4141,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -4149,6 +4152,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/cloudshell-v1.ts
+++ b/packages/gcp/src/services/cloudshell-v1.ts
@@ -280,6 +280,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -291,6 +292,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -303,6 +305,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -313,6 +316,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/cloudsupport-v2.ts
+++ b/packages/gcp/src/services/cloudsupport-v2.ts
@@ -581,6 +581,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -592,6 +593,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -604,6 +606,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -614,6 +617,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/cloudtasks-v2.ts
+++ b/packages/gcp/src/services/cloudtasks-v2.ts
@@ -633,6 +633,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -644,6 +645,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -656,6 +658,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -666,6 +669,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/cloudtrace-v2.ts
+++ b/packages/gcp/src/services/cloudtrace-v2.ts
@@ -317,6 +317,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -328,6 +329,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -340,6 +342,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -350,6 +353,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/composer-v1.ts
+++ b/packages/gcp/src/services/composer-v1.ts
@@ -1161,6 +1161,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1172,6 +1173,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1184,6 +1186,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1194,6 +1197,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/compute-v1.ts
+++ b/packages/gcp/src/services/compute-v1.ts
@@ -33201,6 +33201,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -33212,6 +33213,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -33224,6 +33226,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -33234,6 +33237,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/config-v1.ts
+++ b/packages/gcp/src/services/config-v1.ts
@@ -1489,6 +1489,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1500,6 +1501,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1512,6 +1514,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1522,6 +1525,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/connectors-v2.ts
+++ b/packages/gcp/src/services/connectors-v2.ts
@@ -1431,6 +1431,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1442,6 +1443,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1454,6 +1456,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1464,6 +1467,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/contactcenteraiplatform-v1alpha1.ts
+++ b/packages/gcp/src/services/contactcenteraiplatform-v1alpha1.ts
@@ -802,6 +802,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -813,6 +814,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -825,6 +827,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -835,6 +838,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/contactcenterinsights-v1.ts
+++ b/packages/gcp/src/services/contactcenterinsights-v1.ts
@@ -13983,6 +13983,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -13994,6 +13995,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -14006,6 +14008,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -14016,6 +14019,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/container-v1.ts
+++ b/packages/gcp/src/services/container-v1.ts
@@ -5062,6 +5062,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -5073,6 +5074,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -5085,6 +5087,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -5095,6 +5098,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/containeranalysis-v1.ts
+++ b/packages/gcp/src/services/containeranalysis-v1.ts
@@ -3950,6 +3950,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3961,6 +3962,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3973,6 +3975,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3983,6 +3986,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/content-v2.1.ts
+++ b/packages/gcp/src/services/content-v2.1.ts
@@ -6712,6 +6712,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -6723,6 +6724,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -6735,6 +6737,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -6745,6 +6748,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/contentwarehouse-v1.ts
+++ b/packages/gcp/src/services/contentwarehouse-v1.ts
@@ -3923,6 +3923,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3934,6 +3935,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3946,6 +3948,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3956,6 +3959,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/css-v1.ts
+++ b/packages/gcp/src/services/css-v1.ts
@@ -621,6 +621,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -632,6 +633,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -644,6 +646,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -654,6 +657,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/customsearch-v1.ts
+++ b/packages/gcp/src/services/customsearch-v1.ts
@@ -453,6 +453,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -464,6 +465,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/datacatalog-v1.ts
+++ b/packages/gcp/src/services/datacatalog-v1.ts
@@ -2263,6 +2263,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2274,6 +2275,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2286,6 +2288,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2296,6 +2299,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/dataflow-v1b3.ts
+++ b/packages/gcp/src/services/dataflow-v1b3.ts
@@ -4060,6 +4060,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -4071,6 +4072,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -4083,6 +4085,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -4093,6 +4096,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/dataform-v1.ts
+++ b/packages/gcp/src/services/dataform-v1.ts
@@ -2031,6 +2031,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2042,6 +2043,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2054,6 +2056,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2064,6 +2067,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/datafusion-v1.ts
+++ b/packages/gcp/src/services/datafusion-v1.ts
@@ -687,6 +687,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -698,6 +699,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -710,6 +712,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -720,6 +723,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/datalabeling-v1beta1.ts
+++ b/packages/gcp/src/services/datalabeling-v1beta1.ts
@@ -3857,6 +3857,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3868,6 +3869,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3880,6 +3882,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3890,6 +3893,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/datalineage-v1.ts
+++ b/packages/gcp/src/services/datalineage-v1.ts
@@ -531,6 +531,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -542,6 +543,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -554,6 +556,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -564,6 +567,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/datamanager-v1.ts
+++ b/packages/gcp/src/services/datamanager-v1.ts
@@ -1576,6 +1576,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1587,6 +1588,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1599,6 +1601,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1609,6 +1612,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/datamigration-v1.ts
+++ b/packages/gcp/src/services/datamigration-v1.ts
@@ -3490,6 +3490,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3501,6 +3502,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3513,6 +3515,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3523,6 +3526,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/datapipelines-v1.ts
+++ b/packages/gcp/src/services/datapipelines-v1.ts
@@ -507,6 +507,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -518,6 +519,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -530,6 +532,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -540,6 +543,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/dataplex-v1.ts
+++ b/packages/gcp/src/services/dataplex-v1.ts
@@ -5691,6 +5691,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -5702,6 +5703,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -5714,6 +5716,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -5724,6 +5727,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/dataportability-v1.ts
+++ b/packages/gcp/src/services/dataportability-v1.ts
@@ -156,6 +156,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -167,6 +168,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -179,6 +181,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -189,6 +192,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/dataproc-v1.ts
+++ b/packages/gcp/src/services/dataproc-v1.ts
@@ -5363,6 +5363,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -5374,6 +5375,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -5386,6 +5388,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -5396,6 +5399,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/datastore-v1.ts
+++ b/packages/gcp/src/services/datastore-v1.ts
@@ -1479,6 +1479,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1490,6 +1491,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1502,6 +1504,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1512,6 +1515,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/datastream-v1.ts
+++ b/packages/gcp/src/services/datastream-v1.ts
@@ -2590,6 +2590,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2601,6 +2602,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2613,6 +2615,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2623,6 +2626,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/deploymentmanager-v2.ts
+++ b/packages/gcp/src/services/deploymentmanager-v2.ts
@@ -1095,6 +1095,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1106,6 +1107,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1118,6 +1120,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1128,6 +1131,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/developerconnect-v1.ts
+++ b/packages/gcp/src/services/developerconnect-v1.ts
@@ -1306,6 +1306,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1317,6 +1318,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1329,6 +1331,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1339,6 +1342,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/developerknowledge-v1alpha.ts
+++ b/packages/gcp/src/services/developerknowledge-v1alpha.ts
@@ -88,6 +88,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -99,6 +100,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/dfareporting-v5.ts
+++ b/packages/gcp/src/services/dfareporting-v5.ts
@@ -7611,6 +7611,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -7622,6 +7623,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -7634,6 +7636,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -7644,6 +7647,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/dialogflow-v3.ts
+++ b/packages/gcp/src/services/dialogflow-v3.ts
@@ -11637,6 +11637,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -11648,6 +11649,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -11660,6 +11662,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -11670,6 +11673,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/digitalassetlinks-v1.ts
+++ b/packages/gcp/src/services/digitalassetlinks-v1.ts
@@ -221,6 +221,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -232,6 +233,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -244,6 +246,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -254,6 +257,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/discovery-v1.ts
+++ b/packages/gcp/src/services/discovery-v1.ts
@@ -421,6 +421,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -432,6 +433,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/discoveryengine-v1.ts
+++ b/packages/gcp/src/services/discoveryengine-v1.ts
@@ -20574,6 +20574,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -20585,6 +20586,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -20597,6 +20599,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -20607,6 +20610,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/displayvideo-v4.ts
+++ b/packages/gcp/src/services/displayvideo-v4.ts
@@ -9708,6 +9708,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -9719,6 +9720,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -9731,6 +9733,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -9741,6 +9744,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/dlp-v2.ts
+++ b/packages/gcp/src/services/dlp-v2.ts
@@ -6367,6 +6367,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -6378,6 +6379,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -6390,6 +6392,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -6400,6 +6403,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/dns-v1.ts
+++ b/packages/gcp/src/services/dns-v1.ts
@@ -1197,6 +1197,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1208,6 +1209,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1220,6 +1222,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1230,6 +1233,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/docs-v1.ts
+++ b/packages/gcp/src/services/docs-v1.ts
@@ -3436,6 +3436,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3447,6 +3448,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3459,6 +3461,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3469,6 +3472,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/documentai-v1.ts
+++ b/packages/gcp/src/services/documentai-v1.ts
@@ -6418,6 +6418,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -6429,6 +6430,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -6441,6 +6443,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -6451,6 +6454,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/domains-v1.ts
+++ b/packages/gcp/src/services/domains-v1.ts
@@ -1124,6 +1124,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1135,6 +1136,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1147,6 +1149,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1157,6 +1160,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/doubleclickbidmanager-v2.ts
+++ b/packages/gcp/src/services/doubleclickbidmanager-v2.ts
@@ -303,6 +303,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -314,6 +315,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -326,6 +328,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -336,6 +339,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/doubleclicksearch-v2.ts
+++ b/packages/gcp/src/services/doubleclicksearch-v2.ts
@@ -439,6 +439,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -450,6 +451,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -462,6 +464,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -472,6 +475,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/drive-v3.ts
+++ b/packages/gcp/src/services/drive-v3.ts
@@ -1770,6 +1770,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1781,6 +1782,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1793,6 +1795,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1803,6 +1806,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/driveactivity-v2.ts
+++ b/packages/gcp/src/services/driveactivity-v2.ts
@@ -949,6 +949,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -960,6 +961,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -972,6 +974,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -982,6 +985,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/drivelabels-v2.ts
+++ b/packages/gcp/src/services/drivelabels-v2.ts
@@ -1749,6 +1749,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1760,6 +1761,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1772,6 +1774,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1782,6 +1785,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/essentialcontacts-v1.ts
+++ b/packages/gcp/src/services/essentialcontacts-v1.ts
@@ -139,6 +139,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -150,6 +151,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -162,6 +164,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -172,6 +175,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/eventarc-v1.ts
+++ b/packages/gcp/src/services/eventarc-v1.ts
@@ -1182,6 +1182,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1193,6 +1194,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1205,6 +1207,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1215,6 +1218,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/factchecktools-v1alpha1.ts
+++ b/packages/gcp/src/services/factchecktools-v1alpha1.ts
@@ -305,6 +305,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -316,6 +317,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -328,6 +330,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -338,6 +341,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/fcm-v1.ts
+++ b/packages/gcp/src/services/fcm-v1.ts
@@ -343,6 +343,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -354,6 +355,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -366,6 +368,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -376,6 +379,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/fcmdata-v1beta1.ts
+++ b/packages/gcp/src/services/fcmdata-v1beta1.ts
@@ -211,6 +211,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -222,6 +223,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/file-v1.ts
+++ b/packages/gcp/src/services/file-v1.ts
@@ -1101,6 +1101,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1112,6 +1113,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1124,6 +1126,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1134,6 +1137,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/firebase-v1beta1.ts
+++ b/packages/gcp/src/services/firebase-v1beta1.ts
@@ -729,6 +729,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -740,6 +741,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -752,6 +754,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -762,6 +765,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/firebaseappcheck-v1.ts
+++ b/packages/gcp/src/services/firebaseappcheck-v1.ts
@@ -740,6 +740,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -751,6 +752,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -763,6 +765,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -773,6 +776,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/firebaseappdistribution-v1.ts
+++ b/packages/gcp/src/services/firebaseappdistribution-v1.ts
@@ -773,6 +773,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -784,6 +785,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -796,6 +798,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -806,6 +809,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/firebaseapphosting-v1.ts
+++ b/packages/gcp/src/services/firebaseapphosting-v1.ts
@@ -1019,6 +1019,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1030,6 +1031,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1042,6 +1044,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1052,6 +1055,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/firebasedatabase-v1beta.ts
+++ b/packages/gcp/src/services/firebasedatabase-v1beta.ts
@@ -96,6 +96,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -107,6 +108,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -119,6 +121,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -129,6 +132,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/firebasedataconnect-v1.ts
+++ b/packages/gcp/src/services/firebasedataconnect-v1.ts
@@ -669,6 +669,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -680,6 +681,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -692,6 +694,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -702,6 +705,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/firebasedynamiclinks-v1.ts
+++ b/packages/gcp/src/services/firebasedynamiclinks-v1.ts
@@ -586,6 +586,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -597,6 +598,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -609,6 +611,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -619,6 +622,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/firebasehosting-v1.ts
+++ b/packages/gcp/src/services/firebasehosting-v1.ts
@@ -259,6 +259,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -270,6 +271,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -282,6 +284,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -292,6 +295,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/firebaseml-v1.ts
+++ b/packages/gcp/src/services/firebaseml-v1.ts
@@ -116,6 +116,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -127,6 +128,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -139,6 +141,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -149,6 +152,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/firebaserules-v1.ts
+++ b/packages/gcp/src/services/firebaserules-v1.ts
@@ -405,6 +405,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -416,6 +417,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -428,6 +430,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -438,6 +441,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/firebasestorage-v1beta.ts
+++ b/packages/gcp/src/services/firebasestorage-v1beta.ts
@@ -89,6 +89,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -100,6 +101,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -112,6 +114,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -122,6 +125,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/firestore-v1.ts
+++ b/packages/gcp/src/services/firestore-v1.ts
@@ -2404,6 +2404,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2415,6 +2416,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2427,6 +2429,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2437,6 +2440,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/fitness-v1.ts
+++ b/packages/gcp/src/services/fitness-v1.ts
@@ -462,6 +462,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -473,6 +474,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -485,6 +487,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -495,6 +498,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/forms-v1.ts
+++ b/packages/gcp/src/services/forms-v1.ts
@@ -947,6 +947,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -958,6 +959,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -970,6 +972,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -980,6 +983,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/games-v1.ts
+++ b/packages/gcp/src/services/games-v1.ts
@@ -1484,6 +1484,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1495,6 +1496,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1507,6 +1509,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1517,6 +1520,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/gamesConfiguration-v1configuration.ts
+++ b/packages/gcp/src/services/gamesConfiguration-v1configuration.ts
@@ -260,6 +260,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -271,6 +272,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -283,6 +285,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -293,6 +296,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/gamesManagement-v1management.ts
+++ b/packages/gcp/src/services/gamesManagement-v1management.ts
@@ -252,6 +252,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -263,6 +264,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -275,6 +277,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -285,6 +288,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/gkebackup-v1.ts
+++ b/packages/gcp/src/services/gkebackup-v1.ts
@@ -1781,6 +1781,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1792,6 +1793,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1804,6 +1806,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1814,6 +1817,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/gkehub-v2.ts
+++ b/packages/gcp/src/services/gkehub-v2.ts
@@ -2082,6 +2082,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2093,6 +2094,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2105,6 +2107,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2115,6 +2118,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/gkeonprem-v1.ts
+++ b/packages/gcp/src/services/gkeonprem-v1.ts
@@ -2836,6 +2836,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2847,6 +2848,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2859,6 +2861,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2869,6 +2872,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/gmail-v1.ts
+++ b/packages/gcp/src/services/gmail-v1.ts
@@ -941,6 +941,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -952,6 +953,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -964,6 +966,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -974,6 +977,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/gmailpostmastertools-v2.ts
+++ b/packages/gcp/src/services/gmailpostmastertools-v2.ts
@@ -411,6 +411,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -422,6 +423,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -434,6 +436,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -444,6 +447,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/groupsmigration-v1.ts
+++ b/packages/gcp/src/services/groupsmigration-v1.ts
@@ -44,6 +44,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -55,6 +56,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -67,6 +69,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -77,6 +80,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/groupssettings-v1.ts
+++ b/packages/gcp/src/services/groupssettings-v1.ts
@@ -224,6 +224,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -235,6 +236,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -247,6 +249,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -257,6 +260,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/health-v4.ts
+++ b/packages/gcp/src/services/health-v4.ts
@@ -2082,6 +2082,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2093,6 +2094,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2105,6 +2107,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2115,6 +2118,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/healthcare-v1.ts
+++ b/packages/gcp/src/services/healthcare-v1.ts
@@ -2781,6 +2781,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2792,6 +2793,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2804,6 +2806,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2814,6 +2817,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/homegraph-v1.ts
+++ b/packages/gcp/src/services/homegraph-v1.ts
@@ -303,6 +303,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -314,6 +315,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -326,6 +328,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -336,6 +339,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/hypercomputecluster-v1.ts
+++ b/packages/gcp/src/services/hypercomputecluster-v1.ts
@@ -987,6 +987,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -998,6 +999,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1010,6 +1012,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1020,6 +1023,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/iam-v2.ts
+++ b/packages/gcp/src/services/iam-v2.ts
@@ -410,6 +410,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -421,6 +422,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -433,6 +435,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -443,6 +446,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/iamcredentials-v1.ts
+++ b/packages/gcp/src/services/iamcredentials-v1.ts
@@ -178,6 +178,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -189,6 +190,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -201,6 +203,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -211,6 +214,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/iap-v1.ts
+++ b/packages/gcp/src/services/iap-v1.ts
@@ -562,6 +562,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -573,6 +574,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -585,6 +587,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -595,6 +598,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/identitytoolkit-v3.ts
+++ b/packages/gcp/src/services/identitytoolkit-v3.ts
@@ -1326,6 +1326,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1337,6 +1338,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1349,6 +1351,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1359,6 +1362,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/ids-v1.ts
+++ b/packages/gcp/src/services/ids-v1.ts
@@ -235,6 +235,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -246,6 +247,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -258,6 +260,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -268,6 +271,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/indexing-v3.ts
+++ b/packages/gcp/src/services/indexing-v3.ts
@@ -77,6 +77,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -88,6 +89,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -100,6 +102,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -110,6 +113,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/integrations-v1.ts
+++ b/packages/gcp/src/services/integrations-v1.ts
@@ -7726,6 +7726,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -7737,6 +7738,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -7749,6 +7751,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -7759,6 +7762,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/jobs-v4.ts
+++ b/packages/gcp/src/services/jobs-v4.ts
@@ -1279,6 +1279,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1290,6 +1291,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1302,6 +1304,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1312,6 +1315,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/keep-v1.ts
+++ b/packages/gcp/src/services/keep-v1.ts
@@ -237,6 +237,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -248,6 +249,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -260,6 +262,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -270,6 +273,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/kgsearch-v1.ts
+++ b/packages/gcp/src/services/kgsearch-v1.ts
@@ -47,6 +47,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -58,6 +59,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/kmsinventory-v1.ts
+++ b/packages/gcp/src/services/kmsinventory-v1.ts
@@ -471,6 +471,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -482,6 +483,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/language-v2.ts
+++ b/packages/gcp/src/services/language-v2.ts
@@ -3634,6 +3634,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3645,6 +3646,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3657,6 +3659,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3667,6 +3670,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/libraryagent-v1.ts
+++ b/packages/gcp/src/services/libraryagent-v1.ts
@@ -90,6 +90,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -101,6 +102,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -113,6 +115,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -123,6 +126,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/licensing-v1.ts
+++ b/packages/gcp/src/services/licensing-v1.ts
@@ -96,6 +96,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -107,6 +108,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -119,6 +121,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -129,6 +132,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/localservices-v1.ts
+++ b/packages/gcp/src/services/localservices-v1.ts
@@ -290,6 +290,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -301,6 +302,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/logging-v2.ts
+++ b/packages/gcp/src/services/logging-v2.ts
@@ -1928,6 +1928,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1939,6 +1940,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1951,6 +1953,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1961,6 +1964,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/looker-v1.ts
+++ b/packages/gcp/src/services/looker-v1.ts
@@ -711,6 +711,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -722,6 +723,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -734,6 +736,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -744,6 +747,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/managedidentities-v1.ts
+++ b/packages/gcp/src/services/managedidentities-v1.ts
@@ -1220,6 +1220,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1231,6 +1232,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1243,6 +1245,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1253,6 +1256,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/managedkafka-v1.ts
+++ b/packages/gcp/src/services/managedkafka-v1.ts
@@ -992,6 +992,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1003,6 +1004,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1015,6 +1017,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1025,6 +1028,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/manufacturers-v1.ts
+++ b/packages/gcp/src/services/manufacturers-v1.ts
@@ -678,6 +678,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -689,6 +690,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -701,6 +703,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -711,6 +714,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/marketingplatformadmin-v1alpha.ts
+++ b/packages/gcp/src/services/marketingplatformadmin-v1alpha.ts
@@ -265,6 +265,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -276,6 +277,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -288,6 +290,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -298,6 +301,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/meet-v2.ts
+++ b/packages/gcp/src/services/meet-v2.ts
@@ -550,6 +550,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -561,6 +562,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -573,6 +575,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -583,6 +586,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/memcache-v1.ts
+++ b/packages/gcp/src/services/memcache-v1.ts
@@ -990,6 +990,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1001,6 +1002,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1013,6 +1015,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1023,6 +1026,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/merchantapi-reviews_v1beta.ts
+++ b/packages/gcp/src/services/merchantapi-reviews_v1beta.ts
@@ -595,6 +595,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -606,6 +607,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -618,6 +620,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -628,6 +631,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/metastore-v1.ts
+++ b/packages/gcp/src/services/metastore-v1.ts
@@ -1260,6 +1260,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1271,6 +1272,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1283,6 +1285,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1293,6 +1296,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/migrationcenter-v1.ts
+++ b/packages/gcp/src/services/migrationcenter-v1.ts
@@ -3519,6 +3519,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3530,6 +3531,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3542,6 +3544,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3552,6 +3555,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/ml-v1.ts
+++ b/packages/gcp/src/services/ml-v1.ts
@@ -1764,6 +1764,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1775,6 +1776,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1787,6 +1789,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1797,6 +1800,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/monitoring-v3.ts
+++ b/packages/gcp/src/services/monitoring-v3.ts
@@ -2505,6 +2505,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2516,6 +2517,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2528,6 +2530,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2538,6 +2541,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/mybusinessaccountmanagement-v1.ts
+++ b/packages/gcp/src/services/mybusinessaccountmanagement-v1.ts
@@ -290,6 +290,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -301,6 +302,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -313,6 +315,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -323,6 +326,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/mybusinessbusinessinformation-v1.ts
+++ b/packages/gcp/src/services/mybusinessbusinessinformation-v1.ts
@@ -839,6 +839,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -850,6 +851,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -862,6 +864,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -872,6 +875,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/mybusinesslodging-v1.ts
+++ b/packages/gcp/src/services/mybusinesslodging-v1.ts
@@ -3464,6 +3464,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3475,6 +3476,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3487,6 +3489,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3497,6 +3500,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/mybusinessnotifications-v1.ts
+++ b/packages/gcp/src/services/mybusinessnotifications-v1.ts
@@ -61,6 +61,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -72,6 +73,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -84,6 +86,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -94,6 +97,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/mybusinessplaceactions-v1.ts
+++ b/packages/gcp/src/services/mybusinessplaceactions-v1.ts
@@ -133,6 +133,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -144,6 +145,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -156,6 +158,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -166,6 +169,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/mybusinessqanda-v1.ts
+++ b/packages/gcp/src/services/mybusinessqanda-v1.ts
@@ -151,6 +151,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -162,6 +163,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -174,6 +176,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -184,6 +187,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/mybusinessverifications-v1.ts
+++ b/packages/gcp/src/services/mybusinessverifications-v1.ts
@@ -390,6 +390,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -401,6 +402,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -413,6 +415,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -423,6 +426,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/netapp-v1.ts
+++ b/packages/gcp/src/services/netapp-v1.ts
@@ -1901,6 +1901,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1912,6 +1913,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1924,6 +1926,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1934,6 +1937,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/networkconnectivity-v1.ts
+++ b/packages/gcp/src/services/networkconnectivity-v1.ts
@@ -2508,6 +2508,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2519,6 +2520,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2531,6 +2533,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2541,6 +2544,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/networkmanagement-v1.ts
+++ b/packages/gcp/src/services/networkmanagement-v1.ts
@@ -2189,6 +2189,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2200,6 +2201,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2212,6 +2214,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2222,6 +2225,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/networksecurity-v1.ts
+++ b/packages/gcp/src/services/networksecurity-v1.ts
@@ -2380,6 +2380,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2391,6 +2392,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2403,6 +2405,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2413,6 +2416,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/networkservices-v1.ts
+++ b/packages/gcp/src/services/networkservices-v1.ts
@@ -2057,6 +2057,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2068,6 +2069,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2080,6 +2082,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2090,6 +2093,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/notebooks-v2.ts
+++ b/packages/gcp/src/services/notebooks-v2.ts
@@ -939,6 +939,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -950,6 +951,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -962,6 +964,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -972,6 +975,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/oauth2-v2.ts
+++ b/packages/gcp/src/services/oauth2-v2.ts
@@ -98,6 +98,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -109,6 +110,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -121,6 +123,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -131,6 +134,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/observability-v1.ts
+++ b/packages/gcp/src/services/observability-v1.ts
@@ -385,6 +385,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -396,6 +397,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -408,6 +410,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -418,6 +421,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/ondemandscanning-v1.ts
+++ b/packages/gcp/src/services/ondemandscanning-v1.ts
@@ -2007,6 +2007,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2018,6 +2019,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2030,6 +2032,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2040,6 +2043,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/oracledatabase-v1.ts
+++ b/packages/gcp/src/services/oracledatabase-v1.ts
@@ -2923,6 +2923,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2934,6 +2935,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2946,6 +2948,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2956,6 +2959,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/orgpolicy-v2.ts
+++ b/packages/gcp/src/services/orgpolicy-v2.ts
@@ -390,6 +390,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -401,6 +402,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -413,6 +415,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -423,6 +426,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/osconfig-v2.ts
+++ b/packages/gcp/src/services/osconfig-v2.ts
@@ -1053,6 +1053,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1064,6 +1065,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1076,6 +1078,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1086,6 +1089,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/oslogin-v1.ts
+++ b/packages/gcp/src/services/oslogin-v1.ts
@@ -166,6 +166,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -177,6 +178,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -189,6 +191,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -199,6 +202,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/pagespeedonline-v5.ts
+++ b/packages/gcp/src/services/pagespeedonline-v5.ts
@@ -612,6 +612,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -623,6 +624,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/parallelstore-v1.ts
+++ b/packages/gcp/src/services/parallelstore-v1.ts
@@ -359,6 +359,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -370,6 +371,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -382,6 +384,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -392,6 +395,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/parametermanager-v1.ts
+++ b/packages/gcp/src/services/parametermanager-v1.ts
@@ -198,6 +198,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -209,6 +210,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -221,6 +223,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -231,6 +234,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/paymentsresellersubscription-v1.ts
+++ b/packages/gcp/src/services/paymentsresellersubscription-v1.ts
@@ -908,6 +908,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -919,6 +920,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -931,6 +933,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -941,6 +944,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/people-v1.ts
+++ b/packages/gcp/src/services/people-v1.ts
@@ -1416,6 +1416,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1427,6 +1428,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1439,6 +1441,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1449,6 +1452,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/places-v1.ts
+++ b/packages/gcp/src/services/places-v1.ts
@@ -1769,6 +1769,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1780,6 +1781,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1792,6 +1794,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1802,6 +1805,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/playcustomapp-v1.ts
+++ b/packages/gcp/src/services/playcustomapp-v1.ts
@@ -62,6 +62,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -73,6 +74,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -85,6 +87,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -95,6 +98,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/playdeveloperreporting-v1beta1.ts
+++ b/packages/gcp/src/services/playdeveloperreporting-v1beta1.ts
@@ -1134,6 +1134,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1145,6 +1146,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1157,6 +1159,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1167,6 +1170,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/playgrouping-v1alpha1.ts
+++ b/packages/gcp/src/services/playgrouping-v1alpha1.ts
@@ -88,6 +88,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -99,6 +100,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -111,6 +113,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -121,6 +124,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/playintegrity-v1.ts
+++ b/packages/gcp/src/services/playintegrity-v1.ts
@@ -412,6 +412,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -423,6 +424,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -435,6 +437,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -445,6 +448,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/policyanalyzer-v1.ts
+++ b/packages/gcp/src/services/policyanalyzer-v1.ts
@@ -83,6 +83,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -94,6 +95,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/policysimulator-v1.ts
+++ b/packages/gcp/src/services/policysimulator-v1.ts
@@ -1005,6 +1005,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1016,6 +1017,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1028,6 +1030,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1038,6 +1041,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/policytroubleshooter-v3.ts
+++ b/packages/gcp/src/services/policytroubleshooter-v3.ts
@@ -829,6 +829,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -840,6 +841,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -852,6 +854,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -862,6 +865,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/pollen-v1.ts
+++ b/packages/gcp/src/services/pollen-v1.ts
@@ -229,6 +229,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -240,6 +241,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/privateca-v1.ts
+++ b/packages/gcp/src/services/privateca-v1.ts
@@ -1329,6 +1329,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1340,6 +1341,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1352,6 +1354,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1362,6 +1365,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/prod_tt_sasportal-v1alpha1.ts
+++ b/packages/gcp/src/services/prod_tt_sasportal-v1alpha1.ts
@@ -814,6 +814,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -825,6 +826,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -837,6 +839,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -847,6 +850,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/publicca-v1.ts
+++ b/packages/gcp/src/services/publicca-v1.ts
@@ -47,6 +47,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -58,6 +59,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -70,6 +72,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -80,6 +83,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/pubsub-v1.ts
+++ b/packages/gcp/src/services/pubsub-v1.ts
@@ -1137,6 +1137,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1148,6 +1149,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1160,6 +1162,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1170,6 +1173,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/pubsublite-v1.ts
+++ b/packages/gcp/src/services/pubsublite-v1.ts
@@ -500,6 +500,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -511,6 +512,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -523,6 +525,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -533,6 +536,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/rapidmigrationassessment-v1.ts
+++ b/packages/gcp/src/services/rapidmigrationassessment-v1.ts
@@ -307,6 +307,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -318,6 +319,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -330,6 +332,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -340,6 +343,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/readerrevenuesubscriptionlinking-v1.ts
+++ b/packages/gcp/src/services/readerrevenuesubscriptionlinking-v1.ts
@@ -89,6 +89,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -100,6 +101,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -112,6 +114,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -122,6 +125,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/realtimebidding-v1.ts
+++ b/packages/gcp/src/services/realtimebidding-v1.ts
@@ -1260,6 +1260,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1271,6 +1272,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1283,6 +1285,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1293,6 +1296,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/recaptchaenterprise-v1.ts
+++ b/packages/gcp/src/services/recaptchaenterprise-v1.ts
@@ -1630,6 +1630,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1641,6 +1642,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1653,6 +1655,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1663,6 +1666,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/recommendationengine-v1beta1.ts
+++ b/packages/gcp/src/services/recommendationengine-v1beta1.ts
@@ -1082,6 +1082,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1093,6 +1094,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1105,6 +1107,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1115,6 +1118,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/recommender-v1.ts
+++ b/packages/gcp/src/services/recommender-v1.ts
@@ -581,6 +581,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -592,6 +593,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -604,6 +606,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -614,6 +617,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/redis-v1.ts
+++ b/packages/gcp/src/services/redis-v1.ts
@@ -2769,6 +2769,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2780,6 +2781,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2792,6 +2794,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2802,6 +2805,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/reseller-v1.ts
+++ b/packages/gcp/src/services/reseller-v1.ts
@@ -293,6 +293,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -304,6 +305,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -316,6 +318,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -326,6 +329,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/retail-v2.ts
+++ b/packages/gcp/src/services/retail-v2.ts
@@ -4820,6 +4820,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -4831,6 +4832,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -4843,6 +4845,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -4853,6 +4856,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/run-v2.ts
+++ b/packages/gcp/src/services/run-v2.ts
@@ -3584,6 +3584,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3595,6 +3596,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3607,6 +3609,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3617,6 +3620,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/runtimeconfig-v1.ts
+++ b/packages/gcp/src/services/runtimeconfig-v1.ts
@@ -99,6 +99,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -110,6 +111,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -122,6 +124,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -132,6 +135,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/saasservicemgmt-v1.ts
+++ b/packages/gcp/src/services/saasservicemgmt-v1.ts
@@ -1034,6 +1034,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1045,6 +1046,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1057,6 +1059,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1067,6 +1070,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/safebrowsing-v5.ts
+++ b/packages/gcp/src/services/safebrowsing-v5.ts
@@ -337,6 +337,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -348,6 +349,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/sasportal-v1alpha1.ts
+++ b/packages/gcp/src/services/sasportal-v1alpha1.ts
@@ -814,6 +814,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -825,6 +826,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -837,6 +839,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -847,6 +850,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/script-v1.ts
+++ b/packages/gcp/src/services/script-v1.ts
@@ -570,6 +570,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -581,6 +582,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -593,6 +595,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -603,6 +606,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/searchads360-v0.ts
+++ b/packages/gcp/src/services/searchads360-v0.ts
@@ -6043,6 +6043,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -6054,6 +6055,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -6066,6 +6068,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -6076,6 +6079,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/searchconsole-v1.ts
+++ b/packages/gcp/src/services/searchconsole-v1.ts
@@ -688,6 +688,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -699,6 +700,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -711,6 +713,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -721,6 +724,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/secretmanager-v1.ts
+++ b/packages/gcp/src/services/secretmanager-v1.ts
@@ -555,6 +555,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -566,6 +567,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -578,6 +580,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -588,6 +591,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/securesourcemanager-v1.ts
+++ b/packages/gcp/src/services/securesourcemanager-v1.ts
@@ -1047,6 +1047,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1058,6 +1059,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1070,6 +1072,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1080,6 +1083,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/securitycenter-v1.ts
+++ b/packages/gcp/src/services/securitycenter-v1.ts
@@ -8358,6 +8358,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -8369,6 +8370,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -8381,6 +8383,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -8391,6 +8394,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/securityposture-v1.ts
+++ b/packages/gcp/src/services/securityposture-v1.ts
@@ -819,6 +819,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -830,6 +831,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -842,6 +844,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -852,6 +855,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/serviceconsumermanagement-v1.ts
+++ b/packages/gcp/src/services/serviceconsumermanagement-v1.ts
@@ -2035,6 +2035,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2046,6 +2047,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2058,6 +2060,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2068,6 +2071,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/servicecontrol-v2.ts
+++ b/packages/gcp/src/services/servicecontrol-v2.ts
@@ -809,6 +809,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -820,6 +821,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -832,6 +834,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -842,6 +845,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/servicedirectory-v1.ts
+++ b/packages/gcp/src/services/servicedirectory-v1.ts
@@ -283,6 +283,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -294,6 +295,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -306,6 +308,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -316,6 +319,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/servicemanagement-v1.ts
+++ b/packages/gcp/src/services/servicemanagement-v1.ts
@@ -2036,6 +2036,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2047,6 +2048,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2059,6 +2061,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2069,6 +2072,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/servicenetworking-v1.ts
+++ b/packages/gcp/src/services/servicenetworking-v1.ts
@@ -2324,6 +2324,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2335,6 +2336,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2347,6 +2349,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2357,6 +2360,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/serviceusage-v1.ts
+++ b/packages/gcp/src/services/serviceusage-v1.ts
@@ -2362,6 +2362,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2373,6 +2374,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2385,6 +2387,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2395,6 +2398,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/sheets-v4.ts
+++ b/packages/gcp/src/services/sheets-v4.ts
@@ -5096,6 +5096,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -5107,6 +5108,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -5119,6 +5121,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -5129,6 +5132,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/siteVerification-v1.ts
+++ b/packages/gcp/src/services/siteVerification-v1.ts
@@ -94,6 +94,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -105,6 +106,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -117,6 +119,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -127,6 +130,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/slides-v1.ts
+++ b/packages/gcp/src/services/slides-v1.ts
@@ -2881,6 +2881,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2892,6 +2893,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2904,6 +2906,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2914,6 +2917,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/smartdevicemanagement-v1.ts
+++ b/packages/gcp/src/services/smartdevicemanagement-v1.ts
@@ -162,6 +162,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -173,6 +174,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -185,6 +187,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -195,6 +198,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/solar-v1.ts
+++ b/packages/gcp/src/services/solar-v1.ts
@@ -483,6 +483,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -494,6 +495,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/spanner-v1.ts
+++ b/packages/gcp/src/services/spanner-v1.ts
@@ -3184,6 +3184,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3195,6 +3196,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3207,6 +3209,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3217,6 +3220,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/speech-v1.ts
+++ b/packages/gcp/src/services/speech-v1.ts
@@ -661,6 +661,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -672,6 +673,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -684,6 +686,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -694,6 +697,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/sqladmin-v1.ts
+++ b/packages/gcp/src/services/sqladmin-v1.ts
@@ -3727,6 +3727,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3738,6 +3739,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3750,6 +3752,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3760,6 +3763,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/storage-v1.ts
+++ b/packages/gcp/src/services/storage-v1.ts
@@ -1259,6 +1259,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1270,6 +1271,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1282,6 +1284,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1292,6 +1295,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/storagebatchoperations-v1.ts
+++ b/packages/gcp/src/services/storagebatchoperations-v1.ts
@@ -567,6 +567,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -578,6 +579,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -590,6 +592,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -600,6 +603,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/storagetransfer-v1.ts
+++ b/packages/gcp/src/services/storagetransfer-v1.ts
@@ -930,6 +930,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -941,6 +942,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -953,6 +955,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -963,6 +966,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/streetviewpublish-v1.ts
+++ b/packages/gcp/src/services/streetviewpublish-v1.ts
@@ -545,6 +545,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -556,6 +557,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -568,6 +570,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -578,6 +581,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/sts-v1.ts
+++ b/packages/gcp/src/services/sts-v1.ts
@@ -200,6 +200,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -211,6 +212,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -223,6 +225,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -233,6 +236,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/tagmanager-v2.ts
+++ b/packages/gcp/src/services/tagmanager-v2.ts
@@ -1822,6 +1822,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1833,6 +1834,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1845,6 +1847,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1855,6 +1858,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/tasks-v1.ts
+++ b/packages/gcp/src/services/tasks-v1.ts
@@ -201,6 +201,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -212,6 +213,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -224,6 +226,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -234,6 +237,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/testing-v1.ts
+++ b/packages/gcp/src/services/testing-v1.ts
@@ -1627,6 +1627,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1638,6 +1639,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1650,6 +1652,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1660,6 +1663,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/texttospeech-v1.ts
+++ b/packages/gcp/src/services/texttospeech-v1.ts
@@ -456,6 +456,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -467,6 +468,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -479,6 +481,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -489,6 +492,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/threatintelligence-v1beta.ts
+++ b/packages/gcp/src/services/threatintelligence-v1beta.ts
@@ -1002,6 +1002,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1013,6 +1014,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1025,6 +1027,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1035,6 +1038,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/toolresults-v1beta3.ts
+++ b/packages/gcp/src/services/toolresults-v1beta3.ts
@@ -1757,6 +1757,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1768,6 +1769,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1780,6 +1782,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1790,6 +1793,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/tpu-v2.ts
+++ b/packages/gcp/src/services/tpu-v2.ts
@@ -865,6 +865,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -876,6 +877,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -888,6 +890,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -898,6 +901,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/trafficdirector-v3.ts
+++ b/packages/gcp/src/services/trafficdirector-v3.ts
@@ -839,6 +839,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -850,6 +851,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -862,6 +864,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -872,6 +875,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/transcoder-v1.ts
+++ b/packages/gcp/src/services/transcoder-v1.ts
@@ -1136,6 +1136,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1147,6 +1148,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1159,6 +1161,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1169,6 +1172,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/translate-v3.ts
+++ b/packages/gcp/src/services/translate-v3.ts
@@ -1177,6 +1177,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1188,6 +1189,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1200,6 +1202,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1210,6 +1213,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/travelimpactmodel-v1.ts
+++ b/packages/gcp/src/services/travelimpactmodel-v1.ts
@@ -309,6 +309,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -320,6 +321,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -332,6 +334,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -342,6 +345,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/vault-v1.ts
+++ b/packages/gcp/src/services/vault-v1.ts
@@ -1152,6 +1152,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1163,6 +1164,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1175,6 +1177,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1185,6 +1188,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/verifiedaccess-v2.ts
+++ b/packages/gcp/src/services/verifiedaccess-v2.ts
@@ -299,6 +299,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -310,6 +311,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -322,6 +324,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -332,6 +335,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/versionhistory-v1.ts
+++ b/packages/gcp/src/services/versionhistory-v1.ts
@@ -195,6 +195,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -206,6 +207,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/videointelligence-v1.ts
+++ b/packages/gcp/src/services/videointelligence-v1.ts
@@ -4147,6 +4147,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -4158,6 +4159,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -4170,6 +4172,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -4180,6 +4183,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/vision-v1.ts
+++ b/packages/gcp/src/services/vision-v1.ts
@@ -5888,6 +5888,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -5899,6 +5900,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -5911,6 +5913,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -5921,6 +5924,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/vmmigration-v1.ts
+++ b/packages/gcp/src/services/vmmigration-v1.ts
@@ -2751,6 +2751,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2762,6 +2763,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2774,6 +2776,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2784,6 +2787,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/vmwareengine-v1.ts
+++ b/packages/gcp/src/services/vmwareengine-v1.ts
@@ -2045,6 +2045,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2056,6 +2057,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2068,6 +2070,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2078,6 +2081,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/vpcaccess-v1.ts
+++ b/packages/gcp/src/services/vpcaccess-v1.ts
@@ -248,6 +248,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -259,6 +260,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -271,6 +273,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -281,6 +284,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/walletobjects-v1.ts
+++ b/packages/gcp/src/services/walletobjects-v1.ts
@@ -4397,6 +4397,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -4408,6 +4409,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -4420,6 +4422,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -4430,6 +4433,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/webfonts-v1.ts
+++ b/packages/gcp/src/services/webfonts-v1.ts
@@ -113,6 +113,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -124,6 +125,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/services/webrisk-v1.ts
+++ b/packages/gcp/src/services/webrisk-v1.ts
@@ -291,6 +291,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -302,6 +303,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -314,6 +316,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -324,6 +327,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/websecurityscanner-v1.ts
+++ b/packages/gcp/src/services/websecurityscanner-v1.ts
@@ -609,6 +609,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -620,6 +621,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -632,6 +634,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -642,6 +645,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/workflowexecutions-v1.ts
+++ b/packages/gcp/src/services/workflowexecutions-v1.ts
@@ -449,6 +449,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -460,6 +461,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -472,6 +474,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -482,6 +485,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/workflows-v1.ts
+++ b/packages/gcp/src/services/workflows-v1.ts
@@ -259,6 +259,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -270,6 +271,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -282,6 +284,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -292,6 +295,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/workloadmanager-v1.ts
+++ b/packages/gcp/src/services/workloadmanager-v1.ts
@@ -2360,6 +2360,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2371,6 +2372,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2383,6 +2385,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2393,6 +2396,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/workspaceevents-v1.ts
+++ b/packages/gcp/src/services/workspaceevents-v1.ts
@@ -491,6 +491,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -502,6 +503,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -514,6 +516,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -524,6 +527,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/workstations-v1.ts
+++ b/packages/gcp/src/services/workstations-v1.ts
@@ -972,6 +972,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -983,6 +984,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -995,6 +997,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1005,6 +1008,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/youtube-v3.ts
+++ b/packages/gcp/src/services/youtube-v3.ts
@@ -5252,6 +5252,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -5263,6 +5264,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -5275,6 +5277,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -5285,6 +5288,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/youtubeAnalytics-v2.ts
+++ b/packages/gcp/src/services/youtubeAnalytics-v2.ts
@@ -250,6 +250,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -261,6 +262,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -273,6 +275,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -283,6 +286,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/services/youtubereporting-v1.ts
+++ b/packages/gcp/src/services/youtubereporting-v1.ts
@@ -450,6 +450,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -461,6 +462,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -473,6 +475,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -483,6 +486,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/admin-datatransfer_v1.ts
+++ b/packages/gcp/src/unstable-services/admin-datatransfer_v1.ts
@@ -154,6 +154,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -165,6 +166,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -177,6 +179,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -187,6 +190,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/admin-directory_v1.ts
+++ b/packages/gcp/src/unstable-services/admin-directory_v1.ts
@@ -2792,6 +2792,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2803,6 +2804,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2815,6 +2817,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2825,6 +2828,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/admob-v1beta.ts
+++ b/packages/gcp/src/unstable-services/admob-v1beta.ts
@@ -1052,6 +1052,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1063,6 +1064,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1075,6 +1077,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1085,6 +1088,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/adsenseplatform-v1alpha.ts
+++ b/packages/gcp/src/unstable-services/adsenseplatform-v1alpha.ts
@@ -314,6 +314,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -325,6 +326,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -337,6 +339,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -347,6 +350,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/aiplatform-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/aiplatform-v1beta1.ts
@@ -34124,6 +34124,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -34135,6 +34136,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -34147,6 +34149,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -34157,6 +34160,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/alloydb-v1alpha.ts
+++ b/packages/gcp/src/unstable-services/alloydb-v1alpha.ts
@@ -3430,6 +3430,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3441,6 +3442,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3453,6 +3455,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3463,6 +3466,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/alloydb-v1beta.ts
+++ b/packages/gcp/src/unstable-services/alloydb-v1beta.ts
@@ -3415,6 +3415,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3426,6 +3427,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3438,6 +3440,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3448,6 +3451,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/analyticsadmin-v1alpha.ts
+++ b/packages/gcp/src/unstable-services/analyticsadmin-v1alpha.ts
@@ -3597,6 +3597,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3608,6 +3609,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3620,6 +3622,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3630,6 +3633,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/analyticshub-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/analyticshub-v1beta1.ts
@@ -595,6 +595,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -606,6 +607,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -618,6 +620,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -628,6 +631,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/apigateway-v1beta.ts
+++ b/packages/gcp/src/unstable-services/apigateway-v1beta.ts
@@ -522,6 +522,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -533,6 +534,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -545,6 +547,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -555,6 +558,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/appengine-v1alpha.ts
+++ b/packages/gcp/src/unstable-services/appengine-v1alpha.ts
@@ -589,6 +589,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -600,6 +601,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -612,6 +614,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -622,6 +625,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/appengine-v1beta.ts
+++ b/packages/gcp/src/unstable-services/appengine-v1beta.ts
@@ -1826,6 +1826,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1837,6 +1838,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1849,6 +1851,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1859,6 +1862,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/apphub-v1alpha.ts
+++ b/packages/gcp/src/unstable-services/apphub-v1alpha.ts
@@ -896,6 +896,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -907,6 +908,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -919,6 +921,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -929,6 +932,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/artifactregistry-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/artifactregistry-v1beta1.ts
@@ -384,6 +384,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -395,6 +396,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -407,6 +409,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -417,6 +420,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/artifactregistry-v1beta2.ts
+++ b/packages/gcp/src/unstable-services/artifactregistry-v1beta2.ts
@@ -676,6 +676,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -687,6 +688,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -699,6 +701,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -709,6 +712,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/assuredworkloads-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/assuredworkloads-v1beta1.ts
@@ -1143,6 +1143,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1154,6 +1155,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1166,6 +1168,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1176,6 +1179,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/authorizedbuyersmarketplace-v1alpha.ts
+++ b/packages/gcp/src/unstable-services/authorizedbuyersmarketplace-v1alpha.ts
@@ -1665,6 +1665,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1676,6 +1677,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1688,6 +1690,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1698,6 +1701,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/authorizedbuyersmarketplace-v1beta.ts
+++ b/packages/gcp/src/unstable-services/authorizedbuyersmarketplace-v1beta.ts
@@ -509,6 +509,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -520,6 +521,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -532,6 +534,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -542,6 +545,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/beyondcorp-v1alpha.ts
+++ b/packages/gcp/src/unstable-services/beyondcorp-v1alpha.ts
@@ -2349,6 +2349,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2360,6 +2361,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2372,6 +2374,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2382,6 +2385,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/bigqueryconnection-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/bigqueryconnection-v1beta1.ts
@@ -250,6 +250,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -261,6 +262,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -273,6 +275,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -283,6 +286,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/bigquerydatapolicy-v1.ts
+++ b/packages/gcp/src/unstable-services/bigquerydatapolicy-v1.ts
@@ -238,6 +238,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -249,6 +250,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -261,6 +263,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -271,6 +274,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/billingbudgets-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/billingbudgets-v1beta1.ts
@@ -272,6 +272,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -283,6 +284,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -295,6 +297,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -305,6 +308,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/binaryauthorization-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/binaryauthorization-v1beta1.ts
@@ -368,6 +368,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -379,6 +380,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -391,6 +393,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -401,6 +404,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/ces-v1beta.ts
+++ b/packages/gcp/src/unstable-services/ces-v1beta.ts
@@ -5530,6 +5530,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -5541,6 +5542,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -5553,6 +5555,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -5563,6 +5566,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/chromewebstore-v1.1.ts
+++ b/packages/gcp/src/unstable-services/chromewebstore-v1.1.ts
@@ -101,6 +101,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -112,6 +113,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -124,6 +126,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -134,6 +137,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudasset-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/cloudasset-v1beta1.ts
@@ -981,6 +981,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -992,6 +993,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1004,6 +1006,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1014,6 +1017,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudasset-v1p1beta1.ts
+++ b/packages/gcp/src/unstable-services/cloudasset-v1p1beta1.ts
@@ -903,6 +903,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -914,6 +915,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/unstable-services/cloudasset-v1p5beta1.ts
+++ b/packages/gcp/src/unstable-services/cloudasset-v1p5beta1.ts
@@ -881,6 +881,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -892,6 +893,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/unstable-services/cloudasset-v1p7beta1.ts
+++ b/packages/gcp/src/unstable-services/cloudasset-v1p7beta1.ts
@@ -936,6 +936,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -947,6 +948,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -959,6 +961,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -969,6 +972,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudbilling-v1beta.ts
+++ b/packages/gcp/src/unstable-services/cloudbilling-v1beta.ts
@@ -1434,6 +1434,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1445,6 +1446,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1457,6 +1459,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1467,6 +1470,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudbuild-v1.ts
+++ b/packages/gcp/src/unstable-services/cloudbuild-v1.ts
@@ -2392,6 +2392,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2403,6 +2404,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2415,6 +2417,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2425,6 +2428,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudcontrolspartner-v1beta.ts
+++ b/packages/gcp/src/unstable-services/cloudcontrolspartner-v1beta.ts
@@ -538,6 +538,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -549,6 +550,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -561,6 +563,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -571,6 +574,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudfunctions-v1.ts
+++ b/packages/gcp/src/unstable-services/cloudfunctions-v1.ts
@@ -612,6 +612,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -623,6 +624,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -635,6 +637,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -645,6 +648,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudfunctions-v2alpha.ts
+++ b/packages/gcp/src/unstable-services/cloudfunctions-v2alpha.ts
@@ -1035,6 +1035,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1046,6 +1047,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1058,6 +1060,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1068,6 +1071,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudfunctions-v2beta.ts
+++ b/packages/gcp/src/unstable-services/cloudfunctions-v2beta.ts
@@ -1035,6 +1035,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1046,6 +1047,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1058,6 +1060,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1068,6 +1071,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudidentity-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/cloudidentity-v1beta1.ts
@@ -2467,6 +2467,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2478,6 +2479,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2490,6 +2492,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2500,6 +2503,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudlocationfinder-v1alpha.ts
+++ b/packages/gcp/src/unstable-services/cloudlocationfinder-v1alpha.ts
@@ -130,6 +130,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -141,6 +142,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/unstable-services/cloudresourcemanager-v1.ts
+++ b/packages/gcp/src/unstable-services/cloudresourcemanager-v1.ts
@@ -861,6 +861,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -872,6 +873,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -884,6 +886,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -894,6 +897,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudresourcemanager-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/cloudresourcemanager-v1beta1.ts
@@ -566,6 +566,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -577,6 +578,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -589,6 +591,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -599,6 +602,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudresourcemanager-v2.ts
+++ b/packages/gcp/src/unstable-services/cloudresourcemanager-v2.ts
@@ -547,6 +547,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -558,6 +559,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -570,6 +572,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -580,6 +583,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudresourcemanager-v2beta1.ts
+++ b/packages/gcp/src/unstable-services/cloudresourcemanager-v2beta1.ts
@@ -547,6 +547,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -558,6 +559,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -570,6 +572,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -580,6 +583,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudscheduler-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/cloudscheduler-v1beta1.ts
@@ -414,6 +414,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -425,6 +426,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -437,6 +439,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -447,6 +450,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudsupport-v2beta.ts
+++ b/packages/gcp/src/unstable-services/cloudsupport-v2beta.ts
@@ -676,6 +676,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -687,6 +688,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -699,6 +701,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -709,6 +712,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudtasks-v2beta2.ts
+++ b/packages/gcp/src/unstable-services/cloudtasks-v2beta2.ts
@@ -778,6 +778,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -789,6 +790,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -801,6 +803,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -811,6 +814,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudtasks-v2beta3.ts
+++ b/packages/gcp/src/unstable-services/cloudtasks-v2beta3.ts
@@ -690,6 +690,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -701,6 +702,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -713,6 +715,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -723,6 +726,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudtrace-v1.ts
+++ b/packages/gcp/src/unstable-services/cloudtrace-v1.ts
@@ -101,6 +101,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -112,6 +113,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -124,6 +126,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -134,6 +137,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/cloudtrace-v2beta1.ts
+++ b/packages/gcp/src/unstable-services/cloudtrace-v2beta1.ts
@@ -76,6 +76,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -87,6 +88,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -99,6 +101,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -109,6 +112,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/composer-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/composer-v1beta1.ts
@@ -1166,6 +1166,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1177,6 +1178,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1189,6 +1191,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1199,6 +1202,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/compute-alpha.ts
+++ b/packages/gcp/src/unstable-services/compute-alpha.ts
@@ -41131,6 +41131,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -41142,6 +41143,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -41154,6 +41156,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -41164,6 +41167,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/compute-beta.ts
+++ b/packages/gcp/src/unstable-services/compute-beta.ts
@@ -36493,6 +36493,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -36504,6 +36505,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -36516,6 +36518,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -36526,6 +36529,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/connectors-v1.ts
+++ b/packages/gcp/src/unstable-services/connectors-v1.ts
@@ -4071,6 +4071,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -4082,6 +4083,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -4094,6 +4096,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -4104,6 +4107,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/container-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/container-v1beta1.ts
@@ -5528,6 +5528,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -5539,6 +5540,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -5551,6 +5553,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -5561,6 +5564,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/containeranalysis-v1alpha1.ts
+++ b/packages/gcp/src/unstable-services/containeranalysis-v1alpha1.ts
@@ -4396,6 +4396,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -4407,6 +4408,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -4419,6 +4421,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -4429,6 +4432,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/containeranalysis-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/containeranalysis-v1beta1.ts
@@ -3979,6 +3979,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3990,6 +3991,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -4002,6 +4004,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -4012,6 +4015,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/datacatalog-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/datacatalog-v1beta1.ts
@@ -2354,6 +2354,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2365,6 +2366,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2377,6 +2379,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2387,6 +2390,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/dataform-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/dataform-v1beta1.ts
@@ -2031,6 +2031,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2042,6 +2043,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2054,6 +2056,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2064,6 +2067,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/datafusion-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/datafusion-v1beta1.ts
@@ -744,6 +744,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -755,6 +756,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -767,6 +769,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -777,6 +780,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/datamigration-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/datamigration-v1beta1.ts
@@ -980,6 +980,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -991,6 +992,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1003,6 +1005,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1013,6 +1016,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/dataportability-v1beta.ts
+++ b/packages/gcp/src/unstable-services/dataportability-v1beta.ts
@@ -156,6 +156,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -167,6 +168,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -179,6 +181,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -189,6 +192,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/datastore-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/datastore-v1beta1.ts
@@ -466,6 +466,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -477,6 +478,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -489,6 +491,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -499,6 +502,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/datastore-v1beta3.ts
+++ b/packages/gcp/src/unstable-services/datastore-v1beta3.ts
@@ -1280,6 +1280,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1291,6 +1292,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1303,6 +1305,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1313,6 +1316,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/datastream-v1alpha1.ts
+++ b/packages/gcp/src/unstable-services/datastream-v1alpha1.ts
@@ -1232,6 +1232,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1243,6 +1244,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1255,6 +1257,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1265,6 +1268,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/deploymentmanager-alpha.ts
+++ b/packages/gcp/src/unstable-services/deploymentmanager-alpha.ts
@@ -1550,6 +1550,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1561,6 +1562,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1573,6 +1575,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1583,6 +1586,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/deploymentmanager-v2beta.ts
+++ b/packages/gcp/src/unstable-services/deploymentmanager-v2beta.ts
@@ -1489,6 +1489,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1500,6 +1501,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1512,6 +1514,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1522,6 +1525,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/dfareporting-v3.5.ts
+++ b/packages/gcp/src/unstable-services/dfareporting-v3.5.ts
@@ -363,6 +363,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -374,6 +375,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -386,6 +388,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -396,6 +399,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/dfareporting-v4.ts
+++ b/packages/gcp/src/unstable-services/dfareporting-v4.ts
@@ -8011,6 +8011,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -8022,6 +8023,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -8034,6 +8036,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -8044,6 +8047,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/dialogflow-v2.ts
+++ b/packages/gcp/src/unstable-services/dialogflow-v2.ts
@@ -12177,6 +12177,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -12188,6 +12189,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -12200,6 +12202,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -12210,6 +12213,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/dialogflow-v2beta1.ts
+++ b/packages/gcp/src/unstable-services/dialogflow-v2beta1.ts
@@ -12331,6 +12331,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -12342,6 +12343,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -12354,6 +12356,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -12364,6 +12367,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/dialogflow-v3beta1.ts
+++ b/packages/gcp/src/unstable-services/dialogflow-v3beta1.ts
@@ -12571,6 +12571,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -12582,6 +12583,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -12594,6 +12596,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -12604,6 +12607,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/discoveryengine-v1alpha.ts
+++ b/packages/gcp/src/unstable-services/discoveryengine-v1alpha.ts
@@ -21777,6 +21777,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -21788,6 +21789,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -21800,6 +21802,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -21810,6 +21813,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/discoveryengine-v1beta.ts
+++ b/packages/gcp/src/unstable-services/discoveryengine-v1beta.ts
@@ -19812,6 +19812,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -19823,6 +19824,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -19835,6 +19837,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -19845,6 +19848,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/displayvideo-v2.ts
+++ b/packages/gcp/src/unstable-services/displayvideo-v2.ts
@@ -7733,6 +7733,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -7744,6 +7745,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -7756,6 +7758,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -7766,6 +7769,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/displayvideo-v3.ts
+++ b/packages/gcp/src/unstable-services/displayvideo-v3.ts
@@ -9446,6 +9446,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -9457,6 +9458,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -9469,6 +9471,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -9479,6 +9482,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/dns-v1beta2.ts
+++ b/packages/gcp/src/unstable-services/dns-v1beta2.ts
@@ -1194,6 +1194,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1205,6 +1206,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1217,6 +1219,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1227,6 +1230,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/documentai-v1beta3.ts
+++ b/packages/gcp/src/unstable-services/documentai-v1beta3.ts
@@ -6534,6 +6534,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -6545,6 +6546,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -6557,6 +6559,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -6567,6 +6570,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/domains-v1alpha2.ts
+++ b/packages/gcp/src/unstable-services/domains-v1alpha2.ts
@@ -1131,6 +1131,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1142,6 +1143,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1154,6 +1156,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1164,6 +1167,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/domains-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/domains-v1beta1.ts
@@ -1124,6 +1124,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1135,6 +1136,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1147,6 +1149,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1157,6 +1160,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/drive-v2.ts
+++ b/packages/gcp/src/unstable-services/drive-v2.ts
@@ -1898,6 +1898,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1909,6 +1910,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1921,6 +1923,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1931,6 +1934,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/drivelabels-v2beta.ts
+++ b/packages/gcp/src/unstable-services/drivelabels-v2beta.ts
@@ -1786,6 +1786,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1797,6 +1798,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1809,6 +1811,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1819,6 +1822,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/file-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/file-v1beta1.ts
@@ -1199,6 +1199,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1210,6 +1211,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1222,6 +1224,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1232,6 +1235,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/firebaseappcheck-v1beta.ts
+++ b/packages/gcp/src/unstable-services/firebaseappcheck-v1beta.ts
@@ -871,6 +871,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -882,6 +883,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -894,6 +896,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -904,6 +907,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/firebaseappdistribution-v1alpha.ts
+++ b/packages/gcp/src/unstable-services/firebaseappdistribution-v1alpha.ts
@@ -1102,6 +1102,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1113,6 +1114,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1125,6 +1127,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1135,6 +1138,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/firebaseapphosting-v1beta.ts
+++ b/packages/gcp/src/unstable-services/firebaseapphosting-v1beta.ts
@@ -1029,6 +1029,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1040,6 +1041,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1052,6 +1054,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1062,6 +1065,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/firebasedataconnect-v1beta.ts
+++ b/packages/gcp/src/unstable-services/firebasedataconnect-v1beta.ts
@@ -669,6 +669,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -680,6 +681,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -692,6 +694,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -702,6 +705,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/firebasehosting-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/firebasehosting-v1beta1.ts
@@ -913,6 +913,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -924,6 +925,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -936,6 +938,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -946,6 +949,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/firebaseml-v1beta2.ts
+++ b/packages/gcp/src/unstable-services/firebaseml-v1beta2.ts
@@ -186,6 +186,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -197,6 +198,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -209,6 +211,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -219,6 +222,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/firebaseml-v2beta.ts
+++ b/packages/gcp/src/unstable-services/firebaseml-v2beta.ts
@@ -2337,6 +2337,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2348,6 +2349,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2360,6 +2362,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2370,6 +2373,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/firestore-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/firestore-v1beta1.ts
@@ -1634,6 +1634,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1645,6 +1646,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1657,6 +1659,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1667,6 +1670,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/firestore-v1beta2.ts
+++ b/packages/gcp/src/unstable-services/firestore-v1beta2.ts
@@ -564,6 +564,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -575,6 +576,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -587,6 +589,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -597,6 +600,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/gkehub-v1.ts
+++ b/packages/gcp/src/unstable-services/gkehub-v1.ts
@@ -3276,6 +3276,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3287,6 +3288,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3299,6 +3301,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3309,6 +3312,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/gkehub-v1alpha.ts
+++ b/packages/gcp/src/unstable-services/gkehub-v1alpha.ts
@@ -4026,6 +4026,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -4037,6 +4038,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -4049,6 +4051,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -4059,6 +4062,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/gkehub-v1beta.ts
+++ b/packages/gcp/src/unstable-services/gkehub-v1beta.ts
@@ -3638,6 +3638,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3649,6 +3650,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3661,6 +3663,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3671,6 +3674,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/gkehub-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/gkehub-v1beta1.ts
@@ -634,6 +634,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -645,6 +646,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -657,6 +659,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -667,6 +670,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/gkehub-v2alpha.ts
+++ b/packages/gcp/src/unstable-services/gkehub-v2alpha.ts
@@ -2082,6 +2082,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2093,6 +2094,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2105,6 +2107,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2115,6 +2118,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/gkehub-v2beta.ts
+++ b/packages/gcp/src/unstable-services/gkehub-v2beta.ts
@@ -2082,6 +2082,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2093,6 +2094,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2105,6 +2107,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2115,6 +2118,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/gmailpostmastertools-v1.ts
+++ b/packages/gcp/src/unstable-services/gmailpostmastertools-v1.ts
@@ -192,6 +192,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -203,6 +204,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/unstable-services/gmailpostmastertools-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/gmailpostmastertools-v1beta1.ts
@@ -195,6 +195,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -206,6 +207,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/unstable-services/healthcare-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/healthcare-v1beta1.ts
@@ -3229,6 +3229,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3240,6 +3241,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3252,6 +3254,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3262,6 +3265,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/iam-v1.ts
+++ b/packages/gcp/src/unstable-services/iam-v1.ts
@@ -1833,6 +1833,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1844,6 +1845,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1856,6 +1858,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1866,6 +1869,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/iam-v2beta.ts
+++ b/packages/gcp/src/unstable-services/iam-v2beta.ts
@@ -412,6 +412,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -423,6 +424,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -435,6 +437,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -445,6 +448,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/iap-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/iap-v1beta1.ts
@@ -127,6 +127,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -138,6 +139,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -150,6 +152,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -160,6 +163,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/identitytoolkit-v1.ts
+++ b/packages/gcp/src/unstable-services/identitytoolkit-v1.ts
@@ -1985,6 +1985,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1996,6 +1997,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2008,6 +2010,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2018,6 +2021,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/identitytoolkit-v2.ts
+++ b/packages/gcp/src/unstable-services/identitytoolkit-v2.ts
@@ -1945,6 +1945,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1956,6 +1957,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1968,6 +1970,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1978,6 +1981,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/jobs-v3.ts
+++ b/packages/gcp/src/unstable-services/jobs-v3.ts
@@ -1301,6 +1301,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1312,6 +1313,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1324,6 +1326,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1334,6 +1337,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/jobs-v3p1beta1.ts
+++ b/packages/gcp/src/unstable-services/jobs-v3p1beta1.ts
@@ -1394,6 +1394,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1405,6 +1406,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1417,6 +1419,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1427,6 +1430,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/language-v1.ts
+++ b/packages/gcp/src/unstable-services/language-v1.ts
@@ -3941,6 +3941,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3952,6 +3953,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3964,6 +3966,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3974,6 +3977,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/language-v1beta2.ts
+++ b/packages/gcp/src/unstable-services/language-v1beta2.ts
@@ -3951,6 +3951,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3962,6 +3963,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3974,6 +3976,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3984,6 +3987,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/managedidentities-v1alpha1.ts
+++ b/packages/gcp/src/unstable-services/managedidentities-v1alpha1.ts
@@ -1228,6 +1228,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1239,6 +1240,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1251,6 +1253,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1261,6 +1264,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/managedidentities-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/managedidentities-v1beta1.ts
@@ -1231,6 +1231,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1242,6 +1243,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1254,6 +1256,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1264,6 +1267,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/memcache-v1beta2.ts
+++ b/packages/gcp/src/unstable-services/memcache-v1beta2.ts
@@ -1013,6 +1013,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1024,6 +1025,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1036,6 +1038,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1046,6 +1049,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-accounts_v1.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-accounts_v1.ts
@@ -2276,6 +2276,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2287,6 +2288,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2299,6 +2301,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2309,6 +2312,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-accounts_v1beta.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-accounts_v1beta.ts
@@ -2208,6 +2208,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2219,6 +2220,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2231,6 +2233,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2241,6 +2244,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-conversions_v1.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-conversions_v1.ts
@@ -234,6 +234,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -245,6 +246,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -257,6 +259,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -267,6 +270,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-conversions_v1beta.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-conversions_v1beta.ts
@@ -234,6 +234,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -245,6 +246,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -257,6 +259,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -267,6 +270,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-datasources_v1.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-datasources_v1.ts
@@ -467,6 +467,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -478,6 +479,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -490,6 +492,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -500,6 +503,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-datasources_v1beta.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-datasources_v1beta.ts
@@ -472,6 +472,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -483,6 +484,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -495,6 +497,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -505,6 +508,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-inventories_v1.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-inventories_v1.ts
@@ -314,6 +314,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -325,6 +326,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -337,6 +339,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -347,6 +350,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-inventories_v1beta.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-inventories_v1beta.ts
@@ -259,6 +259,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -270,6 +271,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -282,6 +284,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -292,6 +295,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-issueresolution_v1.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-issueresolution_v1.ts
@@ -672,6 +672,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -683,6 +684,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -695,6 +697,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -705,6 +708,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-issueresolution_v1beta.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-issueresolution_v1beta.ts
@@ -672,6 +672,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -683,6 +684,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -695,6 +697,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -705,6 +708,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-lfp_v1.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-lfp_v1.ts
@@ -373,6 +373,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -384,6 +385,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -396,6 +398,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -406,6 +409,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-lfp_v1beta.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-lfp_v1beta.ts
@@ -373,6 +373,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -384,6 +385,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -396,6 +398,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -406,6 +409,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-notifications_v1.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-notifications_v1.ts
@@ -151,6 +151,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -162,6 +163,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -174,6 +176,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -184,6 +187,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-notifications_v1beta.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-notifications_v1beta.ts
@@ -151,6 +151,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -162,6 +163,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -174,6 +176,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -184,6 +187,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-ordertracking_v1.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-ordertracking_v1.ts
@@ -286,6 +286,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -297,6 +298,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -309,6 +311,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -319,6 +322,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-ordertracking_v1beta.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-ordertracking_v1beta.ts
@@ -289,6 +289,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -300,6 +301,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -312,6 +314,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -322,6 +325,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-products_v1.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-products_v1.ts
@@ -1331,6 +1331,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1342,6 +1343,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1354,6 +1356,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1364,6 +1367,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-products_v1beta.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-products_v1beta.ts
@@ -1023,6 +1023,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1034,6 +1035,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1046,6 +1048,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1056,6 +1059,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-promotions_v1.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-promotions_v1.ts
@@ -519,6 +519,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -530,6 +531,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -542,6 +544,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -552,6 +555,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-promotions_v1beta.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-promotions_v1beta.ts
@@ -519,6 +519,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -530,6 +531,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -542,6 +544,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -552,6 +555,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-quota_v1.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-quota_v1.ts
@@ -194,6 +194,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -205,6 +206,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/unstable-services/merchantapi-quota_v1beta.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-quota_v1beta.ts
@@ -157,6 +157,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -168,6 +169,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/unstable-services/merchantapi-reports_v1.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-reports_v1.ts
@@ -987,6 +987,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -998,6 +999,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1010,6 +1012,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1020,6 +1023,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/merchantapi-reports_v1beta.ts
+++ b/packages/gcp/src/unstable-services/merchantapi-reports_v1beta.ts
@@ -987,6 +987,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -998,6 +999,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1010,6 +1012,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1020,6 +1023,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/metastore-v1alpha.ts
+++ b/packages/gcp/src/unstable-services/metastore-v1alpha.ts
@@ -1368,6 +1368,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1379,6 +1380,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1391,6 +1393,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1401,6 +1404,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/metastore-v1beta.ts
+++ b/packages/gcp/src/unstable-services/metastore-v1beta.ts
@@ -1368,6 +1368,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1379,6 +1380,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1391,6 +1393,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1401,6 +1404,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/migrationcenter-v1alpha1.ts
+++ b/packages/gcp/src/unstable-services/migrationcenter-v1alpha1.ts
@@ -5008,6 +5008,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -5019,6 +5020,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -5031,6 +5033,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -5041,6 +5044,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/monitoring-v1.ts
+++ b/packages/gcp/src/unstable-services/monitoring-v1.ts
@@ -1488,6 +1488,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1499,6 +1500,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1511,6 +1513,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1521,6 +1524,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/netapp-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/netapp-v1beta1.ts
@@ -1911,6 +1911,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1922,6 +1923,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1934,6 +1936,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1944,6 +1947,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/networkconnectivity-v1alpha1.ts
+++ b/packages/gcp/src/unstable-services/networkconnectivity-v1alpha1.ts
@@ -520,6 +520,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -531,6 +532,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -543,6 +545,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -553,6 +556,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/networkmanagement-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/networkmanagement-v1beta1.ts
@@ -2189,6 +2189,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2200,6 +2201,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2212,6 +2214,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2222,6 +2225,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/networksecurity-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/networksecurity-v1beta1.ts
@@ -2541,6 +2541,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2552,6 +2553,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2564,6 +2566,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2574,6 +2577,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/networkservices-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/networkservices-v1beta1.ts
@@ -2140,6 +2140,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2151,6 +2152,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2163,6 +2165,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2173,6 +2176,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/notebooks-v1.ts
+++ b/packages/gcp/src/unstable-services/notebooks-v1.ts
@@ -1700,6 +1700,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1711,6 +1712,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1723,6 +1725,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1733,6 +1736,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/ondemandscanning-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/ondemandscanning-v1beta1.ts
@@ -2005,6 +2005,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2016,6 +2017,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2028,6 +2030,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2038,6 +2041,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/osconfig-v1.ts
+++ b/packages/gcp/src/unstable-services/osconfig-v1.ts
@@ -2145,6 +2145,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2156,6 +2157,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2168,6 +2170,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2178,6 +2181,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/osconfig-v1alpha.ts
+++ b/packages/gcp/src/unstable-services/osconfig-v1alpha.ts
@@ -1639,6 +1639,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1650,6 +1651,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1662,6 +1664,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1672,6 +1675,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/osconfig-v1beta.ts
+++ b/packages/gcp/src/unstable-services/osconfig-v1beta.ts
@@ -1437,6 +1437,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1448,6 +1449,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1460,6 +1462,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1470,6 +1473,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/osconfig-v2beta.ts
+++ b/packages/gcp/src/unstable-services/osconfig-v2beta.ts
@@ -1056,6 +1056,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1067,6 +1068,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1079,6 +1081,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1089,6 +1092,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/oslogin-v1alpha.ts
+++ b/packages/gcp/src/unstable-services/oslogin-v1alpha.ts
@@ -234,6 +234,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -245,6 +246,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -257,6 +259,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -267,6 +270,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/oslogin-v1beta.ts
+++ b/packages/gcp/src/unstable-services/oslogin-v1beta.ts
@@ -234,6 +234,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -245,6 +246,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -257,6 +259,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -267,6 +270,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/parallelstore-v1beta.ts
+++ b/packages/gcp/src/unstable-services/parallelstore-v1beta.ts
@@ -353,6 +353,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -364,6 +365,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -376,6 +378,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -386,6 +389,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/playdeveloperreporting-v1alpha1.ts
+++ b/packages/gcp/src/unstable-services/playdeveloperreporting-v1alpha1.ts
@@ -1142,6 +1142,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1153,6 +1154,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1165,6 +1167,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1175,6 +1178,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/policyanalyzer-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/policyanalyzer-v1beta1.ts
@@ -85,6 +85,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -96,6 +97,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/unstable-services/policysimulator-v1alpha.ts
+++ b/packages/gcp/src/unstable-services/policysimulator-v1alpha.ts
@@ -591,6 +591,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -602,6 +603,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);

--- a/packages/gcp/src/unstable-services/policysimulator-v1beta.ts
+++ b/packages/gcp/src/unstable-services/policysimulator-v1beta.ts
@@ -993,6 +993,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1004,6 +1005,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1016,6 +1018,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1026,6 +1029,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/policytroubleshooter-v1.ts
+++ b/packages/gcp/src/unstable-services/policytroubleshooter-v1.ts
@@ -306,6 +306,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -317,6 +318,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -329,6 +331,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -339,6 +342,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/policytroubleshooter-v1beta.ts
+++ b/packages/gcp/src/unstable-services/policytroubleshooter-v1beta.ts
@@ -291,6 +291,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -302,6 +303,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -314,6 +316,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -324,6 +327,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/policytroubleshooter-v3beta.ts
+++ b/packages/gcp/src/unstable-services/policytroubleshooter-v3beta.ts
@@ -1199,6 +1199,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1210,6 +1211,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1222,6 +1224,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1232,6 +1235,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/privateca-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/privateca-v1beta1.ts
@@ -244,6 +244,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -255,6 +256,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -267,6 +269,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -277,6 +280,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/publicca-v1alpha1.ts
+++ b/packages/gcp/src/unstable-services/publicca-v1alpha1.ts
@@ -47,6 +47,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -58,6 +59,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -70,6 +72,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -80,6 +83,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/publicca-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/publicca-v1beta1.ts
@@ -47,6 +47,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -58,6 +59,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -70,6 +72,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -80,6 +83,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/pubsub-v1beta1a.ts
+++ b/packages/gcp/src/unstable-services/pubsub-v1beta1a.ts
@@ -275,6 +275,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -286,6 +287,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -298,6 +300,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -308,6 +311,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/pubsub-v1beta2.ts
+++ b/packages/gcp/src/unstable-services/pubsub-v1beta2.ts
@@ -311,6 +311,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -322,6 +323,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -334,6 +336,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -344,6 +347,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/recommender-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/recommender-v1beta1.ts
@@ -695,6 +695,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -706,6 +707,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -718,6 +720,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -728,6 +731,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/redis-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/redis-v1beta1.ts
@@ -2769,6 +2769,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2780,6 +2781,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2792,6 +2794,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2802,6 +2805,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/retail-v2alpha.ts
+++ b/packages/gcp/src/unstable-services/retail-v2alpha.ts
@@ -5318,6 +5318,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -5329,6 +5330,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -5341,6 +5343,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -5351,6 +5354,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/retail-v2beta.ts
+++ b/packages/gcp/src/unstable-services/retail-v2beta.ts
@@ -5056,6 +5056,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -5067,6 +5068,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -5079,6 +5081,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -5089,6 +5092,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/run-v1.ts
+++ b/packages/gcp/src/unstable-services/run-v1.ts
@@ -3043,6 +3043,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3054,6 +3055,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3066,6 +3068,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3076,6 +3079,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/runtimeconfig-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/runtimeconfig-v1beta1.ts
@@ -279,6 +279,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -290,6 +291,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -302,6 +304,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -312,6 +315,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/saasservicemgmt-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/saasservicemgmt-v1beta1.ts
@@ -1517,6 +1517,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1528,6 +1529,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1540,6 +1542,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1550,6 +1553,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/safebrowsing-v4.ts
+++ b/packages/gcp/src/unstable-services/safebrowsing-v4.ts
@@ -747,6 +747,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -758,6 +759,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -770,6 +772,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -780,6 +783,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/secretmanager-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/secretmanager-v1beta1.ts
@@ -412,6 +412,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -423,6 +424,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -435,6 +437,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -445,6 +448,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/secretmanager-v1beta2.ts
+++ b/packages/gcp/src/unstable-services/secretmanager-v1beta2.ts
@@ -555,6 +555,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -566,6 +567,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -578,6 +580,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -588,6 +591,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/securitycenter-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/securitycenter-v1beta1.ts
@@ -7635,6 +7635,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -7646,6 +7647,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -7658,6 +7660,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -7668,6 +7671,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/securitycenter-v1beta2.ts
+++ b/packages/gcp/src/unstable-services/securitycenter-v1beta2.ts
@@ -7368,6 +7368,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -7379,6 +7380,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -7391,6 +7393,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -7401,6 +7404,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/serviceconsumermanagement-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/serviceconsumermanagement-v1beta1.ts
@@ -1994,6 +1994,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2005,6 +2006,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2017,6 +2019,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2027,6 +2030,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/servicecontrol-v1.ts
+++ b/packages/gcp/src/unstable-services/servicecontrol-v1.ts
@@ -1411,6 +1411,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1422,6 +1423,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1434,6 +1436,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1444,6 +1447,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/servicedirectory-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/servicedirectory-v1beta1.ts
@@ -301,6 +301,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -312,6 +313,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -324,6 +326,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -334,6 +337,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/servicenetworking-v1beta.ts
+++ b/packages/gcp/src/unstable-services/servicenetworking-v1beta.ts
@@ -1977,6 +1977,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1988,6 +1989,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2000,6 +2002,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2010,6 +2013,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/serviceusage-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/serviceusage-v1beta1.ts
@@ -2598,6 +2598,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2609,6 +2610,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2621,6 +2623,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2631,6 +2634,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/speech-v1p1beta1.ts
+++ b/packages/gcp/src/unstable-services/speech-v1p1beta1.ts
@@ -673,6 +673,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -684,6 +685,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -696,6 +698,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -706,6 +709,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/sqladmin-v1beta4.ts
+++ b/packages/gcp/src/unstable-services/sqladmin-v1beta4.ts
@@ -3728,6 +3728,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -3739,6 +3740,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -3751,6 +3753,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -3761,6 +3764,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/sts-v1beta.ts
+++ b/packages/gcp/src/unstable-services/sts-v1beta.ts
@@ -197,6 +197,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -208,6 +209,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -220,6 +222,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -230,6 +233,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/tagmanager-v1.ts
+++ b/packages/gcp/src/unstable-services/tagmanager-v1.ts
@@ -851,6 +851,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -862,6 +863,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -874,6 +876,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -884,6 +887,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/texttospeech-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/texttospeech-v1beta1.ts
@@ -468,6 +468,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -479,6 +480,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -491,6 +493,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -501,6 +504,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/tpu-v1.ts
+++ b/packages/gcp/src/unstable-services/tpu-v1.ts
@@ -387,6 +387,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -398,6 +399,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -410,6 +412,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -420,6 +423,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/tpu-v1alpha1.ts
+++ b/packages/gcp/src/unstable-services/tpu-v1alpha1.ts
@@ -387,6 +387,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -398,6 +399,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -410,6 +412,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -420,6 +423,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/tpu-v2alpha1.ts
+++ b/packages/gcp/src/unstable-services/tpu-v2alpha1.ts
@@ -1070,6 +1070,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1081,6 +1082,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1093,6 +1095,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1103,6 +1106,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/trafficdirector-v2.ts
+++ b/packages/gcp/src/unstable-services/trafficdirector-v2.ts
@@ -598,6 +598,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -609,6 +610,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -621,6 +623,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -631,6 +634,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/translate-v2.ts
+++ b/packages/gcp/src/unstable-services/translate-v2.ts
@@ -132,6 +132,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -143,6 +144,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -155,6 +157,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -165,6 +168,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/translate-v3beta1.ts
+++ b/packages/gcp/src/unstable-services/translate-v3beta1.ts
@@ -623,6 +623,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -634,6 +635,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -646,6 +648,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -656,6 +659,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/verifiedaccess-v1.ts
+++ b/packages/gcp/src/unstable-services/verifiedaccess-v1.ts
@@ -97,6 +97,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -108,6 +109,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -120,6 +122,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -130,6 +133,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/videointelligence-v1beta2.ts
+++ b/packages/gcp/src/unstable-services/videointelligence-v1beta2.ts
@@ -4125,6 +4125,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -4136,6 +4137,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -4148,6 +4150,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -4158,6 +4161,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/videointelligence-v1p1beta1.ts
+++ b/packages/gcp/src/unstable-services/videointelligence-v1p1beta1.ts
@@ -4127,6 +4127,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -4138,6 +4139,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -4150,6 +4152,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -4160,6 +4163,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/videointelligence-v1p2beta1.ts
+++ b/packages/gcp/src/unstable-services/videointelligence-v1p2beta1.ts
@@ -4127,6 +4127,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -4138,6 +4139,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -4150,6 +4152,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -4160,6 +4163,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/videointelligence-v1p3beta1.ts
+++ b/packages/gcp/src/unstable-services/videointelligence-v1p3beta1.ts
@@ -4128,6 +4128,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -4139,6 +4140,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -4151,6 +4153,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -4161,6 +4164,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/vision-v1p1beta1.ts
+++ b/packages/gcp/src/unstable-services/vision-v1p1beta1.ts
@@ -5766,6 +5766,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -5777,6 +5778,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -5789,6 +5791,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -5799,6 +5802,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/vision-v1p2beta1.ts
+++ b/packages/gcp/src/unstable-services/vision-v1p2beta1.ts
@@ -5766,6 +5766,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -5777,6 +5778,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -5789,6 +5791,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -5799,6 +5802,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/vmmigration-v1alpha1.ts
+++ b/packages/gcp/src/unstable-services/vmmigration-v1alpha1.ts
@@ -2886,6 +2886,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -2897,6 +2898,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -2909,6 +2911,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -2919,6 +2922,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/vpcaccess-v1beta1.ts
+++ b/packages/gcp/src/unstable-services/vpcaccess-v1beta1.ts
@@ -254,6 +254,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -265,6 +266,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -277,6 +279,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -287,6 +290,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/websecurityscanner-v1alpha.ts
+++ b/packages/gcp/src/unstable-services/websecurityscanner-v1alpha.ts
@@ -434,6 +434,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -445,6 +446,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -457,6 +459,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -467,6 +470,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/websecurityscanner-v1beta.ts
+++ b/packages/gcp/src/unstable-services/websecurityscanner-v1beta.ts
@@ -587,6 +587,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -598,6 +599,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -610,6 +612,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -620,6 +623,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/workflowexecutions-v1beta.ts
+++ b/packages/gcp/src/unstable-services/workflowexecutions-v1beta.ts
@@ -176,6 +176,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -187,6 +188,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -199,6 +201,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -209,6 +212,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/workflows-v1beta.ts
+++ b/packages/gcp/src/unstable-services/workflows-v1beta.ts
@@ -198,6 +198,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -209,6 +210,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -221,6 +223,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -231,6 +234,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/src/unstable-services/workstations-v1beta.ts
+++ b/packages/gcp/src/unstable-services/workstations-v1beta.ts
@@ -1024,6 +1024,7 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(NotFound, [{ httpStatus: 404 }]);
 
@@ -1035,6 +1036,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(Forbidden, [{ httpStatus: 403 }]);
@@ -1047,6 +1049,7 @@ export class BadRequest extends Schema.TaggedErrorClass<BadRequest>()(
     status: Schema.optional(Schema.String),
     reason: Schema.optional(Schema.String),
     domain: Schema.optional(Schema.String),
+    details: Schema.optional(Schema.Array(Schema.Unknown)),
   },
 ) {}
 T.applyErrorMatchers(BadRequest, [{ httpStatus: 400 }]);
@@ -1057,6 +1060,7 @@ export class Conflict extends Schema.TaggedErrorClass<Conflict>()("Conflict", {
   status: Schema.optional(Schema.String),
   reason: Schema.optional(Schema.String),
   domain: Schema.optional(Schema.String),
+  details: Schema.optional(Schema.Array(Schema.Unknown)),
 }) {}
 T.applyErrorMatchers(Conflict, [{ httpStatus: 409 }]);
 

--- a/packages/gcp/test/error-details.test.ts
+++ b/packages/gcp/test/error-details.test.ts
@@ -1,0 +1,174 @@
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+import { describe, expect, it } from "vitest";
+import { Credentials } from "../src/credentials.ts";
+import * as crm from "../src/services/cloudresourcemanager-v3.ts";
+
+// Mocks the HttpClient to return GCP-style error envelopes and asserts
+// that the typed error surface preserves the structured fields
+// (`status`, `details[]`) that GCP returns alongside the human-readable
+// `message`. Without this, HTTP-status-only matching forces consumers
+// to disambiguate sub-cases by string-matching the `message`, which is
+// fragile and locale-dependent.
+
+const fakeCredentials = Layer.succeed(Credentials, {
+  accessToken: Redacted.make("ya29.fake-test-token"),
+  project: "fake-test-project",
+});
+
+const respondWith = (
+  status: number,
+  body: unknown,
+): Layer.Layer<HttpClient.HttpClient> =>
+  Layer.succeed(
+    HttpClient.HttpClient,
+    HttpClient.make((request) =>
+      Effect.succeed(
+        HttpClientResponse.fromWeb(
+          request,
+          new Response(JSON.stringify(body), {
+            status,
+            headers: { "content-type": "application/json" },
+          }),
+        ),
+      ),
+    ),
+  );
+
+describe("GCP error envelope decoding", () => {
+  it("BadRequest: surfaces gRPC status and details[] from the error envelope", async () => {
+    // The exact 400 GCP returns from cloudbilling.updateBillingInfo
+    // when the billing account's project-attach quota is exhausted.
+    // Captured live, then redacted: the response shape (HTTP 400 +
+    // `FAILED_PRECONDITION` + a `QuotaFailure` detail with a
+    // remediation link) is canonical for this class of error.
+    const errorBody = {
+      error: {
+        code: 400,
+        message: "Precondition check failed.",
+        status: "FAILED_PRECONDITION",
+        details: [
+          {
+            "@type": "type.googleapis.com/google.rpc.QuotaFailure",
+            violations: [
+              {
+                subject: "billingAccounts/01A860-D25444-D4B584",
+                description:
+                  "Cloud billing quota exceeded: https://support.google.com/code/contact/billing_quota_increase",
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    // Catching by tag narrows to the per-service inline `BadRequest`
+    // class, which declares `status` and `details` as part of its
+    // Schema — so the assertions below access them without any casts.
+    // That's the whole point: structured info reaches the user with
+    // full type-safety.
+    const program = Effect.gen(function* () {
+      const getProjects = yield* crm.getProjects;
+      return yield* getProjects({ name: "projects/test" });
+    }).pipe(
+      Effect.catchTag("BadRequest", (e) =>
+        Effect.succeed({
+          tag: e._tag,
+          message: e.message,
+          status: e.status,
+          details: e.details,
+        }),
+      ),
+    );
+
+    const result = await Effect.runPromise(
+      program.pipe(
+        Effect.provide(respondWith(400, errorBody)),
+        Effect.provide(fakeCredentials),
+      ),
+    );
+
+    expect(result.tag).toBe("BadRequest");
+    expect(result.message).toBe("Precondition check failed.");
+    expect(result.status).toBe("FAILED_PRECONDITION");
+    expect(result.details).toBeDefined();
+    expect(result.details).toHaveLength(1);
+    expect((result.details![0] as { "@type": string })["@type"]).toBe(
+      "type.googleapis.com/google.rpc.QuotaFailure",
+    );
+  });
+
+  it("NotFound: details optional — undefined when omitted by the server", async () => {
+    // GCP returns NotFound without a structured `details[]` for many
+    // operations. The schema field stays optional so this still narrows
+    // cleanly.
+    const errorBody = {
+      error: {
+        code: 404,
+        message: "Project does not exist or caller lacks access.",
+        status: "NOT_FOUND",
+      },
+    };
+
+    const program = Effect.gen(function* () {
+      const getProjects = yield* crm.getProjects;
+      return yield* getProjects({ name: "projects/missing" });
+    }).pipe(
+      Effect.catchTag("NotFound", (e) =>
+        Effect.succeed({
+          tag: e._tag,
+          status: e.status,
+          details: e.details,
+        }),
+      ),
+    );
+
+    const result = await Effect.runPromise(
+      program.pipe(
+        Effect.provide(respondWith(404, errorBody)),
+        Effect.provide(fakeCredentials),
+      ),
+    );
+
+    expect(result.tag).toBe("NotFound");
+    expect(result.status).toBe("NOT_FOUND");
+    expect(result.details).toBeUndefined();
+  });
+
+  it("Forbidden: handles missing `error` envelope (legacy bare-string body) without throwing", async () => {
+    // GCP normally returns the structured envelope, but some quota /
+    // edge endpoints have been observed returning bare strings. The
+    // parse should fall through with undefined fields rather than
+    // crashing the matcher.
+    const errorBody = "permission denied";
+
+    const program = Effect.gen(function* () {
+      const getProjects = yield* crm.getProjects;
+      return yield* getProjects({ name: "projects/x" });
+    }).pipe(
+      Effect.catchTag("Forbidden", (e) =>
+        Effect.succeed({
+          tag: e._tag,
+          status: e.status,
+          details: e.details,
+        }),
+      ),
+    );
+
+    const result = await Effect.runPromise(
+      program.pipe(
+        Effect.provide(respondWith(403, errorBody)),
+        Effect.provide(fakeCredentials),
+      ),
+    );
+
+    expect(result.tag).toBe("Forbidden");
+    // No envelope → no structured fields, but the error class is still
+    // chosen by HTTP status and the message falls back to the status code.
+    expect(result.status).toBeUndefined();
+    expect(result.details).toBeUndefined();
+  });
+});


### PR DESCRIPTION
GCP's standard error envelope carries a gRPC-style `status` string and a typed `details[]` array alongside the human-readable `message`, but `matchError` was dropping both. This patch threads them onto the typed error so consumers can disambiguate sub-cases without string-matching the locale-dependent message.

Why this matters in practice — the same HTTP 400 covers `FAILED_PRECONDITION` (e.g. billing-account project-attach quota exhausted) and `INVALID_ARGUMENT` (malformed input), and only the structured envelope distinguishes them. Detecting quota errors today requires `e.message.includes("Precondition check failed")`; with this change it's:

```ts
yield* updateBillingInfo({ ... }).pipe(
  Effect.catchTag("BadRequest", (e) => {
    if (
      e.status === "FAILED_PRECONDITION" &&
      e.details?.some((d: any) => d["@type"]?.endsWith("QuotaFailure"))
    ) {
      // surface quota-specific remediation
    }
    return Effect.fail(e);
  }),
);
```

Implementation is kept GCP-local — `packages/core` is not touched.

```diff
 // packages/gcp/scripts/generate.ts (template for per-service inline classes)
   lines.push(`    domain: Schema.optional(Schema.String),`);
+  lines.push(`    details: Schema.optional(Schema.Array(Schema.Unknown)),`);
```

```diff
 // packages/gcp/src/client/api.ts
-    return Effect.fail(
-      new ErrorClass({
-        message,
-        retryAfter: parseRetryAfterForStatus(status, headers),
-      }),
-    );
+    const instance = new ErrorClass({
+      message,
+      retryAfter: parseRetryAfterForStatus(status, headers),
+    });
+    const tackOn = instance as unknown as EnvelopeAddenda;
+    if (envelope.status !== undefined) tackOn.status = envelope.status;
+    if (envelope.details !== undefined) tackOn.details = envelope.details;
+    return Effect.fail(instance);
```

The runtime instance comes from core's `HTTP_STATUS_MAP` as before, but `Effect.catchTag` matches by `_tag` and narrows to the per-service inline class — which now declares `details` in its schema. Consumers see fully-typed `e.status` / `e.details` with no casts. `details` is added to the codegen template once and all 509 services regenerate to pick it up.

`packages/gcp/test/error-details.test.ts` covers the canonical `QuotaFailure` case, the missing-details case, and a bare-string body fallback. All assertions narrow through `Effect.catchTag` and read `e.status` / `e.details` directly. Test structure (Layer-mocked `HttpClient` + `Credentials`, flat `describe`/`it`, `vitest`) mirrors `base-url.test.ts` and `path-substitution.test.ts`.

### On the tack-on pattern

AWS uses `Schema.decodeUnknownEffect` to decode the response body straight into the per-operation error class, so each class can be defined with all its fields and constructed with them in one step. Cloudflare uses pre-construction matchers that route to the right error class before instantiation. Neither needs to mutate the instance after building.

GCP can't follow either pattern without restructuring its dual-class architecture (per-service inline classes for the typed user-facing surface, core `HTTP_STATUS_MAP` classes for runtime construction). The tack-on pattern is the smallest change that delivers the structured fields without restructuring or touching `core`. Happy to discuss whether a deeper refactor is preferred — e.g. moving construction to per-service classes so `details` can flow through the constructor like `message` does today.
