### PR TITLE
fix(cloudflare): classify code 1000 "Request timeout" as GatewayTimeout

### DIFF
--- a/packages/cloudflare/src/client/api.ts
+++ b/packages/cloudflare/src/client/api.ts
@@ -30,6 +30,7 @@ import { getPath, type RequestParts } from "@distilled.cloud/core/traits";
 import {
   CloudflareHttpError,
   Forbidden,
+  GatewayTimeout,
   HTTP_STATUS_MAP,
   InternalServerError,
   InvalidRoute,
@@ -107,6 +108,15 @@ const GLOBAL_ERROR_CODE_MAP: Record<
   // accountId or zoneId) doesn't resolve to a real resource. Surfacing it
   // globally keeps tests for unknown-resource cases off UnknownCloudflareError.
   7003: (message) => new InvalidRoute({ code: 7003, message }),
+  // 1000: dual-use code. Cloudflare uses it for several unrelated conditions,
+  // but the "Request timeout" variant is unambiguous from the message and is
+  // a transient, retryable failure. Map only that variant to GatewayTimeout
+  // (retryable + server error); fall back to UnknownCloudflareError for
+  // anything else carried under code 1000 to preserve existing behavior.
+  1000: (message) =>
+    /\btimeout\b/i.test(message)
+      ? new GatewayTimeout({ message })
+      : new UnknownCloudflareError({ code: 1000, message }),
 };
 
 /**


### PR DESCRIPTION
Cloudflare returns code `1000` with message `"Request timeout"` inside the standard error envelope for transient timeout failures. Today this falls through to `UnknownCloudflareError`, which isn't retryable and isn't reflected in operation result types — callers can't pattern-match on it and the default retry policy doesn't ride it out.

Map it globally to `GatewayTimeout`, which is already in `DEFAULT_ERRORS` (so it's already in every operation's typed error union) and carries `ServerError + Retryable` categories.

The match is gated on the message because Cloudflare reuses code `1000` for unrelated conditions; only the timeout variant flips, everything else under code `1000` continues to surface as `UnknownCloudflareError`.

```diff
- Error: UnknownCloudflareError: {"error":"Request timeout"}
-   Serialized Error: { code: 1000, _tag: 'UnknownCloudflareError' }
+ Error: GatewayTimeout: Request timeout
+   Serialized Error: { _tag: 'GatewayTimeout', message: 'Request timeout' }
```
