### PR TITLE
fix(core/openapi): merge allOf body + re-export operations from root

### DIFF
--- a/packages/coinbase/src/index.ts
+++ b/packages/coinbase/src/index.ts
@@ -12,4 +12,5 @@ export * as T from "./traits.ts";
 export * as Retry from "./retry.ts";
 export { API } from "./client.ts";
 export * from "./errors.ts";
+export * from "./operations/index.ts";
 export { SensitiveString, SensitiveNullableString } from "./sensitive.ts";

--- a/packages/core/scripts/generate-openapi.ts
+++ b/packages/core/scripts/generate-openapi.ts
@@ -851,6 +851,33 @@ function generateInputSchema3(
         bodySchema = resolveRef(spec, bodySchema.$ref);
       }
 
+      // Flatten `allOf` so a body schema like `{ allOf: [BranchCreateRequest,
+      // AnnotationCreateValueRequest] }` exposes the union of its sub-schemas'
+      // properties as fields, instead of degenerating to an empty body.
+      if (bodySchema.allOf && bodySchema.allOf.length > 0) {
+        const mergedProps: Record<string, SchemaObject> = {
+          ...(bodySchema.properties ?? {}),
+        };
+        const mergedRequired: string[] = [...(bodySchema.required ?? [])];
+        for (const subSchema of bodySchema.allOf) {
+          const resolvedSub = subSchema.$ref
+            ? (resolveRef(spec, subSchema.$ref) as SchemaObject)
+            : subSchema;
+          if (resolvedSub.properties) {
+            Object.assign(mergedProps, resolvedSub.properties);
+          }
+          if (resolvedSub.required) {
+            mergedRequired.push(...resolvedSub.required);
+          }
+        }
+        bodySchema = {
+          ...bodySchema,
+          type: "object",
+          properties: mergedProps,
+          required: [...new Set(mergedRequired)],
+        };
+      }
+
       if (bodySchema.properties) {
         const required = new Set(bodySchema.required || []);
         for (const [key, value] of Object.entries(bodySchema.properties)) {

--- a/packages/expo-eas/src/index.ts
+++ b/packages/expo-eas/src/index.ts
@@ -12,4 +12,5 @@ export * as T from "./traits.ts";
 export * as Retry from "./retry.ts";
 export { API } from "./client.ts";
 export * from "./errors.ts";
+export * from "./operations/index.ts";
 export { SensitiveString, SensitiveNullableString } from "./sensitive.ts";

--- a/packages/fly-io/src/index.ts
+++ b/packages/fly-io/src/index.ts
@@ -12,4 +12,5 @@ export * as T from "./traits.ts";
 export * as Retry from "./retry.ts";
 export { API } from "./client.ts";
 export * from "./errors.ts";
+export * from "./operations/index.ts";
 export { SensitiveString, SensitiveNullableString } from "./sensitive.ts";

--- a/packages/mongodb-atlas/src/index.ts
+++ b/packages/mongodb-atlas/src/index.ts
@@ -12,4 +12,5 @@ export * as T from "./traits.ts";
 export * as Retry from "./retry.ts";
 export { API } from "./client.ts";
 export * from "./errors.ts";
+export * from "./operations/index.ts";
 export { SensitiveString, SensitiveNullableString } from "./sensitive.ts";

--- a/packages/neon/src/index.ts
+++ b/packages/neon/src/index.ts
@@ -12,4 +12,5 @@ export * as T from "./traits.ts";
 export * as Retry from "./retry.ts";
 export { API } from "./client.ts";
 export * from "./errors.ts";
+export * from "./operations/index.ts";
 export { SensitiveString, SensitiveNullableString } from "./sensitive.ts";

--- a/packages/neon/src/operations/createOrgApiKey.ts
+++ b/packages/neon/src/operations/createOrgApiKey.ts
@@ -5,6 +5,8 @@ import * as T from "../traits.ts";
 // Input Schema
 export const CreateOrgApiKeyInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   org_id: Schema.String.pipe(T.PathParam()),
+  key_name: Schema.String,
+  project_id: Schema.optional(Schema.String),
 }).pipe(T.Http({ method: "POST", path: "/organizations/{org_id}/api_keys" }));
 export type CreateOrgApiKeyInput = typeof CreateOrgApiKeyInput.Type;
 

