### PR TITLE
fix(cloudflare/queues): tag QueueHandlerMissing (code 11001) as a typed error

### DIFF
--- a/packages/cloudflare/patches/queues/createConsumer.json
+++ b/packages/cloudflare/patches/queues/createConsumer.json
@@ -2,6 +2,10 @@
   "errors": {
     "InvalidRequestBody": [{ "code": 10026 }],
     "QueueNotFound": [{ "code": 11000 }],
+    "QueueHandlerMissing": [
+      { "code": 11001 },
+      { "status": 400, "message": { "includes": "queue handler is missing" } }
+    ],
     "ConsumerAlreadyExists": [{ "code": 11004 }],
     "WorkerNotFound": [{ "code": 10007 }],
     "InvalidRoute": [{ "code": 7003 }]

--- a/packages/cloudflare/patches/queues/updateConsumer.json
+++ b/packages/cloudflare/patches/queues/updateConsumer.json
@@ -2,6 +2,10 @@
   "errors": {
     "InvalidRequestBody": [{ "code": 10026 }],
     "QueueNotFound": [{ "code": 11000 }],
+    "QueueHandlerMissing": [
+      { "code": 11001 },
+      { "status": 400, "message": { "includes": "queue handler is missing" } }
+    ],
     "ConsumerNotFound": [
       { "code": 10013 },
       { "code": 10105 },

--- a/packages/cloudflare/specs/cloudflare/queues.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/queues.openapi.yml
@@ -267,6 +267,11 @@ paths:
           - code: 10026
         QueueNotFound:
           - code: 11000
+        QueueHandlerMissing:
+          - code: 11001
+          - status: 400
+            message:
+              includes: queue handler is missing
         ConsumerNotFound:
           - code: 10013
           - code: 10105
@@ -594,6 +599,11 @@ paths:
           - code: 10026
         QueueNotFound:
           - code: 11000
+        QueueHandlerMissing:
+          - code: 11001
+          - status: 400
+            message:
+              includes: queue handler is missing
         ConsumerAlreadyExists:
           - code: 11004
         WorkerNotFound:

--- a/packages/cloudflare/src/services/queues.ts
+++ b/packages/cloudflare/src/services/queues.ts
@@ -68,6 +68,15 @@ export class QueueAlreadyExists extends Schema.TaggedErrorClass<QueueAlreadyExis
 ) {}
 T.applyErrorMatchers(QueueAlreadyExists, [{ code: 11009 }]);
 
+export class QueueHandlerMissing extends Schema.TaggedErrorClass<QueueHandlerMissing>()(
+  "QueueHandlerMissing",
+  { code: Schema.Number, message: Schema.String },
+) {}
+T.applyErrorMatchers(QueueHandlerMissing, [
+  { code: 11001 },
+  { status: 400, message: { includes: "queue handler is missing" } },
+]);
+
 export class QueueNotFound extends Schema.TaggedErrorClass<QueueNotFound>()(
   "QueueNotFound",
   { code: Schema.Number, message: Schema.String },
@@ -602,6 +611,7 @@ export type CreateConsumerError =
   | DefaultErrors
   | InvalidRequestBody
   | QueueNotFound
+  | QueueHandlerMissing
   | ConsumerAlreadyExists
   | WorkerNotFound
   | InvalidRoute;
@@ -617,6 +627,7 @@ export const createConsumer: API.OperationMethod<
   errors: [
     InvalidRequestBody,
     QueueNotFound,
+    QueueHandlerMissing,
     ConsumerAlreadyExists,
     WorkerNotFound,
     InvalidRoute,
@@ -808,6 +819,7 @@ export type UpdateConsumerError =
   | DefaultErrors
   | InvalidRequestBody
   | QueueNotFound
+  | QueueHandlerMissing
   | ConsumerNotFound
   | WorkerNotFound
   | InvalidRoute;
@@ -823,6 +835,7 @@ export const updateConsumer: API.OperationMethod<
   errors: [
     InvalidRequestBody,
     QueueNotFound,
+    QueueHandlerMissing,
     ConsumerNotFound,
     WorkerNotFound,
     InvalidRoute,


### PR DESCRIPTION
Cloudflare returns code `11001` ("queue handler is missing") on both `createConsumer` and `updateConsumer` when the target Worker exists but its deployed script doesn't export a `queue` handler — typically transient when a sibling Worker is mid-upload. CF also occasionally surfaces the same condition as a bare HTTP 400 with the literal "queue handler is missing" message in the body, so this patch covers both shapes.

```diff
   "QueueNotFound": [{ "code": 11000 }],
+  "QueueHandlerMissing": [
+    { "code": 11001 },
+    { "status": 400, "message": { "includes": "queue handler is missing" } }
+  ],
   "ConsumerAlreadyExists": [{ "code": 11004 }],
```

Without this, callers had to match `UnknownCloudflareError` + read `code`, or fall back to the generic `BadRequest` with a regex on `message`. Both are escape hatches typed-error tagging is meant to prevent.
