### PR TITLE
fix(cloudflare/workers): widen json binding value to unknown

### DIFF
--- a/packages/cloudflare/patches/workers/createBetaWorkerVersion.json
+++ b/packages/cloudflare/patches/workers/createBetaWorkerVersion.json
@@ -4,6 +4,7 @@
   },
   "request": {
     "properties": {
+      "bindings[].json": { "type": "unknown" },
       "bindings[]": {
         "appendUnion": [
           {
@@ -47,6 +48,7 @@
   },
   "response": {
     "properties": {
+      "bindings[].json": { "type": "unknown" },
       "bindings[]": {
         "appendUnion": [
           {

--- a/packages/cloudflare/patches/workers/createScriptVersion.json
+++ b/packages/cloudflare/patches/workers/createScriptVersion.json
@@ -4,6 +4,7 @@
   },
   "request": {
     "properties": {
+      "metadata.bindings[].json": { "type": "unknown" },
       "metadata.bindings[]": {
         "appendUnion": [
           {
@@ -47,6 +48,7 @@
   },
   "response": {
     "properties": {
+      "resources.bindings[].json": { "type": "unknown" },
       "resources.bindings[]": {
         "appendUnion": [
           {

--- a/packages/cloudflare/patches/workers/getBetaWorkerVersion.json
+++ b/packages/cloudflare/patches/workers/getBetaWorkerVersion.json
@@ -5,6 +5,7 @@
   },
   "response": {
     "properties": {
+      "bindings[].json": { "type": "unknown" },
       "bindings[]": {
         "appendUnion": [
           {

--- a/packages/cloudflare/patches/workers/getScriptScriptAndVersionSetting.json
+++ b/packages/cloudflare/patches/workers/getScriptScriptAndVersionSetting.json
@@ -36,6 +36,7 @@
           ]
         }
       },
+      "bindings[].json": { "type": "unknown" },
       "bindings[]": {
         "appendUnion": [
           {

--- a/packages/cloudflare/patches/workers/getScriptVersion.json
+++ b/packages/cloudflare/patches/workers/getScriptVersion.json
@@ -5,6 +5,7 @@
   },
   "response": {
     "properties": {
+      "resources.bindings[].json": { "type": "unknown" },
       "resources.bindings[]": {
         "appendUnion": [
           {

--- a/packages/cloudflare/patches/workers/listBetaWorkerVersions.json
+++ b/packages/cloudflare/patches/workers/listBetaWorkerVersions.json
@@ -4,6 +4,7 @@
   },
   "response": {
     "properties": {
+      "result[].bindings[].json": { "type": "unknown" },
       "result[].bindings[]": {
         "appendUnion": [
           {

--- a/packages/cloudflare/patches/workers/patchScriptScriptAndVersionSetting.json
+++ b/packages/cloudflare/patches/workers/patchScriptScriptAndVersionSetting.json
@@ -5,6 +5,7 @@
   },
   "request": {
     "properties": {
+      "settings.bindings[].json": { "type": "unknown" },
       "settings.bindings[]": {
         "appendUnion": [
           {
@@ -49,6 +50,7 @@
   "response": {
     "properties": {
       "placement": { "type": "unknown" },
+      "bindings[].json": { "type": "unknown" },
       "bindings[]": {
         "appendUnion": [
           {

--- a/packages/cloudflare/patches/workers/putScript.json
+++ b/packages/cloudflare/patches/workers/putScript.json
@@ -26,6 +26,7 @@
   },
   "request": {
     "properties": {
+      "metadata.bindings[].json": { "type": "unknown" },
       "metadata.bindings[]": {
         "appendUnion": [
           {

--- a/packages/cloudflare/specs/cloudflare/workers.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers.openapi.yml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  title: Cloudflare WORKERS API
+  title: Cloudflare Workers API
   version: 0.0.0
 servers:
   - url: https://api.cloudflare.com/client/v4
@@ -950,7 +950,6 @@ paths:
                         - type: object
                           properties:
                             json:
-                              type: string
                               description: JSON data to use.
                             name:
                               type: string
@@ -2662,7 +2661,6 @@ paths:
                       - type: object
                         properties:
                           json:
-                            type: string
                             description: JSON data to use.
                           name:
                             type: string
@@ -3511,7 +3509,6 @@ paths:
                         - type: object
                           properties:
                             json:
-                              type: string
                               description: JSON data to use.
                             name:
                               type: string
@@ -6339,7 +6336,6 @@ paths:
                           - type: object
                             properties:
                               json:
-                                type: string
                                 description: JSON data to use.
                               name:
                                 type: string
@@ -9708,7 +9704,6 @@ paths:
                         - type: object
                           properties:
                             json:
-                              type: string
                               description: JSON data to use.
                             name:
                               type: string
@@ -10448,7 +10443,6 @@ paths:
                           - type: object
                             properties:
                               json:
-                                type: string
                                 description: JSON data to use.
                               name:
                                 type: string
@@ -11302,7 +11296,6 @@ paths:
                         - type: object
                           properties:
                             json:
-                              type: string
                               description: JSON data to use.
                             name:
                               type: string
@@ -13027,7 +13020,6 @@ paths:
                             - type: object
                               properties:
                                 json:
-                                  type: string
                                   description: JSON data to use.
                                 name:
                                   type: string
@@ -13855,7 +13847,6 @@ paths:
                           - type: object
                             properties:
                               json:
-                                type: string
                                 description: JSON data to use.
                               name:
                                 type: string
@@ -14508,7 +14499,6 @@ paths:
                             - type: object
                               properties:
                                 json:
-                                  type: string
                                   description: JSON data to use.
                                 name:
                                   type: string

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -975,7 +975,7 @@ export interface GetBetaWorkerVersionResponse {
             versionId?: string | null;
           }
         | { name: string; type: "images" }
-        | { json: string; name: string; type: "json" }
+        | { json: unknown; name: string; type: "json" }
         | { name: string; namespaceId: string; type: "kv_namespace" }
         | { certificateId: string; name: string; type: "mtls_certificate" }
         | { name: string; text: string; type: "plain_text" }
@@ -1244,7 +1244,7 @@ export const GetBetaWorkerVersionResponse =
               type: Schema.Literal("hyperdrive"),
             }),
             Schema.Struct({
-              json: Schema.String,
+              json: Schema.Unknown,
               name: Schema.String,
               type: Schema.Literal("json"),
             }),
@@ -1714,7 +1714,7 @@ export interface ListBetaWorkerVersionsResponse {
               versionId?: string | null;
             }
           | { name: string; type: "images" }
-          | { json: string; name: string; type: "json" }
+          | { json: unknown; name: string; type: "json" }
           | { name: string; namespaceId: string; type: "kv_namespace" }
           | { certificateId: string; name: string; type: "mtls_certificate" }
           | { name: string; text: string; type: "plain_text" }
@@ -1988,7 +1988,7 @@ export const ListBetaWorkerVersionsResponse =
                   type: Schema.Literal("hyperdrive"),
                 }),
                 Schema.Struct({
-                  json: Schema.String,
+                  json: Schema.Unknown,
                   name: Schema.String,
                   type: Schema.Literal("json"),
                 }),
@@ -2459,7 +2459,7 @@ export interface CreateBetaWorkerVersionRequest {
     | { id: string; name: string; type: "hyperdrive" }
     | { name: string; type: "inherit"; oldName?: string; versionId?: string }
     | { name: string; type: "images" }
-    | { json: string; name: string; type: "json" }
+    | { json: unknown; name: string; type: "json" }
     | { name: string; namespaceId: string; type: "kv_namespace" }
     | { certificateId: string; name: string; type: "mtls_certificate" }
     | { name: string; text: string; type: "plain_text" }
@@ -2692,7 +2692,7 @@ export const CreateBetaWorkerVersionRequest =
             type: Schema.Literal("hyperdrive"),
           }),
           Schema.Struct({
-            json: Schema.String,
+            json: Schema.Unknown,
             name: Schema.String,
             type: Schema.Literal("json"),
           }),
@@ -3089,7 +3089,7 @@ export interface CreateBetaWorkerVersionResponse {
             versionId?: string | null;
           }
         | { name: string; type: "images" }
-        | { json: string; name: string; type: "json" }
+        | { json: unknown; name: string; type: "json" }
         | { name: string; namespaceId: string; type: "kv_namespace" }
         | { certificateId: string; name: string; type: "mtls_certificate" }
         | { name: string; text: string; type: "plain_text" }
@@ -3358,7 +3358,7 @@ export const CreateBetaWorkerVersionResponse =
               type: Schema.Literal("hyperdrive"),
             }),
             Schema.Struct({
-              json: Schema.String,
+              json: Schema.Unknown,
               name: Schema.String,
               type: Schema.Literal("json"),
             }),
@@ -6553,7 +6553,7 @@ export interface PutScriptRequest {
       | { id: string; name: string; type: "hyperdrive" }
       | { name: string; type: "inherit"; oldName?: string; versionId?: string }
       | { name: string; type: "images" }
-      | { json: string; name: string; type: "json" }
+      | { json: unknown; name: string; type: "json" }
       | { name: string; namespaceId: string; type: "kv_namespace" }
       | { certificateId: string; name: string; type: "mtls_certificate" }
       | { name: string; text: string; type: "plain_text" }
@@ -6826,7 +6826,7 @@ export const PutScriptRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
             type: Schema.Literal("hyperdrive"),
           }),
           Schema.Struct({
-            json: Schema.String,
+            json: Schema.Unknown,
             name: Schema.String,
             type: Schema.Literal("json"),
           }),
@@ -9655,7 +9655,7 @@ export interface GetScriptScriptAndVersionSettingResponse {
             versionId?: string | null;
           }
         | { name: string; type: "images" }
-        | { json: string; name: string; type: "json" }
+        | { json: unknown; name: string; type: "json" }
         | { name: string; namespaceId: string; type: "kv_namespace" }
         | { certificateId: string; name: string; type: "mtls_certificate" }
         | { name: string; text: string; type: "plain_text" }
@@ -9846,7 +9846,7 @@ export const GetScriptScriptAndVersionSettingResponse =
               type: Schema.Literal("hyperdrive"),
             }),
             Schema.Struct({
-              json: Schema.String,
+              json: Schema.Unknown,
               name: Schema.String,
               type: Schema.Literal("json"),
             }),
@@ -10233,7 +10233,7 @@ export interface PatchScriptScriptAndVersionSettingRequest {
       | { id: string; name: string; type: "hyperdrive" }
       | { name: string; type: "inherit"; oldName?: string; versionId?: string }
       | { name: string; type: "images" }
-      | { json: string; name: string; type: "json" }
+      | { json: unknown; name: string; type: "json" }
       | { name: string; namespaceId: string; type: "kv_namespace" }
       | { certificateId: string; name: string; type: "mtls_certificate" }
       | { name: string; text: string; type: "plain_text" }
@@ -10438,7 +10438,7 @@ export const PatchScriptScriptAndVersionSettingRequest =
                 type: Schema.Literal("hyperdrive"),
               }),
               Schema.Struct({
-                json: Schema.String,
+                json: Schema.Unknown,
                 name: Schema.String,
                 type: Schema.Literal("json"),
               }),
@@ -10866,7 +10866,7 @@ export interface PatchScriptScriptAndVersionSettingResponse {
             versionId?: string | null;
           }
         | { name: string; type: "images" }
-        | { json: string; name: string; type: "json" }
+        | { json: unknown; name: string; type: "json" }
         | { name: string; namespaceId: string; type: "kv_namespace" }
         | { certificateId: string; name: string; type: "mtls_certificate" }
         | { name: string; text: string; type: "plain_text" }
@@ -11051,7 +11051,7 @@ export const PatchScriptScriptAndVersionSettingResponse =
               type: Schema.Literal("hyperdrive"),
             }),
             Schema.Struct({
-              json: Schema.String,
+              json: Schema.Unknown,
               name: Schema.String,
               type: Schema.Literal("json"),
             }),
@@ -12572,7 +12572,7 @@ export interface GetScriptVersionResponse {
               versionId?: string | null;
             }
           | { name: string; type: "images" }
-          | { json: string; name: string; type: "json" }
+          | { json: unknown; name: string; type: "json" }
           | { name: string; namespaceId: string; type: "kv_namespace" }
           | { certificateId: string; name: string; type: "mtls_certificate" }
           | { name: string; text: string; type: "plain_text" }
@@ -12766,7 +12766,7 @@ export const GetScriptVersionResponse =
                 type: Schema.Literal("hyperdrive"),
               }),
               Schema.Struct({
-                json: Schema.String,
+                json: Schema.Unknown,
                 name: Schema.String,
                 type: Schema.Literal("json"),
               }),
@@ -13332,7 +13332,7 @@ export interface CreateScriptVersionRequest {
       | { id: string; name: string; type: "hyperdrive" }
       | { name: string; type: "inherit"; oldName?: string; versionId?: string }
       | { name: string; type: "images" }
-      | { json: string; name: string; type: "json" }
+      | { json: unknown; name: string; type: "json" }
       | { name: string; namespaceId: string; type: "kv_namespace" }
       | { certificateId: string; name: string; type: "mtls_certificate" }
       | { name: string; text: string; type: "plain_text" }
@@ -13502,7 +13502,7 @@ export const CreateScriptVersionRequest =
               type: Schema.Literal("hyperdrive"),
             }),
             Schema.Struct({
-              json: Schema.String,
+              json: Schema.Unknown,
               name: Schema.String,
               type: Schema.Literal("json"),
             }),
@@ -13756,7 +13756,7 @@ export interface CreateScriptVersionResponse {
               versionId?: string | null;
             }
           | { name: string; type: "images" }
-          | { json: string; name: string; type: "json" }
+          | { json: unknown; name: string; type: "json" }
           | { name: string; namespaceId: string; type: "kv_namespace" }
           | { certificateId: string; name: string; type: "mtls_certificate" }
           | { name: string; text: string; type: "plain_text" }
@@ -13952,7 +13952,7 @@ export const CreateScriptVersionResponse =
                 type: Schema.Literal("hyperdrive"),
               }),
               Schema.Struct({
-                json: Schema.String,
+                json: Schema.Unknown,
                 name: Schema.String,
                 type: Schema.Literal("json"),
               }),


### PR DESCRIPTION
Cloudflare's `json` env binding takes the raw JSON value embedded directly in the metadata struct — not a stringified one. Wrangler sends:

```json
{ "name": "X", "type": "json", "json": { "foo": "bar" } }
```

not

```json
{ "name": "X", "type": "json", "json": "{\"foo\":\"bar\"}" }
```

…and Cloudflare's runtime delivers `env.X` as the parsed value. The upstream Cloudflare TypeScript SDK declares the field as `json: string`, but in practice it's any JSON value. Sending a string makes it arrive at the worker as the literal string.

Patches the request + response shapes for every operation that has a `json` binding variant to make the field `Schema.Unknown` / `unknown`.

### Affected operations

- `putScript`
- `createScriptVersion` (req + resp)
- `getScriptVersion` (resp)
- `getScriptScriptAndVersionSetting` (resp)
- `patchScriptScriptAndVersionSetting` (req + resp)
- `createBetaWorkerVersion` (req + resp)
- `getBetaWorkerVersion` (resp)
- `listBetaWorkerVersions` (resp)
- `createScriptEdgePreview` / `createServiceEdgePreview` (auto-patched via shared `metadata.bindings` shape)

### Verification

`bun run scripts/generate.ts --service workers` now emits `json: Schema.Unknown` for every json binding variant. `bun run check` passes; tests pass aside from one unrelated pre-existing flake (`accounts.test.ts > verifyToken > error - for verification failure`, fails on `main` without these changes too).

Unblocks alchemy-run/alchemy-effect#269 — once this lands, alchemy can send typed env values (numbers, booleans, objects, arrays) and have them arrive in `env` already parsed.