--- a/packages/neon/src/operations/createProjectBranch.ts
+++ b/packages/neon/src/operations/createProjectBranch.ts
@@ -7,6 +7,50 @@ import { SensitiveString } from "../sensitive.ts";
 export const CreateProjectBranchInput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     project_id: Schema.String.pipe(T.PathParam()),
+    endpoints: Schema.optional(
+      Schema.Array(
+        Schema.Struct({
+          type: Schema.Literals(["read_only", "read_write"]),
+          settings: Schema.optional(
+            Schema.Struct({
+              pg_settings: Schema.optional(
+                Schema.Record(Schema.String, Schema.String),
+              ),
+              pgbouncer_settings: Schema.optional(
+                Schema.Record(Schema.String, Schema.String),
+              ),
+              preload_libraries: Schema.optional(
+                Schema.Struct({
+                  use_defaults: Schema.optional(Schema.Boolean),
+                  enabled_libraries: Schema.optional(
+                    Schema.Array(Schema.String),
+                  ),
+                }),
+              ),
+            }),
+          ),
+          autoscaling_limit_min_cu: Schema.optional(Schema.Number),
+          autoscaling_limit_max_cu: Schema.optional(Schema.Number),
+          provisioner: Schema.optional(Schema.String),
+          suspend_timeout_seconds: Schema.optional(Schema.Number),
+        }),
+      ),
+    ),
+    branch: Schema.optional(
+      Schema.Struct({
+        parent_id: Schema.optional(Schema.String),
+        name: Schema.optional(Schema.String),
+        parent_lsn: Schema.optional(Schema.String),
+        parent_timestamp: Schema.optional(Schema.String),
+        protected: Schema.optional(Schema.Boolean),
+        archived: Schema.optional(Schema.Boolean),
+        init_source: Schema.optional(Schema.String),
+        expires_at: Schema.optional(Schema.String),
+      }),
+    ),
+    annotation_value: Schema.optional(
+      Schema.Record(Schema.String, Schema.String),
+    ),
   }).pipe(T.Http({ method: "POST", path: "/projects/{project_id}/branches" }));
 export type CreateProjectBranchInput = typeof CreateProjectBranchInput.Type;
 

--- a/packages/neon/src/operations/createProjectBranchAnonymized.ts
+++ b/packages/neon/src/operations/createProjectBranchAnonymized.ts
@@ -7,6 +7,67 @@ import { SensitiveString } from "../sensitive.ts";
 export const CreateProjectBranchAnonymizedInput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     project_id: Schema.String.pipe(T.PathParam()),
+    annotation_value: Schema.optional(
+      Schema.Record(Schema.String, Schema.String),
+    ),
+    branch_create: Schema.optional(
+      Schema.Struct({
+        endpoints: Schema.optional(
+          Schema.Array(
+            Schema.Struct({
+              type: Schema.Literals(["read_only", "read_write"]),
+              settings: Schema.optional(
+                Schema.Struct({
+                  pg_settings: Schema.optional(
+                    Schema.Record(Schema.String, Schema.String),
+                  ),
+                  pgbouncer_settings: Schema.optional(
+                    Schema.Record(Schema.String, Schema.String),
+                  ),
+                  preload_libraries: Schema.optional(
+                    Schema.Struct({
+                      use_defaults: Schema.optional(Schema.Boolean),
+                      enabled_libraries: Schema.optional(
+                        Schema.Array(Schema.String),
+                      ),
+                    }),
+                  ),
+                }),
+              ),
+              autoscaling_limit_min_cu: Schema.optional(Schema.Number),
+              autoscaling_limit_max_cu: Schema.optional(Schema.Number),
+              provisioner: Schema.optional(Schema.String),
+              suspend_timeout_seconds: Schema.optional(Schema.Number),
+            }),
+          ),
+        ),
+        branch: Schema.optional(
+          Schema.Struct({
+            parent_id: Schema.optional(Schema.String),
+            name: Schema.optional(Schema.String),
+            parent_lsn: Schema.optional(Schema.String),
+            parent_timestamp: Schema.optional(Schema.String),
+            protected: Schema.optional(Schema.Boolean),
+            archived: Schema.optional(Schema.Boolean),
+            init_source: Schema.optional(Schema.String),
+            expires_at: Schema.optional(Schema.String),
+          }),
+        ),
+      }),
+    ),
+    masking_rules: Schema.optional(
+      Schema.Array(
+        Schema.Struct({
+          database_name: Schema.String,
+          schema_name: Schema.String,
+          table_name: Schema.String,
+          column_name: Schema.String,
+          masking_function: Schema.optional(Schema.String),
+          masking_value: Schema.optional(Schema.String),
+        }),
+      ),
+    ),
+    start_anonymization: Schema.optional(Schema.Boolean),
   }).pipe(
     T.Http({
       method: "POST",

--- a/packages/neon/src/operations/sendNeonAuthTestEmail.ts
+++ b/packages/neon/src/operations/sendNeonAuthTestEmail.ts
@@ -1,12 +1,20 @@
 import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
+import { SensitiveString } from "../sensitive.ts";
 
 // Input Schema
 export const SendNeonAuthTestEmailInput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     project_id: Schema.String.pipe(T.PathParam()),
     branch_id: Schema.String.pipe(T.PathParam()),
+    host: Schema.String,
+    port: Schema.Number,
+    username: Schema.String,
+    password: SensitiveString,
+    sender_email: Schema.String,
+    sender_name: Schema.String,
+    recipient_email: Schema.String,
   }).pipe(
     T.Http({
       method: "POST",

--- a/packages/planetscale/src/index.ts
+++ b/packages/planetscale/src/index.ts
@@ -12,4 +12,5 @@ export * as T from "./traits.ts";
 export * as Retry from "./retry.ts";
 export { API } from "./client.ts";
 export * from "./errors.ts";
+export * from "./operations/index.ts";
 export { SensitiveString, SensitiveNullableString } from "./sensitive.ts";

--- a/packages/posthog/src/index.ts
+++ b/packages/posthog/src/index.ts
@@ -12,4 +12,5 @@ export * as T from "./traits.ts";
 export * as Retry from "./retry.ts";
 export { API } from "./client.ts";
 export * from "./errors.ts";
+export * from "./operations/index.ts";
 export { SensitiveString, SensitiveNullableString } from "./sensitive.ts";

--- a/packages/prisma-postgres/src/index.ts
+++ b/packages/prisma-postgres/src/index.ts
@@ -12,4 +12,5 @@ export * as T from "./traits.ts";
 export * as Retry from "./retry.ts";
 export { API } from "./client.ts";
 export * from "./errors.ts";
+export * from "./operations/index.ts";
 export { SensitiveString, SensitiveNullableString } from "./sensitive.ts";

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -12,4 +12,5 @@ export * as T from "./traits.ts";
 export * as Retry from "./retry.ts";
 export { API } from "./client.ts";
 export * from "./errors.ts";
+export * from "./operations/index.ts";
 export { SensitiveString, SensitiveNullableString } from "./sensitive.ts";

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -12,4 +12,5 @@ export * as T from "./traits.ts";
 export * as Retry from "./retry.ts";
 export { API } from "./client.ts";
 export * from "./errors.ts";
+export * from "./operations/index.ts";
 export { SensitiveString, SensitiveNullableString } from "./sensitive.ts";

--- a/packages/turso/src/index.ts
+++ b/packages/turso/src/index.ts
@@ -12,4 +12,5 @@ export * as T from "./traits.ts";
 export * as Retry from "./retry.ts";
 export { API } from "./client.ts";
 export * from "./errors.ts";
+export * from "./operations/index.ts";
 export { SensitiveString, SensitiveNullableString } from "./sensitive.ts";

--- a/packages/typesense/src/index.ts
+++ b/packages/typesense/src/index.ts
@@ -12,4 +12,5 @@ export * as T from "./traits.ts";
 export * as Retry from "./retry.ts";
 export { API } from "./client.ts";
 export * from "./errors.ts";
+export * from "./operations/index.ts";
 export { SensitiveString, SensitiveNullableString } from "./sensitive.ts";

--- a/packages/typesense/src/operations/createConversationModel.ts
+++ b/packages/typesense/src/operations/createConversationModel.ts
@@ -2,12 +2,21 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { BadRequest } from "../errors.ts";
+import { SensitiveString } from "../sensitive.ts";
 
 // Input Schema
 export const CreateConversationModelInput =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
-    T.Http({ method: "POST", path: "/conversations/models" }),
-  );
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    id: Schema.optional(Schema.String),
+    model_name: Schema.String,
+    api_key: Schema.optional(SensitiveString),
+    history_collection: Schema.String,
+    account_id: Schema.optional(Schema.String),
+    system_prompt: Schema.optional(Schema.String),
+    ttl: Schema.optional(Schema.Number),
+    max_bytes: Schema.Number,
+    vllm_url: Schema.optional(Schema.String),
+  }).pipe(T.Http({ method: "POST", path: "/conversations/models" }));
 export type CreateConversationModelInput =
   typeof CreateConversationModelInput.Type;
 

--- a/packages/typesense/src/operations/createNLSearchModel.ts
+++ b/packages/typesense/src/operations/createNLSearchModel.ts
@@ -2,12 +2,31 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { BadRequest } from "../errors.ts";
+import { SensitiveString } from "../sensitive.ts";
 
 // Input Schema
 export const CreateNLSearchModelInput =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
-    T.Http({ method: "POST", path: "/nl_search_models" }),
-  );
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    model_name: Schema.optional(Schema.String),
+    api_key: Schema.optional(SensitiveString),
+    api_url: Schema.optional(Schema.String),
+    max_bytes: Schema.optional(Schema.Number),
+    temperature: Schema.optional(Schema.Number),
+    system_prompt: Schema.optional(Schema.String),
+    top_p: Schema.optional(Schema.Number),
+    top_k: Schema.optional(Schema.Number),
+    stop_sequences: Schema.optional(Schema.Array(Schema.String)),
+    api_version: Schema.optional(Schema.String),
+    project_id: Schema.optional(Schema.String),
+    access_token: Schema.optional(SensitiveString),
+    refresh_token: Schema.optional(SensitiveString),
+    client_id: Schema.optional(Schema.String),
+    client_secret: Schema.optional(SensitiveString),
+    region: Schema.optional(Schema.String),
+    max_output_tokens: Schema.optional(Schema.Number),
+    account_id: Schema.optional(Schema.String),
+    id: Schema.optional(Schema.String),
+  }).pipe(T.Http({ method: "POST", path: "/nl_search_models" }));
 export type CreateNLSearchModelInput = typeof CreateNLSearchModelInput.Type;
 
 // Output Schema

--- a/packages/workos/src/index.ts
+++ b/packages/workos/src/index.ts
@@ -12,4 +12,5 @@ export * as T from "./traits.ts";
 export * as Retry from "./retry.ts";
 export { API } from "./client.ts";
 export * from "./errors.ts";
+export * from "./operations/index.ts";
 export { SensitiveString, SensitiveNullableString } from "./sensitive.ts";

--- a/packages/workos/src/operations/AuthorizationControllerCheck.ts
+++ b/packages/workos/src/operations/AuthorizationControllerCheck.ts
@@ -7,6 +7,7 @@ import { Forbidden, NotFound, UnprocessableEntity } from "../errors.ts";
 export const AuthorizationControllerCheckInput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     organization_membership_id: Schema.String.pipe(T.PathParam()),
+    permission_slug: Schema.String,
   }).pipe(
     T.Http({
       method: "POST",

--- a/packages/workos/src/operations/AuthorizationResourcesByExternalIdControllerUpdateByExternalId.ts
+++ b/packages/workos/src/operations/AuthorizationResourcesByExternalIdControllerUpdateByExternalId.ts
@@ -15,6 +15,8 @@ export const AuthorizationResourcesByExternalIdControllerUpdateByExternalIdInput
     organization_id: Schema.String.pipe(T.PathParam()),
     resource_type_slug: Schema.String.pipe(T.PathParam()),
     external_id: Schema.String.pipe(T.PathParam()),
+    name: Schema.optional(Schema.String),
+    description: Schema.optional(Schema.NullOr(Schema.String)),
   }).pipe(
     T.Http({
       method: "PATCH",

--- a/packages/workos/src/operations/AuthorizationResourcesControllerCreate.ts
+++ b/packages/workos/src/operations/AuthorizationResourcesControllerCreate.ts
@@ -11,9 +11,13 @@ import {
 
 // Input Schema
 export const AuthorizationResourcesControllerCreateInput =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
-    T.Http({ method: "POST", path: "/authorization/resources" }),
-  );
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    external_id: Schema.String,
+    name: Schema.String,
+    description: Schema.optional(Schema.NullOr(Schema.String)),
+    resource_type_slug: Schema.String,
+    organization_id: Schema.String,
+  }).pipe(T.Http({ method: "POST", path: "/authorization/resources" }));
 export type AuthorizationResourcesControllerCreateInput =
   typeof AuthorizationResourcesControllerCreateInput.Type;
 

--- a/packages/workos/src/operations/AuthorizationResourcesControllerUpdate.ts
+++ b/packages/workos/src/operations/AuthorizationResourcesControllerUpdate.ts
@@ -13,6 +13,8 @@ import {
 export const AuthorizationResourcesControllerUpdateInput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     resource_id: Schema.String.pipe(T.PathParam()),
+    name: Schema.optional(Schema.String),
+    description: Schema.optional(Schema.NullOr(Schema.String)),
   }).pipe(
     T.Http({ method: "PATCH", path: "/authorization/resources/{resource_id}" }),
   );

--- a/packages/workos/src/operations/AuthorizationRoleAssignmentsControllerAssignRole.ts
+++ b/packages/workos/src/operations/AuthorizationRoleAssignmentsControllerAssignRole.ts
@@ -7,6 +7,7 @@ import { Forbidden, NotFound, UnprocessableEntity } from "../errors.ts";
 export const AuthorizationRoleAssignmentsControllerAssignRoleInput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     organization_membership_id: Schema.String.pipe(T.PathParam()),
+    role_slug: Schema.String,
   }).pipe(
     T.Http({
       method: "POST",

--- a/packages/workos/src/operations/AuthorizationRoleAssignmentsControllerRemoveRoleByCriteria.ts
+++ b/packages/workos/src/operations/AuthorizationRoleAssignmentsControllerRemoveRoleByCriteria.ts
@@ -7,6 +7,7 @@ import { Forbidden, NotFound, UnprocessableEntity } from "../errors.ts";
 export const AuthorizationRoleAssignmentsControllerRemoveRoleByCriteriaInput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     organization_membership_id: Schema.String.pipe(T.PathParam()),
+    role_slug: Schema.String,
   }).pipe(
     T.Http({
       method: "DELETE",

--- a/packages/workos/src/operations/UserlandUserOrganizationMembershipsControllerCreate.ts
+++ b/packages/workos/src/operations/UserlandUserOrganizationMembershipsControllerCreate.ts
@@ -5,7 +5,10 @@ import { BadRequest, NotFound, UnprocessableEntity } from "../errors.ts";
 
 // Input Schema
 export const UserlandUserOrganizationMembershipsControllerCreateInput =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    user_id: Schema.String,
+    organization_id: Schema.String,
+  }).pipe(
     T.Http({
       method: "POST",
       path: "/user_management/organization_memberships",

--- a/packages/workos/src/operations/UserlandUsersControllerCreate.ts
+++ b/packages/workos/src/operations/UserlandUsersControllerCreate.ts
@@ -5,9 +5,16 @@ import { BadRequest, NotFound, UnprocessableEntity } from "../errors.ts";
 
 // Input Schema
 export const UserlandUsersControllerCreateInput =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
-    T.Http({ method: "POST", path: "/user_management/users" }),
-  );
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    email: Schema.String,
+    first_name: Schema.optional(Schema.NullOr(Schema.String)),
+    last_name: Schema.optional(Schema.NullOr(Schema.String)),
+    email_verified: Schema.optional(Schema.NullOr(Schema.Boolean)),
+    metadata: Schema.optional(
+      Schema.NullOr(Schema.Record(Schema.String, Schema.String)),
+    ),
+    external_id: Schema.optional(Schema.NullOr(Schema.String)),
+  }).pipe(T.Http({ method: "POST", path: "/user_management/users" }));
 export type UserlandUsersControllerCreateInput =
   typeof UserlandUsersControllerCreateInput.Type;
 

--- a/packages/workos/src/operations/UserlandUsersControllerUpdate.ts
+++ b/packages/workos/src/operations/UserlandUsersControllerUpdate.ts
@@ -7,6 +7,15 @@ import { BadRequest, UnprocessableEntity } from "../errors.ts";
 export const UserlandUsersControllerUpdateInput =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     id: Schema.String.pipe(T.PathParam()),
+    email: Schema.optional(Schema.String),
+    first_name: Schema.optional(Schema.String),
+    last_name: Schema.optional(Schema.String),
+    email_verified: Schema.optional(Schema.Boolean),
+    metadata: Schema.optional(
+      Schema.NullOr(Schema.Record(Schema.String, Schema.String)),
+    ),
+    external_id: Schema.optional(Schema.NullOr(Schema.String)),
+    locale: Schema.optional(Schema.NullOr(Schema.String)),
   }).pipe(T.Http({ method: "PUT", path: "/user_management/users/{id}" }));
 export type UserlandUsersControllerUpdateInput =
   typeof UserlandUsersControllerUpdateInput.Type;

--- a/scripts/create-sdk.ts
+++ b/scripts/create-sdk.ts
@@ -1315,6 +1315,7 @@ export * as T from "./traits.ts";
 export * as Retry from "./retry.ts";
 export { API } from "./client.ts";
 export * from "./errors.ts";
+export * from "./operations/index.ts";
 export { SensitiveString, SensitiveNullableString } from "./sensitive.ts";
 `,
     );


### PR DESCRIPTION
Three changes that travel together:

### 1. Generator: merge `allOf` in request body schemas

When a requestBody schema is `{ allOf: [A, B] }` the generator was checking only `bodySchema.properties` and producing an input schema with no body fields:

```ts
// before — body fields silently dropped
export const CreateProjectBranchInput = Schema.Struct({
  project_id: Schema.String.pipe(T.PathParam()),
}).pipe(T.Http({ method: "POST", path: "/projects/{project_id}/branches" }));

// after — allOf merged into a flat body shape
export const CreateProjectBranchInput = Schema.Struct({
  project_id: Schema.String.pipe(T.PathParam()),
  endpoints: Schema.optional(Schema.Array(...)),
  branch: Schema.optional(Schema.Struct({ name, parent_id, ... })),
}).pipe(T.Http({ method: "POST", path: "/projects/{project_id}/branches" }));
```

Flatten `allOf` (resolving `$ref` entries) into merged `{ properties, required }` before walking body fields.

### 2. Re-export operations from each SDK's package root

```ts
// before — operations were only reachable via the subpath import
import { createProject } from "@distilled.cloud/neon/Operations";

// after — flat import works
import { createProject } from "@distilled.cloud/neon";
```

`src/index.ts` of every SDK that has a generated `operations/` directory now re-exports it, and the `create-sdk` scaffolding emits the same line for new SDKs.

### 3. Regenerate every OpenAPI SDK

Picks up the `allOf` fix in the wild. Beyond Neon's four ops, this also fills in body fields for two Typesense ops (`createConversationModel`, `createNLSearchModel`) and nine WorkOS ops (`Authorization*`, `UserlandUsers*`, `UserlandUserOrganizationMemberships*`).
