### PR TITLE
feat(cloudflare): add R2 listObjects and deleteObjects operations and update pagination wrappers

### DIFF
--- a/packages/cloudflare/scripts/generate.ts
+++ b/packages/cloudflare/scripts/generate.ts
@@ -746,7 +746,7 @@ function buildPaginatedResponseType(
           },
           {
             name: "result_info",
-            required: true,
+            required: false,
             type: {
               kind: "object",
               properties: [
@@ -782,7 +782,7 @@ function buildPaginatedResponseType(
           { name: "result", required: true, type: arrayOfItems },
           {
             name: "result_info",
-            required: true,
+            required: false,
             type: {
               kind: "object",
               properties: [
@@ -819,7 +819,7 @@ function buildPaginatedResponseType(
           { name: "result", required: true, type: arrayOfItems },
           {
             name: "result_info",
-            required: true,
+            required: false,
             type: {
               kind: "object",
               properties: [
@@ -850,7 +850,7 @@ function buildPaginatedResponseType(
           { name: "result", required: true, type: arrayOfItems },
           {
             name: "result_info",
-            required: true,
+            required: false,
             type: {
               kind: "object",
               properties: [

--- a/packages/cloudflare/specs/cloudflare-patch/r2-object.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare-patch/r2-object.openapi.yml
@@ -7,6 +7,135 @@ servers:
   - url: https://api.cloudflare.com/client/v4
 x-distilled-service: r2
 paths:
+  /accounts/{account_id}/r2/buckets/{bucketName}/objects:
+    get:
+      operationId: listObjects
+      summary: List objects in an R2 bucket.
+      description: |
+        Lists objects in an R2 bucket. Returns object metadata including key, size, etag,
+        last modified date, HTTP metadata, and custom metadata. Supports cursor-based
+        pagination via `cursor` and `per_page`.
+      x-distilled-response-path: result
+      x-distilled-errors:
+        NoSuchBucket:
+          - code: 10006
+        InvalidRoute:
+          - code: 7003
+        NoRoute:
+          - code: 10015
+      parameters:
+        - $ref: "#/components/parameters/BucketName"
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/Jurisdiction"
+        - name: per_page
+          in: query
+          required: false
+          description: Maximum number of objects to return per page (1-1000).
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 20
+        - name: prefix
+          in: query
+          required: false
+          description: Restrict results to keys beginning with this prefix.
+          schema:
+            type: string
+        - name: delimiter
+          in: query
+          required: false
+          description: Single character used to group keys.
+          schema:
+            type: string
+        - name: cursor
+          in: query
+          required: false
+          description: Pagination cursor returned by a previous List Objects call.
+          schema:
+            type: string
+        - name: start_after
+          in: query
+          required: false
+          description: Returns keys lexicographically after this key.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/R2Object"
+                  result_info:
+                    $ref: "#/components/schemas/R2ListObjectsResultInfo"
+    delete:
+      operationId: deleteObjects
+      summary: Bulk-delete objects from an R2 bucket.
+      description: |
+        Deletes multiple objects from an R2 bucket in a single request. Provide a JSON
+        array of object keys in `keys`; up to 1000 keys per request. Per-key errors are
+        reported in the response body without failing the request as a whole.
+
+        For prefix-based async deletion (returns a job descriptor), pass a `prefix` query
+        parameter and an empty `keys` array.
+      x-distilled-response-path: result
+      x-distilled-errors:
+        NoSuchBucket:
+          - code: 10006
+        InvalidRoute:
+          - code: 7003
+        NoRoute:
+          - code: 10015
+      parameters:
+        - $ref: "#/components/parameters/BucketName"
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/Jurisdiction"
+        - name: prefix
+          in: query
+          required: false
+          description: |
+            When set, switches to "delete by prefix" mode and asynchronously deletes every
+            object whose key begins with the given prefix. The response is a prefix-delete
+            job descriptor instead of a per-key list. Pass an empty body when using prefix
+            mode.
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: string
+              example:
+                - path/to/object-a.txt
+                - path/to/object-b.txt
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    oneOf:
+                      - type: array
+                        description: Per-key delete results (delete-by-list mode).
+                        items:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                              description: Key of the deleted object.
+                      - $ref: "#/components/schemas/R2PrefixDeleteJob"
   /accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}:
     get:
       operationId: getObject
@@ -171,3 +300,89 @@ components:
           - default
           - eu
           - fedramp
+  schemas:
+    R2Object:
+      type: object
+      description: Metadata for an R2 object.
+      properties:
+        key:
+          type: string
+          description: The object key (name).
+        size:
+          type: integer
+          description: Object size in bytes.
+        etag:
+          type: string
+          description: Entity tag (raw hex digest, no surrounding quotes).
+        last_modified:
+          type: string
+          format: date-time
+          description: When the object was last modified.
+        storage_class:
+          type: string
+          enum:
+            - Standard
+            - InfrequentAccess
+        ssec:
+          type: boolean
+          description: Whether the object is encrypted with a customer-supplied key.
+        custom_metadata:
+          type: object
+          additionalProperties:
+            type: string
+          description: Custom metadata key-value pairs.
+        http_metadata:
+          type: object
+          description: HTTP metadata associated with the object.
+          additionalProperties: true
+    R2ListObjectsResultInfo:
+      type: object
+      description: Pagination information for List Objects responses.
+      properties:
+        cursor:
+          type: string
+          description: Cursor to pass to the next List Objects call.
+        is_truncated:
+          type: boolean
+          description: Whether more results are available; if true, use `cursor` to fetch them.
+        per_page:
+          type: integer
+          description: Maximum objects returned per page.
+        delimited:
+          type: array
+          description: Common prefixes when a delimiter is specified.
+          items:
+            type: string
+    R2PrefixDeleteJob:
+      type: object
+      description: Descriptor of an asynchronous prefix-delete job.
+      properties:
+        id:
+          type: string
+        jobType:
+          type: string
+          enum:
+            - prefixDelete
+        status:
+          type: string
+          enum:
+            - ENQUEUED
+            - RUNNING
+            - COMPLETED
+            - FAILED
+            - CANCELLED
+        startTime:
+          type: string
+          format: date-time
+        endTime:
+          type: string
+          format: date-time
+        prefixDelete:
+          type: object
+          properties:
+            prefix:
+              type: string
+            deletedObjects:
+              type: integer
+            isBucketClear:
+              type: boolean

--- a/packages/cloudflare/specs/cloudflare-patch/r2-object.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare-patch/r2-object.openapi.yml
@@ -13,9 +13,9 @@ paths:
       summary: List objects in an R2 bucket.
       description: |
         Lists objects in an R2 bucket. Returns object metadata including key, size, etag,
-        last modified date, HTTP metadata, and custom metadata. Supports cursor-based
-        pagination via `cursor` and `per_page`.
-      x-distilled-response-path: result
+        last modified date, HTTP metadata, and custom metadata. Cursor-paginated — call
+        `.items()` on the operation for an `Effect.Stream` of every object across pages.
+      x-distilled-pagination-class: CursorPagination
       x-distilled-errors:
         NoSuchBucket:
           - code: 10006
@@ -66,9 +66,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/R2Object"
+                $ref: "#/components/schemas/R2Object"
     delete:
       operationId: deleteObjects
       summary: Bulk-delete objects from an R2 bucket.

--- a/packages/cloudflare/specs/cloudflare-patch/r2-object.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare-patch/r2-object.openapi.yml
@@ -66,14 +66,9 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  result:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/R2Object"
-                  result_info:
-                    $ref: "#/components/schemas/R2ListObjectsResultInfo"
+                type: array
+                items:
+                  $ref: "#/components/schemas/R2Object"
     delete:
       operationId: deleteObjects
       summary: Bulk-delete objects from an R2 bucket.
@@ -123,19 +118,16 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  result:
-                    oneOf:
-                      - type: array
-                        description: Per-key delete results (delete-by-list mode).
-                        items:
-                          type: object
-                          properties:
-                            key:
-                              type: string
-                              description: Key of the deleted object.
-                      - $ref: "#/components/schemas/R2PrefixDeleteJob"
+                oneOf:
+                  - type: array
+                    description: Per-key delete results (delete-by-list mode).
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                          description: Key of the deleted object.
+                  - $ref: "#/components/schemas/R2PrefixDeleteJob"
   /accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}:
     get:
       operationId: getObject
@@ -335,24 +327,6 @@ components:
           type: object
           description: HTTP metadata associated with the object.
           additionalProperties: true
-    R2ListObjectsResultInfo:
-      type: object
-      description: Pagination information for List Objects responses.
-      properties:
-        cursor:
-          type: string
-          description: Cursor to pass to the next List Objects call.
-        is_truncated:
-          type: boolean
-          description: Whether more results are available; if true, use `cursor` to fetch them.
-        per_page:
-          type: integer
-          description: Maximum objects returned per page.
-        delimited:
-          type: array
-          description: Common prefixes when a delimiter is specified.
-          items:
-            type: string
     R2PrefixDeleteJob:
       type: object
       description: Descriptor of an asynchronous prefix-delete job.

--- a/packages/cloudflare/specs/cloudflare/containers.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/containers.openapi.yml
@@ -1,7 +1,8 @@
 openapi: 3.1.0
 info:
-  title: Cloudflare CONTAINERS API
+  title: Cloudflare Containers API
   version: 0.0.0
+  description: Reverse-engineered low-level Cloudflare Containers API.
 servers:
   - url: https://api.cloudflare.com/client/v4
 x-distilled-service: containers

--- a/packages/cloudflare/specs/cloudflare/r2.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/r2.openapi.yml
@@ -1,7 +1,8 @@
 openapi: 3.1.0
 info:
-  title: Cloudflare R2 API
+  title: Cloudflare R2 Object API
   version: 0.0.0
+  description: R2 object operations not exposed in the Cloudflare TypeScript SDK.
 servers:
   - url: https://api.cloudflare.com/client/v4
 x-distilled-service: r2
@@ -2720,6 +2721,254 @@ paths:
       responses:
         "200":
           description: Success
+      x-distilled-response-path: result
+      x-distilled-errors:
+        NoSuchBucket:
+          - code: 10006
+        InvalidRoute:
+          - code: 7003
+        NoRoute:
+          - code: 10015
+  /accounts/{account_id}/r2/buckets/{bucketName}/objects:
+    get:
+      operationId: listObjects
+      summary: List objects in an R2 bucket.
+      description: >
+        Lists objects in an R2 bucket. Returns object metadata including key,
+        size, etag,
+
+        last modified date, HTTP metadata, and custom metadata. Supports
+        cursor-based
+
+        pagination via `cursor` and `per_page`.
+      parameters:
+        - name: bucketName
+          in: path
+          required: true
+          description: Name of the R2 bucket.
+          schema:
+            type: string
+        - name: account_id
+          in: path
+          required: true
+          description: Account ID.
+          schema:
+            type: string
+        - name: per_page
+          in: query
+          required: false
+          description: Maximum number of objects to return per page (1-1000).
+          schema:
+            type: number
+        - name: prefix
+          in: query
+          required: false
+          description: Restrict results to keys beginning with this prefix.
+          schema:
+            type: string
+        - name: delimiter
+          in: query
+          required: false
+          description: Single character used to group keys.
+          schema:
+            type: string
+        - name: cursor
+          in: query
+          required: false
+          description: Pagination cursor returned by a previous List Objects call.
+          schema:
+            type: string
+        - name: start_after
+          in: query
+          required: false
+          description: Returns keys lexicographically after this key.
+          schema:
+            type: string
+        - name: cf-r2-jurisdiction
+          in: header
+          required: false
+          description: Jurisdiction where objects in this bucket are guaranteed to be
+            stored.
+          schema:
+            type: string
+            enum:
+              - default
+              - eu
+              - fedramp
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                          description: The object key (name).
+                        size:
+                          type: number
+                          description: Object size in bytes.
+                        etag:
+                          type: string
+                          description: Entity tag (raw hex digest, no surrounding quotes).
+                        last_modified:
+                          type: string
+                          description: When the object was last modified.
+                        storage_class:
+                          type: string
+                          enum:
+                            - Standard
+                            - InfrequentAccess
+                        ssec:
+                          type: boolean
+                          description: Whether the object is encrypted with a customer-supplied key.
+                        custom_metadata:
+                          description: Custom metadata key-value pairs.
+                        http_metadata:
+                          description: HTTP metadata associated with the object.
+                  result_info:
+                    type: object
+                    properties:
+                      cursor:
+                        type: string
+                        description: Cursor to pass to the next List Objects call.
+                      is_truncated:
+                        type: boolean
+                        description: Whether more results are available; if true, use `cursor` to fetch
+                          them.
+                      per_page:
+                        type: number
+                        description: Maximum objects returned per page.
+                      delimited:
+                        type: array
+                        items:
+                          type: string
+                        description: Common prefixes when a delimiter is specified.
+      x-distilled-response-path: result
+      x-distilled-errors:
+        NoSuchBucket:
+          - code: 10006
+        InvalidRoute:
+          - code: 7003
+        NoRoute:
+          - code: 10015
+    delete:
+      operationId: deleteObjects
+      summary: Bulk-delete objects from an R2 bucket.
+      description: >
+        Deletes multiple objects from an R2 bucket in a single request. Provide
+        a JSON
+
+        array of object keys in `keys`; up to 1000 keys per request. Per-key
+        errors are
+
+        reported in the response body without failing the request as a whole.
+
+
+        For prefix-based async deletion (returns a job descriptor), pass a
+        `prefix` query
+
+        parameter and an empty `keys` array.
+      parameters:
+        - name: bucketName
+          in: path
+          required: true
+          description: Name of the R2 bucket.
+          schema:
+            type: string
+        - name: account_id
+          in: path
+          required: true
+          description: Account ID.
+          schema:
+            type: string
+        - name: prefix
+          in: query
+          required: false
+          description: >
+            When set, switches to "delete by prefix" mode and asynchronously
+            deletes every
+
+            object whose key begins with the given prefix. The response is a
+            prefix-delete
+
+            job descriptor instead of a per-key list. Pass an empty body when
+            using prefix
+
+            mode.
+          schema:
+            type: string
+        - name: cf-r2-jurisdiction
+          in: header
+          required: false
+          description: Jurisdiction where objects in this bucket are guaranteed to be
+            stored.
+          schema:
+            type: string
+            enum:
+              - default
+              - eu
+              - fedramp
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    oneOf:
+                      - type: array
+                        items:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                              description: Key of the deleted object.
+                      - type: object
+                        properties:
+                          id:
+                            type: string
+                          jobType:
+                            type: string
+                            enum:
+                              - prefixDelete
+                          status:
+                            type: string
+                            enum:
+                              - ENQUEUED
+                              - RUNNING
+                              - COMPLETED
+                              - FAILED
+                              - CANCELLED
+                          startTime:
+                            type: string
+                          endTime:
+                            type: string
+                          prefixDelete:
+                            type: object
+                            properties:
+                              prefix:
+                                type: string
+                              deletedObjects:
+                                type: number
+                              isBucketClear:
+                                type: boolean
       x-distilled-response-path: result
       x-distilled-errors:
         NoSuchBucket:

--- a/packages/cloudflare/specs/cloudflare/r2.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/r2.openapi.yml
@@ -2801,55 +2801,34 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  result:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          type: string
-                          description: The object key (name).
-                        size:
-                          type: number
-                          description: Object size in bytes.
-                        etag:
-                          type: string
-                          description: Entity tag (raw hex digest, no surrounding quotes).
-                        last_modified:
-                          type: string
-                          description: When the object was last modified.
-                        storage_class:
-                          type: string
-                          enum:
-                            - Standard
-                            - InfrequentAccess
-                        ssec:
-                          type: boolean
-                          description: Whether the object is encrypted with a customer-supplied key.
-                        custom_metadata:
-                          description: Custom metadata key-value pairs.
-                        http_metadata:
-                          description: HTTP metadata associated with the object.
-                  result_info:
-                    type: object
-                    properties:
-                      cursor:
-                        type: string
-                        description: Cursor to pass to the next List Objects call.
-                      is_truncated:
-                        type: boolean
-                        description: Whether more results are available; if true, use `cursor` to fetch
-                          them.
-                      per_page:
-                        type: number
-                        description: Maximum objects returned per page.
-                      delimited:
-                        type: array
-                        items:
-                          type: string
-                        description: Common prefixes when a delimiter is specified.
+                type: array
+                items:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                      description: The object key (name).
+                    size:
+                      type: number
+                      description: Object size in bytes.
+                    etag:
+                      type: string
+                      description: Entity tag (raw hex digest, no surrounding quotes).
+                    last_modified:
+                      type: string
+                      description: When the object was last modified.
+                    storage_class:
+                      type: string
+                      enum:
+                        - Standard
+                        - InfrequentAccess
+                    ssec:
+                      type: boolean
+                      description: Whether the object is encrypted with a customer-supplied key.
+                    custom_metadata:
+                      description: Custom metadata key-value pairs.
+                    http_metadata:
+                      description: HTTP metadata associated with the object.
       x-distilled-response-path: result
       x-distilled-errors:
         NoSuchBucket:
@@ -2929,46 +2908,43 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  result:
-                    oneOf:
-                      - type: array
-                        items:
-                          type: object
-                          properties:
-                            key:
-                              type: string
-                              description: Key of the deleted object.
-                      - type: object
+                oneOf:
+                  - type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                          description: Key of the deleted object.
+                  - type: object
+                    properties:
+                      id:
+                        type: string
+                      jobType:
+                        type: string
+                        enum:
+                          - prefixDelete
+                      status:
+                        type: string
+                        enum:
+                          - ENQUEUED
+                          - RUNNING
+                          - COMPLETED
+                          - FAILED
+                          - CANCELLED
+                      startTime:
+                        type: string
+                      endTime:
+                        type: string
+                      prefixDelete:
+                        type: object
                         properties:
-                          id:
+                          prefix:
                             type: string
-                          jobType:
-                            type: string
-                            enum:
-                              - prefixDelete
-                          status:
-                            type: string
-                            enum:
-                              - ENQUEUED
-                              - RUNNING
-                              - COMPLETED
-                              - FAILED
-                              - CANCELLED
-                          startTime:
-                            type: string
-                          endTime:
-                            type: string
-                          prefixDelete:
-                            type: object
-                            properties:
-                              prefix:
-                                type: string
-                              deletedObjects:
-                                type: number
-                              isBucketClear:
-                                type: boolean
+                          deletedObjects:
+                            type: number
+                          isBucketClear:
+                            type: boolean
       x-distilled-response-path: result
       x-distilled-errors:
         NoSuchBucket:

--- a/packages/cloudflare/specs/cloudflare/r2.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/r2.openapi.yml
@@ -2737,10 +2737,11 @@ paths:
         Lists objects in an R2 bucket. Returns object metadata including key,
         size, etag,
 
-        last modified date, HTTP metadata, and custom metadata. Supports
-        cursor-based
+        last modified date, HTTP metadata, and custom metadata. Cursor-paginated
+        — call
 
-        pagination via `cursor` and `per_page`.
+        `.items()` on the operation for an `Effect.Stream` of every object
+        across pages.
       parameters:
         - name: bucketName
           in: path
@@ -2801,35 +2802,33 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    key:
-                      type: string
-                      description: The object key (name).
-                    size:
-                      type: number
-                      description: Object size in bytes.
-                    etag:
-                      type: string
-                      description: Entity tag (raw hex digest, no surrounding quotes).
-                    last_modified:
-                      type: string
-                      description: When the object was last modified.
-                    storage_class:
-                      type: string
-                      enum:
-                        - Standard
-                        - InfrequentAccess
-                    ssec:
-                      type: boolean
-                      description: Whether the object is encrypted with a customer-supplied key.
-                    custom_metadata:
-                      description: Custom metadata key-value pairs.
-                    http_metadata:
-                      description: HTTP metadata associated with the object.
-      x-distilled-response-path: result
+                type: object
+                properties:
+                  key:
+                    type: string
+                    description: The object key (name).
+                  size:
+                    type: number
+                    description: Object size in bytes.
+                  etag:
+                    type: string
+                    description: Entity tag (raw hex digest, no surrounding quotes).
+                  last_modified:
+                    type: string
+                    description: When the object was last modified.
+                  storage_class:
+                    type: string
+                    enum:
+                      - Standard
+                      - InfrequentAccess
+                  ssec:
+                    type: boolean
+                    description: Whether the object is encrypted with a customer-supplied key.
+                  custom_metadata:
+                    description: Custom metadata key-value pairs.
+                  http_metadata:
+                    description: HTTP metadata associated with the object.
+      x-distilled-pagination-class: CursorPagination
       x-distilled-errors:
         NoSuchBucket:
           - code: 10006

--- a/packages/cloudflare/specs/cloudflare/secrets-store.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/secrets-store.openapi.yml
@@ -1,7 +1,13 @@
 openapi: 3.1.0
 info:
-  title: Cloudflare SECRETS-STORE API
+  title: Cloudflare Secrets Store API (patch overrides)
   version: 0.0.0
+  description: |
+    Operation overrides for endpoints whose upstream OpenAPI shape is wrong.
+    Currently:
+      - createStore: upstream models the request body as an array of objects
+        and the response as a paginated array, but the actual API takes a
+        single `{ name }` object and returns a single store object.
 servers:
   - url: https://api.cloudflare.com/client/v4
 x-distilled-service: secrets-store

--- a/packages/cloudflare/specs/cloudflare/workers.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers.openapi.yml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  title: Cloudflare WORKERS API
+  title: Cloudflare Workers API
   version: 0.0.0
 servers:
   - url: https://api.cloudflare.com/client/v4

--- a/packages/cloudflare/src/services/abuse-reports.ts
+++ b/packages/cloudflare/src/services/abuse-reports.ts
@@ -298,12 +298,12 @@ export interface ListAbuseReportsResponse {
         }[]
       | null;
   };
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAbuseReportsResponse =
@@ -394,18 +394,25 @@ export const ListAbuseReportsResponse =
         ]),
       ),
     }),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -672,12 +679,12 @@ export interface ListMitigationsResponse {
         }[]
       | null;
   };
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListMitigationsResponse =
@@ -729,18 +736,25 @@ export const ListMitigationsResponse =
         ]),
       ),
     }),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/accounts.ts
+++ b/packages/cloudflare/src/services/accounts.ts
@@ -253,12 +253,12 @@ export interface ListAccountsResponse {
       enforceTwofactor?: boolean | null;
     } | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAccountsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -315,18 +315,23 @@ export const ListAccountsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -895,7 +900,7 @@ export interface ListLogAuditsResponse {
     } | null;
     zone?: { id?: string | null; name?: string | null } | null;
   }[];
-  resultInfo: { cursors?: { after?: string | null } | null };
+  resultInfo?: { cursors?: { after?: string | null } | null } | null;
 }
 
 export const ListLogAuditsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -1031,16 +1036,23 @@ export const ListLogAuditsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       ),
     }),
   ),
-  resultInfo: Schema.Struct({
-    cursors: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          after: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        }),
-        Schema.Null,
-      ]),
-    ),
-  }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        cursors: Schema.optional(
+          Schema.Union([
+            Schema.Struct({
+              after: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }),
+            Schema.Null,
+          ]),
+        ),
+      }),
+      Schema.Null,
+    ]),
+  ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
 ) as unknown as Schema.Schema<ListLogAuditsResponse>;
@@ -1497,12 +1509,12 @@ export interface ListMembersResponse {
       twoFactorAuthenticationEnabled?: boolean | null;
     } | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListMembersResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -1767,18 +1779,23 @@ export const ListMembersResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       ),
     }),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -2758,12 +2775,12 @@ export interface ListRolesResponse {
       zones?: { read?: boolean | null; write?: boolean | null } | null;
     };
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListRolesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -2947,18 +2964,23 @@ export const ListRolesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       ),
     }),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -3875,12 +3897,12 @@ export interface ListTokensResponse {
       | null;
     status?: "active" | "disabled" | "expired" | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListTokensResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -3974,18 +3996,23 @@ export const ListTokensResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/ai-gateway.ts
+++ b/packages/cloudflare/src/services/ai-gateway.ts
@@ -279,12 +279,12 @@ export interface ListAiGatewaysResponse {
     } | null;
     zdr?: boolean | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAiGatewaysResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
@@ -407,18 +407,25 @@ export const ListAiGatewaysResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   },
 ).pipe(
@@ -1389,12 +1396,12 @@ export interface ListDatasetsResponse {
     modifiedAt: string;
     name: string;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListDatasetsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -1445,18 +1452,23 @@ export const ListDatasetsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -2178,12 +2190,12 @@ export interface ListEvaluationsResponse {
     }[];
     totalLogs: number;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListEvaluationsResponse =
@@ -2287,18 +2299,25 @@ export const ListEvaluationsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -2751,12 +2770,12 @@ export interface ListEvaluationTypesResponse {
     name: string;
     type: string;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListEvaluationTypesResponse =
@@ -2784,18 +2803,25 @@ export const ListEvaluationTypesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -3176,12 +3202,12 @@ export interface ListLogsResponse {
     statusCode?: number | null;
     step?: number | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListLogsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -3234,18 +3260,23 @@ export const ListLogsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/ai.ts
+++ b/packages/cloudflare/src/services/ai.ts
@@ -574,28 +574,33 @@ export const ListModelsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export interface ListModelsResponse {
   result: unknown[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListModelsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   result: Schema.Array(Schema.Unknown),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/alerting.ts
+++ b/packages/cloudflare/src/services/alerting.ts
@@ -738,12 +738,12 @@ export interface ListHistoriesResponse {
     policyId?: string | null;
     sent?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListHistoriesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -777,18 +777,23 @@ export const ListHistoriesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/api-gateway.ts
+++ b/packages/cloudflare/src/services/api-gateway.ts
@@ -328,12 +328,12 @@ export interface ListDiscoveryOperationsResponse {
       } | null;
     } | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListDiscoveryOperationsResponse =
@@ -395,18 +395,25 @@ export const ListDiscoveryOperationsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -1073,12 +1080,12 @@ export interface ListOperationsResponse {
         }
       | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListOperationsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
@@ -1366,18 +1373,25 @@ export const ListOperationsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   },
 ).pipe(
@@ -2994,12 +3008,12 @@ export interface ListUserSchemasResponse {
     source?: string | null;
     validationEnabled?: boolean | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListUserSchemasResponse =
@@ -3025,18 +3039,25 @@ export const ListUserSchemasResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -3391,12 +3412,12 @@ export interface ListUserSchemaHostsResponse {
     name: string;
     schemaId: string;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListUserSchemaHostsResponse =
@@ -3416,18 +3437,25 @@ export const ListUserSchemaHostsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -3600,12 +3628,12 @@ export interface ListUserSchemaOperationsResponse {
           | "TRACE";
       }
   )[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListUserSchemaOperationsResponse =
@@ -3910,18 +3938,25 @@ export const ListUserSchemaOperationsResponse =
         }),
       ]),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/audit-logs.ts
+++ b/packages/cloudflare/src/services/audit-logs.ts
@@ -93,12 +93,12 @@ export interface ListAuditLogsResponse {
     resource?: { id?: string | null; type?: string | null } | null;
     when?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAuditLogsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -156,18 +156,23 @@ export const ListAuditLogsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       when: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
     }),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/client-certificates.ts
+++ b/packages/cloudflare/src/services/client-certificates.ts
@@ -223,12 +223,12 @@ export interface ListClientCertificatesResponse {
       | null;
     validityDays?: number | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListClientCertificatesResponse =
@@ -306,18 +306,25 @@ export const ListClientCertificatesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/custom-certificates.ts
+++ b/packages/cloudflare/src/services/custom-certificates.ts
@@ -247,12 +247,12 @@ export interface ListCustomCertificatesResponse {
     } | null;
     policy?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListCustomCertificatesResponse =
@@ -352,18 +352,25 @@ export const ListCustomCertificatesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/custom-hostnames.ts
+++ b/packages/cloudflare/src/services/custom-hostnames.ts
@@ -976,12 +976,12 @@ export interface ListCustomHostnamesResponse {
       | null;
     verificationErrors?: string[] | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListCustomHostnamesResponse =
@@ -1258,18 +1258,25 @@ export const ListCustomHostnamesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/d1.ts
+++ b/packages/cloudflare/src/services/d1.ts
@@ -158,12 +158,12 @@ export interface ListDatabasesResponse {
     uuid?: string | null;
     version?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListDatabasesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -182,18 +182,23 @@ export const ListDatabasesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/dns-firewall.ts
+++ b/packages/cloudflare/src/services/dns-firewall.ts
@@ -465,12 +465,12 @@ export interface ListDnsFirewallsResponse {
       onlyWhenUpstreamUnhealthy?: boolean | null;
     } | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListDnsFirewallsResponse =
@@ -525,18 +525,25 @@ export const ListDnsFirewallsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/dns.ts
+++ b/packages/cloudflare/src/services/dns.ts
@@ -5276,12 +5276,12 @@ export interface ListRecordsResponse {
         tagsModifiedOn?: string | null;
       }
   )[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListRecordsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -6817,18 +6817,23 @@ export const ListRecordsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       ),
     ]),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -27723,12 +27728,12 @@ export interface ListSettingAccountViewsResponse {
     name: string;
     zones: string[];
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListSettingAccountViewsResponse =
@@ -27750,18 +27755,25 @@ export const ListSettingAccountViewsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/durable-objects.ts
+++ b/packages/cloudflare/src/services/durable-objects.ts
@@ -64,12 +64,12 @@ export interface ListNamespacesResponse {
     script?: string | null;
     useSqlite?: boolean | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListNamespacesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
@@ -91,18 +91,25 @@ export const ListNamespacesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   },
 ).pipe(
@@ -157,7 +164,7 @@ export const ListNamespaceObjectsRequest =
 
 export interface ListNamespaceObjectsResponse {
   result: { id?: string | null; hasStoredData?: boolean | null }[];
-  resultInfo: { cursors?: { after?: string | null } | null };
+  resultInfo?: { cursors?: { after?: string | null } | null } | null;
 }
 
 export const ListNamespaceObjectsResponse =
@@ -170,16 +177,23 @@ export const ListNamespaceObjectsResponse =
         ),
       }),
     ),
-    resultInfo: Schema.Struct({
-      cursors: Schema.optional(
-        Schema.Union([
-          Schema.Struct({
-            after: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          }),
-          Schema.Null,
-        ]),
-      ),
-    }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          cursors: Schema.optional(
+            Schema.Union([
+              Schema.Struct({
+                after: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }),
+              Schema.Null,
+            ]),
+          ),
+        }),
+        Schema.Null,
+      ]),
+    ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
   ) as unknown as Schema.Schema<ListNamespaceObjectsResponse>;

--- a/packages/cloudflare/src/services/email-routing.ts
+++ b/packages/cloudflare/src/services/email-routing.ts
@@ -110,12 +110,12 @@ export interface ListAddressesResponse {
     tag?: string | null;
     verified?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAddressesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -129,18 +129,23 @@ export const ListAddressesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       verified: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
     }),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -1462,12 +1467,12 @@ export interface ListRulesResponse {
     priority?: number | null;
     tag?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListRulesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -1511,18 +1516,23 @@ export const ListRulesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       tag: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
     }),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/email-security.ts
+++ b/packages/cloudflare/src/services/email-security.ts
@@ -570,12 +570,12 @@ export interface ListInvestigatesResponse {
       spf?: "pass" | "neutral" | "fail" | "error" | "none" | null;
     } | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListInvestigatesResponse =
@@ -820,18 +820,25 @@ export const ListInvestigatesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -1815,12 +1822,12 @@ export interface ListSettingAllowPoliciesResponse {
     isSender?: boolean | null;
     isSpoof?: boolean | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListSettingAllowPoliciesResponse =
@@ -1862,18 +1869,25 @@ export const ListSettingAllowPoliciesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -2341,12 +2355,12 @@ export interface ListSettingBlockSendersResponse {
     patternType: "EMAIL" | "DOMAIN" | "IP" | "UNKNOWN";
     comments?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListSettingBlockSendersResponse =
@@ -2372,18 +2386,25 @@ export const ListSettingBlockSendersResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -2932,12 +2953,12 @@ export interface ListSettingDomainsResponse {
     requireTlsOutbound?: boolean | null;
     spfStatus?: "none" | "good" | "neutral" | "open" | "invalid" | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListSettingDomainsResponse =
@@ -3074,18 +3095,25 @@ export const ListSettingDomainsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -3631,12 +3659,12 @@ export interface ListSettingImpersonationRegistriesResponse {
     externalDirectoryNodeId?: string | null;
     provenance?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListSettingImpersonationRegistriesResponse =
@@ -3676,18 +3704,25 @@ export const ListSettingImpersonationRegistriesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -4073,12 +4108,12 @@ export interface ListSettingTrustedDomainsResponse {
     pattern: string;
     comments?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListSettingTrustedDomainsResponse =
@@ -4106,18 +4141,25 @@ export const ListSettingTrustedDomainsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -4549,12 +4591,12 @@ export interface ListSubmissionsResponse {
     subject?: string | null;
     type?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListSubmissionsResponse =
@@ -4634,18 +4676,25 @@ export const ListSubmissionsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/filters.ts
+++ b/packages/cloudflare/src/services/filters.ts
@@ -103,12 +103,12 @@ export interface ListFiltersResponse {
     paused?: boolean | null;
     ref?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListFiltersResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -121,18 +121,23 @@ export const ListFiltersResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       ref: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
     }),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/firewall.ts
+++ b/packages/cloudflare/src/services/firewall.ts
@@ -208,12 +208,12 @@ export interface ListAccessRulesResponse {
       type?: "user" | "organization" | null;
     } | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAccessRulesResponse =
@@ -302,18 +302,25 @@ export const ListAccessRulesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -936,12 +943,12 @@ export interface ListLockdownsResponse {
     paused: boolean;
     urls: string[];
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListLockdownsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -981,18 +988,23 @@ export const ListLockdownsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -1624,12 +1636,12 @@ export interface ListRulesResponse {
       | null;
     ref?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListRulesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -1696,18 +1708,23 @@ export const ListRulesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       ref: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
     }),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -2744,12 +2761,12 @@ export interface ListUaRulesResponse {
     mode?: "block" | "challenge" | "js_challenge" | "managed_challenge" | null;
     paused?: boolean | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListUaRulesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -2780,18 +2797,23 @@ export const ListUaRulesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       paused: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
     }),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -3324,12 +3346,12 @@ export interface ListWafOverridesResponse {
     rules?: Record<string, unknown> | null;
     urls?: string[] | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListWafOverridesResponse =
@@ -3437,18 +3459,25 @@ export const ListWafOverridesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -4065,29 +4094,36 @@ export const ListWafPackagesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 
 export interface ListWafPackagesResponse {
   result: unknown[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListWafPackagesResponse =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     result: Schema.Array(Schema.Unknown),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -4214,12 +4250,12 @@ export interface ListWafPackageGroupsResponse {
     modifiedRulesCount?: number | null;
     packageId?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListWafPackageGroupsResponse =
@@ -4254,18 +4290,25 @@ export const ListWafPackageGroupsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -4456,12 +4499,12 @@ export interface ListWafPackageRulesResponse {
         priority: string;
       }
   )[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListWafPackageRulesResponse =
@@ -4535,18 +4578,25 @@ export const ListWafPackageRulesResponse =
         ),
       ]),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/healthchecks.ts
+++ b/packages/cloudflare/src/services/healthchecks.ts
@@ -309,12 +309,12 @@ export interface ListHealthchecksResponse {
     timeout?: number | null;
     type?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListHealthchecksResponse =
@@ -450,18 +450,25 @@ export const ListHealthchecksResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/images.ts
+++ b/packages/cloudflare/src/services/images.ts
@@ -158,12 +158,12 @@ export interface ListV1sResponse {
         }[]
       | null;
   };
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListV1sResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -208,18 +208,23 @@ export const ListV1sResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       ]),
     ),
   }),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/intel.ts
+++ b/packages/cloudflare/src/services/intel.ts
@@ -252,12 +252,12 @@ export interface ListAttackSurfaceReportIssuesResponse {
         }[]
       | null;
   };
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAttackSurfaceReportIssuesResponse =
@@ -371,18 +371,25 @@ export const ListAttackSurfaceReportIssuesResponse =
         ]),
       ),
     }),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -991,12 +998,12 @@ export interface ListDnsResponse {
         }[]
       | null;
   };
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListDnsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -1047,18 +1054,23 @@ export const ListDnsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       ]),
     ),
   }),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/kv.ts
+++ b/packages/cloudflare/src/services/kv.ts
@@ -166,12 +166,12 @@ export const ListNamespacesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export interface ListNamespacesResponse {
   result: { id: string; title: string; supportsUrlEncoding?: boolean | null }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListNamespacesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
@@ -191,18 +191,25 @@ export const ListNamespacesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   },
 ).pipe(
@@ -567,7 +574,7 @@ export interface ListNamespaceKeysResponse {
     expiration?: number | null;
     metadata?: unknown | null;
   }[];
-  resultInfo: { cursors?: { after?: string | null } | null };
+  resultInfo?: { cursors?: { after?: string | null } | null } | null;
 }
 
 export const ListNamespaceKeysResponse =
@@ -579,16 +586,23 @@ export const ListNamespaceKeysResponse =
         metadata: Schema.optional(Schema.Union([Schema.Unknown, Schema.Null])),
       }),
     ),
-    resultInfo: Schema.Struct({
-      cursors: Schema.optional(
-        Schema.Union([
-          Schema.Struct({
-            after: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          }),
-          Schema.Null,
-        ]),
-      ),
-    }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          cursors: Schema.optional(
+            Schema.Union([
+              Schema.Struct({
+                after: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+              }),
+              Schema.Null,
+            ]),
+          ),
+        }),
+        Schema.Null,
+      ]),
+    ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
   ) as unknown as Schema.Schema<ListNamespaceKeysResponse>;

--- a/packages/cloudflare/src/services/load-balancers.ts
+++ b/packages/cloudflare/src/services/load-balancers.ts
@@ -8601,12 +8601,12 @@ export interface ListSearchesResponse {
         }[]
       | null;
   };
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListSearchesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -8659,18 +8659,23 @@ export const ListSearchesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       ]),
     ),
   }),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/magic-cloud-networking.ts
+++ b/packages/cloudflare/src/services/magic-cloud-networking.ts
@@ -9421,12 +9421,12 @@ export interface ListResourcesResponse {
       | { id: string; clientType: "MAGIC_WAN_CLOUD_ONRAMP"; name: string }[]
       | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListResourcesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -9922,18 +9922,23 @@ export const ListResourcesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/memberships.ts
+++ b/packages/cloudflare/src/services/memberships.ts
@@ -490,12 +490,12 @@ export interface ListMembershipsResponse {
     roles?: string[] | null;
     status?: "accepted" | "pending" | "rejected" | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListMembershipsResponse =
@@ -762,18 +762,25 @@ export const ListMembershipsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/origin-ca-certificates.ts
+++ b/packages/cloudflare/src/services/origin-ca-certificates.ts
@@ -126,12 +126,12 @@ export interface ListOriginCACertificatesResponse {
     certificate?: string | null;
     expiresOn?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListOriginCACertificatesResponse =
@@ -171,18 +171,25 @@ export const ListOriginCACertificatesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/pages.ts
+++ b/packages/cloudflare/src/services/pages.ts
@@ -1242,12 +1242,12 @@ export interface ListProjectsResponse {
     } | null;
     subdomain?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListProjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -1966,18 +1966,23 @@ export const ListProjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -4983,12 +4988,12 @@ export interface ListProjectDeploymentsResponse {
     url: string;
     usesFunctions?: boolean | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListProjectDeploymentsResponse =
@@ -5163,18 +5168,25 @@ export const ListProjectDeploymentsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/queues.ts
+++ b/packages/cloudflare/src/services/queues.ts
@@ -3305,12 +3305,12 @@ export interface ListSubscriptionsResponse {
       | { type?: "workersBuilds.worker" | null; workerName?: string | null }
       | { type?: "workflows.workflow" | null; workflowName?: string | null };
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListSubscriptionsResponse =
@@ -3398,18 +3398,25 @@ export const ListSubscriptionsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/r2.ts
+++ b/packages/cloudflare/src/services/r2.ts
@@ -10,9 +10,7 @@ import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
-import {
-  type DefaultErrors,
-} from "../errors.ts";
+import { type DefaultErrors } from "../errors.ts";
 import { UploadableSchema } from "../schemas.ts";
 import { SensitiveString } from "../sensitive.ts";
 
@@ -24,85 +22,88 @@ export class BucketAlreadyExists extends Schema.TaggedErrorClass<BucketAlreadyEx
   "BucketAlreadyExists",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(BucketAlreadyExists, [{"code":10004}]);
+T.applyErrorMatchers(BucketAlreadyExists, [{ code: 10004 }]);
 
 export class BucketNotFound extends Schema.TaggedErrorClass<BucketNotFound>()(
   "BucketNotFound",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(BucketNotFound, [{"code":10085}]);
+T.applyErrorMatchers(BucketNotFound, [{ code: 10085 }]);
 
 export class DomainNotFound extends Schema.TaggedErrorClass<DomainNotFound>()(
   "DomainNotFound",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(DomainNotFound, [{"code":10053}]);
+T.applyErrorMatchers(DomainNotFound, [{ code: 10053 }]);
 
 export class EventNotificationConfigNotFound extends Schema.TaggedErrorClass<EventNotificationConfigNotFound>()(
   "EventNotificationConfigNotFound",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(EventNotificationConfigNotFound, [{"code":11011}]);
+T.applyErrorMatchers(EventNotificationConfigNotFound, [{ code: 11011 }]);
 
 export class EventNotificationRuleConflict extends Schema.TaggedErrorClass<EventNotificationRuleConflict>()(
   "EventNotificationRuleConflict",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(EventNotificationRuleConflict, [{"code":11020}]);
+T.applyErrorMatchers(EventNotificationRuleConflict, [{ code: 11020 }]);
 
 export class InvalidBucketName extends Schema.TaggedErrorClass<InvalidBucketName>()(
   "InvalidBucketName",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(InvalidBucketName, [{"code":10005}]);
+T.applyErrorMatchers(InvalidBucketName, [{ code: 10005 }]);
 
 export class InvalidEventNotificationConfig extends Schema.TaggedErrorClass<InvalidEventNotificationConfig>()(
   "InvalidEventNotificationConfig",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(InvalidEventNotificationConfig, [{"code":11014},{"code":11019}]);
+T.applyErrorMatchers(InvalidEventNotificationConfig, [
+  { code: 11014 },
+  { code: 11019 },
+]);
 
 export class InvalidRoute extends Schema.TaggedErrorClass<InvalidRoute>()(
   "InvalidRoute",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(InvalidRoute, [{"code":7003}]);
+T.applyErrorMatchers(InvalidRoute, [{ code: 7003 }]);
 
 export class InvalidUpstreamCredentials extends Schema.TaggedErrorClass<InvalidUpstreamCredentials>()(
   "InvalidUpstreamCredentials",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(InvalidUpstreamCredentials, [{"code":10063}]);
+T.applyErrorMatchers(InvalidUpstreamCredentials, [{ code: 10063 }]);
 
 export class NoCorsConfiguration extends Schema.TaggedErrorClass<NoCorsConfiguration>()(
   "NoCorsConfiguration",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(NoCorsConfiguration, [{"code":10059}]);
+T.applyErrorMatchers(NoCorsConfiguration, [{ code: 10059 }]);
 
 export class NoEventNotificationConfig extends Schema.TaggedErrorClass<NoEventNotificationConfig>()(
   "NoEventNotificationConfig",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(NoEventNotificationConfig, [{"code":11015}]);
+T.applyErrorMatchers(NoEventNotificationConfig, [{ code: 11015 }]);
 
-export class NoRoute extends Schema.TaggedErrorClass<NoRoute>()(
-  "NoRoute",
-  { code: Schema.Number, message: Schema.String },
-) {}
-T.applyErrorMatchers(NoRoute, [{"code":10015}]);
+export class NoRoute extends Schema.TaggedErrorClass<NoRoute>()("NoRoute", {
+  code: Schema.Number,
+  message: Schema.String,
+}) {}
+T.applyErrorMatchers(NoRoute, [{ code: 10015 }]);
 
 export class NoSuchBucket extends Schema.TaggedErrorClass<NoSuchBucket>()(
   "NoSuchBucket",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(NoSuchBucket, [{"code":10006}]);
+T.applyErrorMatchers(NoSuchBucket, [{ code: 10006 }]);
 
 export class QueueNotFound extends Schema.TaggedErrorClass<QueueNotFound>()(
   "QueueNotFound",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(QueueNotFound, [{"code":11000}]);
+T.applyErrorMatchers(QueueNotFound, [{ code: 11000 }]);
 
 // =============================================================================
 // AllSuperSlurperJob
@@ -112,17 +113,24 @@ export interface AbortAllSuperSlurperJobRequest {
   accountId: string;
 }
 
-export const AbortAllSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  accountId: Schema.String.pipe(T.HttpPath("account_id"))
-})
-  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/slurper/jobs/abortAll" })) as unknown as Schema.Schema<AbortAllSuperSlurperJobRequest>;
+export const AbortAllSuperSlurperJobRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/accounts/{account_id}/slurper/jobs/abortAll",
+    }),
+  ) as unknown as Schema.Schema<AbortAllSuperSlurperJobRequest>;
 
 export type AbortAllSuperSlurperJobResponse = string;
 
-export const AbortAllSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<AbortAllSuperSlurperJobResponse>;
+export const AbortAllSuperSlurperJobResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<AbortAllSuperSlurperJobResponse>;
 
-export type AbortAllSuperSlurperJobError =
-  | DefaultErrors;
+export type AbortAllSuperSlurperJobError = DefaultErrors;
 
 export const abortAllSuperSlurperJob: API.OperationMethod<
   AbortAllSuperSlurperJobRequest,
@@ -134,7 +142,6 @@ export const abortAllSuperSlurperJob: API.OperationMethod<
   output: AbortAllSuperSlurperJobResponse,
   errors: [],
 }));
-
 
 // =============================================================================
 // Bucket
@@ -151,9 +158,15 @@ export interface GetBucketRequest {
 export const GetBucketRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}" })) as unknown as Schema.Schema<GetBucketRequest>;
+  jurisdiction: Schema.optional(
+    Schema.Literals(["default", "eu", "fedramp"]),
+  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+}).pipe(
+  T.Http({
+    method: "GET",
+    path: "/accounts/{account_id}/r2/buckets/{bucketName}",
+  }),
+) as unknown as Schema.Schema<GetBucketRequest>;
 
 export interface GetBucketResponse {
   /** Creation timestamp. */
@@ -161,7 +174,20 @@ export interface GetBucketResponse {
   /** Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp" | null;
   /** Location of the bucket. */
-  location?: "apac" | "eeur" | "enam" | "weur" | "wnam" | "oc" | "APAC" | "EEUR" | "ENAM" | "WEUR" | "WNAM" | "OC" | null;
+  location?:
+    | "apac"
+    | "eeur"
+    | "enam"
+    | "weur"
+    | "wnam"
+    | "oc"
+    | "APAC"
+    | "EEUR"
+    | "ENAM"
+    | "WEUR"
+    | "WNAM"
+    | "OC"
+    | null;
   /** Name of the bucket. */
   name?: string | null;
   /** Storage class for newly uploaded objects, unless specified otherwise. */
@@ -170,16 +196,50 @@ export interface GetBucketResponse {
 
 export const GetBucketResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   creationDate: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
-  location: Schema.optional(Schema.Union([Schema.Literals(["apac", "eeur", "enam", "weur", "wnam", "oc", "APAC", "EEUR", "ENAM", "WEUR", "WNAM", "OC"]), Schema.Null])),
+  jurisdiction: Schema.optional(
+    Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null]),
+  ),
+  location: Schema.optional(
+    Schema.Union([
+      Schema.Literals([
+        "apac",
+        "eeur",
+        "enam",
+        "weur",
+        "wnam",
+        "oc",
+        "APAC",
+        "EEUR",
+        "ENAM",
+        "WEUR",
+        "WNAM",
+        "OC",
+      ]),
+      Schema.Null,
+    ]),
+  ),
   name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  storageClass: Schema.optional(Schema.Union([Schema.Literals(["Standard", "InfrequentAccess"]), Schema.Null]))
-}).pipe(Schema.encodeKeys({ creationDate: "creation_date", jurisdiction: "jurisdiction", location: "location", name: "name", storageClass: "storage_class" })).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketResponse>;
+  storageClass: Schema.optional(
+    Schema.Union([
+      Schema.Literals(["Standard", "InfrequentAccess"]),
+      Schema.Null,
+    ]),
+  ),
+})
+  .pipe(
+    Schema.encodeKeys({
+      creationDate: "creation_date",
+      jurisdiction: "jurisdiction",
+      location: "location",
+      name: "name",
+      storageClass: "storage_class",
+    }),
+  )
+  .pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<GetBucketResponse>;
 
-export type GetBucketError =
-  | DefaultErrors
-  | NoSuchBucket
-  | InvalidRoute;
+export type GetBucketError = DefaultErrors | NoSuchBucket | InvalidRoute;
 
 export const getBucket: API.OperationMethod<
   GetBucketRequest,
@@ -214,32 +274,105 @@ export interface ListBucketsRequest {
 export const ListBucketsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
   cursor: Schema.optional(Schema.String).pipe(T.HttpQuery("cursor")),
-  direction: Schema.optional(Schema.Literals(["asc", "desc"])).pipe(T.HttpQuery("direction")),
-  nameContains: Schema.optional(Schema.String).pipe(T.HttpQuery("name_contains")),
+  direction: Schema.optional(Schema.Literals(["asc", "desc"])).pipe(
+    T.HttpQuery("direction"),
+  ),
+  nameContains: Schema.optional(Schema.String).pipe(
+    T.HttpQuery("name_contains"),
+  ),
   order: Schema.optional(Schema.Literal("name")).pipe(T.HttpQuery("order")),
   perPage: Schema.optional(Schema.Number).pipe(T.HttpQuery("per_page")),
   startAfter: Schema.optional(Schema.String).pipe(T.HttpQuery("start_after")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets" })) as unknown as Schema.Schema<ListBucketsRequest>;
+  jurisdiction: Schema.optional(
+    Schema.Literals(["default", "eu", "fedramp"]),
+  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+}).pipe(
+  T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets" }),
+) as unknown as Schema.Schema<ListBucketsRequest>;
 
 export interface ListBucketsResponse {
-  buckets?: ({ creationDate?: string | null; jurisdiction?: "default" | "eu" | "fedramp" | null; location?: "apac" | "eeur" | "enam" | "weur" | "wnam" | "oc" | "APAC" | "EEUR" | "ENAM" | "WEUR" | "WNAM" | "OC" | null; name?: string | null; storageClass?: "Standard" | "InfrequentAccess" | null })[] | null;
+  buckets?:
+    | {
+        creationDate?: string | null;
+        jurisdiction?: "default" | "eu" | "fedramp" | null;
+        location?:
+          | "apac"
+          | "eeur"
+          | "enam"
+          | "weur"
+          | "wnam"
+          | "oc"
+          | "APAC"
+          | "EEUR"
+          | "ENAM"
+          | "WEUR"
+          | "WNAM"
+          | "OC"
+          | null;
+        name?: string | null;
+        storageClass?: "Standard" | "InfrequentAccess" | null;
+      }[]
+    | null;
 }
 
 export const ListBucketsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  buckets: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
-  creationDate: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
-  location: Schema.optional(Schema.Union([Schema.Literals(["apac", "eeur", "enam", "weur", "wnam", "oc", "APAC", "EEUR", "ENAM", "WEUR", "WNAM", "OC"]), Schema.Null])),
-  name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  storageClass: Schema.optional(Schema.Union([Schema.Literals(["Standard", "InfrequentAccess"]), Schema.Null]))
-}).pipe(Schema.encodeKeys({ creationDate: "creation_date", jurisdiction: "jurisdiction", location: "location", name: "name", storageClass: "storage_class" }))), Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListBucketsResponse>;
+  buckets: Schema.optional(
+    Schema.Union([
+      Schema.Array(
+        Schema.Struct({
+          creationDate: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          jurisdiction: Schema.optional(
+            Schema.Union([
+              Schema.Literals(["default", "eu", "fedramp"]),
+              Schema.Null,
+            ]),
+          ),
+          location: Schema.optional(
+            Schema.Union([
+              Schema.Literals([
+                "apac",
+                "eeur",
+                "enam",
+                "weur",
+                "wnam",
+                "oc",
+                "APAC",
+                "EEUR",
+                "ENAM",
+                "WEUR",
+                "WNAM",
+                "OC",
+              ]),
+              Schema.Null,
+            ]),
+          ),
+          name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          storageClass: Schema.optional(
+            Schema.Union([
+              Schema.Literals(["Standard", "InfrequentAccess"]),
+              Schema.Null,
+            ]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            creationDate: "creation_date",
+            jurisdiction: "jurisdiction",
+            location: "location",
+            name: "name",
+            storageClass: "storage_class",
+          }),
+        ),
+      ),
+      Schema.Null,
+    ]),
+  ),
+}).pipe(
+  T.ResponsePath("result"),
+) as unknown as Schema.Schema<ListBucketsResponse>;
 
-export type ListBucketsError =
-  | DefaultErrors
-  | InvalidRoute;
+export type ListBucketsError = DefaultErrors | InvalidRoute;
 
 export const listBuckets: API.OperationMethod<
   ListBucketsRequest,
@@ -267,12 +400,19 @@ export interface CreateBucketRequest {
 
 export const CreateBucketRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  jurisdiction: Schema.optional(
+    Schema.Literals(["default", "eu", "fedramp"]),
+  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
   name: Schema.String,
-  locationHint: Schema.optional(Schema.Literals(["apac", "eeur", "enam", "weur", "wnam", "oc"])),
-  storageClass: Schema.optional(Schema.Literals(["Standard", "InfrequentAccess"]))
-})
-  .pipe(T.Http({ method: "POST", path: "/accounts/{account_id}/r2/buckets" })) as unknown as Schema.Schema<CreateBucketRequest>;
+  locationHint: Schema.optional(
+    Schema.Literals(["apac", "eeur", "enam", "weur", "wnam", "oc"]),
+  ),
+  storageClass: Schema.optional(
+    Schema.Literals(["Standard", "InfrequentAccess"]),
+  ),
+}).pipe(
+  T.Http({ method: "POST", path: "/accounts/{account_id}/r2/buckets" }),
+) as unknown as Schema.Schema<CreateBucketRequest>;
 
 export interface CreateBucketResponse {
   /** Creation timestamp. */
@@ -280,7 +420,20 @@ export interface CreateBucketResponse {
   /** Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp" | null;
   /** Location of the bucket. */
-  location?: "apac" | "eeur" | "enam" | "weur" | "wnam" | "oc" | "APAC" | "EEUR" | "ENAM" | "WEUR" | "WNAM" | "OC" | null;
+  location?:
+    | "apac"
+    | "eeur"
+    | "enam"
+    | "weur"
+    | "wnam"
+    | "oc"
+    | "APAC"
+    | "EEUR"
+    | "ENAM"
+    | "WEUR"
+    | "WNAM"
+    | "OC"
+    | null;
   /** Name of the bucket. */
   name?: string | null;
   /** Storage class for newly uploaded objects, unless specified otherwise. */
@@ -289,11 +442,48 @@ export interface CreateBucketResponse {
 
 export const CreateBucketResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   creationDate: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
-  location: Schema.optional(Schema.Union([Schema.Literals(["apac", "eeur", "enam", "weur", "wnam", "oc", "APAC", "EEUR", "ENAM", "WEUR", "WNAM", "OC"]), Schema.Null])),
+  jurisdiction: Schema.optional(
+    Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null]),
+  ),
+  location: Schema.optional(
+    Schema.Union([
+      Schema.Literals([
+        "apac",
+        "eeur",
+        "enam",
+        "weur",
+        "wnam",
+        "oc",
+        "APAC",
+        "EEUR",
+        "ENAM",
+        "WEUR",
+        "WNAM",
+        "OC",
+      ]),
+      Schema.Null,
+    ]),
+  ),
   name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  storageClass: Schema.optional(Schema.Union([Schema.Literals(["Standard", "InfrequentAccess"]), Schema.Null]))
-}).pipe(Schema.encodeKeys({ creationDate: "creation_date", jurisdiction: "jurisdiction", location: "location", name: "name", storageClass: "storage_class" })).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<CreateBucketResponse>;
+  storageClass: Schema.optional(
+    Schema.Union([
+      Schema.Literals(["Standard", "InfrequentAccess"]),
+      Schema.Null,
+    ]),
+  ),
+})
+  .pipe(
+    Schema.encodeKeys({
+      creationDate: "creation_date",
+      jurisdiction: "jurisdiction",
+      location: "location",
+      name: "name",
+      storageClass: "storage_class",
+    }),
+  )
+  .pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<CreateBucketResponse>;
 
 export type CreateBucketError =
   | DefaultErrors
@@ -325,10 +515,18 @@ export interface PatchBucketRequest {
 export const PatchBucketRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  storageClass: Schema.Literals(["Standard", "InfrequentAccess"]).pipe(T.HttpHeader("cf-r2-storage-class")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "PATCH", path: "/accounts/{account_id}/r2/buckets/{bucketName}" })) as unknown as Schema.Schema<PatchBucketRequest>;
+  storageClass: Schema.Literals(["Standard", "InfrequentAccess"]).pipe(
+    T.HttpHeader("cf-r2-storage-class"),
+  ),
+  jurisdiction: Schema.optional(
+    Schema.Literals(["default", "eu", "fedramp"]),
+  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+}).pipe(
+  T.Http({
+    method: "PATCH",
+    path: "/accounts/{account_id}/r2/buckets/{bucketName}",
+  }),
+) as unknown as Schema.Schema<PatchBucketRequest>;
 
 export interface PatchBucketResponse {
   /** Creation timestamp. */
@@ -336,7 +534,20 @@ export interface PatchBucketResponse {
   /** Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp" | null;
   /** Location of the bucket. */
-  location?: "apac" | "eeur" | "enam" | "weur" | "wnam" | "oc" | "APAC" | "EEUR" | "ENAM" | "WEUR" | "WNAM" | "OC" | null;
+  location?:
+    | "apac"
+    | "eeur"
+    | "enam"
+    | "weur"
+    | "wnam"
+    | "oc"
+    | "APAC"
+    | "EEUR"
+    | "ENAM"
+    | "WEUR"
+    | "WNAM"
+    | "OC"
+    | null;
   /** Name of the bucket. */
   name?: string | null;
   /** Storage class for newly uploaded objects, unless specified otherwise. */
@@ -345,16 +556,50 @@ export interface PatchBucketResponse {
 
 export const PatchBucketResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   creationDate: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
-  location: Schema.optional(Schema.Union([Schema.Literals(["apac", "eeur", "enam", "weur", "wnam", "oc", "APAC", "EEUR", "ENAM", "WEUR", "WNAM", "OC"]), Schema.Null])),
+  jurisdiction: Schema.optional(
+    Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null]),
+  ),
+  location: Schema.optional(
+    Schema.Union([
+      Schema.Literals([
+        "apac",
+        "eeur",
+        "enam",
+        "weur",
+        "wnam",
+        "oc",
+        "APAC",
+        "EEUR",
+        "ENAM",
+        "WEUR",
+        "WNAM",
+        "OC",
+      ]),
+      Schema.Null,
+    ]),
+  ),
   name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  storageClass: Schema.optional(Schema.Union([Schema.Literals(["Standard", "InfrequentAccess"]), Schema.Null]))
-}).pipe(Schema.encodeKeys({ creationDate: "creation_date", jurisdiction: "jurisdiction", location: "location", name: "name", storageClass: "storage_class" })).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PatchBucketResponse>;
+  storageClass: Schema.optional(
+    Schema.Union([
+      Schema.Literals(["Standard", "InfrequentAccess"]),
+      Schema.Null,
+    ]),
+  ),
+})
+  .pipe(
+    Schema.encodeKeys({
+      creationDate: "creation_date",
+      jurisdiction: "jurisdiction",
+      location: "location",
+      name: "name",
+      storageClass: "storage_class",
+    }),
+  )
+  .pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<PatchBucketResponse>;
 
-export type PatchBucketError =
-  | DefaultErrors
-  | NoSuchBucket
-  | InvalidRoute;
+export type PatchBucketError = DefaultErrors | NoSuchBucket | InvalidRoute;
 
 export const patchBucket: API.OperationMethod<
   PatchBucketRequest,
@@ -378,13 +623,22 @@ export interface DeleteBucketRequest {
 export const DeleteBucketRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/r2/buckets/{bucketName}" })) as unknown as Schema.Schema<DeleteBucketRequest>;
+  jurisdiction: Schema.optional(
+    Schema.Literals(["default", "eu", "fedramp"]),
+  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+}).pipe(
+  T.Http({
+    method: "DELETE",
+    path: "/accounts/{account_id}/r2/buckets/{bucketName}",
+  }),
+) as unknown as Schema.Schema<DeleteBucketRequest>;
 
 export type DeleteBucketResponse = unknown;
 
-export const DeleteBucketResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteBucketResponse>;
+export const DeleteBucketResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<DeleteBucketResponse>;
 
 export type DeleteBucketError =
   | DefaultErrors
@@ -403,7 +657,6 @@ export const deleteBucket: API.OperationMethod<
   errors: [NoSuchBucket, InvalidRoute, NoRoute],
 }));
 
-
 // =============================================================================
 // BucketCor
 // =============================================================================
@@ -419,26 +672,60 @@ export interface GetBucketCorsRequest {
 export const GetBucketCorsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/cors" })) as unknown as Schema.Schema<GetBucketCorsRequest>;
+  jurisdiction: Schema.optional(
+    Schema.Literals(["default", "eu", "fedramp"]),
+  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+}).pipe(
+  T.Http({
+    method: "GET",
+    path: "/accounts/{account_id}/r2/buckets/{bucketName}/cors",
+  }),
+) as unknown as Schema.Schema<GetBucketCorsRequest>;
 
 export interface GetBucketCorsResponse {
-  rules?: ({ allowed: { methods: ("GET" | "PUT" | "POST" | "DELETE" | "HEAD")[]; origins: string[]; headers?: string[] | null }; id?: string | null; exposeHeaders?: string[] | null; maxAgeSeconds?: number | null })[] | null;
+  rules?:
+    | {
+        allowed: {
+          methods: ("GET" | "PUT" | "POST" | "DELETE" | "HEAD")[];
+          origins: string[];
+          headers?: string[] | null;
+        };
+        id?: string | null;
+        exposeHeaders?: string[] | null;
+        maxAgeSeconds?: number | null;
+      }[]
+    | null;
 }
 
 export const GetBucketCorsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  rules: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
-  allowed: Schema.Struct({
-    methods: Schema.Array(Schema.Literals(["GET", "PUT", "POST", "DELETE", "HEAD"])),
-    origins: Schema.Array(Schema.String),
-    headers: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null]))
-  }),
-  id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  exposeHeaders: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
-  maxAgeSeconds: Schema.optional(Schema.Union([Schema.Number, Schema.Null]))
-})), Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketCorsResponse>;
+  rules: Schema.optional(
+    Schema.Union([
+      Schema.Array(
+        Schema.Struct({
+          allowed: Schema.Struct({
+            methods: Schema.Array(
+              Schema.Literals(["GET", "PUT", "POST", "DELETE", "HEAD"]),
+            ),
+            origins: Schema.Array(Schema.String),
+            headers: Schema.optional(
+              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+            ),
+          }),
+          id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          exposeHeaders: Schema.optional(
+            Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+          ),
+          maxAgeSeconds: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }),
+      ),
+      Schema.Null,
+    ]),
+  ),
+}).pipe(
+  T.ResponsePath("result"),
+) as unknown as Schema.Schema<GetBucketCorsResponse>;
 
 export type GetBucketCorsError =
   | DefaultErrors
@@ -464,34 +751,55 @@ export interface PutBucketCorsRequest {
   /** Header param: Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp";
   /** Body param: */
-  rules?: ({ allowed: { methods: ("GET" | "PUT" | "POST" | "DELETE" | "HEAD")[]; origins: string[]; headers?: string[] }; id?: string; exposeHeaders?: string[]; maxAgeSeconds?: number })[];
+  rules?: {
+    allowed: {
+      methods: ("GET" | "PUT" | "POST" | "DELETE" | "HEAD")[];
+      origins: string[];
+      headers?: string[];
+    };
+    id?: string;
+    exposeHeaders?: string[];
+    maxAgeSeconds?: number;
+  }[];
 }
 
 export const PutBucketCorsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  rules: Schema.optional(Schema.Array(Schema.Struct({
-  allowed: Schema.Struct({
-    methods: Schema.Array(Schema.Literals(["GET", "PUT", "POST", "DELETE", "HEAD"])),
-    origins: Schema.Array(Schema.String),
-    headers: Schema.optional(Schema.Array(Schema.String))
+  jurisdiction: Schema.optional(
+    Schema.Literals(["default", "eu", "fedramp"]),
+  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  rules: Schema.optional(
+    Schema.Array(
+      Schema.Struct({
+        allowed: Schema.Struct({
+          methods: Schema.Array(
+            Schema.Literals(["GET", "PUT", "POST", "DELETE", "HEAD"]),
+          ),
+          origins: Schema.Array(Schema.String),
+          headers: Schema.optional(Schema.Array(Schema.String)),
+        }),
+        id: Schema.optional(Schema.String),
+        exposeHeaders: Schema.optional(Schema.Array(Schema.String)),
+        maxAgeSeconds: Schema.optional(Schema.Number),
+      }),
+    ),
+  ),
+}).pipe(
+  T.Http({
+    method: "PUT",
+    path: "/accounts/{account_id}/r2/buckets/{bucketName}/cors",
   }),
-  id: Schema.optional(Schema.String),
-  exposeHeaders: Schema.optional(Schema.Array(Schema.String)),
-  maxAgeSeconds: Schema.optional(Schema.Number)
-})))
-})
-  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/cors" })) as unknown as Schema.Schema<PutBucketCorsRequest>;
+) as unknown as Schema.Schema<PutBucketCorsRequest>;
 
 export type PutBucketCorsResponse = unknown;
 
-export const PutBucketCorsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutBucketCorsResponse>;
+export const PutBucketCorsResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<PutBucketCorsResponse>;
 
-export type PutBucketCorsError =
-  | DefaultErrors
-  | NoSuchBucket
-  | InvalidRoute;
+export type PutBucketCorsError = DefaultErrors | NoSuchBucket | InvalidRoute;
 
 export const putBucketCors: API.OperationMethod<
   PutBucketCorsRequest,
@@ -512,21 +820,28 @@ export interface DeleteBucketCorsRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const DeleteBucketCorsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/r2/buckets/{bucketName}/cors" })) as unknown as Schema.Schema<DeleteBucketCorsRequest>;
+export const DeleteBucketCorsRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    jurisdiction: Schema.optional(
+      Schema.Literals(["default", "eu", "fedramp"]),
+    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/accounts/{account_id}/r2/buckets/{bucketName}/cors",
+    }),
+  ) as unknown as Schema.Schema<DeleteBucketCorsRequest>;
 
 export type DeleteBucketCorsResponse = unknown;
 
-export const DeleteBucketCorsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteBucketCorsResponse>;
+export const DeleteBucketCorsResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<DeleteBucketCorsResponse>;
 
-export type DeleteBucketCorsError =
-  | DefaultErrors
-  | NoSuchBucket
-  | InvalidRoute;
+export type DeleteBucketCorsError = DefaultErrors | NoSuchBucket | InvalidRoute;
 
 export const deleteBucketCors: API.OperationMethod<
   DeleteBucketCorsRequest,
@@ -538,7 +853,6 @@ export const deleteBucketCors: API.OperationMethod<
   output: DeleteBucketCorsResponse,
   errors: [NoSuchBucket, InvalidRoute],
 }));
-
 
 // =============================================================================
 // BucketDomainCustom
@@ -553,20 +867,42 @@ export interface GetBucketDomainCustomRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const GetBucketDomainCustomRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-  domain: Schema.String.pipe(T.HttpPath("domain")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom/{domain}" })) as unknown as Schema.Schema<GetBucketDomainCustomRequest>;
+export const GetBucketDomainCustomRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+    domain: Schema.String.pipe(T.HttpPath("domain")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    jurisdiction: Schema.optional(
+      Schema.Literals(["default", "eu", "fedramp"]),
+    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom/{domain}",
+    }),
+  ) as unknown as Schema.Schema<GetBucketDomainCustomRequest>;
 
 export interface GetBucketDomainCustomResponse {
   /** Domain name of the custom domain to be added. */
   domain: string;
   /** Whether this bucket is publicly accessible at the specified custom domain. */
   enabled: boolean;
-  status: { ownership: "pending" | "active" | "deactivated" | "blocked" | "error" | "unknown"; ssl: "initializing" | "pending" | "active" | "deactivated" | "error" | "unknown" };
+  status: {
+    ownership:
+      | "pending"
+      | "active"
+      | "deactivated"
+      | "blocked"
+      | "error"
+      | "unknown";
+    ssl:
+      | "initializing"
+      | "pending"
+      | "active"
+      | "deactivated"
+      | "error"
+      | "unknown";
+  };
   /** An allowlist of ciphers for TLS termination. These ciphers must be in the BoringSSL format. */
   ciphers?: string[] | null;
   /** Minimum TLS Version the custom domain will accept for incoming connections. If not set, defaults to 1.0. */
@@ -577,18 +913,42 @@ export interface GetBucketDomainCustomResponse {
   zoneName?: string | null;
 }
 
-export const GetBucketDomainCustomResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  domain: Schema.String,
-  enabled: Schema.Boolean,
-  status: Schema.Struct({
-  ownership: Schema.Literals(["pending", "active", "deactivated", "blocked", "error", "unknown"]),
-  ssl: Schema.Literals(["initializing", "pending", "active", "deactivated", "error", "unknown"])
-}),
-  ciphers: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
-  minTLS: Schema.optional(Schema.Union([Schema.Literals(["1.0", "1.1", "1.2", "1.3"]), Schema.Null])),
-  zoneId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  zoneName: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketDomainCustomResponse>;
+export const GetBucketDomainCustomResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    domain: Schema.String,
+    enabled: Schema.Boolean,
+    status: Schema.Struct({
+      ownership: Schema.Literals([
+        "pending",
+        "active",
+        "deactivated",
+        "blocked",
+        "error",
+        "unknown",
+      ]),
+      ssl: Schema.Literals([
+        "initializing",
+        "pending",
+        "active",
+        "deactivated",
+        "error",
+        "unknown",
+      ]),
+    }),
+    ciphers: Schema.optional(
+      Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+    ),
+    minTLS: Schema.optional(
+      Schema.Union([
+        Schema.Literals(["1.0", "1.1", "1.2", "1.3"]),
+        Schema.Null,
+      ]),
+    ),
+    zoneId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    zoneName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  }).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<GetBucketDomainCustomResponse>;
 
 export type GetBucketDomainCustomError =
   | DefaultErrors
@@ -615,31 +975,87 @@ export interface ListBucketDomainCustomsRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const ListBucketDomainCustomsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom" })) as unknown as Schema.Schema<ListBucketDomainCustomsRequest>;
+export const ListBucketDomainCustomsRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    jurisdiction: Schema.optional(
+      Schema.Literals(["default", "eu", "fedramp"]),
+    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom",
+    }),
+  ) as unknown as Schema.Schema<ListBucketDomainCustomsRequest>;
 
 export interface ListBucketDomainCustomsResponse {
-  domains: ({ domain: string; enabled: boolean; status: { ownership: "pending" | "active" | "deactivated" | "blocked" | "error" | "unknown"; ssl: "initializing" | "pending" | "active" | "deactivated" | "error" | "unknown" }; ciphers?: string[] | null; minTLS?: "1.0" | "1.1" | "1.2" | "1.3" | null; zoneId?: string | null; zoneName?: string | null })[];
+  domains: {
+    domain: string;
+    enabled: boolean;
+    status: {
+      ownership:
+        | "pending"
+        | "active"
+        | "deactivated"
+        | "blocked"
+        | "error"
+        | "unknown";
+      ssl:
+        | "initializing"
+        | "pending"
+        | "active"
+        | "deactivated"
+        | "error"
+        | "unknown";
+    };
+    ciphers?: string[] | null;
+    minTLS?: "1.0" | "1.1" | "1.2" | "1.3" | null;
+    zoneId?: string | null;
+    zoneName?: string | null;
+  }[];
 }
 
-export const ListBucketDomainCustomsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  domains: Schema.Array(Schema.Struct({
-  domain: Schema.String,
-  enabled: Schema.Boolean,
-  status: Schema.Struct({
-    ownership: Schema.Literals(["pending", "active", "deactivated", "blocked", "error", "unknown"]),
-    ssl: Schema.Literals(["initializing", "pending", "active", "deactivated", "error", "unknown"])
-  }),
-  ciphers: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
-  minTLS: Schema.optional(Schema.Union([Schema.Literals(["1.0", "1.1", "1.2", "1.3"]), Schema.Null])),
-  zoneId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  zoneName: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
-}))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListBucketDomainCustomsResponse>;
+export const ListBucketDomainCustomsResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    domains: Schema.Array(
+      Schema.Struct({
+        domain: Schema.String,
+        enabled: Schema.Boolean,
+        status: Schema.Struct({
+          ownership: Schema.Literals([
+            "pending",
+            "active",
+            "deactivated",
+            "blocked",
+            "error",
+            "unknown",
+          ]),
+          ssl: Schema.Literals([
+            "initializing",
+            "pending",
+            "active",
+            "deactivated",
+            "error",
+            "unknown",
+          ]),
+        }),
+        ciphers: Schema.optional(
+          Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+        ),
+        minTLS: Schema.optional(
+          Schema.Union([
+            Schema.Literals(["1.0", "1.1", "1.2", "1.3"]),
+            Schema.Null,
+          ]),
+        ),
+        zoneId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+        zoneName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      }),
+    ),
+  }).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<ListBucketDomainCustomsResponse>;
 
 export type ListBucketDomainCustomsError =
   | DefaultErrors
@@ -675,17 +1091,24 @@ export interface CreateBucketDomainCustomRequest {
   minTLS?: "1.0" | "1.1" | "1.2" | "1.3";
 }
 
-export const CreateBucketDomainCustomRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  domain: Schema.String,
-  enabled: Schema.Boolean,
-  zoneId: Schema.String,
-  ciphers: Schema.optional(Schema.Array(Schema.String)),
-  minTLS: Schema.optional(Schema.Literals(["1.0", "1.1", "1.2", "1.3"]))
-})
-  .pipe(T.Http({ method: "POST", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom" })) as unknown as Schema.Schema<CreateBucketDomainCustomRequest>;
+export const CreateBucketDomainCustomRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    jurisdiction: Schema.optional(
+      Schema.Literals(["default", "eu", "fedramp"]),
+    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+    domain: Schema.String,
+    enabled: Schema.Boolean,
+    zoneId: Schema.String,
+    ciphers: Schema.optional(Schema.Array(Schema.String)),
+    minTLS: Schema.optional(Schema.Literals(["1.0", "1.1", "1.2", "1.3"])),
+  }).pipe(
+    T.Http({
+      method: "POST",
+      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom",
+    }),
+  ) as unknown as Schema.Schema<CreateBucketDomainCustomRequest>;
 
 export interface CreateBucketDomainCustomResponse {
   /** Domain name of the affected custom domain. */
@@ -698,12 +1121,22 @@ export interface CreateBucketDomainCustomResponse {
   minTLS?: "1.0" | "1.1" | "1.2" | "1.3" | null;
 }
 
-export const CreateBucketDomainCustomResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  domain: Schema.String,
-  enabled: Schema.Boolean,
-  ciphers: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
-  minTLS: Schema.optional(Schema.Union([Schema.Literals(["1.0", "1.1", "1.2", "1.3"]), Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<CreateBucketDomainCustomResponse>;
+export const CreateBucketDomainCustomResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    domain: Schema.String,
+    enabled: Schema.Boolean,
+    ciphers: Schema.optional(
+      Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+    ),
+    minTLS: Schema.optional(
+      Schema.Union([
+        Schema.Literals(["1.0", "1.1", "1.2", "1.3"]),
+        Schema.Null,
+      ]),
+    ),
+  }).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<CreateBucketDomainCustomResponse>;
 
 export type CreateBucketDomainCustomError =
   | DefaultErrors
@@ -736,16 +1169,23 @@ export interface UpdateBucketDomainCustomRequest {
   minTLS?: "1.0" | "1.1" | "1.2" | "1.3";
 }
 
-export const UpdateBucketDomainCustomRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-  domain: Schema.String.pipe(T.HttpPath("domain")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  ciphers: Schema.optional(Schema.Array(Schema.String)),
-  enabled: Schema.optional(Schema.Boolean),
-  minTLS: Schema.optional(Schema.Literals(["1.0", "1.1", "1.2", "1.3"]))
-})
-  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom/{domain}" })) as unknown as Schema.Schema<UpdateBucketDomainCustomRequest>;
+export const UpdateBucketDomainCustomRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+    domain: Schema.String.pipe(T.HttpPath("domain")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    jurisdiction: Schema.optional(
+      Schema.Literals(["default", "eu", "fedramp"]),
+    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+    ciphers: Schema.optional(Schema.Array(Schema.String)),
+    enabled: Schema.optional(Schema.Boolean),
+    minTLS: Schema.optional(Schema.Literals(["1.0", "1.1", "1.2", "1.3"])),
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom/{domain}",
+    }),
+  ) as unknown as Schema.Schema<UpdateBucketDomainCustomRequest>;
 
 export interface UpdateBucketDomainCustomResponse {
   /** Domain name of the affected custom domain. */
@@ -758,15 +1198,24 @@ export interface UpdateBucketDomainCustomResponse {
   minTLS?: "1.0" | "1.1" | "1.2" | "1.3" | null;
 }
 
-export const UpdateBucketDomainCustomResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  domain: Schema.String,
-  ciphers: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
-  enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-  minTLS: Schema.optional(Schema.Union([Schema.Literals(["1.0", "1.1", "1.2", "1.3"]), Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<UpdateBucketDomainCustomResponse>;
+export const UpdateBucketDomainCustomResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    domain: Schema.String,
+    ciphers: Schema.optional(
+      Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+    ),
+    enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+    minTLS: Schema.optional(
+      Schema.Union([
+        Schema.Literals(["1.0", "1.1", "1.2", "1.3"]),
+        Schema.Null,
+      ]),
+    ),
+  }).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<UpdateBucketDomainCustomResponse>;
 
-export type UpdateBucketDomainCustomError =
-  | DefaultErrors;
+export type UpdateBucketDomainCustomError = DefaultErrors;
 
 export const updateBucketDomainCustom: API.OperationMethod<
   UpdateBucketDomainCustomRequest,
@@ -788,25 +1237,34 @@ export interface DeleteBucketDomainCustomRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const DeleteBucketDomainCustomRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-  domain: Schema.String.pipe(T.HttpPath("domain")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom/{domain}" })) as unknown as Schema.Schema<DeleteBucketDomainCustomRequest>;
+export const DeleteBucketDomainCustomRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+    domain: Schema.String.pipe(T.HttpPath("domain")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    jurisdiction: Schema.optional(
+      Schema.Literals(["default", "eu", "fedramp"]),
+    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom/{domain}",
+    }),
+  ) as unknown as Schema.Schema<DeleteBucketDomainCustomRequest>;
 
 export interface DeleteBucketDomainCustomResponse {
   /** Name of the removed custom domain. */
   domain: string;
 }
 
-export const DeleteBucketDomainCustomResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  domain: Schema.String
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteBucketDomainCustomResponse>;
+export const DeleteBucketDomainCustomResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    domain: Schema.String,
+  }).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<DeleteBucketDomainCustomResponse>;
 
-export type DeleteBucketDomainCustomError =
-  | DefaultErrors;
+export type DeleteBucketDomainCustomError = DefaultErrors;
 
 export const deleteBucketDomainCustom: API.OperationMethod<
   DeleteBucketDomainCustomRequest,
@@ -818,7 +1276,6 @@ export const deleteBucketDomainCustom: API.OperationMethod<
   output: DeleteBucketDomainCustomResponse,
   errors: [],
 }));
-
 
 // =============================================================================
 // BucketDomainManaged
@@ -832,12 +1289,19 @@ export interface ListBucketDomainManagedsRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const ListBucketDomainManagedsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/managed" })) as unknown as Schema.Schema<ListBucketDomainManagedsRequest>;
+export const ListBucketDomainManagedsRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    jurisdiction: Schema.optional(
+      Schema.Literals(["default", "eu", "fedramp"]),
+    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/managed",
+    }),
+  ) as unknown as Schema.Schema<ListBucketDomainManagedsRequest>;
 
 export interface ListBucketDomainManagedsResponse {
   /** Bucket ID. */
@@ -848,11 +1312,14 @@ export interface ListBucketDomainManagedsResponse {
   enabled: boolean;
 }
 
-export const ListBucketDomainManagedsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  bucketId: Schema.String,
-  domain: Schema.String,
-  enabled: Schema.Boolean
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListBucketDomainManagedsResponse>;
+export const ListBucketDomainManagedsResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    bucketId: Schema.String,
+    domain: Schema.String,
+    enabled: Schema.Boolean,
+  }).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<ListBucketDomainManagedsResponse>;
 
 export type ListBucketDomainManagedsError =
   | DefaultErrors
@@ -880,13 +1347,20 @@ export interface PutBucketDomainManagedRequest {
   enabled: boolean;
 }
 
-export const PutBucketDomainManagedRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  enabled: Schema.Boolean
-})
-  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/managed" })) as unknown as Schema.Schema<PutBucketDomainManagedRequest>;
+export const PutBucketDomainManagedRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    jurisdiction: Schema.optional(
+      Schema.Literals(["default", "eu", "fedramp"]),
+    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+    enabled: Schema.Boolean,
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/managed",
+    }),
+  ) as unknown as Schema.Schema<PutBucketDomainManagedRequest>;
 
 export interface PutBucketDomainManagedResponse {
   /** Bucket ID. */
@@ -897,11 +1371,14 @@ export interface PutBucketDomainManagedResponse {
   enabled: boolean;
 }
 
-export const PutBucketDomainManagedResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  bucketId: Schema.String,
-  domain: Schema.String,
-  enabled: Schema.Boolean
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutBucketDomainManagedResponse>;
+export const PutBucketDomainManagedResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    bucketId: Schema.String,
+    domain: Schema.String,
+    enabled: Schema.Boolean,
+  }).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<PutBucketDomainManagedResponse>;
 
 export type PutBucketDomainManagedError =
   | DefaultErrors
@@ -919,7 +1396,6 @@ export const putBucketDomainManaged: API.OperationMethod<
   errors: [NoSuchBucket, InvalidRoute],
 }));
 
-
 // =============================================================================
 // BucketEventNotification
 // =============================================================================
@@ -933,34 +1409,78 @@ export interface GetBucketEventNotificationRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const GetBucketEventNotificationRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-  queueId: Schema.String.pipe(T.HttpPath("queueId")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration/queues/{queueId}" })) as unknown as Schema.Schema<GetBucketEventNotificationRequest>;
+export const GetBucketEventNotificationRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+    queueId: Schema.String.pipe(T.HttpPath("queueId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    jurisdiction: Schema.optional(
+      Schema.Literals(["default", "eu", "fedramp"]),
+    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration/queues/{queueId}",
+    }),
+  ) as unknown as Schema.Schema<GetBucketEventNotificationRequest>;
 
 export interface GetBucketEventNotificationResponse {
   /** Queue ID. */
   queueId?: string | null;
   /** Name of the queue. */
   queueName?: string | null;
-  rules?: ({ actions: ("PutObject" | "CopyObject" | "DeleteObject" | "CompleteMultipartUpload" | "LifecycleDeletion")[]; createdAt?: string | null; description?: string | null; prefix?: string | null; ruleId?: string | null; suffix?: string | null })[] | null;
+  rules?:
+    | {
+        actions: (
+          | "PutObject"
+          | "CopyObject"
+          | "DeleteObject"
+          | "CompleteMultipartUpload"
+          | "LifecycleDeletion"
+        )[];
+        createdAt?: string | null;
+        description?: string | null;
+        prefix?: string | null;
+        ruleId?: string | null;
+        suffix?: string | null;
+      }[]
+    | null;
 }
 
-export const GetBucketEventNotificationResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  queueId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  queueName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  rules: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
-  actions: Schema.Array(Schema.Literals(["PutObject", "CopyObject", "DeleteObject", "CompleteMultipartUpload", "LifecycleDeletion"])),
-  createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  description: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  ruleId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  suffix: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
-})), Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketEventNotificationResponse>;
+export const GetBucketEventNotificationResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    queueId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    queueName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    rules: Schema.optional(
+      Schema.Union([
+        Schema.Array(
+          Schema.Struct({
+            actions: Schema.Array(
+              Schema.Literals([
+                "PutObject",
+                "CopyObject",
+                "DeleteObject",
+                "CompleteMultipartUpload",
+                "LifecycleDeletion",
+              ]),
+            ),
+            createdAt: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+            description: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+            prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+            ruleId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+            suffix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          }),
+        ),
+        Schema.Null,
+      ]),
+    ),
+  }).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<GetBucketEventNotificationResponse>;
 
 export type GetBucketEventNotificationError =
   | DefaultErrors
@@ -978,7 +1498,13 @@ export const getBucketEventNotification: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetBucketEventNotificationRequest,
   output: GetBucketEventNotificationResponse,
-  errors: [BucketNotFound, NoEventNotificationConfig, EventNotificationConfigNotFound, QueueNotFound, InvalidRoute],
+  errors: [
+    BucketNotFound,
+    NoEventNotificationConfig,
+    EventNotificationConfigNotFound,
+    QueueNotFound,
+    InvalidRoute,
+  ],
 }));
 
 export interface ListBucketEventNotificationsRequest {
@@ -989,35 +1515,102 @@ export interface ListBucketEventNotificationsRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const ListBucketEventNotificationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration" })) as unknown as Schema.Schema<ListBucketEventNotificationsRequest>;
+export const ListBucketEventNotificationsRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    jurisdiction: Schema.optional(
+      Schema.Literals(["default", "eu", "fedramp"]),
+    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration",
+    }),
+  ) as unknown as Schema.Schema<ListBucketEventNotificationsRequest>;
 
 export interface ListBucketEventNotificationsResponse {
   /** Name of the bucket. */
   bucketName?: string | null;
   /** List of queues associated with the bucket. */
-  queues?: ({ queueId?: string | null; queueName?: string | null; rules?: ({ actions: ("PutObject" | "CopyObject" | "DeleteObject" | "CompleteMultipartUpload" | "LifecycleDeletion")[]; createdAt?: string | null; description?: string | null; prefix?: string | null; ruleId?: string | null; suffix?: string | null })[] | null })[] | null;
+  queues?:
+    | {
+        queueId?: string | null;
+        queueName?: string | null;
+        rules?:
+          | {
+              actions: (
+                | "PutObject"
+                | "CopyObject"
+                | "DeleteObject"
+                | "CompleteMultipartUpload"
+                | "LifecycleDeletion"
+              )[];
+              createdAt?: string | null;
+              description?: string | null;
+              prefix?: string | null;
+              ruleId?: string | null;
+              suffix?: string | null;
+            }[]
+          | null;
+      }[]
+    | null;
 }
 
-export const ListBucketEventNotificationsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  bucketName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  queues: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
-  queueId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  queueName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  rules: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
-    actions: Schema.Array(Schema.Literals(["PutObject", "CopyObject", "DeleteObject", "CompleteMultipartUpload", "LifecycleDeletion"])),
-    createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    description: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    ruleId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    suffix: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
-  })), Schema.Null]))
-})), Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListBucketEventNotificationsResponse>;
+export const ListBucketEventNotificationsResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    bucketName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    queues: Schema.optional(
+      Schema.Union([
+        Schema.Array(
+          Schema.Struct({
+            queueId: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+            queueName: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+            rules: Schema.optional(
+              Schema.Union([
+                Schema.Array(
+                  Schema.Struct({
+                    actions: Schema.Array(
+                      Schema.Literals([
+                        "PutObject",
+                        "CopyObject",
+                        "DeleteObject",
+                        "CompleteMultipartUpload",
+                        "LifecycleDeletion",
+                      ]),
+                    ),
+                    createdAt: Schema.optional(
+                      Schema.Union([Schema.String, Schema.Null]),
+                    ),
+                    description: Schema.optional(
+                      Schema.Union([Schema.String, Schema.Null]),
+                    ),
+                    prefix: Schema.optional(
+                      Schema.Union([Schema.String, Schema.Null]),
+                    ),
+                    ruleId: Schema.optional(
+                      Schema.Union([Schema.String, Schema.Null]),
+                    ),
+                    suffix: Schema.optional(
+                      Schema.Union([Schema.String, Schema.Null]),
+                    ),
+                  }),
+                ),
+                Schema.Null,
+              ]),
+            ),
+          }),
+        ),
+        Schema.Null,
+      ]),
+    ),
+  }).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<ListBucketEventNotificationsResponse>;
 
 export type ListBucketEventNotificationsError =
   | DefaultErrors
@@ -1034,7 +1627,12 @@ export const listBucketEventNotifications: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: ListBucketEventNotificationsRequest,
   output: ListBucketEventNotificationsResponse,
-  errors: [NoSuchBucket, InvalidRoute, NoEventNotificationConfig, BucketNotFound],
+  errors: [
+    NoSuchBucket,
+    InvalidRoute,
+    NoEventNotificationConfig,
+    BucketNotFound,
+  ],
 }));
 
 export interface PutBucketEventNotificationRequest {
@@ -1045,26 +1643,57 @@ export interface PutBucketEventNotificationRequest {
   /** Header param: Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp";
   /** Body param: Array of rules to drive notifications. */
-  rules: ({ actions: ("PutObject" | "CopyObject" | "DeleteObject" | "CompleteMultipartUpload" | "LifecycleDeletion")[]; description?: string; prefix?: string; suffix?: string })[];
+  rules: {
+    actions: (
+      | "PutObject"
+      | "CopyObject"
+      | "DeleteObject"
+      | "CompleteMultipartUpload"
+      | "LifecycleDeletion"
+    )[];
+    description?: string;
+    prefix?: string;
+    suffix?: string;
+  }[];
 }
 
-export const PutBucketEventNotificationRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-  queueId: Schema.String.pipe(T.HttpPath("queueId")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  rules: Schema.Array(Schema.Struct({
-  actions: Schema.Array(Schema.Literals(["PutObject", "CopyObject", "DeleteObject", "CompleteMultipartUpload", "LifecycleDeletion"])),
-  description: Schema.optional(Schema.String),
-  prefix: Schema.optional(Schema.String),
-  suffix: Schema.optional(Schema.String)
-}))
-})
-  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration/queues/{queueId}" })) as unknown as Schema.Schema<PutBucketEventNotificationRequest>;
+export const PutBucketEventNotificationRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+    queueId: Schema.String.pipe(T.HttpPath("queueId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    jurisdiction: Schema.optional(
+      Schema.Literals(["default", "eu", "fedramp"]),
+    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+    rules: Schema.Array(
+      Schema.Struct({
+        actions: Schema.Array(
+          Schema.Literals([
+            "PutObject",
+            "CopyObject",
+            "DeleteObject",
+            "CompleteMultipartUpload",
+            "LifecycleDeletion",
+          ]),
+        ),
+        description: Schema.optional(Schema.String),
+        prefix: Schema.optional(Schema.String),
+        suffix: Schema.optional(Schema.String),
+      }),
+    ),
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration/queues/{queueId}",
+    }),
+  ) as unknown as Schema.Schema<PutBucketEventNotificationRequest>;
 
 export type PutBucketEventNotificationResponse = unknown;
 
-export const PutBucketEventNotificationResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutBucketEventNotificationResponse>;
+export const PutBucketEventNotificationResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<PutBucketEventNotificationResponse>;
 
 export type PutBucketEventNotificationError =
   | DefaultErrors
@@ -1082,7 +1711,13 @@ export const putBucketEventNotification: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: PutBucketEventNotificationRequest,
   output: PutBucketEventNotificationResponse,
-  errors: [BucketNotFound, InvalidEventNotificationConfig, EventNotificationRuleConflict, QueueNotFound, InvalidRoute],
+  errors: [
+    BucketNotFound,
+    InvalidEventNotificationConfig,
+    EventNotificationRuleConflict,
+    QueueNotFound,
+    InvalidRoute,
+  ],
 }));
 
 export interface DeleteBucketEventNotificationRequest {
@@ -1094,17 +1729,27 @@ export interface DeleteBucketEventNotificationRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const DeleteBucketEventNotificationRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-  queueId: Schema.String.pipe(T.HttpPath("queueId")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration/queues/{queueId}" })) as unknown as Schema.Schema<DeleteBucketEventNotificationRequest>;
+export const DeleteBucketEventNotificationRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+    queueId: Schema.String.pipe(T.HttpPath("queueId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    jurisdiction: Schema.optional(
+      Schema.Literals(["default", "eu", "fedramp"]),
+    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration/queues/{queueId}",
+    }),
+  ) as unknown as Schema.Schema<DeleteBucketEventNotificationRequest>;
 
 export type DeleteBucketEventNotificationResponse = unknown;
 
-export const DeleteBucketEventNotificationResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteBucketEventNotificationResponse>;
+export const DeleteBucketEventNotificationResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<DeleteBucketEventNotificationResponse>;
 
 export type DeleteBucketEventNotificationError =
   | DefaultErrors
@@ -1121,9 +1766,13 @@ export const deleteBucketEventNotification: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: DeleteBucketEventNotificationRequest,
   output: DeleteBucketEventNotificationResponse,
-  errors: [BucketNotFound, EventNotificationConfigNotFound, QueueNotFound, InvalidRoute],
+  errors: [
+    BucketNotFound,
+    EventNotificationConfigNotFound,
+    QueueNotFound,
+    InvalidRoute,
+  ],
 }));
-
 
 // =============================================================================
 // BucketLifecycle
@@ -1137,51 +1786,126 @@ export interface GetBucketLifecycleRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const GetBucketLifecycleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/lifecycle" })) as unknown as Schema.Schema<GetBucketLifecycleRequest>;
+export const GetBucketLifecycleRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    jurisdiction: Schema.optional(
+      Schema.Literals(["default", "eu", "fedramp"]),
+    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/r2/buckets/{bucketName}/lifecycle",
+    }),
+  ) as unknown as Schema.Schema<GetBucketLifecycleRequest>;
 
 export interface GetBucketLifecycleResponse {
-  rules?: ({ id: string; conditions: { prefix?: string | null }; enabled: boolean; abortMultipartUploadsTransition?: { condition?: { maxAge: number; type: "Age" } | null } | null; deleteObjectsTransition?: { condition?: { maxAge: number; type: "Age" } | { date: string; type: "Date" } | null } | null; storageClassTransitions?: ({ condition: { maxAge: number; type: "Age" } | { date: string; type: "Date" }; storageClass: "InfrequentAccess" })[] | null })[] | null;
+  rules?:
+    | {
+        id: string;
+        conditions: { prefix?: string | null };
+        enabled: boolean;
+        abortMultipartUploadsTransition?: {
+          condition?: { maxAge: number; type: "Age" } | null;
+        } | null;
+        deleteObjectsTransition?: {
+          condition?:
+            | { maxAge: number; type: "Age" }
+            | { date: string; type: "Date" }
+            | null;
+        } | null;
+        storageClassTransitions?:
+          | {
+              condition:
+                | { maxAge: number; type: "Age" }
+                | { date: string; type: "Date" };
+              storageClass: "InfrequentAccess";
+            }[]
+          | null;
+      }[]
+    | null;
 }
 
-export const GetBucketLifecycleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  rules: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
-  id: Schema.String,
-  conditions: Schema.Struct({
-    prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
-  }),
-  enabled: Schema.Boolean,
-  abortMultipartUploadsTransition: Schema.optional(Schema.Union([Schema.Struct({
-    condition: Schema.optional(Schema.Union([Schema.Struct({
-      maxAge: Schema.Number,
-      type: Schema.Literal("Age")
-    }), Schema.Null]))
-  }), Schema.Null])),
-  deleteObjectsTransition: Schema.optional(Schema.Union([Schema.Struct({
-    condition: Schema.optional(Schema.Union([Schema.Union([Schema.Struct({
-      maxAge: Schema.Number,
-      type: Schema.Literal("Age")
-    }), Schema.Struct({
-      date: Schema.String,
-      type: Schema.Literal("Date")
-    })]), Schema.Null]))
-  }), Schema.Null])),
-  storageClassTransitions: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
-    condition: Schema.Union([Schema.Struct({
-      maxAge: Schema.Number,
-      type: Schema.Literal("Age")
-    }), Schema.Struct({
-      date: Schema.String,
-      type: Schema.Literal("Date")
-    })]),
-    storageClass: Schema.Literal("InfrequentAccess")
-  })), Schema.Null]))
-})), Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketLifecycleResponse>;
+export const GetBucketLifecycleResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    rules: Schema.optional(
+      Schema.Union([
+        Schema.Array(
+          Schema.Struct({
+            id: Schema.String,
+            conditions: Schema.Struct({
+              prefix: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }),
+            enabled: Schema.Boolean,
+            abortMultipartUploadsTransition: Schema.optional(
+              Schema.Union([
+                Schema.Struct({
+                  condition: Schema.optional(
+                    Schema.Union([
+                      Schema.Struct({
+                        maxAge: Schema.Number,
+                        type: Schema.Literal("Age"),
+                      }),
+                      Schema.Null,
+                    ]),
+                  ),
+                }),
+                Schema.Null,
+              ]),
+            ),
+            deleteObjectsTransition: Schema.optional(
+              Schema.Union([
+                Schema.Struct({
+                  condition: Schema.optional(
+                    Schema.Union([
+                      Schema.Union([
+                        Schema.Struct({
+                          maxAge: Schema.Number,
+                          type: Schema.Literal("Age"),
+                        }),
+                        Schema.Struct({
+                          date: Schema.String,
+                          type: Schema.Literal("Date"),
+                        }),
+                      ]),
+                      Schema.Null,
+                    ]),
+                  ),
+                }),
+                Schema.Null,
+              ]),
+            ),
+            storageClassTransitions: Schema.optional(
+              Schema.Union([
+                Schema.Array(
+                  Schema.Struct({
+                    condition: Schema.Union([
+                      Schema.Struct({
+                        maxAge: Schema.Number,
+                        type: Schema.Literal("Age"),
+                      }),
+                      Schema.Struct({
+                        date: Schema.String,
+                        type: Schema.Literal("Date"),
+                      }),
+                    ]),
+                    storageClass: Schema.Literal("InfrequentAccess"),
+                  }),
+                ),
+                Schema.Null,
+              ]),
+            ),
+          }),
+        ),
+        Schema.Null,
+      ]),
+    ),
+  }).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<GetBucketLifecycleResponse>;
 
 export type GetBucketLifecycleError =
   | DefaultErrors
@@ -1206,51 +1930,101 @@ export interface PutBucketLifecycleRequest {
   /** Header param: Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp";
   /** Body param: */
-  rules?: ({ id: string; conditions: { prefix: string }; enabled: boolean; abortMultipartUploadsTransition?: { condition?: { maxAge: number; type: "Age" } }; deleteObjectsTransition?: { condition?: { maxAge: number; type: "Age" } | { date: string; type: "Date" } }; storageClassTransitions?: ({ condition: { maxAge: number; type: "Age" } | { date: string; type: "Date" }; storageClass: "InfrequentAccess" })[] })[];
+  rules?: {
+    id: string;
+    conditions: { prefix: string };
+    enabled: boolean;
+    abortMultipartUploadsTransition?: {
+      condition?: { maxAge: number; type: "Age" };
+    };
+    deleteObjectsTransition?: {
+      condition?:
+        | { maxAge: number; type: "Age" }
+        | { date: string; type: "Date" };
+    };
+    storageClassTransitions?: {
+      condition:
+        | { maxAge: number; type: "Age" }
+        | { date: string; type: "Date" };
+      storageClass: "InfrequentAccess";
+    }[];
+  }[];
 }
 
-export const PutBucketLifecycleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  rules: Schema.optional(Schema.Array(Schema.Struct({
-  id: Schema.String,
-  conditions: Schema.Struct({
-    prefix: Schema.String
-  }),
-  enabled: Schema.Boolean,
-  abortMultipartUploadsTransition: Schema.optional(Schema.Struct({
-    condition: Schema.optional(Schema.Struct({
-      maxAge: Schema.Number,
-      type: Schema.Literal("Age")
-    }))
-  })),
-  deleteObjectsTransition: Schema.optional(Schema.Struct({
-    condition: Schema.optional(Schema.Union([Schema.Struct({
-      maxAge: Schema.Number,
-      type: Schema.Literal("Age")
-    }), Schema.Struct({
-      date: Schema.String,
-      type: Schema.Literal("Date")
-    })]))
-  })),
-  storageClassTransitions: Schema.optional(Schema.Array(Schema.Struct({
-    condition: Schema.Union([Schema.Struct({
-      maxAge: Schema.Number,
-      type: Schema.Literal("Age")
-    }), Schema.Struct({
-      date: Schema.String,
-      type: Schema.Literal("Date")
-    })]),
-    storageClass: Schema.Literal("InfrequentAccess")
-  })))
-})))
-})
-  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/lifecycle" })) as unknown as Schema.Schema<PutBucketLifecycleRequest>;
+export const PutBucketLifecycleRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    jurisdiction: Schema.optional(
+      Schema.Literals(["default", "eu", "fedramp"]),
+    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+    rules: Schema.optional(
+      Schema.Array(
+        Schema.Struct({
+          id: Schema.String,
+          conditions: Schema.Struct({
+            prefix: Schema.String,
+          }),
+          enabled: Schema.Boolean,
+          abortMultipartUploadsTransition: Schema.optional(
+            Schema.Struct({
+              condition: Schema.optional(
+                Schema.Struct({
+                  maxAge: Schema.Number,
+                  type: Schema.Literal("Age"),
+                }),
+              ),
+            }),
+          ),
+          deleteObjectsTransition: Schema.optional(
+            Schema.Struct({
+              condition: Schema.optional(
+                Schema.Union([
+                  Schema.Struct({
+                    maxAge: Schema.Number,
+                    type: Schema.Literal("Age"),
+                  }),
+                  Schema.Struct({
+                    date: Schema.String,
+                    type: Schema.Literal("Date"),
+                  }),
+                ]),
+              ),
+            }),
+          ),
+          storageClassTransitions: Schema.optional(
+            Schema.Array(
+              Schema.Struct({
+                condition: Schema.Union([
+                  Schema.Struct({
+                    maxAge: Schema.Number,
+                    type: Schema.Literal("Age"),
+                  }),
+                  Schema.Struct({
+                    date: Schema.String,
+                    type: Schema.Literal("Date"),
+                  }),
+                ]),
+                storageClass: Schema.Literal("InfrequentAccess"),
+              }),
+            ),
+          ),
+        }),
+      ),
+    ),
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/accounts/{account_id}/r2/buckets/{bucketName}/lifecycle",
+    }),
+  ) as unknown as Schema.Schema<PutBucketLifecycleRequest>;
 
 export type PutBucketLifecycleResponse = unknown;
 
-export const PutBucketLifecycleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutBucketLifecycleResponse>;
+export const PutBucketLifecycleResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<PutBucketLifecycleResponse>;
 
 export type PutBucketLifecycleError =
   | DefaultErrors
@@ -1268,7 +2042,6 @@ export const putBucketLifecycle: API.OperationMethod<
   errors: [NoSuchBucket, InvalidRoute],
 }));
 
-
 // =============================================================================
 // BucketLock
 // =============================================================================
@@ -1284,35 +2057,61 @@ export interface GetBucketLockRequest {
 export const GetBucketLockRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/lock" })) as unknown as Schema.Schema<GetBucketLockRequest>;
+  jurisdiction: Schema.optional(
+    Schema.Literals(["default", "eu", "fedramp"]),
+  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+}).pipe(
+  T.Http({
+    method: "GET",
+    path: "/accounts/{account_id}/r2/buckets/{bucketName}/lock",
+  }),
+) as unknown as Schema.Schema<GetBucketLockRequest>;
 
 export interface GetBucketLockResponse {
-  rules?: ({ id: string; condition: { maxAgeSeconds: number; type: "Age" } | { date: string; type: "Date" } | { type: "Indefinite" }; enabled: boolean; prefix?: string | null })[] | null;
+  rules?:
+    | {
+        id: string;
+        condition:
+          | { maxAgeSeconds: number; type: "Age" }
+          | { date: string; type: "Date" }
+          | { type: "Indefinite" };
+        enabled: boolean;
+        prefix?: string | null;
+      }[]
+    | null;
 }
 
 export const GetBucketLockResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  rules: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
-  id: Schema.String,
-  condition: Schema.Union([Schema.Struct({
-    maxAgeSeconds: Schema.Number,
-    type: Schema.Literal("Age")
-  }), Schema.Struct({
-    date: Schema.String,
-    type: Schema.Literal("Date")
-  }), Schema.Struct({
-    type: Schema.Literal("Indefinite")
-  })]),
-  enabled: Schema.Boolean,
-  prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
-})), Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketLockResponse>;
+  rules: Schema.optional(
+    Schema.Union([
+      Schema.Array(
+        Schema.Struct({
+          id: Schema.String,
+          condition: Schema.Union([
+            Schema.Struct({
+              maxAgeSeconds: Schema.Number,
+              type: Schema.Literal("Age"),
+            }),
+            Schema.Struct({
+              date: Schema.String,
+              type: Schema.Literal("Date"),
+            }),
+            Schema.Struct({
+              type: Schema.Literal("Indefinite"),
+            }),
+          ]),
+          enabled: Schema.Boolean,
+          prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+        }),
+      ),
+      Schema.Null,
+    ]),
+  ),
+}).pipe(
+  T.ResponsePath("result"),
+) as unknown as Schema.Schema<GetBucketLockResponse>;
 
-export type GetBucketLockError =
-  | DefaultErrors
-  | NoSuchBucket
-  | InvalidRoute;
+export type GetBucketLockError = DefaultErrors | NoSuchBucket | InvalidRoute;
 
 export const getBucketLock: API.OperationMethod<
   GetBucketLockRequest,
@@ -1332,38 +2131,60 @@ export interface PutBucketLockRequest {
   /** Header param: Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp";
   /** Body param: */
-  rules?: ({ id: string; condition: { maxAgeSeconds: number; type: "Age" } | { date: string; type: "Date" } | { type: "Indefinite" }; enabled: boolean; prefix?: string })[];
+  rules?: {
+    id: string;
+    condition:
+      | { maxAgeSeconds: number; type: "Age" }
+      | { date: string; type: "Date" }
+      | { type: "Indefinite" };
+    enabled: boolean;
+    prefix?: string;
+  }[];
 }
 
 export const PutBucketLockRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  rules: Schema.optional(Schema.Array(Schema.Struct({
-  id: Schema.String,
-  condition: Schema.Union([Schema.Struct({
-    maxAgeSeconds: Schema.Number,
-    type: Schema.Literal("Age")
-  }), Schema.Struct({
-    date: Schema.String,
-    type: Schema.Literal("Date")
-  }), Schema.Struct({
-    type: Schema.Literal("Indefinite")
-  })]),
-  enabled: Schema.Boolean,
-  prefix: Schema.optional(Schema.String)
-})))
-})
-  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/lock" })) as unknown as Schema.Schema<PutBucketLockRequest>;
+  jurisdiction: Schema.optional(
+    Schema.Literals(["default", "eu", "fedramp"]),
+  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  rules: Schema.optional(
+    Schema.Array(
+      Schema.Struct({
+        id: Schema.String,
+        condition: Schema.Union([
+          Schema.Struct({
+            maxAgeSeconds: Schema.Number,
+            type: Schema.Literal("Age"),
+          }),
+          Schema.Struct({
+            date: Schema.String,
+            type: Schema.Literal("Date"),
+          }),
+          Schema.Struct({
+            type: Schema.Literal("Indefinite"),
+          }),
+        ]),
+        enabled: Schema.Boolean,
+        prefix: Schema.optional(Schema.String),
+      }),
+    ),
+  ),
+}).pipe(
+  T.Http({
+    method: "PUT",
+    path: "/accounts/{account_id}/r2/buckets/{bucketName}/lock",
+  }),
+) as unknown as Schema.Schema<PutBucketLockRequest>;
 
 export type PutBucketLockResponse = unknown;
 
-export const PutBucketLockResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutBucketLockResponse>;
+export const PutBucketLockResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<PutBucketLockResponse>;
 
-export type PutBucketLockError =
-  | DefaultErrors
-  | NoSuchBucket
-  | InvalidRoute;
+export type PutBucketLockError = DefaultErrors | NoSuchBucket | InvalidRoute;
 
 export const putBucketLock: API.OperationMethod<
   PutBucketLockRequest,
@@ -1376,7 +2197,6 @@ export const putBucketLock: API.OperationMethod<
   errors: [NoSuchBucket, InvalidRoute],
 }));
 
-
 // =============================================================================
 // BucketMetric
 // =============================================================================
@@ -1386,48 +2206,127 @@ export interface ListBucketMetricsRequest {
   accountId: string;
 }
 
-export const ListBucketMetricsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  accountId: Schema.String.pipe(T.HttpPath("account_id"))
-})
-  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/metrics" })) as unknown as Schema.Schema<ListBucketMetricsRequest>;
+export const ListBucketMetricsRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  }).pipe(
+    T.Http({ method: "GET", path: "/accounts/{account_id}/r2/metrics" }),
+  ) as unknown as Schema.Schema<ListBucketMetricsRequest>;
 
 export interface ListBucketMetricsResponse {
   /** Metrics based on what state they are in(uploaded or published). */
-  infrequentAccess?: { published?: { metadataSize?: number | null; objects?: number | null; payloadSize?: number | null } | null; uploaded?: { metadataSize?: number | null; objects?: number | null; payloadSize?: number | null } | null } | null;
+  infrequentAccess?: {
+    published?: {
+      metadataSize?: number | null;
+      objects?: number | null;
+      payloadSize?: number | null;
+    } | null;
+    uploaded?: {
+      metadataSize?: number | null;
+      objects?: number | null;
+      payloadSize?: number | null;
+    } | null;
+  } | null;
   /** Metrics based on what state they are in(uploaded or published). */
-  standard?: { published?: { metadataSize?: number | null; objects?: number | null; payloadSize?: number | null } | null; uploaded?: { metadataSize?: number | null; objects?: number | null; payloadSize?: number | null } | null } | null;
+  standard?: {
+    published?: {
+      metadataSize?: number | null;
+      objects?: number | null;
+      payloadSize?: number | null;
+    } | null;
+    uploaded?: {
+      metadataSize?: number | null;
+      objects?: number | null;
+      payloadSize?: number | null;
+    } | null;
+  } | null;
 }
 
-export const ListBucketMetricsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  infrequentAccess: Schema.optional(Schema.Union([Schema.Struct({
-  published: Schema.optional(Schema.Union([Schema.Struct({
-    metadataSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    objects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    payloadSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null]))
-  }), Schema.Null])),
-  uploaded: Schema.optional(Schema.Union([Schema.Struct({
-    metadataSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    objects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    payloadSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null]))
-  }), Schema.Null]))
-}), Schema.Null])),
-  standard: Schema.optional(Schema.Union([Schema.Struct({
-  published: Schema.optional(Schema.Union([Schema.Struct({
-    metadataSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    objects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    payloadSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null]))
-  }), Schema.Null])),
-  uploaded: Schema.optional(Schema.Union([Schema.Struct({
-    metadataSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    objects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    payloadSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null]))
-  }), Schema.Null]))
-}), Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListBucketMetricsResponse>;
+export const ListBucketMetricsResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    infrequentAccess: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          published: Schema.optional(
+            Schema.Union([
+              Schema.Struct({
+                metadataSize: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+                objects: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+                payloadSize: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+              }),
+              Schema.Null,
+            ]),
+          ),
+          uploaded: Schema.optional(
+            Schema.Union([
+              Schema.Struct({
+                metadataSize: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+                objects: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+                payloadSize: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+              }),
+              Schema.Null,
+            ]),
+          ),
+        }),
+        Schema.Null,
+      ]),
+    ),
+    standard: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          published: Schema.optional(
+            Schema.Union([
+              Schema.Struct({
+                metadataSize: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+                objects: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+                payloadSize: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+              }),
+              Schema.Null,
+            ]),
+          ),
+          uploaded: Schema.optional(
+            Schema.Union([
+              Schema.Struct({
+                metadataSize: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+                objects: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+                payloadSize: Schema.optional(
+                  Schema.Union([Schema.Number, Schema.Null]),
+                ),
+              }),
+              Schema.Null,
+            ]),
+          ),
+        }),
+        Schema.Null,
+      ]),
+    ),
+  }).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<ListBucketMetricsResponse>;
 
-export type ListBucketMetricsError =
-  | DefaultErrors
-  | InvalidRoute;
+export type ListBucketMetricsError = DefaultErrors | InvalidRoute;
 
 export const listBucketMetrics: API.OperationMethod<
   ListBucketMetricsRequest,
@@ -1439,7 +2338,6 @@ export const listBucketMetrics: API.OperationMethod<
   output: ListBucketMetricsResponse,
   errors: [InvalidRoute],
 }));
-
 
 // =============================================================================
 // BucketSippy
@@ -1456,39 +2354,74 @@ export interface GetBucketSippyRequest {
 export const GetBucketSippyRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/sippy" })) as unknown as Schema.Schema<GetBucketSippyRequest>;
+  jurisdiction: Schema.optional(
+    Schema.Literals(["default", "eu", "fedramp"]),
+  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+}).pipe(
+  T.Http({
+    method: "GET",
+    path: "/accounts/{account_id}/r2/buckets/{bucketName}/sippy",
+  }),
+) as unknown as Schema.Schema<GetBucketSippyRequest>;
 
 export interface GetBucketSippyResponse {
   /** Details about the configured destination bucket. */
-  destination?: { accessKeyId?: string | null; account?: string | null; bucket?: string | null; provider?: "r2" | null } | null;
+  destination?: {
+    accessKeyId?: string | null;
+    account?: string | null;
+    bucket?: string | null;
+    provider?: "r2" | null;
+  } | null;
   /** State of Sippy for this bucket. */
   enabled?: boolean | null;
   /** Details about the configured source bucket. */
-  source?: { bucket?: string | null; bucketUrl?: string | null; provider?: "aws" | "gcs" | "s3" | null; region?: string | null } | null;
+  source?: {
+    bucket?: string | null;
+    bucketUrl?: string | null;
+    provider?: "aws" | "gcs" | "s3" | null;
+    region?: string | null;
+  } | null;
 }
 
-export const GetBucketSippyResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  destination: Schema.optional(Schema.Union([Schema.Struct({
-  accessKeyId: Schema.optional(Schema.Union([SensitiveString, Schema.Null])),
-  account: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  provider: Schema.optional(Schema.Union([Schema.Literal("r2"), Schema.Null]))
-}), Schema.Null])),
-  enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-  source: Schema.optional(Schema.Union([Schema.Struct({
-  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  bucketUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  provider: Schema.optional(Schema.Union([Schema.Literals(["aws", "gcs", "s3"]), Schema.Null])),
-  region: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
-}), Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketSippyResponse>;
+export const GetBucketSippyResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
+  {
+    destination: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          accessKeyId: Schema.optional(
+            Schema.Union([SensitiveString, Schema.Null]),
+          ),
+          account: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          provider: Schema.optional(
+            Schema.Union([Schema.Literal("r2"), Schema.Null]),
+          ),
+        }),
+        Schema.Null,
+      ]),
+    ),
+    enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+    source: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          bucketUrl: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          provider: Schema.optional(
+            Schema.Union([Schema.Literals(["aws", "gcs", "s3"]), Schema.Null]),
+          ),
+          region: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+        }),
+        Schema.Null,
+      ]),
+    ),
+  },
+).pipe(
+  T.ResponsePath("result"),
+) as unknown as Schema.Schema<GetBucketSippyResponse>;
 
-export type GetBucketSippyError =
-  | DefaultErrors
-  | NoSuchBucket
-  | InvalidRoute;
+export type GetBucketSippyError = DefaultErrors | NoSuchBucket | InvalidRoute;
 
 export const getBucketSippy: API.OperationMethod<
   GetBucketSippyRequest,
@@ -1508,54 +2441,106 @@ export interface PutBucketSippyRequest {
   /** Header param: Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp";
   /** Body param: R2 bucket to copy objects to. */
-  destination?: { accessKeyId?: string; provider?: "r2"; secretAccessKey?: string };
+  destination?: {
+    accessKeyId?: string;
+    provider?: "r2";
+    secretAccessKey?: string;
+  };
   /** Body param: AWS S3 bucket to copy objects from. */
-  source?: { accessKeyId?: string; bucket?: string; provider?: "aws"; region?: string; secretAccessKey?: string };
+  source?: {
+    accessKeyId?: string;
+    bucket?: string;
+    provider?: "aws";
+    region?: string;
+    secretAccessKey?: string;
+  };
 }
 
 export const PutBucketSippyRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  destination: Schema.optional(Schema.Struct({
-  accessKeyId: Schema.optional(SensitiveString),
-  provider: Schema.optional(Schema.Literal("r2")),
-  secretAccessKey: Schema.optional(SensitiveString)
-})),
-  source: Schema.optional(Schema.Struct({
-  accessKeyId: Schema.optional(SensitiveString),
-  bucket: Schema.optional(Schema.String),
-  provider: Schema.optional(Schema.Literal("aws")),
-  region: Schema.optional(Schema.String),
-  secretAccessKey: Schema.optional(SensitiveString)
-}))
-})
-  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/sippy" })) as unknown as Schema.Schema<PutBucketSippyRequest>;
+  jurisdiction: Schema.optional(
+    Schema.Literals(["default", "eu", "fedramp"]),
+  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  destination: Schema.optional(
+    Schema.Struct({
+      accessKeyId: Schema.optional(SensitiveString),
+      provider: Schema.optional(Schema.Literal("r2")),
+      secretAccessKey: Schema.optional(SensitiveString),
+    }),
+  ),
+  source: Schema.optional(
+    Schema.Struct({
+      accessKeyId: Schema.optional(SensitiveString),
+      bucket: Schema.optional(Schema.String),
+      provider: Schema.optional(Schema.Literal("aws")),
+      region: Schema.optional(Schema.String),
+      secretAccessKey: Schema.optional(SensitiveString),
+    }),
+  ),
+}).pipe(
+  T.Http({
+    method: "PUT",
+    path: "/accounts/{account_id}/r2/buckets/{bucketName}/sippy",
+  }),
+) as unknown as Schema.Schema<PutBucketSippyRequest>;
 
 export interface PutBucketSippyResponse {
   /** Details about the configured destination bucket. */
-  destination?: { accessKeyId?: string | null; account?: string | null; bucket?: string | null; provider?: "r2" | null } | null;
+  destination?: {
+    accessKeyId?: string | null;
+    account?: string | null;
+    bucket?: string | null;
+    provider?: "r2" | null;
+  } | null;
   /** State of Sippy for this bucket. */
   enabled?: boolean | null;
   /** Details about the configured source bucket. */
-  source?: { bucket?: string | null; bucketUrl?: string | null; provider?: "aws" | "gcs" | "s3" | null; region?: string | null } | null;
+  source?: {
+    bucket?: string | null;
+    bucketUrl?: string | null;
+    provider?: "aws" | "gcs" | "s3" | null;
+    region?: string | null;
+  } | null;
 }
 
-export const PutBucketSippyResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  destination: Schema.optional(Schema.Union([Schema.Struct({
-  accessKeyId: Schema.optional(Schema.Union([SensitiveString, Schema.Null])),
-  account: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  provider: Schema.optional(Schema.Union([Schema.Literal("r2"), Schema.Null]))
-}), Schema.Null])),
-  enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-  source: Schema.optional(Schema.Union([Schema.Struct({
-  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  bucketUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  provider: Schema.optional(Schema.Union([Schema.Literals(["aws", "gcs", "s3"]), Schema.Null])),
-  region: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
-}), Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutBucketSippyResponse>;
+export const PutBucketSippyResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
+  {
+    destination: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          accessKeyId: Schema.optional(
+            Schema.Union([SensitiveString, Schema.Null]),
+          ),
+          account: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          provider: Schema.optional(
+            Schema.Union([Schema.Literal("r2"), Schema.Null]),
+          ),
+        }),
+        Schema.Null,
+      ]),
+    ),
+    enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+    source: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          bucketUrl: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          provider: Schema.optional(
+            Schema.Union([Schema.Literals(["aws", "gcs", "s3"]), Schema.Null]),
+          ),
+          region: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+        }),
+        Schema.Null,
+      ]),
+    ),
+  },
+).pipe(
+  T.ResponsePath("result"),
+) as unknown as Schema.Schema<PutBucketSippyResponse>;
 
 export type PutBucketSippyError =
   | DefaultErrors
@@ -1581,20 +2566,32 @@ export interface DeleteBucketSippyRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const DeleteBucketSippyRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/r2/buckets/{bucketName}/sippy" })) as unknown as Schema.Schema<DeleteBucketSippyRequest>;
+export const DeleteBucketSippyRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    jurisdiction: Schema.optional(
+      Schema.Literals(["default", "eu", "fedramp"]),
+    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/accounts/{account_id}/r2/buckets/{bucketName}/sippy",
+    }),
+  ) as unknown as Schema.Schema<DeleteBucketSippyRequest>;
 
 export interface DeleteBucketSippyResponse {
   enabled?: false | null;
 }
 
-export const DeleteBucketSippyResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  enabled: Schema.optional(Schema.Union([Schema.Literal(false), Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteBucketSippyResponse>;
+export const DeleteBucketSippyResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    enabled: Schema.optional(
+      Schema.Union([Schema.Literal(false), Schema.Null]),
+    ),
+  }).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<DeleteBucketSippyResponse>;
 
 export type DeleteBucketSippyError =
   | DefaultErrors
@@ -1611,7 +2608,6 @@ export const deleteBucketSippy: API.OperationMethod<
   output: DeleteBucketSippyResponse,
   errors: [NoSuchBucket, InvalidRoute],
 }));
-
 
 // =============================================================================
 // Object
@@ -1632,13 +2628,22 @@ export const GetObjectRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   objectName: Schema.String.pipe(T.HttpPath("objectName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  cfR2Jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}" })) as unknown as Schema.Schema<GetObjectRequest>;
+  cfR2Jurisdiction: Schema.optional(
+    Schema.Literals(["default", "eu", "fedramp"]),
+  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+}).pipe(
+  T.Http({
+    method: "GET",
+    path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}",
+  }),
+) as unknown as Schema.Schema<GetObjectRequest>;
 
 export type GetObjectResponse = File | Blob;
 
-export const GetObjectResponse = /*@__PURE__*/ /*#__PURE__*/ UploadableSchema.pipe(T.HttpFormDataFile()).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetObjectResponse>;
+export const GetObjectResponse =
+  /*@__PURE__*/ /*#__PURE__*/ UploadableSchema.pipe(T.HttpFormDataFile()).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<GetObjectResponse>;
 
 export type GetObjectError =
   | DefaultErrors
@@ -1684,22 +2689,59 @@ export const ListObjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   delimiter: Schema.optional(Schema.String).pipe(T.HttpQuery("delimiter")),
   cursor: Schema.optional(Schema.String).pipe(T.HttpQuery("cursor")),
   startAfter: Schema.optional(Schema.String).pipe(T.HttpQuery("start_after")),
-  cfR2Jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects" })) as unknown as Schema.Schema<ListObjectsRequest>;
+  cfR2Jurisdiction: Schema.optional(
+    Schema.Literals(["default", "eu", "fedramp"]),
+  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+}).pipe(
+  T.Http({
+    method: "GET",
+    path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects",
+  }),
+) as unknown as Schema.Schema<ListObjectsRequest>;
 
-export type ListObjectsResponse = ({ key?: string | null; size?: number | null; etag?: string | null; lastModified?: string | null; storageClass?: "Standard" | "InfrequentAccess" | null; ssec?: boolean | null; customMetadata?: unknown | null; httpMetadata?: unknown | null })[];
+export type ListObjectsResponse = {
+  key?: string | null;
+  size?: number | null;
+  etag?: string | null;
+  lastModified?: string | null;
+  storageClass?: "Standard" | "InfrequentAccess" | null;
+  ssec?: boolean | null;
+  customMetadata?: unknown | null;
+  httpMetadata?: unknown | null;
+}[];
 
-export const ListObjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Array(Schema.Struct({
-  key: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  size: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  etag: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  lastModified: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  storageClass: Schema.optional(Schema.Union([Schema.Literals(["Standard", "InfrequentAccess"]), Schema.Null])),
-  ssec: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-  customMetadata: Schema.optional(Schema.Union([Schema.Unknown, Schema.Null])),
-  httpMetadata: Schema.optional(Schema.Union([Schema.Unknown, Schema.Null]))
-}).pipe(Schema.encodeKeys({ key: "key", size: "size", etag: "etag", lastModified: "last_modified", storageClass: "storage_class", ssec: "ssec", customMetadata: "custom_metadata", httpMetadata: "http_metadata" }))).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListObjectsResponse>;
+export const ListObjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Array(
+  Schema.Struct({
+    key: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    size: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    etag: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    lastModified: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    storageClass: Schema.optional(
+      Schema.Union([
+        Schema.Literals(["Standard", "InfrequentAccess"]),
+        Schema.Null,
+      ]),
+    ),
+    ssec: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+    customMetadata: Schema.optional(
+      Schema.Union([Schema.Unknown, Schema.Null]),
+    ),
+    httpMetadata: Schema.optional(Schema.Union([Schema.Unknown, Schema.Null])),
+  }).pipe(
+    Schema.encodeKeys({
+      key: "key",
+      size: "size",
+      etag: "etag",
+      lastModified: "last_modified",
+      storageClass: "storage_class",
+      ssec: "ssec",
+      customMetadata: "custom_metadata",
+      httpMetadata: "http_metadata",
+    }),
+  ),
+).pipe(
+  T.ResponsePath("result"),
+) as unknown as Schema.Schema<ListObjectsResponse>;
 
 export type ListObjectsError =
   | DefaultErrors
@@ -1750,22 +2792,46 @@ export const PutObjectRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   objectName: Schema.String.pipe(T.HttpPath("objectName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  cfR2Jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  contentType: Schema.optional(Schema.String).pipe(T.HttpHeader("content-type")),
-  contentDisposition: Schema.optional(Schema.String).pipe(T.HttpHeader("content-disposition")),
-  contentEncoding: Schema.optional(Schema.String).pipe(T.HttpHeader("content-encoding")),
-  contentLanguage: Schema.optional(Schema.String).pipe(T.HttpHeader("content-language")),
-  contentLength: Schema.optional(Schema.String).pipe(T.HttpHeader("content-length")),
-  cacheControl: Schema.optional(Schema.String).pipe(T.HttpHeader("cache-control")),
+  cfR2Jurisdiction: Schema.optional(
+    Schema.Literals(["default", "eu", "fedramp"]),
+  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  contentType: Schema.optional(Schema.String).pipe(
+    T.HttpHeader("content-type"),
+  ),
+  contentDisposition: Schema.optional(Schema.String).pipe(
+    T.HttpHeader("content-disposition"),
+  ),
+  contentEncoding: Schema.optional(Schema.String).pipe(
+    T.HttpHeader("content-encoding"),
+  ),
+  contentLanguage: Schema.optional(Schema.String).pipe(
+    T.HttpHeader("content-language"),
+  ),
+  contentLength: Schema.optional(Schema.String).pipe(
+    T.HttpHeader("content-length"),
+  ),
+  cacheControl: Schema.optional(Schema.String).pipe(
+    T.HttpHeader("cache-control"),
+  ),
   expires: Schema.optional(Schema.String).pipe(T.HttpHeader("expires")),
-  cfR2StorageClass: Schema.optional(Schema.Literals(["Standard", "InfrequentAccess"])).pipe(T.HttpHeader("cf-r2-storage-class")),
-  body: UploadableSchema.pipe(T.HttpFormDataFile()).pipe(T.HttpBody())
-})
-  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}", contentType: "multipart" })) as unknown as Schema.Schema<PutObjectRequest>;
+  cfR2StorageClass: Schema.optional(
+    Schema.Literals(["Standard", "InfrequentAccess"]),
+  ).pipe(T.HttpHeader("cf-r2-storage-class")),
+  body: UploadableSchema.pipe(T.HttpFormDataFile()).pipe(T.HttpBody()),
+}).pipe(
+  T.Http({
+    method: "PUT",
+    path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}",
+    contentType: "multipart",
+  }),
+) as unknown as Schema.Schema<PutObjectRequest>;
 
 export type PutObjectResponse = unknown;
 
-export const PutObjectResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutObjectResponse>;
+export const PutObjectResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<PutObjectResponse>;
 
 export type PutObjectError =
   | DefaultErrors
@@ -1800,27 +2866,81 @@ export const DeleteObjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
   prefix: Schema.optional(Schema.String).pipe(T.HttpQuery("prefix")),
-  cfR2Jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  body: Schema.optional(Schema.Array(Schema.String)).pipe(T.HttpBody())
-})
-  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects" })) as unknown as Schema.Schema<DeleteObjectsRequest>;
+  cfR2Jurisdiction: Schema.optional(
+    Schema.Literals(["default", "eu", "fedramp"]),
+  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  body: Schema.optional(Schema.Array(Schema.String)).pipe(T.HttpBody()),
+}).pipe(
+  T.Http({
+    method: "DELETE",
+    path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects",
+  }),
+) as unknown as Schema.Schema<DeleteObjectsRequest>;
 
-export type DeleteObjectsResponse = ({ key?: string | null })[] | { id?: string | null; jobType?: "prefixDelete" | null; status?: "ENQUEUED" | "RUNNING" | "COMPLETED" | "FAILED" | "CANCELLED" | null; startTime?: string | null; endTime?: string | null; prefixDelete?: { prefix?: string | null; deletedObjects?: number | null; isBucketClear?: boolean | null } | null };
+export type DeleteObjectsResponse =
+  | { key?: string | null }[]
+  | {
+      id?: string | null;
+      jobType?: "prefixDelete" | null;
+      status?:
+        | "ENQUEUED"
+        | "RUNNING"
+        | "COMPLETED"
+        | "FAILED"
+        | "CANCELLED"
+        | null;
+      startTime?: string | null;
+      endTime?: string | null;
+      prefixDelete?: {
+        prefix?: string | null;
+        deletedObjects?: number | null;
+        isBucketClear?: boolean | null;
+      } | null;
+    };
 
-export const DeleteObjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([Schema.Array(Schema.Struct({
-  key: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
-})), Schema.Struct({
-  id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  jobType: Schema.optional(Schema.Union([Schema.Literal("prefixDelete"), Schema.Null])),
-  status: Schema.optional(Schema.Union([Schema.Literals(["ENQUEUED", "RUNNING", "COMPLETED", "FAILED", "CANCELLED"]), Schema.Null])),
-  startTime: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  endTime: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  prefixDelete: Schema.optional(Schema.Union([Schema.Struct({
-    prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    deletedObjects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    isBucketClear: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null]))
-  }), Schema.Null]))
-})]).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteObjectsResponse>;
+export const DeleteObjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
+  Schema.Array(
+    Schema.Struct({
+      key: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    }),
+  ),
+  Schema.Struct({
+    id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    jobType: Schema.optional(
+      Schema.Union([Schema.Literal("prefixDelete"), Schema.Null]),
+    ),
+    status: Schema.optional(
+      Schema.Union([
+        Schema.Literals([
+          "ENQUEUED",
+          "RUNNING",
+          "COMPLETED",
+          "FAILED",
+          "CANCELLED",
+        ]),
+        Schema.Null,
+      ]),
+    ),
+    startTime: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    endTime: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    prefixDelete: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          deletedObjects: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+          isBucketClear: Schema.optional(
+            Schema.Union([Schema.Boolean, Schema.Null]),
+          ),
+        }),
+        Schema.Null,
+      ]),
+    ),
+  }),
+]).pipe(
+  T.ResponsePath("result"),
+) as unknown as Schema.Schema<DeleteObjectsResponse>;
 
 export type DeleteObjectsError =
   | DefaultErrors
@@ -1854,13 +2974,22 @@ export const DeleteObjectRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   objectName: Schema.String.pipe(T.HttpPath("objectName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  cfR2Jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
-})
-  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}" })) as unknown as Schema.Schema<DeleteObjectRequest>;
+  cfR2Jurisdiction: Schema.optional(
+    Schema.Literals(["default", "eu", "fedramp"]),
+  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+}).pipe(
+  T.Http({
+    method: "DELETE",
+    path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}",
+  }),
+) as unknown as Schema.Schema<DeleteObjectRequest>;
 
 export type DeleteObjectResponse = unknown;
 
-export const DeleteObjectResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteObjectResponse>;
+export const DeleteObjectResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<DeleteObjectResponse>;
 
 export type DeleteObjectError =
   | DefaultErrors
@@ -1878,7 +3007,6 @@ export const deleteObject: API.OperationMethod<
   output: DeleteObjectResponse,
   errors: [NoSuchBucket, InvalidRoute, NoRoute],
 }));
-
 
 // =============================================================================
 // SuperSlurperConnectivityPrecheck
@@ -1901,30 +3029,39 @@ export interface SourceSuperSlurperConnectivityPrecheckRequest {
   region?: string | null;
 }
 
-export const SourceSuperSlurperConnectivityPrecheckRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  bucket: Schema.String,
-  secret: Schema.Struct({
-  accessKeyId: SensitiveString,
-  secretAccessKey: SensitiveString
-}),
-  vendor: Schema.Literal("s3"),
-  endpoint: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  region: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
-})
-  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/slurper/source/connectivity-precheck" })) as unknown as Schema.Schema<SourceSuperSlurperConnectivityPrecheckRequest>;
+export const SourceSuperSlurperConnectivityPrecheckRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    bucket: Schema.String,
+    secret: Schema.Struct({
+      accessKeyId: SensitiveString,
+      secretAccessKey: SensitiveString,
+    }),
+    vendor: Schema.Literal("s3"),
+    endpoint: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    region: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/accounts/{account_id}/slurper/source/connectivity-precheck",
+    }),
+  ) as unknown as Schema.Schema<SourceSuperSlurperConnectivityPrecheckRequest>;
 
 export interface SourceSuperSlurperConnectivityPrecheckResponse {
   connectivityStatus?: "success" | "error" | null;
 }
 
-export const SourceSuperSlurperConnectivityPrecheckResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  connectivityStatus: Schema.optional(Schema.Union([Schema.Literals(["success", "error"]), Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<SourceSuperSlurperConnectivityPrecheckResponse>;
+export const SourceSuperSlurperConnectivityPrecheckResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    connectivityStatus: Schema.optional(
+      Schema.Union([Schema.Literals(["success", "error"]), Schema.Null]),
+    ),
+  }).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<SourceSuperSlurperConnectivityPrecheckResponse>;
 
-export type SourceSuperSlurperConnectivityPrecheckError =
-  | DefaultErrors;
+export type SourceSuperSlurperConnectivityPrecheckError = DefaultErrors;
 
 export const sourceSuperSlurperConnectivityPrecheck: API.OperationMethod<
   SourceSuperSlurperConnectivityPrecheckRequest,
@@ -1950,28 +3087,39 @@ export interface TargetSuperSlurperConnectivityPrecheckRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const TargetSuperSlurperConnectivityPrecheckRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  bucket: Schema.String,
-  secret: Schema.Struct({
-  accessKeyId: SensitiveString,
-  secretAccessKey: SensitiveString
-}),
-  vendor: Schema.Literal("r2"),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"]))
-})
-  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/slurper/target/connectivity-precheck" })) as unknown as Schema.Schema<TargetSuperSlurperConnectivityPrecheckRequest>;
+export const TargetSuperSlurperConnectivityPrecheckRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    bucket: Schema.String,
+    secret: Schema.Struct({
+      accessKeyId: SensitiveString,
+      secretAccessKey: SensitiveString,
+    }),
+    vendor: Schema.Literal("r2"),
+    jurisdiction: Schema.optional(
+      Schema.Literals(["default", "eu", "fedramp"]),
+    ),
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/accounts/{account_id}/slurper/target/connectivity-precheck",
+    }),
+  ) as unknown as Schema.Schema<TargetSuperSlurperConnectivityPrecheckRequest>;
 
 export interface TargetSuperSlurperConnectivityPrecheckResponse {
   connectivityStatus?: "success" | "error" | null;
 }
 
-export const TargetSuperSlurperConnectivityPrecheckResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  connectivityStatus: Schema.optional(Schema.Union([Schema.Literals(["success", "error"]), Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<TargetSuperSlurperConnectivityPrecheckResponse>;
+export const TargetSuperSlurperConnectivityPrecheckResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    connectivityStatus: Schema.optional(
+      Schema.Union([Schema.Literals(["success", "error"]), Schema.Null]),
+    ),
+  }).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<TargetSuperSlurperConnectivityPrecheckResponse>;
 
-export type TargetSuperSlurperConnectivityPrecheckError =
-  | DefaultErrors;
+export type TargetSuperSlurperConnectivityPrecheckError = DefaultErrors;
 
 export const targetSuperSlurperConnectivityPrecheck: API.OperationMethod<
   TargetSuperSlurperConnectivityPrecheckRequest,
@@ -1984,7 +3132,6 @@ export const targetSuperSlurperConnectivityPrecheck: API.OperationMethod<
   errors: [],
 }));
 
-
 // =============================================================================
 // SuperSlurperJob
 // =============================================================================
@@ -1994,55 +3141,138 @@ export interface GetSuperSlurperJobRequest {
   accountId: string;
 }
 
-export const GetSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  jobId: Schema.String.pipe(T.HttpPath("jobId")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id"))
-})
-  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/slurper/jobs/{jobId}" })) as unknown as Schema.Schema<GetSuperSlurperJobRequest>;
+export const GetSuperSlurperJobRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    jobId: Schema.String.pipe(T.HttpPath("jobId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/slurper/jobs/{jobId}",
+    }),
+  ) as unknown as Schema.Schema<GetSuperSlurperJobRequest>;
 
 export interface GetSuperSlurperJobResponse {
   id?: string | null;
   createdAt?: string | null;
   finishedAt?: string | null;
   overwrite?: boolean | null;
-  source?: { bucket?: string | null; endpoint?: string | null; keys?: string[] | null; pathPrefix?: string | null; vendor?: "s3" | null } | { bucket?: string | null; keys?: string[] | null; pathPrefix?: string | null; vendor?: "gcs" | null } | { bucket?: string | null; jurisdiction?: "default" | "eu" | "fedramp" | null; keys?: string[] | null; pathPrefix?: string | null; vendor?: "r2" | null } | null;
+  source?:
+    | {
+        bucket?: string | null;
+        endpoint?: string | null;
+        keys?: string[] | null;
+        pathPrefix?: string | null;
+        vendor?: "s3" | null;
+      }
+    | {
+        bucket?: string | null;
+        keys?: string[] | null;
+        pathPrefix?: string | null;
+        vendor?: "gcs" | null;
+      }
+    | {
+        bucket?: string | null;
+        jurisdiction?: "default" | "eu" | "fedramp" | null;
+        keys?: string[] | null;
+        pathPrefix?: string | null;
+        vendor?: "r2" | null;
+      }
+    | null;
   status?: "running" | "paused" | "aborted" | "completed" | null;
-  target?: { bucket?: string | null; jurisdiction?: "default" | "eu" | "fedramp" | null; vendor?: "r2" | null } | null;
+  target?: {
+    bucket?: string | null;
+    jurisdiction?: "default" | "eu" | "fedramp" | null;
+    vendor?: "r2" | null;
+  } | null;
 }
 
-export const GetSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  finishedAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  overwrite: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-  source: Schema.optional(Schema.Union([Schema.Union([Schema.Struct({
-  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  endpoint: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  keys: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
-  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  vendor: Schema.optional(Schema.Union([Schema.Literal("s3"), Schema.Null]))
-}), Schema.Struct({
-  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  keys: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
-  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  vendor: Schema.optional(Schema.Union([Schema.Literal("gcs"), Schema.Null]))
-}), Schema.Struct({
-  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
-  keys: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
-  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  vendor: Schema.optional(Schema.Union([Schema.Literal("r2"), Schema.Null]))
-})]), Schema.Null])),
-  status: Schema.optional(Schema.Union([Schema.Literals(["running", "paused", "aborted", "completed"]), Schema.Null])),
-  target: Schema.optional(Schema.Union([Schema.Struct({
-  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
-  vendor: Schema.optional(Schema.Union([Schema.Literal("r2"), Schema.Null]))
-}), Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetSuperSlurperJobResponse>;
+export const GetSuperSlurperJobResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    finishedAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    overwrite: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+    source: Schema.optional(
+      Schema.Union([
+        Schema.Union([
+          Schema.Struct({
+            bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+            endpoint: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+            keys: Schema.optional(
+              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+            ),
+            pathPrefix: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+            vendor: Schema.optional(
+              Schema.Union([Schema.Literal("s3"), Schema.Null]),
+            ),
+          }),
+          Schema.Struct({
+            bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+            keys: Schema.optional(
+              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+            ),
+            pathPrefix: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+            vendor: Schema.optional(
+              Schema.Union([Schema.Literal("gcs"), Schema.Null]),
+            ),
+          }),
+          Schema.Struct({
+            bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+            jurisdiction: Schema.optional(
+              Schema.Union([
+                Schema.Literals(["default", "eu", "fedramp"]),
+                Schema.Null,
+              ]),
+            ),
+            keys: Schema.optional(
+              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+            ),
+            pathPrefix: Schema.optional(
+              Schema.Union([Schema.String, Schema.Null]),
+            ),
+            vendor: Schema.optional(
+              Schema.Union([Schema.Literal("r2"), Schema.Null]),
+            ),
+          }),
+        ]),
+        Schema.Null,
+      ]),
+    ),
+    status: Schema.optional(
+      Schema.Union([
+        Schema.Literals(["running", "paused", "aborted", "completed"]),
+        Schema.Null,
+      ]),
+    ),
+    target: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          jurisdiction: Schema.optional(
+            Schema.Union([
+              Schema.Literals(["default", "eu", "fedramp"]),
+              Schema.Null,
+            ]),
+          ),
+          vendor: Schema.optional(
+            Schema.Union([Schema.Literal("r2"), Schema.Null]),
+          ),
+        }),
+        Schema.Null,
+      ]),
+    ),
+  }).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<GetSuperSlurperJobResponse>;
 
-export type GetSuperSlurperJobError =
-  | DefaultErrors;
+export type GetSuperSlurperJobError = DefaultErrors;
 
 export const getSuperSlurperJob: API.OperationMethod<
   GetSuperSlurperJobRequest,
@@ -2064,52 +3294,148 @@ export interface ListSuperSlurperJobsRequest {
   offset?: number;
 }
 
-export const ListSuperSlurperJobsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  limit: Schema.optional(Schema.Number).pipe(T.HttpQuery("limit")),
-  offset: Schema.optional(Schema.Number).pipe(T.HttpQuery("offset"))
-})
-  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/slurper/jobs" })) as unknown as Schema.Schema<ListSuperSlurperJobsRequest>;
+export const ListSuperSlurperJobsRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    limit: Schema.optional(Schema.Number).pipe(T.HttpQuery("limit")),
+    offset: Schema.optional(Schema.Number).pipe(T.HttpQuery("offset")),
+  }).pipe(
+    T.Http({ method: "GET", path: "/accounts/{account_id}/slurper/jobs" }),
+  ) as unknown as Schema.Schema<ListSuperSlurperJobsRequest>;
 
 export interface ListSuperSlurperJobsResponse {
-  result: ({ id?: string | null; createdAt?: string | null; finishedAt?: string | null; overwrite?: boolean | null; source?: { bucket?: string | null; endpoint?: string | null; keys?: string[] | null; pathPrefix?: string | null; vendor?: "s3" | null } | { bucket?: string | null; keys?: string[] | null; pathPrefix?: string | null; vendor?: "gcs" | null } | { bucket?: string | null; jurisdiction?: "default" | "eu" | "fedramp" | null; keys?: string[] | null; pathPrefix?: string | null; vendor?: "r2" | null } | null; status?: "running" | "paused" | "aborted" | "completed" | null; target?: { bucket?: string | null; jurisdiction?: "default" | "eu" | "fedramp" | null; vendor?: "r2" | null } | null })[];
+  result: {
+    id?: string | null;
+    createdAt?: string | null;
+    finishedAt?: string | null;
+    overwrite?: boolean | null;
+    source?:
+      | {
+          bucket?: string | null;
+          endpoint?: string | null;
+          keys?: string[] | null;
+          pathPrefix?: string | null;
+          vendor?: "s3" | null;
+        }
+      | {
+          bucket?: string | null;
+          keys?: string[] | null;
+          pathPrefix?: string | null;
+          vendor?: "gcs" | null;
+        }
+      | {
+          bucket?: string | null;
+          jurisdiction?: "default" | "eu" | "fedramp" | null;
+          keys?: string[] | null;
+          pathPrefix?: string | null;
+          vendor?: "r2" | null;
+        }
+      | null;
+    status?: "running" | "paused" | "aborted" | "completed" | null;
+    target?: {
+      bucket?: string | null;
+      jurisdiction?: "default" | "eu" | "fedramp" | null;
+      vendor?: "r2" | null;
+    } | null;
+  }[];
 }
 
-export const ListSuperSlurperJobsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  result: Schema.Array(Schema.Struct({
-  id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  finishedAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  overwrite: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-  source: Schema.optional(Schema.Union([Schema.Union([Schema.Struct({
-    bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    endpoint: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    keys: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
-    pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    vendor: Schema.optional(Schema.Union([Schema.Literal("s3"), Schema.Null]))
-  }), Schema.Struct({
-    bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    keys: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
-    pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    vendor: Schema.optional(Schema.Union([Schema.Literal("gcs"), Schema.Null]))
-  }), Schema.Struct({
-    bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
-    keys: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
-    pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    vendor: Schema.optional(Schema.Union([Schema.Literal("r2"), Schema.Null]))
-  })]), Schema.Null])),
-  status: Schema.optional(Schema.Union([Schema.Literals(["running", "paused", "aborted", "completed"]), Schema.Null])),
-  target: Schema.optional(Schema.Union([Schema.Struct({
-    bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
-    vendor: Schema.optional(Schema.Union([Schema.Literal("r2"), Schema.Null]))
-  }), Schema.Null]))
-}))
-}) as unknown as Schema.Schema<ListSuperSlurperJobsResponse>;
+export const ListSuperSlurperJobsResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    result: Schema.Array(
+      Schema.Struct({
+        id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+        createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+        finishedAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+        overwrite: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+        source: Schema.optional(
+          Schema.Union([
+            Schema.Union([
+              Schema.Struct({
+                bucket: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                endpoint: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                keys: Schema.optional(
+                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+                ),
+                pathPrefix: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                vendor: Schema.optional(
+                  Schema.Union([Schema.Literal("s3"), Schema.Null]),
+                ),
+              }),
+              Schema.Struct({
+                bucket: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                keys: Schema.optional(
+                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+                ),
+                pathPrefix: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                vendor: Schema.optional(
+                  Schema.Union([Schema.Literal("gcs"), Schema.Null]),
+                ),
+              }),
+              Schema.Struct({
+                bucket: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                jurisdiction: Schema.optional(
+                  Schema.Union([
+                    Schema.Literals(["default", "eu", "fedramp"]),
+                    Schema.Null,
+                  ]),
+                ),
+                keys: Schema.optional(
+                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
+                ),
+                pathPrefix: Schema.optional(
+                  Schema.Union([Schema.String, Schema.Null]),
+                ),
+                vendor: Schema.optional(
+                  Schema.Union([Schema.Literal("r2"), Schema.Null]),
+                ),
+              }),
+            ]),
+            Schema.Null,
+          ]),
+        ),
+        status: Schema.optional(
+          Schema.Union([
+            Schema.Literals(["running", "paused", "aborted", "completed"]),
+            Schema.Null,
+          ]),
+        ),
+        target: Schema.optional(
+          Schema.Union([
+            Schema.Struct({
+              bucket: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+              jurisdiction: Schema.optional(
+                Schema.Union([
+                  Schema.Literals(["default", "eu", "fedramp"]),
+                  Schema.Null,
+                ]),
+              ),
+              vendor: Schema.optional(
+                Schema.Union([Schema.Literal("r2"), Schema.Null]),
+              ),
+            }),
+            Schema.Null,
+          ]),
+        ),
+      }),
+    ),
+  }) as unknown as Schema.Schema<ListSuperSlurperJobsResponse>;
 
-export type ListSuperSlurperJobsError =
-  | DefaultErrors;
+export type ListSuperSlurperJobsError = DefaultErrors;
 
 export const listSuperSlurperJobs: API.PaginatedOperationMethod<
   ListSuperSlurperJobsRequest,
@@ -2132,64 +3458,112 @@ export interface CreateSuperSlurperJobRequest {
   /** Body param: */
   overwrite?: boolean;
   /** Body param: */
-  source?: { bucket: string; secret: { accessKeyId: string; secretAccessKey: string }; vendor: "s3"; endpoint?: string | null; pathPrefix?: string | null; region?: string | null } | { bucket: string; secret: { clientEmail: string; privateKey: string }; vendor: "gcs"; pathPrefix?: string | null } | { bucket: string; secret: { accessKeyId: string; secretAccessKey: string }; vendor: "r2"; jurisdiction?: "default" | "eu" | "fedramp"; pathPrefix?: string | null };
+  source?:
+    | {
+        bucket: string;
+        secret: { accessKeyId: string; secretAccessKey: string };
+        vendor: "s3";
+        endpoint?: string | null;
+        pathPrefix?: string | null;
+        region?: string | null;
+      }
+    | {
+        bucket: string;
+        secret: { clientEmail: string; privateKey: string };
+        vendor: "gcs";
+        pathPrefix?: string | null;
+      }
+    | {
+        bucket: string;
+        secret: { accessKeyId: string; secretAccessKey: string };
+        vendor: "r2";
+        jurisdiction?: "default" | "eu" | "fedramp";
+        pathPrefix?: string | null;
+      };
   /** Body param: */
-  target?: { bucket: string; secret: { accessKeyId: string; secretAccessKey: string }; vendor: "r2"; jurisdiction?: "default" | "eu" | "fedramp" };
+  target?: {
+    bucket: string;
+    secret: { accessKeyId: string; secretAccessKey: string };
+    vendor: "r2";
+    jurisdiction?: "default" | "eu" | "fedramp";
+  };
 }
 
-export const CreateSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  overwrite: Schema.optional(Schema.Boolean),
-  source: Schema.optional(Schema.Union([Schema.Struct({
-  bucket: Schema.String,
-  secret: Schema.Struct({
-    accessKeyId: SensitiveString,
-    secretAccessKey: SensitiveString
-  }),
-  vendor: Schema.Literal("s3"),
-  endpoint: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  region: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
-}), Schema.Struct({
-  bucket: Schema.String,
-  secret: Schema.Struct({
-    clientEmail: Schema.String,
-    privateKey: SensitiveString
-  }),
-  vendor: Schema.Literal("gcs"),
-  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
-}), Schema.Struct({
-  bucket: Schema.String,
-  secret: Schema.Struct({
-    accessKeyId: SensitiveString,
-    secretAccessKey: SensitiveString
-  }),
-  vendor: Schema.Literal("r2"),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])),
-  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
-})])),
-  target: Schema.optional(Schema.Struct({
-  bucket: Schema.String,
-  secret: Schema.Struct({
-    accessKeyId: SensitiveString,
-    secretAccessKey: SensitiveString
-  }),
-  vendor: Schema.Literal("r2"),
-  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"]))
-}))
-})
-  .pipe(T.Http({ method: "POST", path: "/accounts/{account_id}/slurper/jobs" })) as unknown as Schema.Schema<CreateSuperSlurperJobRequest>;
+export const CreateSuperSlurperJobRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    overwrite: Schema.optional(Schema.Boolean),
+    source: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          bucket: Schema.String,
+          secret: Schema.Struct({
+            accessKeyId: SensitiveString,
+            secretAccessKey: SensitiveString,
+          }),
+          vendor: Schema.Literal("s3"),
+          endpoint: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          pathPrefix: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+          region: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+        }),
+        Schema.Struct({
+          bucket: Schema.String,
+          secret: Schema.Struct({
+            clientEmail: Schema.String,
+            privateKey: SensitiveString,
+          }),
+          vendor: Schema.Literal("gcs"),
+          pathPrefix: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+        }),
+        Schema.Struct({
+          bucket: Schema.String,
+          secret: Schema.Struct({
+            accessKeyId: SensitiveString,
+            secretAccessKey: SensitiveString,
+          }),
+          vendor: Schema.Literal("r2"),
+          jurisdiction: Schema.optional(
+            Schema.Literals(["default", "eu", "fedramp"]),
+          ),
+          pathPrefix: Schema.optional(
+            Schema.Union([Schema.String, Schema.Null]),
+          ),
+        }),
+      ]),
+    ),
+    target: Schema.optional(
+      Schema.Struct({
+        bucket: Schema.String,
+        secret: Schema.Struct({
+          accessKeyId: SensitiveString,
+          secretAccessKey: SensitiveString,
+        }),
+        vendor: Schema.Literal("r2"),
+        jurisdiction: Schema.optional(
+          Schema.Literals(["default", "eu", "fedramp"]),
+        ),
+      }),
+    ),
+  }).pipe(
+    T.Http({ method: "POST", path: "/accounts/{account_id}/slurper/jobs" }),
+  ) as unknown as Schema.Schema<CreateSuperSlurperJobRequest>;
 
 export interface CreateSuperSlurperJobResponse {
   id?: string | null;
 }
 
-export const CreateSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  id: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<CreateSuperSlurperJobResponse>;
+export const CreateSuperSlurperJobResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  }).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<CreateSuperSlurperJobResponse>;
 
-export type CreateSuperSlurperJobError =
-  | DefaultErrors;
+export type CreateSuperSlurperJobError = DefaultErrors;
 
 export const createSuperSlurperJob: API.OperationMethod<
   CreateSuperSlurperJobRequest,
@@ -2207,18 +3581,25 @@ export interface AbortSuperSlurperJobRequest {
   accountId: string;
 }
 
-export const AbortSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  jobId: Schema.String.pipe(T.HttpPath("jobId")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id"))
-})
-  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/slurper/jobs/{jobId}/abort" })) as unknown as Schema.Schema<AbortSuperSlurperJobRequest>;
+export const AbortSuperSlurperJobRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    jobId: Schema.String.pipe(T.HttpPath("jobId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/accounts/{account_id}/slurper/jobs/{jobId}/abort",
+    }),
+  ) as unknown as Schema.Schema<AbortSuperSlurperJobRequest>;
 
 export type AbortSuperSlurperJobResponse = string;
 
-export const AbortSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<AbortSuperSlurperJobResponse>;
+export const AbortSuperSlurperJobResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<AbortSuperSlurperJobResponse>;
 
-export type AbortSuperSlurperJobError =
-  | DefaultErrors;
+export type AbortSuperSlurperJobError = DefaultErrors;
 
 export const abortSuperSlurperJob: API.OperationMethod<
   AbortSuperSlurperJobRequest,
@@ -2236,18 +3617,25 @@ export interface PauseSuperSlurperJobRequest {
   accountId: string;
 }
 
-export const PauseSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  jobId: Schema.String.pipe(T.HttpPath("jobId")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id"))
-})
-  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/slurper/jobs/{jobId}/pause" })) as unknown as Schema.Schema<PauseSuperSlurperJobRequest>;
+export const PauseSuperSlurperJobRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    jobId: Schema.String.pipe(T.HttpPath("jobId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/accounts/{account_id}/slurper/jobs/{jobId}/pause",
+    }),
+  ) as unknown as Schema.Schema<PauseSuperSlurperJobRequest>;
 
 export type PauseSuperSlurperJobResponse = string;
 
-export const PauseSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PauseSuperSlurperJobResponse>;
+export const PauseSuperSlurperJobResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<PauseSuperSlurperJobResponse>;
 
-export type PauseSuperSlurperJobError =
-  | DefaultErrors;
+export type PauseSuperSlurperJobError = DefaultErrors;
 
 export const pauseSuperSlurperJob: API.OperationMethod<
   PauseSuperSlurperJobRequest,
@@ -2265,11 +3653,16 @@ export interface ProgressSuperSlurperJobRequest {
   accountId: string;
 }
 
-export const ProgressSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  jobId: Schema.String.pipe(T.HttpPath("jobId")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id"))
-})
-  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/slurper/jobs/{jobId}/progress" })) as unknown as Schema.Schema<ProgressSuperSlurperJobRequest>;
+export const ProgressSuperSlurperJobRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    jobId: Schema.String.pipe(T.HttpPath("jobId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/slurper/jobs/{jobId}/progress",
+    }),
+  ) as unknown as Schema.Schema<ProgressSuperSlurperJobRequest>;
 
 export interface ProgressSuperSlurperJobResponse {
   id?: string | null;
@@ -2281,18 +3674,27 @@ export interface ProgressSuperSlurperJobResponse {
   transferredObjects?: number | null;
 }
 
-export const ProgressSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  failedObjects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  objects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  skippedObjects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  status: Schema.optional(Schema.Union([Schema.Literals(["running", "paused", "aborted", "completed"]), Schema.Null])),
-  transferredObjects: Schema.optional(Schema.Union([Schema.Number, Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ProgressSuperSlurperJobResponse>;
+export const ProgressSuperSlurperJobResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    failedObjects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    objects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    skippedObjects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    status: Schema.optional(
+      Schema.Union([
+        Schema.Literals(["running", "paused", "aborted", "completed"]),
+        Schema.Null,
+      ]),
+    ),
+    transferredObjects: Schema.optional(
+      Schema.Union([Schema.Number, Schema.Null]),
+    ),
+  }).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<ProgressSuperSlurperJobResponse>;
 
-export type ProgressSuperSlurperJobError =
-  | DefaultErrors;
+export type ProgressSuperSlurperJobError = DefaultErrors;
 
 export const progressSuperSlurperJob: API.OperationMethod<
   ProgressSuperSlurperJobRequest,
@@ -2310,18 +3712,25 @@ export interface ResumeSuperSlurperJobRequest {
   accountId: string;
 }
 
-export const ResumeSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  jobId: Schema.String.pipe(T.HttpPath("jobId")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id"))
-})
-  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/slurper/jobs/{jobId}/resume" })) as unknown as Schema.Schema<ResumeSuperSlurperJobRequest>;
+export const ResumeSuperSlurperJobRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    jobId: Schema.String.pipe(T.HttpPath("jobId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/accounts/{account_id}/slurper/jobs/{jobId}/resume",
+    }),
+  ) as unknown as Schema.Schema<ResumeSuperSlurperJobRequest>;
 
 export type ResumeSuperSlurperJobResponse = string;
 
-export const ResumeSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ResumeSuperSlurperJobResponse>;
+export const ResumeSuperSlurperJobResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<ResumeSuperSlurperJobResponse>;
 
-export type ResumeSuperSlurperJobError =
-  | DefaultErrors;
+export type ResumeSuperSlurperJobError = DefaultErrors;
 
 export const resumeSuperSlurperJob: API.OperationMethod<
   ResumeSuperSlurperJobRequest,
@@ -2333,7 +3742,6 @@ export const resumeSuperSlurperJob: API.OperationMethod<
   output: ResumeSuperSlurperJobResponse,
   errors: [],
 }));
-
 
 // =============================================================================
 // SuperSlurperJobLog
@@ -2349,30 +3757,80 @@ export interface ListSuperSlurperJobLogsRequest {
   offset?: number;
 }
 
-export const ListSuperSlurperJobLogsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  jobId: Schema.String.pipe(T.HttpPath("jobId")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  limit: Schema.optional(Schema.Number).pipe(T.HttpQuery("limit")),
-  offset: Schema.optional(Schema.Number).pipe(T.HttpQuery("offset"))
-})
-  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/slurper/jobs/{jobId}/logs" })) as unknown as Schema.Schema<ListSuperSlurperJobLogsRequest>;
+export const ListSuperSlurperJobLogsRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    jobId: Schema.String.pipe(T.HttpPath("jobId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    limit: Schema.optional(Schema.Number).pipe(T.HttpQuery("limit")),
+    offset: Schema.optional(Schema.Number).pipe(T.HttpQuery("offset")),
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/slurper/jobs/{jobId}/logs",
+    }),
+  ) as unknown as Schema.Schema<ListSuperSlurperJobLogsRequest>;
 
 export interface ListSuperSlurperJobLogsResponse {
-  result: ({ createdAt?: string | null; job?: string | null; logType?: "migrationStart" | "migrationComplete" | "migrationAbort" | "migrationError" | "migrationPause" | "migrationResume" | "migrationErrorFailedContinuation" | "importErrorRetryExhaustion" | "importSkippedStorageClass" | "importSkippedOversized" | "importSkippedEmptyObject" | "importSkippedUnsupportedContentType" | "importSkippedExcludedContentType" | "importSkippedInvalidMedia" | "importSkippedRequiresRetrieval" | null; message?: string | null; objectKey?: string | null })[];
+  result: {
+    createdAt?: string | null;
+    job?: string | null;
+    logType?:
+      | "migrationStart"
+      | "migrationComplete"
+      | "migrationAbort"
+      | "migrationError"
+      | "migrationPause"
+      | "migrationResume"
+      | "migrationErrorFailedContinuation"
+      | "importErrorRetryExhaustion"
+      | "importSkippedStorageClass"
+      | "importSkippedOversized"
+      | "importSkippedEmptyObject"
+      | "importSkippedUnsupportedContentType"
+      | "importSkippedExcludedContentType"
+      | "importSkippedInvalidMedia"
+      | "importSkippedRequiresRetrieval"
+      | null;
+    message?: string | null;
+    objectKey?: string | null;
+  }[];
 }
 
-export const ListSuperSlurperJobLogsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  result: Schema.Array(Schema.Struct({
-  createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  job: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  logType: Schema.optional(Schema.Union([Schema.Literals(["migrationStart", "migrationComplete", "migrationAbort", "migrationError", "migrationPause", "migrationResume", "migrationErrorFailedContinuation", "importErrorRetryExhaustion", "importSkippedStorageClass", "importSkippedOversized", "importSkippedEmptyObject", "importSkippedUnsupportedContentType", "importSkippedExcludedContentType", "importSkippedInvalidMedia", "importSkippedRequiresRetrieval"]), Schema.Null])),
-  message: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  objectKey: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
-}))
-}) as unknown as Schema.Schema<ListSuperSlurperJobLogsResponse>;
+export const ListSuperSlurperJobLogsResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    result: Schema.Array(
+      Schema.Struct({
+        createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+        job: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+        logType: Schema.optional(
+          Schema.Union([
+            Schema.Literals([
+              "migrationStart",
+              "migrationComplete",
+              "migrationAbort",
+              "migrationError",
+              "migrationPause",
+              "migrationResume",
+              "migrationErrorFailedContinuation",
+              "importErrorRetryExhaustion",
+              "importSkippedStorageClass",
+              "importSkippedOversized",
+              "importSkippedEmptyObject",
+              "importSkippedUnsupportedContentType",
+              "importSkippedExcludedContentType",
+              "importSkippedInvalidMedia",
+              "importSkippedRequiresRetrieval",
+            ]),
+            Schema.Null,
+          ]),
+        ),
+        message: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+        objectKey: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      }),
+    ),
+  }) as unknown as Schema.Schema<ListSuperSlurperJobLogsResponse>;
 
-export type ListSuperSlurperJobLogsError =
-  | DefaultErrors;
+export type ListSuperSlurperJobLogsError = DefaultErrors;
 
 export const listSuperSlurperJobLogs: API.PaginatedOperationMethod<
   ListSuperSlurperJobLogsRequest,
@@ -2389,7 +3847,6 @@ export const listSuperSlurperJobLogs: API.PaginatedOperationMethod<
   } as const,
 }));
 
-
 // =============================================================================
 // TemporaryCredential
 // =============================================================================
@@ -2402,7 +3859,11 @@ export interface CreateTemporaryCredentialRequest {
   /** Body param: The parent access key id to use for signing. */
   parentAccessKeyId: string;
   /** Body param: Permissions allowed on the credentials. */
-  permission: "admin-read-write" | "admin-read-only" | "object-read-write" | "object-read-only";
+  permission:
+    | "admin-read-write"
+    | "admin-read-only"
+    | "object-read-write"
+    | "object-read-only";
   /** Body param: How long the credentials will live for in seconds. */
   ttlSeconds: number;
   /** Body param: Optional object paths to scope the credentials to. */
@@ -2411,16 +3872,26 @@ export interface CreateTemporaryCredentialRequest {
   prefixes?: string[];
 }
 
-export const CreateTemporaryCredentialRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  bucket: Schema.String,
-  parentAccessKeyId: Schema.String,
-  permission: Schema.Literals(["admin-read-write", "admin-read-only", "object-read-write", "object-read-only"]),
-  ttlSeconds: Schema.Number,
-  objects: Schema.optional(Schema.Array(Schema.String)),
-  prefixes: Schema.optional(Schema.Array(Schema.String))
-})
-  .pipe(T.Http({ method: "POST", path: "/accounts/{account_id}/r2/temp-access-credentials" })) as unknown as Schema.Schema<CreateTemporaryCredentialRequest>;
+export const CreateTemporaryCredentialRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    bucket: Schema.String,
+    parentAccessKeyId: Schema.String,
+    permission: Schema.Literals([
+      "admin-read-write",
+      "admin-read-only",
+      "object-read-write",
+      "object-read-only",
+    ]),
+    ttlSeconds: Schema.Number,
+    objects: Schema.optional(Schema.Array(Schema.String)),
+    prefixes: Schema.optional(Schema.Array(Schema.String)),
+  }).pipe(
+    T.Http({
+      method: "POST",
+      path: "/accounts/{account_id}/r2/temp-access-credentials",
+    }),
+  ) as unknown as Schema.Schema<CreateTemporaryCredentialRequest>;
 
 export interface CreateTemporaryCredentialResponse {
   /** ID for new access key. */
@@ -2431,14 +3902,18 @@ export interface CreateTemporaryCredentialResponse {
   sessionToken?: string | null;
 }
 
-export const CreateTemporaryCredentialResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  accessKeyId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  secretAccessKey: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  sessionToken: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<CreateTemporaryCredentialResponse>;
+export const CreateTemporaryCredentialResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accessKeyId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    secretAccessKey: Schema.optional(
+      Schema.Union([Schema.String, Schema.Null]),
+    ),
+    sessionToken: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  }).pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<CreateTemporaryCredentialResponse>;
 
-export type CreateTemporaryCredentialError =
-  | DefaultErrors;
+export type CreateTemporaryCredentialError = DefaultErrors;
 
 export const createTemporaryCredential: API.OperationMethod<
   CreateTemporaryCredentialRequest,

--- a/packages/cloudflare/src/services/r2.ts
+++ b/packages/cloudflare/src/services/r2.ts
@@ -1688,13 +1688,9 @@ export const ListObjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 })
   .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects" })) as unknown as Schema.Schema<ListObjectsRequest>;
 
-export interface ListObjectsResponse {
-  result?: ({ key?: string | null; size?: number | null; etag?: string | null; lastModified?: string | null; storageClass?: "Standard" | "InfrequentAccess" | null; ssec?: boolean | null; customMetadata?: unknown | null; httpMetadata?: unknown | null })[] | null;
-  resultInfo?: { cursor?: string | null; isTruncated?: boolean | null; perPage?: number | null; delimited?: string[] | null } | null;
-}
+export type ListObjectsResponse = ({ key?: string | null; size?: number | null; etag?: string | null; lastModified?: string | null; storageClass?: "Standard" | "InfrequentAccess" | null; ssec?: boolean | null; customMetadata?: unknown | null; httpMetadata?: unknown | null })[];
 
-export const ListObjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  result: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
+export const ListObjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Array(Schema.Struct({
   key: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
   size: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
   etag: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
@@ -1703,14 +1699,7 @@ export const ListObjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   ssec: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
   customMetadata: Schema.optional(Schema.Union([Schema.Unknown, Schema.Null])),
   httpMetadata: Schema.optional(Schema.Union([Schema.Unknown, Schema.Null]))
-}).pipe(Schema.encodeKeys({ key: "key", size: "size", etag: "etag", lastModified: "last_modified", storageClass: "storage_class", ssec: "ssec", customMetadata: "custom_metadata", httpMetadata: "http_metadata" }))), Schema.Null])),
-  resultInfo: Schema.optional(Schema.Union([Schema.Struct({
-  cursor: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  isTruncated: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-  perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  delimited: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null]))
-}).pipe(Schema.encodeKeys({ cursor: "cursor", isTruncated: "is_truncated", perPage: "per_page", delimited: "delimited" })), Schema.Null]))
-}).pipe(Schema.encodeKeys({ result: "result", resultInfo: "result_info" })).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListObjectsResponse>;
+}).pipe(Schema.encodeKeys({ key: "key", size: "size", etag: "etag", lastModified: "last_modified", storageClass: "storage_class", ssec: "ssec", customMetadata: "custom_metadata", httpMetadata: "http_metadata" }))).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListObjectsResponse>;
 
 export type ListObjectsError =
   | DefaultErrors
@@ -1816,12 +1805,9 @@ export const DeleteObjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 })
   .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects" })) as unknown as Schema.Schema<DeleteObjectsRequest>;
 
-export interface DeleteObjectsResponse {
-  result?: ({ key?: string | null })[] | { id?: string | null; jobType?: "prefixDelete" | null; status?: "ENQUEUED" | "RUNNING" | "COMPLETED" | "FAILED" | "CANCELLED" | null; startTime?: string | null; endTime?: string | null; prefixDelete?: { prefix?: string | null; deletedObjects?: number | null; isBucketClear?: boolean | null } | null } | null;
-}
+export type DeleteObjectsResponse = ({ key?: string | null })[] | { id?: string | null; jobType?: "prefixDelete" | null; status?: "ENQUEUED" | "RUNNING" | "COMPLETED" | "FAILED" | "CANCELLED" | null; startTime?: string | null; endTime?: string | null; prefixDelete?: { prefix?: string | null; deletedObjects?: number | null; isBucketClear?: boolean | null } | null };
 
-export const DeleteObjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  result: Schema.optional(Schema.Union([Schema.Union([Schema.Array(Schema.Struct({
+export const DeleteObjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([Schema.Array(Schema.Struct({
   key: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
 })), Schema.Struct({
   id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
@@ -1834,8 +1820,7 @@ export const DeleteObjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     deletedObjects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
     isBucketClear: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null]))
   }), Schema.Null]))
-})]), Schema.Null]))
-}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteObjectsResponse>;
+})]).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteObjectsResponse>;
 
 export type DeleteObjectsError =
   | DefaultErrors

--- a/packages/cloudflare/src/services/r2.ts
+++ b/packages/cloudflare/src/services/r2.ts
@@ -10,7 +10,9 @@ import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
-import { type DefaultErrors } from "../errors.ts";
+import {
+  type DefaultErrors,
+} from "../errors.ts";
 import { UploadableSchema } from "../schemas.ts";
 import { SensitiveString } from "../sensitive.ts";
 
@@ -22,88 +24,85 @@ export class BucketAlreadyExists extends Schema.TaggedErrorClass<BucketAlreadyEx
   "BucketAlreadyExists",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(BucketAlreadyExists, [{ code: 10004 }]);
+T.applyErrorMatchers(BucketAlreadyExists, [{"code":10004}]);
 
 export class BucketNotFound extends Schema.TaggedErrorClass<BucketNotFound>()(
   "BucketNotFound",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(BucketNotFound, [{ code: 10085 }]);
+T.applyErrorMatchers(BucketNotFound, [{"code":10085}]);
 
 export class DomainNotFound extends Schema.TaggedErrorClass<DomainNotFound>()(
   "DomainNotFound",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(DomainNotFound, [{ code: 10053 }]);
+T.applyErrorMatchers(DomainNotFound, [{"code":10053}]);
 
 export class EventNotificationConfigNotFound extends Schema.TaggedErrorClass<EventNotificationConfigNotFound>()(
   "EventNotificationConfigNotFound",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(EventNotificationConfigNotFound, [{ code: 11011 }]);
+T.applyErrorMatchers(EventNotificationConfigNotFound, [{"code":11011}]);
 
 export class EventNotificationRuleConflict extends Schema.TaggedErrorClass<EventNotificationRuleConflict>()(
   "EventNotificationRuleConflict",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(EventNotificationRuleConflict, [{ code: 11020 }]);
+T.applyErrorMatchers(EventNotificationRuleConflict, [{"code":11020}]);
 
 export class InvalidBucketName extends Schema.TaggedErrorClass<InvalidBucketName>()(
   "InvalidBucketName",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(InvalidBucketName, [{ code: 10005 }]);
+T.applyErrorMatchers(InvalidBucketName, [{"code":10005}]);
 
 export class InvalidEventNotificationConfig extends Schema.TaggedErrorClass<InvalidEventNotificationConfig>()(
   "InvalidEventNotificationConfig",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(InvalidEventNotificationConfig, [
-  { code: 11014 },
-  { code: 11019 },
-]);
+T.applyErrorMatchers(InvalidEventNotificationConfig, [{"code":11014},{"code":11019}]);
 
 export class InvalidRoute extends Schema.TaggedErrorClass<InvalidRoute>()(
   "InvalidRoute",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(InvalidRoute, [{ code: 7003 }]);
+T.applyErrorMatchers(InvalidRoute, [{"code":7003}]);
 
 export class InvalidUpstreamCredentials extends Schema.TaggedErrorClass<InvalidUpstreamCredentials>()(
   "InvalidUpstreamCredentials",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(InvalidUpstreamCredentials, [{ code: 10063 }]);
+T.applyErrorMatchers(InvalidUpstreamCredentials, [{"code":10063}]);
 
 export class NoCorsConfiguration extends Schema.TaggedErrorClass<NoCorsConfiguration>()(
   "NoCorsConfiguration",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(NoCorsConfiguration, [{ code: 10059 }]);
+T.applyErrorMatchers(NoCorsConfiguration, [{"code":10059}]);
 
 export class NoEventNotificationConfig extends Schema.TaggedErrorClass<NoEventNotificationConfig>()(
   "NoEventNotificationConfig",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(NoEventNotificationConfig, [{ code: 11015 }]);
+T.applyErrorMatchers(NoEventNotificationConfig, [{"code":11015}]);
 
-export class NoRoute extends Schema.TaggedErrorClass<NoRoute>()("NoRoute", {
-  code: Schema.Number,
-  message: Schema.String,
-}) {}
-T.applyErrorMatchers(NoRoute, [{ code: 10015 }]);
+export class NoRoute extends Schema.TaggedErrorClass<NoRoute>()(
+  "NoRoute",
+  { code: Schema.Number, message: Schema.String },
+) {}
+T.applyErrorMatchers(NoRoute, [{"code":10015}]);
 
 export class NoSuchBucket extends Schema.TaggedErrorClass<NoSuchBucket>()(
   "NoSuchBucket",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(NoSuchBucket, [{ code: 10006 }]);
+T.applyErrorMatchers(NoSuchBucket, [{"code":10006}]);
 
 export class QueueNotFound extends Schema.TaggedErrorClass<QueueNotFound>()(
   "QueueNotFound",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(QueueNotFound, [{ code: 11000 }]);
+T.applyErrorMatchers(QueueNotFound, [{"code":11000}]);
 
 // =============================================================================
 // AllSuperSlurperJob
@@ -113,24 +112,17 @@ export interface AbortAllSuperSlurperJobRequest {
   accountId: string;
 }
 
-export const AbortAllSuperSlurperJobRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/slurper/jobs/abortAll",
-    }),
-  ) as unknown as Schema.Schema<AbortAllSuperSlurperJobRequest>;
+export const AbortAllSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  accountId: Schema.String.pipe(T.HttpPath("account_id"))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/slurper/jobs/abortAll" })) as unknown as Schema.Schema<AbortAllSuperSlurperJobRequest>;
 
 export type AbortAllSuperSlurperJobResponse = string;
 
-export const AbortAllSuperSlurperJobResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<AbortAllSuperSlurperJobResponse>;
+export const AbortAllSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<AbortAllSuperSlurperJobResponse>;
 
-export type AbortAllSuperSlurperJobError = DefaultErrors;
+export type AbortAllSuperSlurperJobError =
+  | DefaultErrors;
 
 export const abortAllSuperSlurperJob: API.OperationMethod<
   AbortAllSuperSlurperJobRequest,
@@ -142,6 +134,7 @@ export const abortAllSuperSlurperJob: API.OperationMethod<
   output: AbortAllSuperSlurperJobResponse,
   errors: [],
 }));
+
 
 // =============================================================================
 // Bucket
@@ -158,15 +151,9 @@ export interface GetBucketRequest {
 export const GetBucketRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-}).pipe(
-  T.Http({
-    method: "GET",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}",
-  }),
-) as unknown as Schema.Schema<GetBucketRequest>;
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}" })) as unknown as Schema.Schema<GetBucketRequest>;
 
 export interface GetBucketResponse {
   /** Creation timestamp. */
@@ -174,20 +161,7 @@ export interface GetBucketResponse {
   /** Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp" | null;
   /** Location of the bucket. */
-  location?:
-    | "apac"
-    | "eeur"
-    | "enam"
-    | "weur"
-    | "wnam"
-    | "oc"
-    | "APAC"
-    | "EEUR"
-    | "ENAM"
-    | "WEUR"
-    | "WNAM"
-    | "OC"
-    | null;
+  location?: "apac" | "eeur" | "enam" | "weur" | "wnam" | "oc" | "APAC" | "EEUR" | "ENAM" | "WEUR" | "WNAM" | "OC" | null;
   /** Name of the bucket. */
   name?: string | null;
   /** Storage class for newly uploaded objects, unless specified otherwise. */
@@ -196,50 +170,16 @@ export interface GetBucketResponse {
 
 export const GetBucketResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   creationDate: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  jurisdiction: Schema.optional(
-    Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null]),
-  ),
-  location: Schema.optional(
-    Schema.Union([
-      Schema.Literals([
-        "apac",
-        "eeur",
-        "enam",
-        "weur",
-        "wnam",
-        "oc",
-        "APAC",
-        "EEUR",
-        "ENAM",
-        "WEUR",
-        "WNAM",
-        "OC",
-      ]),
-      Schema.Null,
-    ]),
-  ),
+  jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
+  location: Schema.optional(Schema.Union([Schema.Literals(["apac", "eeur", "enam", "weur", "wnam", "oc", "APAC", "EEUR", "ENAM", "WEUR", "WNAM", "OC"]), Schema.Null])),
   name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  storageClass: Schema.optional(
-    Schema.Union([
-      Schema.Literals(["Standard", "InfrequentAccess"]),
-      Schema.Null,
-    ]),
-  ),
-})
-  .pipe(
-    Schema.encodeKeys({
-      creationDate: "creation_date",
-      jurisdiction: "jurisdiction",
-      location: "location",
-      name: "name",
-      storageClass: "storage_class",
-    }),
-  )
-  .pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<GetBucketResponse>;
+  storageClass: Schema.optional(Schema.Union([Schema.Literals(["Standard", "InfrequentAccess"]), Schema.Null]))
+}).pipe(Schema.encodeKeys({ creationDate: "creation_date", jurisdiction: "jurisdiction", location: "location", name: "name", storageClass: "storage_class" })).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketResponse>;
 
-export type GetBucketError = DefaultErrors | NoSuchBucket | InvalidRoute;
+export type GetBucketError =
+  | DefaultErrors
+  | NoSuchBucket
+  | InvalidRoute;
 
 export const getBucket: API.OperationMethod<
   GetBucketRequest,
@@ -274,105 +214,32 @@ export interface ListBucketsRequest {
 export const ListBucketsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
   cursor: Schema.optional(Schema.String).pipe(T.HttpQuery("cursor")),
-  direction: Schema.optional(Schema.Literals(["asc", "desc"])).pipe(
-    T.HttpQuery("direction"),
-  ),
-  nameContains: Schema.optional(Schema.String).pipe(
-    T.HttpQuery("name_contains"),
-  ),
+  direction: Schema.optional(Schema.Literals(["asc", "desc"])).pipe(T.HttpQuery("direction")),
+  nameContains: Schema.optional(Schema.String).pipe(T.HttpQuery("name_contains")),
   order: Schema.optional(Schema.Literal("name")).pipe(T.HttpQuery("order")),
   perPage: Schema.optional(Schema.Number).pipe(T.HttpQuery("per_page")),
   startAfter: Schema.optional(Schema.String).pipe(T.HttpQuery("start_after")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-}).pipe(
-  T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets" }),
-) as unknown as Schema.Schema<ListBucketsRequest>;
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets" })) as unknown as Schema.Schema<ListBucketsRequest>;
 
 export interface ListBucketsResponse {
-  buckets?:
-    | {
-        creationDate?: string | null;
-        jurisdiction?: "default" | "eu" | "fedramp" | null;
-        location?:
-          | "apac"
-          | "eeur"
-          | "enam"
-          | "weur"
-          | "wnam"
-          | "oc"
-          | "APAC"
-          | "EEUR"
-          | "ENAM"
-          | "WEUR"
-          | "WNAM"
-          | "OC"
-          | null;
-        name?: string | null;
-        storageClass?: "Standard" | "InfrequentAccess" | null;
-      }[]
-    | null;
+  buckets?: ({ creationDate?: string | null; jurisdiction?: "default" | "eu" | "fedramp" | null; location?: "apac" | "eeur" | "enam" | "weur" | "wnam" | "oc" | "APAC" | "EEUR" | "ENAM" | "WEUR" | "WNAM" | "OC" | null; name?: string | null; storageClass?: "Standard" | "InfrequentAccess" | null })[] | null;
 }
 
 export const ListBucketsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  buckets: Schema.optional(
-    Schema.Union([
-      Schema.Array(
-        Schema.Struct({
-          creationDate: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          jurisdiction: Schema.optional(
-            Schema.Union([
-              Schema.Literals(["default", "eu", "fedramp"]),
-              Schema.Null,
-            ]),
-          ),
-          location: Schema.optional(
-            Schema.Union([
-              Schema.Literals([
-                "apac",
-                "eeur",
-                "enam",
-                "weur",
-                "wnam",
-                "oc",
-                "APAC",
-                "EEUR",
-                "ENAM",
-                "WEUR",
-                "WNAM",
-                "OC",
-              ]),
-              Schema.Null,
-            ]),
-          ),
-          name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          storageClass: Schema.optional(
-            Schema.Union([
-              Schema.Literals(["Standard", "InfrequentAccess"]),
-              Schema.Null,
-            ]),
-          ),
-        }).pipe(
-          Schema.encodeKeys({
-            creationDate: "creation_date",
-            jurisdiction: "jurisdiction",
-            location: "location",
-            name: "name",
-            storageClass: "storage_class",
-          }),
-        ),
-      ),
-      Schema.Null,
-    ]),
-  ),
-}).pipe(
-  T.ResponsePath("result"),
-) as unknown as Schema.Schema<ListBucketsResponse>;
+  buckets: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
+  creationDate: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
+  location: Schema.optional(Schema.Union([Schema.Literals(["apac", "eeur", "enam", "weur", "wnam", "oc", "APAC", "EEUR", "ENAM", "WEUR", "WNAM", "OC"]), Schema.Null])),
+  name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  storageClass: Schema.optional(Schema.Union([Schema.Literals(["Standard", "InfrequentAccess"]), Schema.Null]))
+}).pipe(Schema.encodeKeys({ creationDate: "creation_date", jurisdiction: "jurisdiction", location: "location", name: "name", storageClass: "storage_class" }))), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListBucketsResponse>;
 
-export type ListBucketsError = DefaultErrors | InvalidRoute;
+export type ListBucketsError =
+  | DefaultErrors
+  | InvalidRoute;
 
 export const listBuckets: API.OperationMethod<
   ListBucketsRequest,
@@ -400,19 +267,12 @@ export interface CreateBucketRequest {
 
 export const CreateBucketRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
   name: Schema.String,
-  locationHint: Schema.optional(
-    Schema.Literals(["apac", "eeur", "enam", "weur", "wnam", "oc"]),
-  ),
-  storageClass: Schema.optional(
-    Schema.Literals(["Standard", "InfrequentAccess"]),
-  ),
-}).pipe(
-  T.Http({ method: "POST", path: "/accounts/{account_id}/r2/buckets" }),
-) as unknown as Schema.Schema<CreateBucketRequest>;
+  locationHint: Schema.optional(Schema.Literals(["apac", "eeur", "enam", "weur", "wnam", "oc"])),
+  storageClass: Schema.optional(Schema.Literals(["Standard", "InfrequentAccess"]))
+})
+  .pipe(T.Http({ method: "POST", path: "/accounts/{account_id}/r2/buckets" })) as unknown as Schema.Schema<CreateBucketRequest>;
 
 export interface CreateBucketResponse {
   /** Creation timestamp. */
@@ -420,20 +280,7 @@ export interface CreateBucketResponse {
   /** Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp" | null;
   /** Location of the bucket. */
-  location?:
-    | "apac"
-    | "eeur"
-    | "enam"
-    | "weur"
-    | "wnam"
-    | "oc"
-    | "APAC"
-    | "EEUR"
-    | "ENAM"
-    | "WEUR"
-    | "WNAM"
-    | "OC"
-    | null;
+  location?: "apac" | "eeur" | "enam" | "weur" | "wnam" | "oc" | "APAC" | "EEUR" | "ENAM" | "WEUR" | "WNAM" | "OC" | null;
   /** Name of the bucket. */
   name?: string | null;
   /** Storage class for newly uploaded objects, unless specified otherwise. */
@@ -442,48 +289,11 @@ export interface CreateBucketResponse {
 
 export const CreateBucketResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   creationDate: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  jurisdiction: Schema.optional(
-    Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null]),
-  ),
-  location: Schema.optional(
-    Schema.Union([
-      Schema.Literals([
-        "apac",
-        "eeur",
-        "enam",
-        "weur",
-        "wnam",
-        "oc",
-        "APAC",
-        "EEUR",
-        "ENAM",
-        "WEUR",
-        "WNAM",
-        "OC",
-      ]),
-      Schema.Null,
-    ]),
-  ),
+  jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
+  location: Schema.optional(Schema.Union([Schema.Literals(["apac", "eeur", "enam", "weur", "wnam", "oc", "APAC", "EEUR", "ENAM", "WEUR", "WNAM", "OC"]), Schema.Null])),
   name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  storageClass: Schema.optional(
-    Schema.Union([
-      Schema.Literals(["Standard", "InfrequentAccess"]),
-      Schema.Null,
-    ]),
-  ),
-})
-  .pipe(
-    Schema.encodeKeys({
-      creationDate: "creation_date",
-      jurisdiction: "jurisdiction",
-      location: "location",
-      name: "name",
-      storageClass: "storage_class",
-    }),
-  )
-  .pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<CreateBucketResponse>;
+  storageClass: Schema.optional(Schema.Union([Schema.Literals(["Standard", "InfrequentAccess"]), Schema.Null]))
+}).pipe(Schema.encodeKeys({ creationDate: "creation_date", jurisdiction: "jurisdiction", location: "location", name: "name", storageClass: "storage_class" })).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<CreateBucketResponse>;
 
 export type CreateBucketError =
   | DefaultErrors
@@ -515,18 +325,10 @@ export interface PatchBucketRequest {
 export const PatchBucketRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  storageClass: Schema.Literals(["Standard", "InfrequentAccess"]).pipe(
-    T.HttpHeader("cf-r2-storage-class"),
-  ),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-}).pipe(
-  T.Http({
-    method: "PATCH",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}",
-  }),
-) as unknown as Schema.Schema<PatchBucketRequest>;
+  storageClass: Schema.Literals(["Standard", "InfrequentAccess"]).pipe(T.HttpHeader("cf-r2-storage-class")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "PATCH", path: "/accounts/{account_id}/r2/buckets/{bucketName}" })) as unknown as Schema.Schema<PatchBucketRequest>;
 
 export interface PatchBucketResponse {
   /** Creation timestamp. */
@@ -534,20 +336,7 @@ export interface PatchBucketResponse {
   /** Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp" | null;
   /** Location of the bucket. */
-  location?:
-    | "apac"
-    | "eeur"
-    | "enam"
-    | "weur"
-    | "wnam"
-    | "oc"
-    | "APAC"
-    | "EEUR"
-    | "ENAM"
-    | "WEUR"
-    | "WNAM"
-    | "OC"
-    | null;
+  location?: "apac" | "eeur" | "enam" | "weur" | "wnam" | "oc" | "APAC" | "EEUR" | "ENAM" | "WEUR" | "WNAM" | "OC" | null;
   /** Name of the bucket. */
   name?: string | null;
   /** Storage class for newly uploaded objects, unless specified otherwise. */
@@ -556,50 +345,16 @@ export interface PatchBucketResponse {
 
 export const PatchBucketResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   creationDate: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  jurisdiction: Schema.optional(
-    Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null]),
-  ),
-  location: Schema.optional(
-    Schema.Union([
-      Schema.Literals([
-        "apac",
-        "eeur",
-        "enam",
-        "weur",
-        "wnam",
-        "oc",
-        "APAC",
-        "EEUR",
-        "ENAM",
-        "WEUR",
-        "WNAM",
-        "OC",
-      ]),
-      Schema.Null,
-    ]),
-  ),
+  jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
+  location: Schema.optional(Schema.Union([Schema.Literals(["apac", "eeur", "enam", "weur", "wnam", "oc", "APAC", "EEUR", "ENAM", "WEUR", "WNAM", "OC"]), Schema.Null])),
   name: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  storageClass: Schema.optional(
-    Schema.Union([
-      Schema.Literals(["Standard", "InfrequentAccess"]),
-      Schema.Null,
-    ]),
-  ),
-})
-  .pipe(
-    Schema.encodeKeys({
-      creationDate: "creation_date",
-      jurisdiction: "jurisdiction",
-      location: "location",
-      name: "name",
-      storageClass: "storage_class",
-    }),
-  )
-  .pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<PatchBucketResponse>;
+  storageClass: Schema.optional(Schema.Union([Schema.Literals(["Standard", "InfrequentAccess"]), Schema.Null]))
+}).pipe(Schema.encodeKeys({ creationDate: "creation_date", jurisdiction: "jurisdiction", location: "location", name: "name", storageClass: "storage_class" })).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PatchBucketResponse>;
 
-export type PatchBucketError = DefaultErrors | NoSuchBucket | InvalidRoute;
+export type PatchBucketError =
+  | DefaultErrors
+  | NoSuchBucket
+  | InvalidRoute;
 
 export const patchBucket: API.OperationMethod<
   PatchBucketRequest,
@@ -623,22 +378,13 @@ export interface DeleteBucketRequest {
 export const DeleteBucketRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-}).pipe(
-  T.Http({
-    method: "DELETE",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}",
-  }),
-) as unknown as Schema.Schema<DeleteBucketRequest>;
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/r2/buckets/{bucketName}" })) as unknown as Schema.Schema<DeleteBucketRequest>;
 
 export type DeleteBucketResponse = unknown;
 
-export const DeleteBucketResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<DeleteBucketResponse>;
+export const DeleteBucketResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteBucketResponse>;
 
 export type DeleteBucketError =
   | DefaultErrors
@@ -657,6 +403,7 @@ export const deleteBucket: API.OperationMethod<
   errors: [NoSuchBucket, InvalidRoute, NoRoute],
 }));
 
+
 // =============================================================================
 // BucketCor
 // =============================================================================
@@ -672,60 +419,26 @@ export interface GetBucketCorsRequest {
 export const GetBucketCorsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-}).pipe(
-  T.Http({
-    method: "GET",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}/cors",
-  }),
-) as unknown as Schema.Schema<GetBucketCorsRequest>;
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/cors" })) as unknown as Schema.Schema<GetBucketCorsRequest>;
 
 export interface GetBucketCorsResponse {
-  rules?:
-    | {
-        allowed: {
-          methods: ("GET" | "PUT" | "POST" | "DELETE" | "HEAD")[];
-          origins: string[];
-          headers?: string[] | null;
-        };
-        id?: string | null;
-        exposeHeaders?: string[] | null;
-        maxAgeSeconds?: number | null;
-      }[]
-    | null;
+  rules?: ({ allowed: { methods: ("GET" | "PUT" | "POST" | "DELETE" | "HEAD")[]; origins: string[]; headers?: string[] | null }; id?: string | null; exposeHeaders?: string[] | null; maxAgeSeconds?: number | null })[] | null;
 }
 
 export const GetBucketCorsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  rules: Schema.optional(
-    Schema.Union([
-      Schema.Array(
-        Schema.Struct({
-          allowed: Schema.Struct({
-            methods: Schema.Array(
-              Schema.Literals(["GET", "PUT", "POST", "DELETE", "HEAD"]),
-            ),
-            origins: Schema.Array(Schema.String),
-            headers: Schema.optional(
-              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-            ),
-          }),
-          id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          exposeHeaders: Schema.optional(
-            Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-          ),
-          maxAgeSeconds: Schema.optional(
-            Schema.Union([Schema.Number, Schema.Null]),
-          ),
-        }),
-      ),
-      Schema.Null,
-    ]),
-  ),
-}).pipe(
-  T.ResponsePath("result"),
-) as unknown as Schema.Schema<GetBucketCorsResponse>;
+  rules: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
+  allowed: Schema.Struct({
+    methods: Schema.Array(Schema.Literals(["GET", "PUT", "POST", "DELETE", "HEAD"])),
+    origins: Schema.Array(Schema.String),
+    headers: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null]))
+  }),
+  id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  exposeHeaders: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+  maxAgeSeconds: Schema.optional(Schema.Union([Schema.Number, Schema.Null]))
+})), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketCorsResponse>;
 
 export type GetBucketCorsError =
   | DefaultErrors
@@ -751,55 +464,34 @@ export interface PutBucketCorsRequest {
   /** Header param: Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp";
   /** Body param: */
-  rules?: {
-    allowed: {
-      methods: ("GET" | "PUT" | "POST" | "DELETE" | "HEAD")[];
-      origins: string[];
-      headers?: string[];
-    };
-    id?: string;
-    exposeHeaders?: string[];
-    maxAgeSeconds?: number;
-  }[];
+  rules?: ({ allowed: { methods: ("GET" | "PUT" | "POST" | "DELETE" | "HEAD")[]; origins: string[]; headers?: string[] }; id?: string; exposeHeaders?: string[]; maxAgeSeconds?: number })[];
 }
 
 export const PutBucketCorsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  rules: Schema.optional(
-    Schema.Array(
-      Schema.Struct({
-        allowed: Schema.Struct({
-          methods: Schema.Array(
-            Schema.Literals(["GET", "PUT", "POST", "DELETE", "HEAD"]),
-          ),
-          origins: Schema.Array(Schema.String),
-          headers: Schema.optional(Schema.Array(Schema.String)),
-        }),
-        id: Schema.optional(Schema.String),
-        exposeHeaders: Schema.optional(Schema.Array(Schema.String)),
-        maxAgeSeconds: Schema.optional(Schema.Number),
-      }),
-    ),
-  ),
-}).pipe(
-  T.Http({
-    method: "PUT",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}/cors",
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  rules: Schema.optional(Schema.Array(Schema.Struct({
+  allowed: Schema.Struct({
+    methods: Schema.Array(Schema.Literals(["GET", "PUT", "POST", "DELETE", "HEAD"])),
+    origins: Schema.Array(Schema.String),
+    headers: Schema.optional(Schema.Array(Schema.String))
   }),
-) as unknown as Schema.Schema<PutBucketCorsRequest>;
+  id: Schema.optional(Schema.String),
+  exposeHeaders: Schema.optional(Schema.Array(Schema.String)),
+  maxAgeSeconds: Schema.optional(Schema.Number)
+})))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/cors" })) as unknown as Schema.Schema<PutBucketCorsRequest>;
 
 export type PutBucketCorsResponse = unknown;
 
-export const PutBucketCorsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<PutBucketCorsResponse>;
+export const PutBucketCorsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutBucketCorsResponse>;
 
-export type PutBucketCorsError = DefaultErrors | NoSuchBucket | InvalidRoute;
+export type PutBucketCorsError =
+  | DefaultErrors
+  | NoSuchBucket
+  | InvalidRoute;
 
 export const putBucketCors: API.OperationMethod<
   PutBucketCorsRequest,
@@ -820,28 +512,21 @@ export interface DeleteBucketCorsRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const DeleteBucketCorsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "DELETE",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/cors",
-    }),
-  ) as unknown as Schema.Schema<DeleteBucketCorsRequest>;
+export const DeleteBucketCorsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/r2/buckets/{bucketName}/cors" })) as unknown as Schema.Schema<DeleteBucketCorsRequest>;
 
 export type DeleteBucketCorsResponse = unknown;
 
-export const DeleteBucketCorsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<DeleteBucketCorsResponse>;
+export const DeleteBucketCorsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteBucketCorsResponse>;
 
-export type DeleteBucketCorsError = DefaultErrors | NoSuchBucket | InvalidRoute;
+export type DeleteBucketCorsError =
+  | DefaultErrors
+  | NoSuchBucket
+  | InvalidRoute;
 
 export const deleteBucketCors: API.OperationMethod<
   DeleteBucketCorsRequest,
@@ -853,6 +538,7 @@ export const deleteBucketCors: API.OperationMethod<
   output: DeleteBucketCorsResponse,
   errors: [NoSuchBucket, InvalidRoute],
 }));
+
 
 // =============================================================================
 // BucketDomainCustom
@@ -867,42 +553,20 @@ export interface GetBucketDomainCustomRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const GetBucketDomainCustomRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    domain: Schema.String.pipe(T.HttpPath("domain")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "GET",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom/{domain}",
-    }),
-  ) as unknown as Schema.Schema<GetBucketDomainCustomRequest>;
+export const GetBucketDomainCustomRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  domain: Schema.String.pipe(T.HttpPath("domain")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom/{domain}" })) as unknown as Schema.Schema<GetBucketDomainCustomRequest>;
 
 export interface GetBucketDomainCustomResponse {
   /** Domain name of the custom domain to be added. */
   domain: string;
   /** Whether this bucket is publicly accessible at the specified custom domain. */
   enabled: boolean;
-  status: {
-    ownership:
-      | "pending"
-      | "active"
-      | "deactivated"
-      | "blocked"
-      | "error"
-      | "unknown";
-    ssl:
-      | "initializing"
-      | "pending"
-      | "active"
-      | "deactivated"
-      | "error"
-      | "unknown";
-  };
+  status: { ownership: "pending" | "active" | "deactivated" | "blocked" | "error" | "unknown"; ssl: "initializing" | "pending" | "active" | "deactivated" | "error" | "unknown" };
   /** An allowlist of ciphers for TLS termination. These ciphers must be in the BoringSSL format. */
   ciphers?: string[] | null;
   /** Minimum TLS Version the custom domain will accept for incoming connections. If not set, defaults to 1.0. */
@@ -913,42 +577,18 @@ export interface GetBucketDomainCustomResponse {
   zoneName?: string | null;
 }
 
-export const GetBucketDomainCustomResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    domain: Schema.String,
-    enabled: Schema.Boolean,
-    status: Schema.Struct({
-      ownership: Schema.Literals([
-        "pending",
-        "active",
-        "deactivated",
-        "blocked",
-        "error",
-        "unknown",
-      ]),
-      ssl: Schema.Literals([
-        "initializing",
-        "pending",
-        "active",
-        "deactivated",
-        "error",
-        "unknown",
-      ]),
-    }),
-    ciphers: Schema.optional(
-      Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-    ),
-    minTLS: Schema.optional(
-      Schema.Union([
-        Schema.Literals(["1.0", "1.1", "1.2", "1.3"]),
-        Schema.Null,
-      ]),
-    ),
-    zoneId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    zoneName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<GetBucketDomainCustomResponse>;
+export const GetBucketDomainCustomResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  domain: Schema.String,
+  enabled: Schema.Boolean,
+  status: Schema.Struct({
+  ownership: Schema.Literals(["pending", "active", "deactivated", "blocked", "error", "unknown"]),
+  ssl: Schema.Literals(["initializing", "pending", "active", "deactivated", "error", "unknown"])
+}),
+  ciphers: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+  minTLS: Schema.optional(Schema.Union([Schema.Literals(["1.0", "1.1", "1.2", "1.3"]), Schema.Null])),
+  zoneId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  zoneName: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketDomainCustomResponse>;
 
 export type GetBucketDomainCustomError =
   | DefaultErrors
@@ -975,87 +615,31 @@ export interface ListBucketDomainCustomsRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const ListBucketDomainCustomsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "GET",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom",
-    }),
-  ) as unknown as Schema.Schema<ListBucketDomainCustomsRequest>;
+export const ListBucketDomainCustomsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom" })) as unknown as Schema.Schema<ListBucketDomainCustomsRequest>;
 
 export interface ListBucketDomainCustomsResponse {
-  domains: {
-    domain: string;
-    enabled: boolean;
-    status: {
-      ownership:
-        | "pending"
-        | "active"
-        | "deactivated"
-        | "blocked"
-        | "error"
-        | "unknown";
-      ssl:
-        | "initializing"
-        | "pending"
-        | "active"
-        | "deactivated"
-        | "error"
-        | "unknown";
-    };
-    ciphers?: string[] | null;
-    minTLS?: "1.0" | "1.1" | "1.2" | "1.3" | null;
-    zoneId?: string | null;
-    zoneName?: string | null;
-  }[];
+  domains: ({ domain: string; enabled: boolean; status: { ownership: "pending" | "active" | "deactivated" | "blocked" | "error" | "unknown"; ssl: "initializing" | "pending" | "active" | "deactivated" | "error" | "unknown" }; ciphers?: string[] | null; minTLS?: "1.0" | "1.1" | "1.2" | "1.3" | null; zoneId?: string | null; zoneName?: string | null })[];
 }
 
-export const ListBucketDomainCustomsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    domains: Schema.Array(
-      Schema.Struct({
-        domain: Schema.String,
-        enabled: Schema.Boolean,
-        status: Schema.Struct({
-          ownership: Schema.Literals([
-            "pending",
-            "active",
-            "deactivated",
-            "blocked",
-            "error",
-            "unknown",
-          ]),
-          ssl: Schema.Literals([
-            "initializing",
-            "pending",
-            "active",
-            "deactivated",
-            "error",
-            "unknown",
-          ]),
-        }),
-        ciphers: Schema.optional(
-          Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-        ),
-        minTLS: Schema.optional(
-          Schema.Union([
-            Schema.Literals(["1.0", "1.1", "1.2", "1.3"]),
-            Schema.Null,
-          ]),
-        ),
-        zoneId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        zoneName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      }),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<ListBucketDomainCustomsResponse>;
+export const ListBucketDomainCustomsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  domains: Schema.Array(Schema.Struct({
+  domain: Schema.String,
+  enabled: Schema.Boolean,
+  status: Schema.Struct({
+    ownership: Schema.Literals(["pending", "active", "deactivated", "blocked", "error", "unknown"]),
+    ssl: Schema.Literals(["initializing", "pending", "active", "deactivated", "error", "unknown"])
+  }),
+  ciphers: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+  minTLS: Schema.optional(Schema.Union([Schema.Literals(["1.0", "1.1", "1.2", "1.3"]), Schema.Null])),
+  zoneId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  zoneName: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+}))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListBucketDomainCustomsResponse>;
 
 export type ListBucketDomainCustomsError =
   | DefaultErrors
@@ -1091,24 +675,17 @@ export interface CreateBucketDomainCustomRequest {
   minTLS?: "1.0" | "1.1" | "1.2" | "1.3";
 }
 
-export const CreateBucketDomainCustomRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-    domain: Schema.String,
-    enabled: Schema.Boolean,
-    zoneId: Schema.String,
-    ciphers: Schema.optional(Schema.Array(Schema.String)),
-    minTLS: Schema.optional(Schema.Literals(["1.0", "1.1", "1.2", "1.3"])),
-  }).pipe(
-    T.Http({
-      method: "POST",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom",
-    }),
-  ) as unknown as Schema.Schema<CreateBucketDomainCustomRequest>;
+export const CreateBucketDomainCustomRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  domain: Schema.String,
+  enabled: Schema.Boolean,
+  zoneId: Schema.String,
+  ciphers: Schema.optional(Schema.Array(Schema.String)),
+  minTLS: Schema.optional(Schema.Literals(["1.0", "1.1", "1.2", "1.3"]))
+})
+  .pipe(T.Http({ method: "POST", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom" })) as unknown as Schema.Schema<CreateBucketDomainCustomRequest>;
 
 export interface CreateBucketDomainCustomResponse {
   /** Domain name of the affected custom domain. */
@@ -1121,22 +698,12 @@ export interface CreateBucketDomainCustomResponse {
   minTLS?: "1.0" | "1.1" | "1.2" | "1.3" | null;
 }
 
-export const CreateBucketDomainCustomResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    domain: Schema.String,
-    enabled: Schema.Boolean,
-    ciphers: Schema.optional(
-      Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-    ),
-    minTLS: Schema.optional(
-      Schema.Union([
-        Schema.Literals(["1.0", "1.1", "1.2", "1.3"]),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<CreateBucketDomainCustomResponse>;
+export const CreateBucketDomainCustomResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  domain: Schema.String,
+  enabled: Schema.Boolean,
+  ciphers: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+  minTLS: Schema.optional(Schema.Union([Schema.Literals(["1.0", "1.1", "1.2", "1.3"]), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<CreateBucketDomainCustomResponse>;
 
 export type CreateBucketDomainCustomError =
   | DefaultErrors
@@ -1169,23 +736,16 @@ export interface UpdateBucketDomainCustomRequest {
   minTLS?: "1.0" | "1.1" | "1.2" | "1.3";
 }
 
-export const UpdateBucketDomainCustomRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    domain: Schema.String.pipe(T.HttpPath("domain")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-    ciphers: Schema.optional(Schema.Array(Schema.String)),
-    enabled: Schema.optional(Schema.Boolean),
-    minTLS: Schema.optional(Schema.Literals(["1.0", "1.1", "1.2", "1.3"])),
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom/{domain}",
-    }),
-  ) as unknown as Schema.Schema<UpdateBucketDomainCustomRequest>;
+export const UpdateBucketDomainCustomRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  domain: Schema.String.pipe(T.HttpPath("domain")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  ciphers: Schema.optional(Schema.Array(Schema.String)),
+  enabled: Schema.optional(Schema.Boolean),
+  minTLS: Schema.optional(Schema.Literals(["1.0", "1.1", "1.2", "1.3"]))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom/{domain}" })) as unknown as Schema.Schema<UpdateBucketDomainCustomRequest>;
 
 export interface UpdateBucketDomainCustomResponse {
   /** Domain name of the affected custom domain. */
@@ -1198,24 +758,15 @@ export interface UpdateBucketDomainCustomResponse {
   minTLS?: "1.0" | "1.1" | "1.2" | "1.3" | null;
 }
 
-export const UpdateBucketDomainCustomResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    domain: Schema.String,
-    ciphers: Schema.optional(
-      Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-    ),
-    enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-    minTLS: Schema.optional(
-      Schema.Union([
-        Schema.Literals(["1.0", "1.1", "1.2", "1.3"]),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<UpdateBucketDomainCustomResponse>;
+export const UpdateBucketDomainCustomResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  domain: Schema.String,
+  ciphers: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+  enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+  minTLS: Schema.optional(Schema.Union([Schema.Literals(["1.0", "1.1", "1.2", "1.3"]), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<UpdateBucketDomainCustomResponse>;
 
-export type UpdateBucketDomainCustomError = DefaultErrors;
+export type UpdateBucketDomainCustomError =
+  | DefaultErrors;
 
 export const updateBucketDomainCustom: API.OperationMethod<
   UpdateBucketDomainCustomRequest,
@@ -1237,34 +788,25 @@ export interface DeleteBucketDomainCustomRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const DeleteBucketDomainCustomRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    domain: Schema.String.pipe(T.HttpPath("domain")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "DELETE",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom/{domain}",
-    }),
-  ) as unknown as Schema.Schema<DeleteBucketDomainCustomRequest>;
+export const DeleteBucketDomainCustomRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  domain: Schema.String.pipe(T.HttpPath("domain")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/custom/{domain}" })) as unknown as Schema.Schema<DeleteBucketDomainCustomRequest>;
 
 export interface DeleteBucketDomainCustomResponse {
   /** Name of the removed custom domain. */
   domain: string;
 }
 
-export const DeleteBucketDomainCustomResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    domain: Schema.String,
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<DeleteBucketDomainCustomResponse>;
+export const DeleteBucketDomainCustomResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  domain: Schema.String
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteBucketDomainCustomResponse>;
 
-export type DeleteBucketDomainCustomError = DefaultErrors;
+export type DeleteBucketDomainCustomError =
+  | DefaultErrors;
 
 export const deleteBucketDomainCustom: API.OperationMethod<
   DeleteBucketDomainCustomRequest,
@@ -1276,6 +818,7 @@ export const deleteBucketDomainCustom: API.OperationMethod<
   output: DeleteBucketDomainCustomResponse,
   errors: [],
 }));
+
 
 // =============================================================================
 // BucketDomainManaged
@@ -1289,19 +832,12 @@ export interface ListBucketDomainManagedsRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const ListBucketDomainManagedsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "GET",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/managed",
-    }),
-  ) as unknown as Schema.Schema<ListBucketDomainManagedsRequest>;
+export const ListBucketDomainManagedsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/managed" })) as unknown as Schema.Schema<ListBucketDomainManagedsRequest>;
 
 export interface ListBucketDomainManagedsResponse {
   /** Bucket ID. */
@@ -1312,14 +848,11 @@ export interface ListBucketDomainManagedsResponse {
   enabled: boolean;
 }
 
-export const ListBucketDomainManagedsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketId: Schema.String,
-    domain: Schema.String,
-    enabled: Schema.Boolean,
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<ListBucketDomainManagedsResponse>;
+export const ListBucketDomainManagedsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketId: Schema.String,
+  domain: Schema.String,
+  enabled: Schema.Boolean
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListBucketDomainManagedsResponse>;
 
 export type ListBucketDomainManagedsError =
   | DefaultErrors
@@ -1347,20 +880,13 @@ export interface PutBucketDomainManagedRequest {
   enabled: boolean;
 }
 
-export const PutBucketDomainManagedRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-    enabled: Schema.Boolean,
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/managed",
-    }),
-  ) as unknown as Schema.Schema<PutBucketDomainManagedRequest>;
+export const PutBucketDomainManagedRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  enabled: Schema.Boolean
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/domains/managed" })) as unknown as Schema.Schema<PutBucketDomainManagedRequest>;
 
 export interface PutBucketDomainManagedResponse {
   /** Bucket ID. */
@@ -1371,14 +897,11 @@ export interface PutBucketDomainManagedResponse {
   enabled: boolean;
 }
 
-export const PutBucketDomainManagedResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketId: Schema.String,
-    domain: Schema.String,
-    enabled: Schema.Boolean,
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<PutBucketDomainManagedResponse>;
+export const PutBucketDomainManagedResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketId: Schema.String,
+  domain: Schema.String,
+  enabled: Schema.Boolean
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutBucketDomainManagedResponse>;
 
 export type PutBucketDomainManagedError =
   | DefaultErrors
@@ -1396,6 +919,7 @@ export const putBucketDomainManaged: API.OperationMethod<
   errors: [NoSuchBucket, InvalidRoute],
 }));
 
+
 // =============================================================================
 // BucketEventNotification
 // =============================================================================
@@ -1409,78 +933,34 @@ export interface GetBucketEventNotificationRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const GetBucketEventNotificationRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    queueId: Schema.String.pipe(T.HttpPath("queueId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "GET",
-      path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration/queues/{queueId}",
-    }),
-  ) as unknown as Schema.Schema<GetBucketEventNotificationRequest>;
+export const GetBucketEventNotificationRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  queueId: Schema.String.pipe(T.HttpPath("queueId")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration/queues/{queueId}" })) as unknown as Schema.Schema<GetBucketEventNotificationRequest>;
 
 export interface GetBucketEventNotificationResponse {
   /** Queue ID. */
   queueId?: string | null;
   /** Name of the queue. */
   queueName?: string | null;
-  rules?:
-    | {
-        actions: (
-          | "PutObject"
-          | "CopyObject"
-          | "DeleteObject"
-          | "CompleteMultipartUpload"
-          | "LifecycleDeletion"
-        )[];
-        createdAt?: string | null;
-        description?: string | null;
-        prefix?: string | null;
-        ruleId?: string | null;
-        suffix?: string | null;
-      }[]
-    | null;
+  rules?: ({ actions: ("PutObject" | "CopyObject" | "DeleteObject" | "CompleteMultipartUpload" | "LifecycleDeletion")[]; createdAt?: string | null; description?: string | null; prefix?: string | null; ruleId?: string | null; suffix?: string | null })[] | null;
 }
 
-export const GetBucketEventNotificationResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    queueId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    queueName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    rules: Schema.optional(
-      Schema.Union([
-        Schema.Array(
-          Schema.Struct({
-            actions: Schema.Array(
-              Schema.Literals([
-                "PutObject",
-                "CopyObject",
-                "DeleteObject",
-                "CompleteMultipartUpload",
-                "LifecycleDeletion",
-              ]),
-            ),
-            createdAt: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            description: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            ruleId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            suffix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          }),
-        ),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<GetBucketEventNotificationResponse>;
+export const GetBucketEventNotificationResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  queueId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  queueName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  rules: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
+  actions: Schema.Array(Schema.Literals(["PutObject", "CopyObject", "DeleteObject", "CompleteMultipartUpload", "LifecycleDeletion"])),
+  createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  description: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  ruleId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  suffix: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+})), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketEventNotificationResponse>;
 
 export type GetBucketEventNotificationError =
   | DefaultErrors
@@ -1498,13 +978,7 @@ export const getBucketEventNotification: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetBucketEventNotificationRequest,
   output: GetBucketEventNotificationResponse,
-  errors: [
-    BucketNotFound,
-    NoEventNotificationConfig,
-    EventNotificationConfigNotFound,
-    QueueNotFound,
-    InvalidRoute,
-  ],
+  errors: [BucketNotFound, NoEventNotificationConfig, EventNotificationConfigNotFound, QueueNotFound, InvalidRoute],
 }));
 
 export interface ListBucketEventNotificationsRequest {
@@ -1515,102 +989,35 @@ export interface ListBucketEventNotificationsRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const ListBucketEventNotificationsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "GET",
-      path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration",
-    }),
-  ) as unknown as Schema.Schema<ListBucketEventNotificationsRequest>;
+export const ListBucketEventNotificationsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration" })) as unknown as Schema.Schema<ListBucketEventNotificationsRequest>;
 
 export interface ListBucketEventNotificationsResponse {
   /** Name of the bucket. */
   bucketName?: string | null;
   /** List of queues associated with the bucket. */
-  queues?:
-    | {
-        queueId?: string | null;
-        queueName?: string | null;
-        rules?:
-          | {
-              actions: (
-                | "PutObject"
-                | "CopyObject"
-                | "DeleteObject"
-                | "CompleteMultipartUpload"
-                | "LifecycleDeletion"
-              )[];
-              createdAt?: string | null;
-              description?: string | null;
-              prefix?: string | null;
-              ruleId?: string | null;
-              suffix?: string | null;
-            }[]
-          | null;
-      }[]
-    | null;
+  queues?: ({ queueId?: string | null; queueName?: string | null; rules?: ({ actions: ("PutObject" | "CopyObject" | "DeleteObject" | "CompleteMultipartUpload" | "LifecycleDeletion")[]; createdAt?: string | null; description?: string | null; prefix?: string | null; ruleId?: string | null; suffix?: string | null })[] | null })[] | null;
 }
 
-export const ListBucketEventNotificationsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    queues: Schema.optional(
-      Schema.Union([
-        Schema.Array(
-          Schema.Struct({
-            queueId: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            queueName: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            rules: Schema.optional(
-              Schema.Union([
-                Schema.Array(
-                  Schema.Struct({
-                    actions: Schema.Array(
-                      Schema.Literals([
-                        "PutObject",
-                        "CopyObject",
-                        "DeleteObject",
-                        "CompleteMultipartUpload",
-                        "LifecycleDeletion",
-                      ]),
-                    ),
-                    createdAt: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                    description: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                    prefix: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                    ruleId: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                    suffix: Schema.optional(
-                      Schema.Union([Schema.String, Schema.Null]),
-                    ),
-                  }),
-                ),
-                Schema.Null,
-              ]),
-            ),
-          }),
-        ),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<ListBucketEventNotificationsResponse>;
+export const ListBucketEventNotificationsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  queues: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
+  queueId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  queueName: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  rules: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
+    actions: Schema.Array(Schema.Literals(["PutObject", "CopyObject", "DeleteObject", "CompleteMultipartUpload", "LifecycleDeletion"])),
+    createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    description: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    ruleId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    suffix: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+  })), Schema.Null]))
+})), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListBucketEventNotificationsResponse>;
 
 export type ListBucketEventNotificationsError =
   | DefaultErrors
@@ -1627,12 +1034,7 @@ export const listBucketEventNotifications: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: ListBucketEventNotificationsRequest,
   output: ListBucketEventNotificationsResponse,
-  errors: [
-    NoSuchBucket,
-    InvalidRoute,
-    NoEventNotificationConfig,
-    BucketNotFound,
-  ],
+  errors: [NoSuchBucket, InvalidRoute, NoEventNotificationConfig, BucketNotFound],
 }));
 
 export interface PutBucketEventNotificationRequest {
@@ -1643,57 +1045,26 @@ export interface PutBucketEventNotificationRequest {
   /** Header param: Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp";
   /** Body param: Array of rules to drive notifications. */
-  rules: {
-    actions: (
-      | "PutObject"
-      | "CopyObject"
-      | "DeleteObject"
-      | "CompleteMultipartUpload"
-      | "LifecycleDeletion"
-    )[];
-    description?: string;
-    prefix?: string;
-    suffix?: string;
-  }[];
+  rules: ({ actions: ("PutObject" | "CopyObject" | "DeleteObject" | "CompleteMultipartUpload" | "LifecycleDeletion")[]; description?: string; prefix?: string; suffix?: string })[];
 }
 
-export const PutBucketEventNotificationRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    queueId: Schema.String.pipe(T.HttpPath("queueId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-    rules: Schema.Array(
-      Schema.Struct({
-        actions: Schema.Array(
-          Schema.Literals([
-            "PutObject",
-            "CopyObject",
-            "DeleteObject",
-            "CompleteMultipartUpload",
-            "LifecycleDeletion",
-          ]),
-        ),
-        description: Schema.optional(Schema.String),
-        prefix: Schema.optional(Schema.String),
-        suffix: Schema.optional(Schema.String),
-      }),
-    ),
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration/queues/{queueId}",
-    }),
-  ) as unknown as Schema.Schema<PutBucketEventNotificationRequest>;
+export const PutBucketEventNotificationRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  queueId: Schema.String.pipe(T.HttpPath("queueId")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  rules: Schema.Array(Schema.Struct({
+  actions: Schema.Array(Schema.Literals(["PutObject", "CopyObject", "DeleteObject", "CompleteMultipartUpload", "LifecycleDeletion"])),
+  description: Schema.optional(Schema.String),
+  prefix: Schema.optional(Schema.String),
+  suffix: Schema.optional(Schema.String)
+}))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration/queues/{queueId}" })) as unknown as Schema.Schema<PutBucketEventNotificationRequest>;
 
 export type PutBucketEventNotificationResponse = unknown;
 
-export const PutBucketEventNotificationResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<PutBucketEventNotificationResponse>;
+export const PutBucketEventNotificationResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutBucketEventNotificationResponse>;
 
 export type PutBucketEventNotificationError =
   | DefaultErrors
@@ -1711,13 +1082,7 @@ export const putBucketEventNotification: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: PutBucketEventNotificationRequest,
   output: PutBucketEventNotificationResponse,
-  errors: [
-    BucketNotFound,
-    InvalidEventNotificationConfig,
-    EventNotificationRuleConflict,
-    QueueNotFound,
-    InvalidRoute,
-  ],
+  errors: [BucketNotFound, InvalidEventNotificationConfig, EventNotificationRuleConflict, QueueNotFound, InvalidRoute],
 }));
 
 export interface DeleteBucketEventNotificationRequest {
@@ -1729,27 +1094,17 @@ export interface DeleteBucketEventNotificationRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const DeleteBucketEventNotificationRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    queueId: Schema.String.pipe(T.HttpPath("queueId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "DELETE",
-      path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration/queues/{queueId}",
-    }),
-  ) as unknown as Schema.Schema<DeleteBucketEventNotificationRequest>;
+export const DeleteBucketEventNotificationRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  queueId: Schema.String.pipe(T.HttpPath("queueId")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/event_notifications/r2/{bucketName}/configuration/queues/{queueId}" })) as unknown as Schema.Schema<DeleteBucketEventNotificationRequest>;
 
 export type DeleteBucketEventNotificationResponse = unknown;
 
-export const DeleteBucketEventNotificationResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<DeleteBucketEventNotificationResponse>;
+export const DeleteBucketEventNotificationResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteBucketEventNotificationResponse>;
 
 export type DeleteBucketEventNotificationError =
   | DefaultErrors
@@ -1766,13 +1121,9 @@ export const deleteBucketEventNotification: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: DeleteBucketEventNotificationRequest,
   output: DeleteBucketEventNotificationResponse,
-  errors: [
-    BucketNotFound,
-    EventNotificationConfigNotFound,
-    QueueNotFound,
-    InvalidRoute,
-  ],
+  errors: [BucketNotFound, EventNotificationConfigNotFound, QueueNotFound, InvalidRoute],
 }));
+
 
 // =============================================================================
 // BucketLifecycle
@@ -1786,126 +1137,51 @@ export interface GetBucketLifecycleRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const GetBucketLifecycleRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "GET",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/lifecycle",
-    }),
-  ) as unknown as Schema.Schema<GetBucketLifecycleRequest>;
+export const GetBucketLifecycleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/lifecycle" })) as unknown as Schema.Schema<GetBucketLifecycleRequest>;
 
 export interface GetBucketLifecycleResponse {
-  rules?:
-    | {
-        id: string;
-        conditions: { prefix?: string | null };
-        enabled: boolean;
-        abortMultipartUploadsTransition?: {
-          condition?: { maxAge: number; type: "Age" } | null;
-        } | null;
-        deleteObjectsTransition?: {
-          condition?:
-            | { maxAge: number; type: "Age" }
-            | { date: string; type: "Date" }
-            | null;
-        } | null;
-        storageClassTransitions?:
-          | {
-              condition:
-                | { maxAge: number; type: "Age" }
-                | { date: string; type: "Date" };
-              storageClass: "InfrequentAccess";
-            }[]
-          | null;
-      }[]
-    | null;
+  rules?: ({ id: string; conditions: { prefix?: string | null }; enabled: boolean; abortMultipartUploadsTransition?: { condition?: { maxAge: number; type: "Age" } | null } | null; deleteObjectsTransition?: { condition?: { maxAge: number; type: "Age" } | { date: string; type: "Date" } | null } | null; storageClassTransitions?: ({ condition: { maxAge: number; type: "Age" } | { date: string; type: "Date" }; storageClass: "InfrequentAccess" })[] | null })[] | null;
 }
 
-export const GetBucketLifecycleResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    rules: Schema.optional(
-      Schema.Union([
-        Schema.Array(
-          Schema.Struct({
-            id: Schema.String,
-            conditions: Schema.Struct({
-              prefix: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-            }),
-            enabled: Schema.Boolean,
-            abortMultipartUploadsTransition: Schema.optional(
-              Schema.Union([
-                Schema.Struct({
-                  condition: Schema.optional(
-                    Schema.Union([
-                      Schema.Struct({
-                        maxAge: Schema.Number,
-                        type: Schema.Literal("Age"),
-                      }),
-                      Schema.Null,
-                    ]),
-                  ),
-                }),
-                Schema.Null,
-              ]),
-            ),
-            deleteObjectsTransition: Schema.optional(
-              Schema.Union([
-                Schema.Struct({
-                  condition: Schema.optional(
-                    Schema.Union([
-                      Schema.Union([
-                        Schema.Struct({
-                          maxAge: Schema.Number,
-                          type: Schema.Literal("Age"),
-                        }),
-                        Schema.Struct({
-                          date: Schema.String,
-                          type: Schema.Literal("Date"),
-                        }),
-                      ]),
-                      Schema.Null,
-                    ]),
-                  ),
-                }),
-                Schema.Null,
-              ]),
-            ),
-            storageClassTransitions: Schema.optional(
-              Schema.Union([
-                Schema.Array(
-                  Schema.Struct({
-                    condition: Schema.Union([
-                      Schema.Struct({
-                        maxAge: Schema.Number,
-                        type: Schema.Literal("Age"),
-                      }),
-                      Schema.Struct({
-                        date: Schema.String,
-                        type: Schema.Literal("Date"),
-                      }),
-                    ]),
-                    storageClass: Schema.Literal("InfrequentAccess"),
-                  }),
-                ),
-                Schema.Null,
-              ]),
-            ),
-          }),
-        ),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<GetBucketLifecycleResponse>;
+export const GetBucketLifecycleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  rules: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
+  id: Schema.String,
+  conditions: Schema.Struct({
+    prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+  }),
+  enabled: Schema.Boolean,
+  abortMultipartUploadsTransition: Schema.optional(Schema.Union([Schema.Struct({
+    condition: Schema.optional(Schema.Union([Schema.Struct({
+      maxAge: Schema.Number,
+      type: Schema.Literal("Age")
+    }), Schema.Null]))
+  }), Schema.Null])),
+  deleteObjectsTransition: Schema.optional(Schema.Union([Schema.Struct({
+    condition: Schema.optional(Schema.Union([Schema.Union([Schema.Struct({
+      maxAge: Schema.Number,
+      type: Schema.Literal("Age")
+    }), Schema.Struct({
+      date: Schema.String,
+      type: Schema.Literal("Date")
+    })]), Schema.Null]))
+  }), Schema.Null])),
+  storageClassTransitions: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
+    condition: Schema.Union([Schema.Struct({
+      maxAge: Schema.Number,
+      type: Schema.Literal("Age")
+    }), Schema.Struct({
+      date: Schema.String,
+      type: Schema.Literal("Date")
+    })]),
+    storageClass: Schema.Literal("InfrequentAccess")
+  })), Schema.Null]))
+})), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketLifecycleResponse>;
 
 export type GetBucketLifecycleError =
   | DefaultErrors
@@ -1930,101 +1206,51 @@ export interface PutBucketLifecycleRequest {
   /** Header param: Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp";
   /** Body param: */
-  rules?: {
-    id: string;
-    conditions: { prefix: string };
-    enabled: boolean;
-    abortMultipartUploadsTransition?: {
-      condition?: { maxAge: number; type: "Age" };
-    };
-    deleteObjectsTransition?: {
-      condition?:
-        | { maxAge: number; type: "Age" }
-        | { date: string; type: "Date" };
-    };
-    storageClassTransitions?: {
-      condition:
-        | { maxAge: number; type: "Age" }
-        | { date: string; type: "Date" };
-      storageClass: "InfrequentAccess";
-    }[];
-  }[];
+  rules?: ({ id: string; conditions: { prefix: string }; enabled: boolean; abortMultipartUploadsTransition?: { condition?: { maxAge: number; type: "Age" } }; deleteObjectsTransition?: { condition?: { maxAge: number; type: "Age" } | { date: string; type: "Date" } }; storageClassTransitions?: ({ condition: { maxAge: number; type: "Age" } | { date: string; type: "Date" }; storageClass: "InfrequentAccess" })[] })[];
 }
 
-export const PutBucketLifecycleRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-    rules: Schema.optional(
-      Schema.Array(
-        Schema.Struct({
-          id: Schema.String,
-          conditions: Schema.Struct({
-            prefix: Schema.String,
-          }),
-          enabled: Schema.Boolean,
-          abortMultipartUploadsTransition: Schema.optional(
-            Schema.Struct({
-              condition: Schema.optional(
-                Schema.Struct({
-                  maxAge: Schema.Number,
-                  type: Schema.Literal("Age"),
-                }),
-              ),
-            }),
-          ),
-          deleteObjectsTransition: Schema.optional(
-            Schema.Struct({
-              condition: Schema.optional(
-                Schema.Union([
-                  Schema.Struct({
-                    maxAge: Schema.Number,
-                    type: Schema.Literal("Age"),
-                  }),
-                  Schema.Struct({
-                    date: Schema.String,
-                    type: Schema.Literal("Date"),
-                  }),
-                ]),
-              ),
-            }),
-          ),
-          storageClassTransitions: Schema.optional(
-            Schema.Array(
-              Schema.Struct({
-                condition: Schema.Union([
-                  Schema.Struct({
-                    maxAge: Schema.Number,
-                    type: Schema.Literal("Age"),
-                  }),
-                  Schema.Struct({
-                    date: Schema.String,
-                    type: Schema.Literal("Date"),
-                  }),
-                ]),
-                storageClass: Schema.Literal("InfrequentAccess"),
-              }),
-            ),
-          ),
-        }),
-      ),
-    ),
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/lifecycle",
-    }),
-  ) as unknown as Schema.Schema<PutBucketLifecycleRequest>;
+export const PutBucketLifecycleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  rules: Schema.optional(Schema.Array(Schema.Struct({
+  id: Schema.String,
+  conditions: Schema.Struct({
+    prefix: Schema.String
+  }),
+  enabled: Schema.Boolean,
+  abortMultipartUploadsTransition: Schema.optional(Schema.Struct({
+    condition: Schema.optional(Schema.Struct({
+      maxAge: Schema.Number,
+      type: Schema.Literal("Age")
+    }))
+  })),
+  deleteObjectsTransition: Schema.optional(Schema.Struct({
+    condition: Schema.optional(Schema.Union([Schema.Struct({
+      maxAge: Schema.Number,
+      type: Schema.Literal("Age")
+    }), Schema.Struct({
+      date: Schema.String,
+      type: Schema.Literal("Date")
+    })]))
+  })),
+  storageClassTransitions: Schema.optional(Schema.Array(Schema.Struct({
+    condition: Schema.Union([Schema.Struct({
+      maxAge: Schema.Number,
+      type: Schema.Literal("Age")
+    }), Schema.Struct({
+      date: Schema.String,
+      type: Schema.Literal("Date")
+    })]),
+    storageClass: Schema.Literal("InfrequentAccess")
+  })))
+})))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/lifecycle" })) as unknown as Schema.Schema<PutBucketLifecycleRequest>;
 
 export type PutBucketLifecycleResponse = unknown;
 
-export const PutBucketLifecycleResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<PutBucketLifecycleResponse>;
+export const PutBucketLifecycleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutBucketLifecycleResponse>;
 
 export type PutBucketLifecycleError =
   | DefaultErrors
@@ -2042,6 +1268,7 @@ export const putBucketLifecycle: API.OperationMethod<
   errors: [NoSuchBucket, InvalidRoute],
 }));
 
+
 // =============================================================================
 // BucketLock
 // =============================================================================
@@ -2057,61 +1284,35 @@ export interface GetBucketLockRequest {
 export const GetBucketLockRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-}).pipe(
-  T.Http({
-    method: "GET",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}/lock",
-  }),
-) as unknown as Schema.Schema<GetBucketLockRequest>;
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/lock" })) as unknown as Schema.Schema<GetBucketLockRequest>;
 
 export interface GetBucketLockResponse {
-  rules?:
-    | {
-        id: string;
-        condition:
-          | { maxAgeSeconds: number; type: "Age" }
-          | { date: string; type: "Date" }
-          | { type: "Indefinite" };
-        enabled: boolean;
-        prefix?: string | null;
-      }[]
-    | null;
+  rules?: ({ id: string; condition: { maxAgeSeconds: number; type: "Age" } | { date: string; type: "Date" } | { type: "Indefinite" }; enabled: boolean; prefix?: string | null })[] | null;
 }
 
 export const GetBucketLockResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  rules: Schema.optional(
-    Schema.Union([
-      Schema.Array(
-        Schema.Struct({
-          id: Schema.String,
-          condition: Schema.Union([
-            Schema.Struct({
-              maxAgeSeconds: Schema.Number,
-              type: Schema.Literal("Age"),
-            }),
-            Schema.Struct({
-              date: Schema.String,
-              type: Schema.Literal("Date"),
-            }),
-            Schema.Struct({
-              type: Schema.Literal("Indefinite"),
-            }),
-          ]),
-          enabled: Schema.Boolean,
-          prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        }),
-      ),
-      Schema.Null,
-    ]),
-  ),
-}).pipe(
-  T.ResponsePath("result"),
-) as unknown as Schema.Schema<GetBucketLockResponse>;
+  rules: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
+  id: Schema.String,
+  condition: Schema.Union([Schema.Struct({
+    maxAgeSeconds: Schema.Number,
+    type: Schema.Literal("Age")
+  }), Schema.Struct({
+    date: Schema.String,
+    type: Schema.Literal("Date")
+  }), Schema.Struct({
+    type: Schema.Literal("Indefinite")
+  })]),
+  enabled: Schema.Boolean,
+  prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+})), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketLockResponse>;
 
-export type GetBucketLockError = DefaultErrors | NoSuchBucket | InvalidRoute;
+export type GetBucketLockError =
+  | DefaultErrors
+  | NoSuchBucket
+  | InvalidRoute;
 
 export const getBucketLock: API.OperationMethod<
   GetBucketLockRequest,
@@ -2131,60 +1332,38 @@ export interface PutBucketLockRequest {
   /** Header param: Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp";
   /** Body param: */
-  rules?: {
-    id: string;
-    condition:
-      | { maxAgeSeconds: number; type: "Age" }
-      | { date: string; type: "Date" }
-      | { type: "Indefinite" };
-    enabled: boolean;
-    prefix?: string;
-  }[];
+  rules?: ({ id: string; condition: { maxAgeSeconds: number; type: "Age" } | { date: string; type: "Date" } | { type: "Indefinite" }; enabled: boolean; prefix?: string })[];
 }
 
 export const PutBucketLockRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  rules: Schema.optional(
-    Schema.Array(
-      Schema.Struct({
-        id: Schema.String,
-        condition: Schema.Union([
-          Schema.Struct({
-            maxAgeSeconds: Schema.Number,
-            type: Schema.Literal("Age"),
-          }),
-          Schema.Struct({
-            date: Schema.String,
-            type: Schema.Literal("Date"),
-          }),
-          Schema.Struct({
-            type: Schema.Literal("Indefinite"),
-          }),
-        ]),
-        enabled: Schema.Boolean,
-        prefix: Schema.optional(Schema.String),
-      }),
-    ),
-  ),
-}).pipe(
-  T.Http({
-    method: "PUT",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}/lock",
-  }),
-) as unknown as Schema.Schema<PutBucketLockRequest>;
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  rules: Schema.optional(Schema.Array(Schema.Struct({
+  id: Schema.String,
+  condition: Schema.Union([Schema.Struct({
+    maxAgeSeconds: Schema.Number,
+    type: Schema.Literal("Age")
+  }), Schema.Struct({
+    date: Schema.String,
+    type: Schema.Literal("Date")
+  }), Schema.Struct({
+    type: Schema.Literal("Indefinite")
+  })]),
+  enabled: Schema.Boolean,
+  prefix: Schema.optional(Schema.String)
+})))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/lock" })) as unknown as Schema.Schema<PutBucketLockRequest>;
 
 export type PutBucketLockResponse = unknown;
 
-export const PutBucketLockResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<PutBucketLockResponse>;
+export const PutBucketLockResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutBucketLockResponse>;
 
-export type PutBucketLockError = DefaultErrors | NoSuchBucket | InvalidRoute;
+export type PutBucketLockError =
+  | DefaultErrors
+  | NoSuchBucket
+  | InvalidRoute;
 
 export const putBucketLock: API.OperationMethod<
   PutBucketLockRequest,
@@ -2197,6 +1376,7 @@ export const putBucketLock: API.OperationMethod<
   errors: [NoSuchBucket, InvalidRoute],
 }));
 
+
 // =============================================================================
 // BucketMetric
 // =============================================================================
@@ -2206,127 +1386,48 @@ export interface ListBucketMetricsRequest {
   accountId: string;
 }
 
-export const ListBucketMetricsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  }).pipe(
-    T.Http({ method: "GET", path: "/accounts/{account_id}/r2/metrics" }),
-  ) as unknown as Schema.Schema<ListBucketMetricsRequest>;
+export const ListBucketMetricsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  accountId: Schema.String.pipe(T.HttpPath("account_id"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/metrics" })) as unknown as Schema.Schema<ListBucketMetricsRequest>;
 
 export interface ListBucketMetricsResponse {
   /** Metrics based on what state they are in(uploaded or published). */
-  infrequentAccess?: {
-    published?: {
-      metadataSize?: number | null;
-      objects?: number | null;
-      payloadSize?: number | null;
-    } | null;
-    uploaded?: {
-      metadataSize?: number | null;
-      objects?: number | null;
-      payloadSize?: number | null;
-    } | null;
-  } | null;
+  infrequentAccess?: { published?: { metadataSize?: number | null; objects?: number | null; payloadSize?: number | null } | null; uploaded?: { metadataSize?: number | null; objects?: number | null; payloadSize?: number | null } | null } | null;
   /** Metrics based on what state they are in(uploaded or published). */
-  standard?: {
-    published?: {
-      metadataSize?: number | null;
-      objects?: number | null;
-      payloadSize?: number | null;
-    } | null;
-    uploaded?: {
-      metadataSize?: number | null;
-      objects?: number | null;
-      payloadSize?: number | null;
-    } | null;
-  } | null;
+  standard?: { published?: { metadataSize?: number | null; objects?: number | null; payloadSize?: number | null } | null; uploaded?: { metadataSize?: number | null; objects?: number | null; payloadSize?: number | null } | null } | null;
 }
 
-export const ListBucketMetricsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    infrequentAccess: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          published: Schema.optional(
-            Schema.Union([
-              Schema.Struct({
-                metadataSize: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                objects: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                payloadSize: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-              }),
-              Schema.Null,
-            ]),
-          ),
-          uploaded: Schema.optional(
-            Schema.Union([
-              Schema.Struct({
-                metadataSize: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                objects: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                payloadSize: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-              }),
-              Schema.Null,
-            ]),
-          ),
-        }),
-        Schema.Null,
-      ]),
-    ),
-    standard: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          published: Schema.optional(
-            Schema.Union([
-              Schema.Struct({
-                metadataSize: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                objects: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                payloadSize: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-              }),
-              Schema.Null,
-            ]),
-          ),
-          uploaded: Schema.optional(
-            Schema.Union([
-              Schema.Struct({
-                metadataSize: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                objects: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-                payloadSize: Schema.optional(
-                  Schema.Union([Schema.Number, Schema.Null]),
-                ),
-              }),
-              Schema.Null,
-            ]),
-          ),
-        }),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<ListBucketMetricsResponse>;
+export const ListBucketMetricsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  infrequentAccess: Schema.optional(Schema.Union([Schema.Struct({
+  published: Schema.optional(Schema.Union([Schema.Struct({
+    metadataSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    objects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    payloadSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null]))
+  }), Schema.Null])),
+  uploaded: Schema.optional(Schema.Union([Schema.Struct({
+    metadataSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    objects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    payloadSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null]))
+  }), Schema.Null]))
+}), Schema.Null])),
+  standard: Schema.optional(Schema.Union([Schema.Struct({
+  published: Schema.optional(Schema.Union([Schema.Struct({
+    metadataSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    objects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    payloadSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null]))
+  }), Schema.Null])),
+  uploaded: Schema.optional(Schema.Union([Schema.Struct({
+    metadataSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    objects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    payloadSize: Schema.optional(Schema.Union([Schema.Number, Schema.Null]))
+  }), Schema.Null]))
+}), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListBucketMetricsResponse>;
 
-export type ListBucketMetricsError = DefaultErrors | InvalidRoute;
+export type ListBucketMetricsError =
+  | DefaultErrors
+  | InvalidRoute;
 
 export const listBucketMetrics: API.OperationMethod<
   ListBucketMetricsRequest,
@@ -2338,6 +1439,7 @@ export const listBucketMetrics: API.OperationMethod<
   output: ListBucketMetricsResponse,
   errors: [InvalidRoute],
 }));
+
 
 // =============================================================================
 // BucketSippy
@@ -2354,74 +1456,39 @@ export interface GetBucketSippyRequest {
 export const GetBucketSippyRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-}).pipe(
-  T.Http({
-    method: "GET",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}/sippy",
-  }),
-) as unknown as Schema.Schema<GetBucketSippyRequest>;
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/sippy" })) as unknown as Schema.Schema<GetBucketSippyRequest>;
 
 export interface GetBucketSippyResponse {
   /** Details about the configured destination bucket. */
-  destination?: {
-    accessKeyId?: string | null;
-    account?: string | null;
-    bucket?: string | null;
-    provider?: "r2" | null;
-  } | null;
+  destination?: { accessKeyId?: string | null; account?: string | null; bucket?: string | null; provider?: "r2" | null } | null;
   /** State of Sippy for this bucket. */
   enabled?: boolean | null;
   /** Details about the configured source bucket. */
-  source?: {
-    bucket?: string | null;
-    bucketUrl?: string | null;
-    provider?: "aws" | "gcs" | "s3" | null;
-    region?: string | null;
-  } | null;
+  source?: { bucket?: string | null; bucketUrl?: string | null; provider?: "aws" | "gcs" | "s3" | null; region?: string | null } | null;
 }
 
-export const GetBucketSippyResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {
-    destination: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          accessKeyId: Schema.optional(
-            Schema.Union([SensitiveString, Schema.Null]),
-          ),
-          account: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          provider: Schema.optional(
-            Schema.Union([Schema.Literal("r2"), Schema.Null]),
-          ),
-        }),
-        Schema.Null,
-      ]),
-    ),
-    enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-    source: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          bucketUrl: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          provider: Schema.optional(
-            Schema.Union([Schema.Literals(["aws", "gcs", "s3"]), Schema.Null]),
-          ),
-          region: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        }),
-        Schema.Null,
-      ]),
-    ),
-  },
-).pipe(
-  T.ResponsePath("result"),
-) as unknown as Schema.Schema<GetBucketSippyResponse>;
+export const GetBucketSippyResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  destination: Schema.optional(Schema.Union([Schema.Struct({
+  accessKeyId: Schema.optional(Schema.Union([SensitiveString, Schema.Null])),
+  account: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  provider: Schema.optional(Schema.Union([Schema.Literal("r2"), Schema.Null]))
+}), Schema.Null])),
+  enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+  source: Schema.optional(Schema.Union([Schema.Struct({
+  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  bucketUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  provider: Schema.optional(Schema.Union([Schema.Literals(["aws", "gcs", "s3"]), Schema.Null])),
+  region: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+}), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetBucketSippyResponse>;
 
-export type GetBucketSippyError = DefaultErrors | NoSuchBucket | InvalidRoute;
+export type GetBucketSippyError =
+  | DefaultErrors
+  | NoSuchBucket
+  | InvalidRoute;
 
 export const getBucketSippy: API.OperationMethod<
   GetBucketSippyRequest,
@@ -2441,106 +1508,54 @@ export interface PutBucketSippyRequest {
   /** Header param: Jurisdiction where objects in this bucket are guaranteed to be stored. */
   jurisdiction?: "default" | "eu" | "fedramp";
   /** Body param: R2 bucket to copy objects to. */
-  destination?: {
-    accessKeyId?: string;
-    provider?: "r2";
-    secretAccessKey?: string;
-  };
+  destination?: { accessKeyId?: string; provider?: "r2"; secretAccessKey?: string };
   /** Body param: AWS S3 bucket to copy objects from. */
-  source?: {
-    accessKeyId?: string;
-    bucket?: string;
-    provider?: "aws";
-    region?: string;
-    secretAccessKey?: string;
-  };
+  source?: { accessKeyId?: string; bucket?: string; provider?: "aws"; region?: string; secretAccessKey?: string };
 }
 
 export const PutBucketSippyRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  destination: Schema.optional(
-    Schema.Struct({
-      accessKeyId: Schema.optional(SensitiveString),
-      provider: Schema.optional(Schema.Literal("r2")),
-      secretAccessKey: Schema.optional(SensitiveString),
-    }),
-  ),
-  source: Schema.optional(
-    Schema.Struct({
-      accessKeyId: Schema.optional(SensitiveString),
-      bucket: Schema.optional(Schema.String),
-      provider: Schema.optional(Schema.Literal("aws")),
-      region: Schema.optional(Schema.String),
-      secretAccessKey: Schema.optional(SensitiveString),
-    }),
-  ),
-}).pipe(
-  T.Http({
-    method: "PUT",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}/sippy",
-  }),
-) as unknown as Schema.Schema<PutBucketSippyRequest>;
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  destination: Schema.optional(Schema.Struct({
+  accessKeyId: Schema.optional(SensitiveString),
+  provider: Schema.optional(Schema.Literal("r2")),
+  secretAccessKey: Schema.optional(SensitiveString)
+})),
+  source: Schema.optional(Schema.Struct({
+  accessKeyId: Schema.optional(SensitiveString),
+  bucket: Schema.optional(Schema.String),
+  provider: Schema.optional(Schema.Literal("aws")),
+  region: Schema.optional(Schema.String),
+  secretAccessKey: Schema.optional(SensitiveString)
+}))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/sippy" })) as unknown as Schema.Schema<PutBucketSippyRequest>;
 
 export interface PutBucketSippyResponse {
   /** Details about the configured destination bucket. */
-  destination?: {
-    accessKeyId?: string | null;
-    account?: string | null;
-    bucket?: string | null;
-    provider?: "r2" | null;
-  } | null;
+  destination?: { accessKeyId?: string | null; account?: string | null; bucket?: string | null; provider?: "r2" | null } | null;
   /** State of Sippy for this bucket. */
   enabled?: boolean | null;
   /** Details about the configured source bucket. */
-  source?: {
-    bucket?: string | null;
-    bucketUrl?: string | null;
-    provider?: "aws" | "gcs" | "s3" | null;
-    region?: string | null;
-  } | null;
+  source?: { bucket?: string | null; bucketUrl?: string | null; provider?: "aws" | "gcs" | "s3" | null; region?: string | null } | null;
 }
 
-export const PutBucketSippyResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {
-    destination: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          accessKeyId: Schema.optional(
-            Schema.Union([SensitiveString, Schema.Null]),
-          ),
-          account: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          provider: Schema.optional(
-            Schema.Union([Schema.Literal("r2"), Schema.Null]),
-          ),
-        }),
-        Schema.Null,
-      ]),
-    ),
-    enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-    source: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          bucketUrl: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          provider: Schema.optional(
-            Schema.Union([Schema.Literals(["aws", "gcs", "s3"]), Schema.Null]),
-          ),
-          region: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        }),
-        Schema.Null,
-      ]),
-    ),
-  },
-).pipe(
-  T.ResponsePath("result"),
-) as unknown as Schema.Schema<PutBucketSippyResponse>;
+export const PutBucketSippyResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  destination: Schema.optional(Schema.Union([Schema.Struct({
+  accessKeyId: Schema.optional(Schema.Union([SensitiveString, Schema.Null])),
+  account: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  provider: Schema.optional(Schema.Union([Schema.Literal("r2"), Schema.Null]))
+}), Schema.Null])),
+  enabled: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+  source: Schema.optional(Schema.Union([Schema.Struct({
+  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  bucketUrl: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  provider: Schema.optional(Schema.Union([Schema.Literals(["aws", "gcs", "s3"]), Schema.Null])),
+  region: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+}), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutBucketSippyResponse>;
 
 export type PutBucketSippyError =
   | DefaultErrors
@@ -2566,32 +1581,20 @@ export interface DeleteBucketSippyRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const DeleteBucketSippyRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  }).pipe(
-    T.Http({
-      method: "DELETE",
-      path: "/accounts/{account_id}/r2/buckets/{bucketName}/sippy",
-    }),
-  ) as unknown as Schema.Schema<DeleteBucketSippyRequest>;
+export const DeleteBucketSippyRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/r2/buckets/{bucketName}/sippy" })) as unknown as Schema.Schema<DeleteBucketSippyRequest>;
 
 export interface DeleteBucketSippyResponse {
   enabled?: false | null;
 }
 
-export const DeleteBucketSippyResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    enabled: Schema.optional(
-      Schema.Union([Schema.Literal(false), Schema.Null]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<DeleteBucketSippyResponse>;
+export const DeleteBucketSippyResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  enabled: Schema.optional(Schema.Union([Schema.Literal(false), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteBucketSippyResponse>;
 
 export type DeleteBucketSippyError =
   | DefaultErrors
@@ -2608,6 +1611,7 @@ export const deleteBucketSippy: API.OperationMethod<
   output: DeleteBucketSippyResponse,
   errors: [NoSuchBucket, InvalidRoute],
 }));
+
 
 // =============================================================================
 // Object
@@ -2628,22 +1632,13 @@ export const GetObjectRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   objectName: Schema.String.pipe(T.HttpPath("objectName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  cfR2Jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-}).pipe(
-  T.Http({
-    method: "GET",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}",
-  }),
-) as unknown as Schema.Schema<GetObjectRequest>;
+  cfR2Jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}" })) as unknown as Schema.Schema<GetObjectRequest>;
 
 export type GetObjectResponse = File | Blob;
 
-export const GetObjectResponse =
-  /*@__PURE__*/ /*#__PURE__*/ UploadableSchema.pipe(T.HttpFormDataFile()).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<GetObjectResponse>;
+export const GetObjectResponse = /*@__PURE__*/ /*#__PURE__*/ UploadableSchema.pipe(T.HttpFormDataFile()).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetObjectResponse>;
 
 export type GetObjectError =
   | DefaultErrors
@@ -2659,6 +1654,78 @@ export const getObject: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetObjectRequest,
   output: GetObjectResponse,
+  errors: [NoSuchBucket, InvalidRoute, NoRoute],
+}));
+
+export interface ListObjectsRequest {
+  /** Name of the R2 bucket. */
+  bucketName: string;
+  /** Account ID. */
+  accountId: string;
+  /** Maximum number of objects to return per page (1-1000). */
+  perPage?: number;
+  /** Restrict results to keys beginning with this prefix. */
+  prefix?: string;
+  /** Single character used to group keys. */
+  delimiter?: string;
+  /** Pagination cursor returned by a previous List Objects call. */
+  cursor?: string;
+  /** Returns keys lexicographically after this key. */
+  startAfter?: string;
+  /** Jurisdiction where objects in this bucket are guaranteed to be stored. */
+  cfR2Jurisdiction?: "default" | "eu" | "fedramp";
+}
+
+export const ListObjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  perPage: Schema.optional(Schema.Number).pipe(T.HttpQuery("per_page")),
+  prefix: Schema.optional(Schema.String).pipe(T.HttpQuery("prefix")),
+  delimiter: Schema.optional(Schema.String).pipe(T.HttpQuery("delimiter")),
+  cursor: Schema.optional(Schema.String).pipe(T.HttpQuery("cursor")),
+  startAfter: Schema.optional(Schema.String).pipe(T.HttpQuery("start_after")),
+  cfR2Jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects" })) as unknown as Schema.Schema<ListObjectsRequest>;
+
+export interface ListObjectsResponse {
+  result?: ({ key?: string | null; size?: number | null; etag?: string | null; lastModified?: string | null; storageClass?: "Standard" | "InfrequentAccess" | null; ssec?: boolean | null; customMetadata?: unknown | null; httpMetadata?: unknown | null })[] | null;
+  resultInfo?: { cursor?: string | null; isTruncated?: boolean | null; perPage?: number | null; delimited?: string[] | null } | null;
+}
+
+export const ListObjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  result: Schema.optional(Schema.Union([Schema.Array(Schema.Struct({
+  key: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  size: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+  etag: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  lastModified: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  storageClass: Schema.optional(Schema.Union([Schema.Literals(["Standard", "InfrequentAccess"]), Schema.Null])),
+  ssec: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+  customMetadata: Schema.optional(Schema.Union([Schema.Unknown, Schema.Null])),
+  httpMetadata: Schema.optional(Schema.Union([Schema.Unknown, Schema.Null]))
+}).pipe(Schema.encodeKeys({ key: "key", size: "size", etag: "etag", lastModified: "last_modified", storageClass: "storage_class", ssec: "ssec", customMetadata: "custom_metadata", httpMetadata: "http_metadata" }))), Schema.Null])),
+  resultInfo: Schema.optional(Schema.Union([Schema.Struct({
+  cursor: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  isTruncated: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+  perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+  delimited: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null]))
+}).pipe(Schema.encodeKeys({ cursor: "cursor", isTruncated: "is_truncated", perPage: "per_page", delimited: "delimited" })), Schema.Null]))
+}).pipe(Schema.encodeKeys({ result: "result", resultInfo: "result_info" })).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ListObjectsResponse>;
+
+export type ListObjectsError =
+  | DefaultErrors
+  | NoSuchBucket
+  | InvalidRoute
+  | NoRoute;
+
+export const listObjects: API.OperationMethod<
+  ListObjectsRequest,
+  ListObjectsResponse,
+  ListObjectsError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: ListObjectsRequest,
+  output: ListObjectsResponse,
   errors: [NoSuchBucket, InvalidRoute, NoRoute],
 }));
 
@@ -2694,46 +1761,22 @@ export const PutObjectRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   objectName: Schema.String.pipe(T.HttpPath("objectName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  cfR2Jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-  contentType: Schema.optional(Schema.String).pipe(
-    T.HttpHeader("content-type"),
-  ),
-  contentDisposition: Schema.optional(Schema.String).pipe(
-    T.HttpHeader("content-disposition"),
-  ),
-  contentEncoding: Schema.optional(Schema.String).pipe(
-    T.HttpHeader("content-encoding"),
-  ),
-  contentLanguage: Schema.optional(Schema.String).pipe(
-    T.HttpHeader("content-language"),
-  ),
-  contentLength: Schema.optional(Schema.String).pipe(
-    T.HttpHeader("content-length"),
-  ),
-  cacheControl: Schema.optional(Schema.String).pipe(
-    T.HttpHeader("cache-control"),
-  ),
+  cfR2Jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  contentType: Schema.optional(Schema.String).pipe(T.HttpHeader("content-type")),
+  contentDisposition: Schema.optional(Schema.String).pipe(T.HttpHeader("content-disposition")),
+  contentEncoding: Schema.optional(Schema.String).pipe(T.HttpHeader("content-encoding")),
+  contentLanguage: Schema.optional(Schema.String).pipe(T.HttpHeader("content-language")),
+  contentLength: Schema.optional(Schema.String).pipe(T.HttpHeader("content-length")),
+  cacheControl: Schema.optional(Schema.String).pipe(T.HttpHeader("cache-control")),
   expires: Schema.optional(Schema.String).pipe(T.HttpHeader("expires")),
-  cfR2StorageClass: Schema.optional(
-    Schema.Literals(["Standard", "InfrequentAccess"]),
-  ).pipe(T.HttpHeader("cf-r2-storage-class")),
-  body: UploadableSchema.pipe(T.HttpFormDataFile()).pipe(T.HttpBody()),
-}).pipe(
-  T.Http({
-    method: "PUT",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}",
-    contentType: "multipart",
-  }),
-) as unknown as Schema.Schema<PutObjectRequest>;
+  cfR2StorageClass: Schema.optional(Schema.Literals(["Standard", "InfrequentAccess"])).pipe(T.HttpHeader("cf-r2-storage-class")),
+  body: UploadableSchema.pipe(T.HttpFormDataFile()).pipe(T.HttpBody())
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}", contentType: "multipart" })) as unknown as Schema.Schema<PutObjectRequest>;
 
 export type PutObjectResponse = unknown;
 
-export const PutObjectResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<PutObjectResponse>;
+export const PutObjectResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PutObjectResponse>;
 
 export type PutObjectError =
   | DefaultErrors
@@ -2752,6 +1795,65 @@ export const putObject: API.OperationMethod<
   errors: [NoSuchBucket, InvalidRoute, NoRoute],
 }));
 
+export interface DeleteObjectsRequest {
+  /** Name of the R2 bucket. */
+  bucketName: string;
+  /** Account ID. */
+  accountId: string;
+  /** When set, switches to "delete by prefix" mode and asynchronously deletes every object whose key begins with the given prefix. The response is a prefix-delete job descriptor instead of a per-key list.  */
+  prefix?: string;
+  /** Jurisdiction where objects in this bucket are guaranteed to be stored. */
+  cfR2Jurisdiction?: "default" | "eu" | "fedramp";
+  body?: string[];
+}
+
+export const DeleteObjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  prefix: Schema.optional(Schema.String).pipe(T.HttpQuery("prefix")),
+  cfR2Jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction")),
+  body: Schema.optional(Schema.Array(Schema.String)).pipe(T.HttpBody())
+})
+  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects" })) as unknown as Schema.Schema<DeleteObjectsRequest>;
+
+export interface DeleteObjectsResponse {
+  result?: ({ key?: string | null })[] | { id?: string | null; jobType?: "prefixDelete" | null; status?: "ENQUEUED" | "RUNNING" | "COMPLETED" | "FAILED" | "CANCELLED" | null; startTime?: string | null; endTime?: string | null; prefixDelete?: { prefix?: string | null; deletedObjects?: number | null; isBucketClear?: boolean | null } | null } | null;
+}
+
+export const DeleteObjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  result: Schema.optional(Schema.Union([Schema.Union([Schema.Array(Schema.Struct({
+  key: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+})), Schema.Struct({
+  id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  jobType: Schema.optional(Schema.Union([Schema.Literal("prefixDelete"), Schema.Null])),
+  status: Schema.optional(Schema.Union([Schema.Literals(["ENQUEUED", "RUNNING", "COMPLETED", "FAILED", "CANCELLED"]), Schema.Null])),
+  startTime: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  endTime: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  prefixDelete: Schema.optional(Schema.Union([Schema.Struct({
+    prefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    deletedObjects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    isBucketClear: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null]))
+  }), Schema.Null]))
+})]), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteObjectsResponse>;
+
+export type DeleteObjectsError =
+  | DefaultErrors
+  | NoSuchBucket
+  | InvalidRoute
+  | NoRoute;
+
+export const deleteObjects: API.OperationMethod<
+  DeleteObjectsRequest,
+  DeleteObjectsResponse,
+  DeleteObjectsError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: DeleteObjectsRequest,
+  output: DeleteObjectsResponse,
+  errors: [NoSuchBucket, InvalidRoute, NoRoute],
+}));
+
 export interface DeleteObjectRequest {
   /** Name of the R2 bucket. */
   bucketName: string;
@@ -2767,22 +1869,13 @@ export const DeleteObjectRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   bucketName: Schema.String.pipe(T.HttpPath("bucketName")),
   objectName: Schema.String.pipe(T.HttpPath("objectName")),
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  cfR2Jurisdiction: Schema.optional(
-    Schema.Literals(["default", "eu", "fedramp"]),
-  ).pipe(T.HttpHeader("cf-r2-jurisdiction")),
-}).pipe(
-  T.Http({
-    method: "DELETE",
-    path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}",
-  }),
-) as unknown as Schema.Schema<DeleteObjectRequest>;
+  cfR2Jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])).pipe(T.HttpHeader("cf-r2-jurisdiction"))
+})
+  .pipe(T.Http({ method: "DELETE", path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}" })) as unknown as Schema.Schema<DeleteObjectRequest>;
 
 export type DeleteObjectResponse = unknown;
 
-export const DeleteObjectResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<DeleteObjectResponse>;
+export const DeleteObjectResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<DeleteObjectResponse>;
 
 export type DeleteObjectError =
   | DefaultErrors
@@ -2800,6 +1893,7 @@ export const deleteObject: API.OperationMethod<
   output: DeleteObjectResponse,
   errors: [NoSuchBucket, InvalidRoute, NoRoute],
 }));
+
 
 // =============================================================================
 // SuperSlurperConnectivityPrecheck
@@ -2822,39 +1916,30 @@ export interface SourceSuperSlurperConnectivityPrecheckRequest {
   region?: string | null;
 }
 
-export const SourceSuperSlurperConnectivityPrecheckRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    bucket: Schema.String,
-    secret: Schema.Struct({
-      accessKeyId: SensitiveString,
-      secretAccessKey: SensitiveString,
-    }),
-    vendor: Schema.Literal("s3"),
-    endpoint: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    region: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/slurper/source/connectivity-precheck",
-    }),
-  ) as unknown as Schema.Schema<SourceSuperSlurperConnectivityPrecheckRequest>;
+export const SourceSuperSlurperConnectivityPrecheckRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  bucket: Schema.String,
+  secret: Schema.Struct({
+  accessKeyId: SensitiveString,
+  secretAccessKey: SensitiveString
+}),
+  vendor: Schema.Literal("s3"),
+  endpoint: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  region: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/slurper/source/connectivity-precheck" })) as unknown as Schema.Schema<SourceSuperSlurperConnectivityPrecheckRequest>;
 
 export interface SourceSuperSlurperConnectivityPrecheckResponse {
   connectivityStatus?: "success" | "error" | null;
 }
 
-export const SourceSuperSlurperConnectivityPrecheckResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    connectivityStatus: Schema.optional(
-      Schema.Union([Schema.Literals(["success", "error"]), Schema.Null]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<SourceSuperSlurperConnectivityPrecheckResponse>;
+export const SourceSuperSlurperConnectivityPrecheckResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  connectivityStatus: Schema.optional(Schema.Union([Schema.Literals(["success", "error"]), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<SourceSuperSlurperConnectivityPrecheckResponse>;
 
-export type SourceSuperSlurperConnectivityPrecheckError = DefaultErrors;
+export type SourceSuperSlurperConnectivityPrecheckError =
+  | DefaultErrors;
 
 export const sourceSuperSlurperConnectivityPrecheck: API.OperationMethod<
   SourceSuperSlurperConnectivityPrecheckRequest,
@@ -2880,39 +1965,28 @@ export interface TargetSuperSlurperConnectivityPrecheckRequest {
   jurisdiction?: "default" | "eu" | "fedramp";
 }
 
-export const TargetSuperSlurperConnectivityPrecheckRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    bucket: Schema.String,
-    secret: Schema.Struct({
-      accessKeyId: SensitiveString,
-      secretAccessKey: SensitiveString,
-    }),
-    vendor: Schema.Literal("r2"),
-    jurisdiction: Schema.optional(
-      Schema.Literals(["default", "eu", "fedramp"]),
-    ),
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/slurper/target/connectivity-precheck",
-    }),
-  ) as unknown as Schema.Schema<TargetSuperSlurperConnectivityPrecheckRequest>;
+export const TargetSuperSlurperConnectivityPrecheckRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  bucket: Schema.String,
+  secret: Schema.Struct({
+  accessKeyId: SensitiveString,
+  secretAccessKey: SensitiveString
+}),
+  vendor: Schema.Literal("r2"),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"]))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/slurper/target/connectivity-precheck" })) as unknown as Schema.Schema<TargetSuperSlurperConnectivityPrecheckRequest>;
 
 export interface TargetSuperSlurperConnectivityPrecheckResponse {
   connectivityStatus?: "success" | "error" | null;
 }
 
-export const TargetSuperSlurperConnectivityPrecheckResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    connectivityStatus: Schema.optional(
-      Schema.Union([Schema.Literals(["success", "error"]), Schema.Null]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<TargetSuperSlurperConnectivityPrecheckResponse>;
+export const TargetSuperSlurperConnectivityPrecheckResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  connectivityStatus: Schema.optional(Schema.Union([Schema.Literals(["success", "error"]), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<TargetSuperSlurperConnectivityPrecheckResponse>;
 
-export type TargetSuperSlurperConnectivityPrecheckError = DefaultErrors;
+export type TargetSuperSlurperConnectivityPrecheckError =
+  | DefaultErrors;
 
 export const targetSuperSlurperConnectivityPrecheck: API.OperationMethod<
   TargetSuperSlurperConnectivityPrecheckRequest,
@@ -2925,6 +1999,7 @@ export const targetSuperSlurperConnectivityPrecheck: API.OperationMethod<
   errors: [],
 }));
 
+
 // =============================================================================
 // SuperSlurperJob
 // =============================================================================
@@ -2934,138 +2009,55 @@ export interface GetSuperSlurperJobRequest {
   accountId: string;
 }
 
-export const GetSuperSlurperJobRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    jobId: Schema.String.pipe(T.HttpPath("jobId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  }).pipe(
-    T.Http({
-      method: "GET",
-      path: "/accounts/{account_id}/slurper/jobs/{jobId}",
-    }),
-  ) as unknown as Schema.Schema<GetSuperSlurperJobRequest>;
+export const GetSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  jobId: Schema.String.pipe(T.HttpPath("jobId")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/slurper/jobs/{jobId}" })) as unknown as Schema.Schema<GetSuperSlurperJobRequest>;
 
 export interface GetSuperSlurperJobResponse {
   id?: string | null;
   createdAt?: string | null;
   finishedAt?: string | null;
   overwrite?: boolean | null;
-  source?:
-    | {
-        bucket?: string | null;
-        endpoint?: string | null;
-        keys?: string[] | null;
-        pathPrefix?: string | null;
-        vendor?: "s3" | null;
-      }
-    | {
-        bucket?: string | null;
-        keys?: string[] | null;
-        pathPrefix?: string | null;
-        vendor?: "gcs" | null;
-      }
-    | {
-        bucket?: string | null;
-        jurisdiction?: "default" | "eu" | "fedramp" | null;
-        keys?: string[] | null;
-        pathPrefix?: string | null;
-        vendor?: "r2" | null;
-      }
-    | null;
+  source?: { bucket?: string | null; endpoint?: string | null; keys?: string[] | null; pathPrefix?: string | null; vendor?: "s3" | null } | { bucket?: string | null; keys?: string[] | null; pathPrefix?: string | null; vendor?: "gcs" | null } | { bucket?: string | null; jurisdiction?: "default" | "eu" | "fedramp" | null; keys?: string[] | null; pathPrefix?: string | null; vendor?: "r2" | null } | null;
   status?: "running" | "paused" | "aborted" | "completed" | null;
-  target?: {
-    bucket?: string | null;
-    jurisdiction?: "default" | "eu" | "fedramp" | null;
-    vendor?: "r2" | null;
-  } | null;
+  target?: { bucket?: string | null; jurisdiction?: "default" | "eu" | "fedramp" | null; vendor?: "r2" | null } | null;
 }
 
-export const GetSuperSlurperJobResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    finishedAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    overwrite: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-    source: Schema.optional(
-      Schema.Union([
-        Schema.Union([
-          Schema.Struct({
-            bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            endpoint: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            keys: Schema.optional(
-              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-            ),
-            pathPrefix: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            vendor: Schema.optional(
-              Schema.Union([Schema.Literal("s3"), Schema.Null]),
-            ),
-          }),
-          Schema.Struct({
-            bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            keys: Schema.optional(
-              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-            ),
-            pathPrefix: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            vendor: Schema.optional(
-              Schema.Union([Schema.Literal("gcs"), Schema.Null]),
-            ),
-          }),
-          Schema.Struct({
-            bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-            jurisdiction: Schema.optional(
-              Schema.Union([
-                Schema.Literals(["default", "eu", "fedramp"]),
-                Schema.Null,
-              ]),
-            ),
-            keys: Schema.optional(
-              Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-            ),
-            pathPrefix: Schema.optional(
-              Schema.Union([Schema.String, Schema.Null]),
-            ),
-            vendor: Schema.optional(
-              Schema.Union([Schema.Literal("r2"), Schema.Null]),
-            ),
-          }),
-        ]),
-        Schema.Null,
-      ]),
-    ),
-    status: Schema.optional(
-      Schema.Union([
-        Schema.Literals(["running", "paused", "aborted", "completed"]),
-        Schema.Null,
-      ]),
-    ),
-    target: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          jurisdiction: Schema.optional(
-            Schema.Union([
-              Schema.Literals(["default", "eu", "fedramp"]),
-              Schema.Null,
-            ]),
-          ),
-          vendor: Schema.optional(
-            Schema.Union([Schema.Literal("r2"), Schema.Null]),
-          ),
-        }),
-        Schema.Null,
-      ]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<GetSuperSlurperJobResponse>;
+export const GetSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  finishedAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  overwrite: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+  source: Schema.optional(Schema.Union([Schema.Union([Schema.Struct({
+  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  endpoint: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  keys: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  vendor: Schema.optional(Schema.Union([Schema.Literal("s3"), Schema.Null]))
+}), Schema.Struct({
+  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  keys: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  vendor: Schema.optional(Schema.Union([Schema.Literal("gcs"), Schema.Null]))
+}), Schema.Struct({
+  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
+  keys: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  vendor: Schema.optional(Schema.Union([Schema.Literal("r2"), Schema.Null]))
+})]), Schema.Null])),
+  status: Schema.optional(Schema.Union([Schema.Literals(["running", "paused", "aborted", "completed"]), Schema.Null])),
+  target: Schema.optional(Schema.Union([Schema.Struct({
+  bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
+  vendor: Schema.optional(Schema.Union([Schema.Literal("r2"), Schema.Null]))
+}), Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetSuperSlurperJobResponse>;
 
-export type GetSuperSlurperJobError = DefaultErrors;
+export type GetSuperSlurperJobError =
+  | DefaultErrors;
 
 export const getSuperSlurperJob: API.OperationMethod<
   GetSuperSlurperJobRequest,
@@ -3087,148 +2079,52 @@ export interface ListSuperSlurperJobsRequest {
   offset?: number;
 }
 
-export const ListSuperSlurperJobsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    limit: Schema.optional(Schema.Number).pipe(T.HttpQuery("limit")),
-    offset: Schema.optional(Schema.Number).pipe(T.HttpQuery("offset")),
-  }).pipe(
-    T.Http({ method: "GET", path: "/accounts/{account_id}/slurper/jobs" }),
-  ) as unknown as Schema.Schema<ListSuperSlurperJobsRequest>;
+export const ListSuperSlurperJobsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  limit: Schema.optional(Schema.Number).pipe(T.HttpQuery("limit")),
+  offset: Schema.optional(Schema.Number).pipe(T.HttpQuery("offset"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/slurper/jobs" })) as unknown as Schema.Schema<ListSuperSlurperJobsRequest>;
 
 export interface ListSuperSlurperJobsResponse {
-  result: {
-    id?: string | null;
-    createdAt?: string | null;
-    finishedAt?: string | null;
-    overwrite?: boolean | null;
-    source?:
-      | {
-          bucket?: string | null;
-          endpoint?: string | null;
-          keys?: string[] | null;
-          pathPrefix?: string | null;
-          vendor?: "s3" | null;
-        }
-      | {
-          bucket?: string | null;
-          keys?: string[] | null;
-          pathPrefix?: string | null;
-          vendor?: "gcs" | null;
-        }
-      | {
-          bucket?: string | null;
-          jurisdiction?: "default" | "eu" | "fedramp" | null;
-          keys?: string[] | null;
-          pathPrefix?: string | null;
-          vendor?: "r2" | null;
-        }
-      | null;
-    status?: "running" | "paused" | "aborted" | "completed" | null;
-    target?: {
-      bucket?: string | null;
-      jurisdiction?: "default" | "eu" | "fedramp" | null;
-      vendor?: "r2" | null;
-    } | null;
-  }[];
+  result: ({ id?: string | null; createdAt?: string | null; finishedAt?: string | null; overwrite?: boolean | null; source?: { bucket?: string | null; endpoint?: string | null; keys?: string[] | null; pathPrefix?: string | null; vendor?: "s3" | null } | { bucket?: string | null; keys?: string[] | null; pathPrefix?: string | null; vendor?: "gcs" | null } | { bucket?: string | null; jurisdiction?: "default" | "eu" | "fedramp" | null; keys?: string[] | null; pathPrefix?: string | null; vendor?: "r2" | null } | null; status?: "running" | "paused" | "aborted" | "completed" | null; target?: { bucket?: string | null; jurisdiction?: "default" | "eu" | "fedramp" | null; vendor?: "r2" | null } | null })[];
 }
 
-export const ListSuperSlurperJobsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    result: Schema.Array(
-      Schema.Struct({
-        id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        finishedAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        overwrite: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-        source: Schema.optional(
-          Schema.Union([
-            Schema.Union([
-              Schema.Struct({
-                bucket: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                endpoint: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                keys: Schema.optional(
-                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-                ),
-                pathPrefix: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                vendor: Schema.optional(
-                  Schema.Union([Schema.Literal("s3"), Schema.Null]),
-                ),
-              }),
-              Schema.Struct({
-                bucket: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                keys: Schema.optional(
-                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-                ),
-                pathPrefix: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                vendor: Schema.optional(
-                  Schema.Union([Schema.Literal("gcs"), Schema.Null]),
-                ),
-              }),
-              Schema.Struct({
-                bucket: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                jurisdiction: Schema.optional(
-                  Schema.Union([
-                    Schema.Literals(["default", "eu", "fedramp"]),
-                    Schema.Null,
-                  ]),
-                ),
-                keys: Schema.optional(
-                  Schema.Union([Schema.Array(Schema.String), Schema.Null]),
-                ),
-                pathPrefix: Schema.optional(
-                  Schema.Union([Schema.String, Schema.Null]),
-                ),
-                vendor: Schema.optional(
-                  Schema.Union([Schema.Literal("r2"), Schema.Null]),
-                ),
-              }),
-            ]),
-            Schema.Null,
-          ]),
-        ),
-        status: Schema.optional(
-          Schema.Union([
-            Schema.Literals(["running", "paused", "aborted", "completed"]),
-            Schema.Null,
-          ]),
-        ),
-        target: Schema.optional(
-          Schema.Union([
-            Schema.Struct({
-              bucket: Schema.optional(
-                Schema.Union([Schema.String, Schema.Null]),
-              ),
-              jurisdiction: Schema.optional(
-                Schema.Union([
-                  Schema.Literals(["default", "eu", "fedramp"]),
-                  Schema.Null,
-                ]),
-              ),
-              vendor: Schema.optional(
-                Schema.Union([Schema.Literal("r2"), Schema.Null]),
-              ),
-            }),
-            Schema.Null,
-          ]),
-        ),
-      }),
-    ),
-  }) as unknown as Schema.Schema<ListSuperSlurperJobsResponse>;
+export const ListSuperSlurperJobsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  result: Schema.Array(Schema.Struct({
+  id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  finishedAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  overwrite: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+  source: Schema.optional(Schema.Union([Schema.Union([Schema.Struct({
+    bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    endpoint: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    keys: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+    pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    vendor: Schema.optional(Schema.Union([Schema.Literal("s3"), Schema.Null]))
+  }), Schema.Struct({
+    bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    keys: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+    pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    vendor: Schema.optional(Schema.Union([Schema.Literal("gcs"), Schema.Null]))
+  }), Schema.Struct({
+    bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
+    keys: Schema.optional(Schema.Union([Schema.Array(Schema.String), Schema.Null])),
+    pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    vendor: Schema.optional(Schema.Union([Schema.Literal("r2"), Schema.Null]))
+  })]), Schema.Null])),
+  status: Schema.optional(Schema.Union([Schema.Literals(["running", "paused", "aborted", "completed"]), Schema.Null])),
+  target: Schema.optional(Schema.Union([Schema.Struct({
+    bucket: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    jurisdiction: Schema.optional(Schema.Union([Schema.Literals(["default", "eu", "fedramp"]), Schema.Null])),
+    vendor: Schema.optional(Schema.Union([Schema.Literal("r2"), Schema.Null]))
+  }), Schema.Null]))
+}))
+}) as unknown as Schema.Schema<ListSuperSlurperJobsResponse>;
 
-export type ListSuperSlurperJobsError = DefaultErrors;
+export type ListSuperSlurperJobsError =
+  | DefaultErrors;
 
 export const listSuperSlurperJobs: API.PaginatedOperationMethod<
   ListSuperSlurperJobsRequest,
@@ -3251,112 +2147,64 @@ export interface CreateSuperSlurperJobRequest {
   /** Body param: */
   overwrite?: boolean;
   /** Body param: */
-  source?:
-    | {
-        bucket: string;
-        secret: { accessKeyId: string; secretAccessKey: string };
-        vendor: "s3";
-        endpoint?: string | null;
-        pathPrefix?: string | null;
-        region?: string | null;
-      }
-    | {
-        bucket: string;
-        secret: { clientEmail: string; privateKey: string };
-        vendor: "gcs";
-        pathPrefix?: string | null;
-      }
-    | {
-        bucket: string;
-        secret: { accessKeyId: string; secretAccessKey: string };
-        vendor: "r2";
-        jurisdiction?: "default" | "eu" | "fedramp";
-        pathPrefix?: string | null;
-      };
+  source?: { bucket: string; secret: { accessKeyId: string; secretAccessKey: string }; vendor: "s3"; endpoint?: string | null; pathPrefix?: string | null; region?: string | null } | { bucket: string; secret: { clientEmail: string; privateKey: string }; vendor: "gcs"; pathPrefix?: string | null } | { bucket: string; secret: { accessKeyId: string; secretAccessKey: string }; vendor: "r2"; jurisdiction?: "default" | "eu" | "fedramp"; pathPrefix?: string | null };
   /** Body param: */
-  target?: {
-    bucket: string;
-    secret: { accessKeyId: string; secretAccessKey: string };
-    vendor: "r2";
-    jurisdiction?: "default" | "eu" | "fedramp";
-  };
+  target?: { bucket: string; secret: { accessKeyId: string; secretAccessKey: string }; vendor: "r2"; jurisdiction?: "default" | "eu" | "fedramp" };
 }
 
-export const CreateSuperSlurperJobRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    overwrite: Schema.optional(Schema.Boolean),
-    source: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          bucket: Schema.String,
-          secret: Schema.Struct({
-            accessKeyId: SensitiveString,
-            secretAccessKey: SensitiveString,
-          }),
-          vendor: Schema.Literal("s3"),
-          endpoint: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          pathPrefix: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-          region: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        }),
-        Schema.Struct({
-          bucket: Schema.String,
-          secret: Schema.Struct({
-            clientEmail: Schema.String,
-            privateKey: SensitiveString,
-          }),
-          vendor: Schema.Literal("gcs"),
-          pathPrefix: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-        }),
-        Schema.Struct({
-          bucket: Schema.String,
-          secret: Schema.Struct({
-            accessKeyId: SensitiveString,
-            secretAccessKey: SensitiveString,
-          }),
-          vendor: Schema.Literal("r2"),
-          jurisdiction: Schema.optional(
-            Schema.Literals(["default", "eu", "fedramp"]),
-          ),
-          pathPrefix: Schema.optional(
-            Schema.Union([Schema.String, Schema.Null]),
-          ),
-        }),
-      ]),
-    ),
-    target: Schema.optional(
-      Schema.Struct({
-        bucket: Schema.String,
-        secret: Schema.Struct({
-          accessKeyId: SensitiveString,
-          secretAccessKey: SensitiveString,
-        }),
-        vendor: Schema.Literal("r2"),
-        jurisdiction: Schema.optional(
-          Schema.Literals(["default", "eu", "fedramp"]),
-        ),
-      }),
-    ),
-  }).pipe(
-    T.Http({ method: "POST", path: "/accounts/{account_id}/slurper/jobs" }),
-  ) as unknown as Schema.Schema<CreateSuperSlurperJobRequest>;
+export const CreateSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  overwrite: Schema.optional(Schema.Boolean),
+  source: Schema.optional(Schema.Union([Schema.Struct({
+  bucket: Schema.String,
+  secret: Schema.Struct({
+    accessKeyId: SensitiveString,
+    secretAccessKey: SensitiveString
+  }),
+  vendor: Schema.Literal("s3"),
+  endpoint: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  region: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+}), Schema.Struct({
+  bucket: Schema.String,
+  secret: Schema.Struct({
+    clientEmail: Schema.String,
+    privateKey: SensitiveString
+  }),
+  vendor: Schema.Literal("gcs"),
+  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+}), Schema.Struct({
+  bucket: Schema.String,
+  secret: Schema.Struct({
+    accessKeyId: SensitiveString,
+    secretAccessKey: SensitiveString
+  }),
+  vendor: Schema.Literal("r2"),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"])),
+  pathPrefix: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+})])),
+  target: Schema.optional(Schema.Struct({
+  bucket: Schema.String,
+  secret: Schema.Struct({
+    accessKeyId: SensitiveString,
+    secretAccessKey: SensitiveString
+  }),
+  vendor: Schema.Literal("r2"),
+  jurisdiction: Schema.optional(Schema.Literals(["default", "eu", "fedramp"]))
+}))
+})
+  .pipe(T.Http({ method: "POST", path: "/accounts/{account_id}/slurper/jobs" })) as unknown as Schema.Schema<CreateSuperSlurperJobRequest>;
 
 export interface CreateSuperSlurperJobResponse {
   id?: string | null;
 }
 
-export const CreateSuperSlurperJobResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<CreateSuperSlurperJobResponse>;
+export const CreateSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  id: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<CreateSuperSlurperJobResponse>;
 
-export type CreateSuperSlurperJobError = DefaultErrors;
+export type CreateSuperSlurperJobError =
+  | DefaultErrors;
 
 export const createSuperSlurperJob: API.OperationMethod<
   CreateSuperSlurperJobRequest,
@@ -3374,25 +2222,18 @@ export interface AbortSuperSlurperJobRequest {
   accountId: string;
 }
 
-export const AbortSuperSlurperJobRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    jobId: Schema.String.pipe(T.HttpPath("jobId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/slurper/jobs/{jobId}/abort",
-    }),
-  ) as unknown as Schema.Schema<AbortSuperSlurperJobRequest>;
+export const AbortSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  jobId: Schema.String.pipe(T.HttpPath("jobId")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id"))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/slurper/jobs/{jobId}/abort" })) as unknown as Schema.Schema<AbortSuperSlurperJobRequest>;
 
 export type AbortSuperSlurperJobResponse = string;
 
-export const AbortSuperSlurperJobResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<AbortSuperSlurperJobResponse>;
+export const AbortSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<AbortSuperSlurperJobResponse>;
 
-export type AbortSuperSlurperJobError = DefaultErrors;
+export type AbortSuperSlurperJobError =
+  | DefaultErrors;
 
 export const abortSuperSlurperJob: API.OperationMethod<
   AbortSuperSlurperJobRequest,
@@ -3410,25 +2251,18 @@ export interface PauseSuperSlurperJobRequest {
   accountId: string;
 }
 
-export const PauseSuperSlurperJobRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    jobId: Schema.String.pipe(T.HttpPath("jobId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/slurper/jobs/{jobId}/pause",
-    }),
-  ) as unknown as Schema.Schema<PauseSuperSlurperJobRequest>;
+export const PauseSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  jobId: Schema.String.pipe(T.HttpPath("jobId")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id"))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/slurper/jobs/{jobId}/pause" })) as unknown as Schema.Schema<PauseSuperSlurperJobRequest>;
 
 export type PauseSuperSlurperJobResponse = string;
 
-export const PauseSuperSlurperJobResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<PauseSuperSlurperJobResponse>;
+export const PauseSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<PauseSuperSlurperJobResponse>;
 
-export type PauseSuperSlurperJobError = DefaultErrors;
+export type PauseSuperSlurperJobError =
+  | DefaultErrors;
 
 export const pauseSuperSlurperJob: API.OperationMethod<
   PauseSuperSlurperJobRequest,
@@ -3446,16 +2280,11 @@ export interface ProgressSuperSlurperJobRequest {
   accountId: string;
 }
 
-export const ProgressSuperSlurperJobRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    jobId: Schema.String.pipe(T.HttpPath("jobId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  }).pipe(
-    T.Http({
-      method: "GET",
-      path: "/accounts/{account_id}/slurper/jobs/{jobId}/progress",
-    }),
-  ) as unknown as Schema.Schema<ProgressSuperSlurperJobRequest>;
+export const ProgressSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  jobId: Schema.String.pipe(T.HttpPath("jobId")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/slurper/jobs/{jobId}/progress" })) as unknown as Schema.Schema<ProgressSuperSlurperJobRequest>;
 
 export interface ProgressSuperSlurperJobResponse {
   id?: string | null;
@@ -3467,27 +2296,18 @@ export interface ProgressSuperSlurperJobResponse {
   transferredObjects?: number | null;
 }
 
-export const ProgressSuperSlurperJobResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    failedObjects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    objects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    skippedObjects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    status: Schema.optional(
-      Schema.Union([
-        Schema.Literals(["running", "paused", "aborted", "completed"]),
-        Schema.Null,
-      ]),
-    ),
-    transferredObjects: Schema.optional(
-      Schema.Union([Schema.Number, Schema.Null]),
-    ),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<ProgressSuperSlurperJobResponse>;
+export const ProgressSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  failedObjects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+  objects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+  skippedObjects: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+  status: Schema.optional(Schema.Union([Schema.Literals(["running", "paused", "aborted", "completed"]), Schema.Null])),
+  transferredObjects: Schema.optional(Schema.Union([Schema.Number, Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ProgressSuperSlurperJobResponse>;
 
-export type ProgressSuperSlurperJobError = DefaultErrors;
+export type ProgressSuperSlurperJobError =
+  | DefaultErrors;
 
 export const progressSuperSlurperJob: API.OperationMethod<
   ProgressSuperSlurperJobRequest,
@@ -3505,25 +2325,18 @@ export interface ResumeSuperSlurperJobRequest {
   accountId: string;
 }
 
-export const ResumeSuperSlurperJobRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    jobId: Schema.String.pipe(T.HttpPath("jobId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  }).pipe(
-    T.Http({
-      method: "PUT",
-      path: "/accounts/{account_id}/slurper/jobs/{jobId}/resume",
-    }),
-  ) as unknown as Schema.Schema<ResumeSuperSlurperJobRequest>;
+export const ResumeSuperSlurperJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  jobId: Schema.String.pipe(T.HttpPath("jobId")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id"))
+})
+  .pipe(T.Http({ method: "PUT", path: "/accounts/{account_id}/slurper/jobs/{jobId}/resume" })) as unknown as Schema.Schema<ResumeSuperSlurperJobRequest>;
 
 export type ResumeSuperSlurperJobResponse = string;
 
-export const ResumeSuperSlurperJobResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<ResumeSuperSlurperJobResponse>;
+export const ResumeSuperSlurperJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(T.ResponsePath("result")) as unknown as Schema.Schema<ResumeSuperSlurperJobResponse>;
 
-export type ResumeSuperSlurperJobError = DefaultErrors;
+export type ResumeSuperSlurperJobError =
+  | DefaultErrors;
 
 export const resumeSuperSlurperJob: API.OperationMethod<
   ResumeSuperSlurperJobRequest,
@@ -3535,6 +2348,7 @@ export const resumeSuperSlurperJob: API.OperationMethod<
   output: ResumeSuperSlurperJobResponse,
   errors: [],
 }));
+
 
 // =============================================================================
 // SuperSlurperJobLog
@@ -3550,80 +2364,30 @@ export interface ListSuperSlurperJobLogsRequest {
   offset?: number;
 }
 
-export const ListSuperSlurperJobLogsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    jobId: Schema.String.pipe(T.HttpPath("jobId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    limit: Schema.optional(Schema.Number).pipe(T.HttpQuery("limit")),
-    offset: Schema.optional(Schema.Number).pipe(T.HttpQuery("offset")),
-  }).pipe(
-    T.Http({
-      method: "GET",
-      path: "/accounts/{account_id}/slurper/jobs/{jobId}/logs",
-    }),
-  ) as unknown as Schema.Schema<ListSuperSlurperJobLogsRequest>;
+export const ListSuperSlurperJobLogsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  jobId: Schema.String.pipe(T.HttpPath("jobId")),
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  limit: Schema.optional(Schema.Number).pipe(T.HttpQuery("limit")),
+  offset: Schema.optional(Schema.Number).pipe(T.HttpQuery("offset"))
+})
+  .pipe(T.Http({ method: "GET", path: "/accounts/{account_id}/slurper/jobs/{jobId}/logs" })) as unknown as Schema.Schema<ListSuperSlurperJobLogsRequest>;
 
 export interface ListSuperSlurperJobLogsResponse {
-  result: {
-    createdAt?: string | null;
-    job?: string | null;
-    logType?:
-      | "migrationStart"
-      | "migrationComplete"
-      | "migrationAbort"
-      | "migrationError"
-      | "migrationPause"
-      | "migrationResume"
-      | "migrationErrorFailedContinuation"
-      | "importErrorRetryExhaustion"
-      | "importSkippedStorageClass"
-      | "importSkippedOversized"
-      | "importSkippedEmptyObject"
-      | "importSkippedUnsupportedContentType"
-      | "importSkippedExcludedContentType"
-      | "importSkippedInvalidMedia"
-      | "importSkippedRequiresRetrieval"
-      | null;
-    message?: string | null;
-    objectKey?: string | null;
-  }[];
+  result: ({ createdAt?: string | null; job?: string | null; logType?: "migrationStart" | "migrationComplete" | "migrationAbort" | "migrationError" | "migrationPause" | "migrationResume" | "migrationErrorFailedContinuation" | "importErrorRetryExhaustion" | "importSkippedStorageClass" | "importSkippedOversized" | "importSkippedEmptyObject" | "importSkippedUnsupportedContentType" | "importSkippedExcludedContentType" | "importSkippedInvalidMedia" | "importSkippedRequiresRetrieval" | null; message?: string | null; objectKey?: string | null })[];
 }
 
-export const ListSuperSlurperJobLogsResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    result: Schema.Array(
-      Schema.Struct({
-        createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        job: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        logType: Schema.optional(
-          Schema.Union([
-            Schema.Literals([
-              "migrationStart",
-              "migrationComplete",
-              "migrationAbort",
-              "migrationError",
-              "migrationPause",
-              "migrationResume",
-              "migrationErrorFailedContinuation",
-              "importErrorRetryExhaustion",
-              "importSkippedStorageClass",
-              "importSkippedOversized",
-              "importSkippedEmptyObject",
-              "importSkippedUnsupportedContentType",
-              "importSkippedExcludedContentType",
-              "importSkippedInvalidMedia",
-              "importSkippedRequiresRetrieval",
-            ]),
-            Schema.Null,
-          ]),
-        ),
-        message: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        objectKey: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      }),
-    ),
-  }) as unknown as Schema.Schema<ListSuperSlurperJobLogsResponse>;
+export const ListSuperSlurperJobLogsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  result: Schema.Array(Schema.Struct({
+  createdAt: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  job: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  logType: Schema.optional(Schema.Union([Schema.Literals(["migrationStart", "migrationComplete", "migrationAbort", "migrationError", "migrationPause", "migrationResume", "migrationErrorFailedContinuation", "importErrorRetryExhaustion", "importSkippedStorageClass", "importSkippedOversized", "importSkippedEmptyObject", "importSkippedUnsupportedContentType", "importSkippedExcludedContentType", "importSkippedInvalidMedia", "importSkippedRequiresRetrieval"]), Schema.Null])),
+  message: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  objectKey: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+}))
+}) as unknown as Schema.Schema<ListSuperSlurperJobLogsResponse>;
 
-export type ListSuperSlurperJobLogsError = DefaultErrors;
+export type ListSuperSlurperJobLogsError =
+  | DefaultErrors;
 
 export const listSuperSlurperJobLogs: API.PaginatedOperationMethod<
   ListSuperSlurperJobLogsRequest,
@@ -3640,6 +2404,7 @@ export const listSuperSlurperJobLogs: API.PaginatedOperationMethod<
   } as const,
 }));
 
+
 // =============================================================================
 // TemporaryCredential
 // =============================================================================
@@ -3652,11 +2417,7 @@ export interface CreateTemporaryCredentialRequest {
   /** Body param: The parent access key id to use for signing. */
   parentAccessKeyId: string;
   /** Body param: Permissions allowed on the credentials. */
-  permission:
-    | "admin-read-write"
-    | "admin-read-only"
-    | "object-read-write"
-    | "object-read-only";
+  permission: "admin-read-write" | "admin-read-only" | "object-read-write" | "object-read-only";
   /** Body param: How long the credentials will live for in seconds. */
   ttlSeconds: number;
   /** Body param: Optional object paths to scope the credentials to. */
@@ -3665,26 +2426,16 @@ export interface CreateTemporaryCredentialRequest {
   prefixes?: string[];
 }
 
-export const CreateTemporaryCredentialRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    bucket: Schema.String,
-    parentAccessKeyId: Schema.String,
-    permission: Schema.Literals([
-      "admin-read-write",
-      "admin-read-only",
-      "object-read-write",
-      "object-read-only",
-    ]),
-    ttlSeconds: Schema.Number,
-    objects: Schema.optional(Schema.Array(Schema.String)),
-    prefixes: Schema.optional(Schema.Array(Schema.String)),
-  }).pipe(
-    T.Http({
-      method: "POST",
-      path: "/accounts/{account_id}/r2/temp-access-credentials",
-    }),
-  ) as unknown as Schema.Schema<CreateTemporaryCredentialRequest>;
+export const CreateTemporaryCredentialRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  bucket: Schema.String,
+  parentAccessKeyId: Schema.String,
+  permission: Schema.Literals(["admin-read-write", "admin-read-only", "object-read-write", "object-read-only"]),
+  ttlSeconds: Schema.Number,
+  objects: Schema.optional(Schema.Array(Schema.String)),
+  prefixes: Schema.optional(Schema.Array(Schema.String))
+})
+  .pipe(T.Http({ method: "POST", path: "/accounts/{account_id}/r2/temp-access-credentials" })) as unknown as Schema.Schema<CreateTemporaryCredentialRequest>;
 
 export interface CreateTemporaryCredentialResponse {
   /** ID for new access key. */
@@ -3695,18 +2446,14 @@ export interface CreateTemporaryCredentialResponse {
   sessionToken?: string | null;
 }
 
-export const CreateTemporaryCredentialResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    accessKeyId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    secretAccessKey: Schema.optional(
-      Schema.Union([Schema.String, Schema.Null]),
-    ),
-    sessionToken: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-  }).pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<CreateTemporaryCredentialResponse>;
+export const CreateTemporaryCredentialResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  accessKeyId: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  secretAccessKey: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  sessionToken: Schema.optional(Schema.Union([Schema.String, Schema.Null]))
+}).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<CreateTemporaryCredentialResponse>;
 
-export type CreateTemporaryCredentialError = DefaultErrors;
+export type CreateTemporaryCredentialError =
+  | DefaultErrors;
 
 export const createTemporaryCredential: API.OperationMethod<
   CreateTemporaryCredentialRequest,

--- a/packages/cloudflare/src/services/r2.ts
+++ b/packages/cloudflare/src/services/r2.ts
@@ -2710,11 +2710,11 @@ export interface ListObjectsResponse {
     customMetadata?: unknown | null;
     httpMetadata?: unknown | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     cursor?: string | null;
     perPage?: number | null;
-  };
+  } | null;
 }
 
 export const ListObjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -2750,16 +2750,21 @@ export const ListObjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    cursor: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      cursor: "cursor",
-      perPage: "per_page",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        cursor: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          cursor: "cursor",
+          perPage: "per_page",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/r2.ts
+++ b/packages/cloudflare/src/services/r2.ts
@@ -2699,48 +2699,70 @@ export const ListObjectsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   }),
 ) as unknown as Schema.Schema<ListObjectsRequest>;
 
-export type ListObjectsResponse = {
-  key?: string | null;
-  size?: number | null;
-  etag?: string | null;
-  lastModified?: string | null;
-  storageClass?: "Standard" | "InfrequentAccess" | null;
-  ssec?: boolean | null;
-  customMetadata?: unknown | null;
-  httpMetadata?: unknown | null;
-}[];
+export interface ListObjectsResponse {
+  result: {
+    key?: string | null;
+    size?: number | null;
+    etag?: string | null;
+    lastModified?: string | null;
+    storageClass?: "Standard" | "InfrequentAccess" | null;
+    ssec?: boolean | null;
+    customMetadata?: unknown | null;
+    httpMetadata?: unknown | null;
+  }[];
+  resultInfo: {
+    count?: number | null;
+    cursor?: string | null;
+    perPage?: number | null;
+  };
+}
 
-export const ListObjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Array(
-  Schema.Struct({
-    key: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    size: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    etag: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    lastModified: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    storageClass: Schema.optional(
-      Schema.Union([
-        Schema.Literals(["Standard", "InfrequentAccess"]),
-        Schema.Null,
-      ]),
+export const ListObjectsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  result: Schema.Array(
+    Schema.Struct({
+      key: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      size: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      etag: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      lastModified: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+      storageClass: Schema.optional(
+        Schema.Union([
+          Schema.Literals(["Standard", "InfrequentAccess"]),
+          Schema.Null,
+        ]),
+      ),
+      ssec: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
+      customMetadata: Schema.optional(
+        Schema.Union([Schema.Unknown, Schema.Null]),
+      ),
+      httpMetadata: Schema.optional(
+        Schema.Union([Schema.Unknown, Schema.Null]),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        key: "key",
+        size: "size",
+        etag: "etag",
+        lastModified: "last_modified",
+        storageClass: "storage_class",
+        ssec: "ssec",
+        customMetadata: "custom_metadata",
+        httpMetadata: "http_metadata",
+      }),
     ),
-    ssec: Schema.optional(Schema.Union([Schema.Boolean, Schema.Null])),
-    customMetadata: Schema.optional(
-      Schema.Union([Schema.Unknown, Schema.Null]),
-    ),
-    httpMetadata: Schema.optional(Schema.Union([Schema.Unknown, Schema.Null])),
+  ),
+  resultInfo: Schema.Struct({
+    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    cursor: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
   }).pipe(
     Schema.encodeKeys({
-      key: "key",
-      size: "size",
-      etag: "etag",
-      lastModified: "last_modified",
-      storageClass: "storage_class",
-      ssec: "ssec",
-      customMetadata: "custom_metadata",
-      httpMetadata: "http_metadata",
+      count: "count",
+      cursor: "cursor",
+      perPage: "per_page",
     }),
   ),
-).pipe(
-  T.ResponsePath("result"),
+}).pipe(
+  Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
 ) as unknown as Schema.Schema<ListObjectsResponse>;
 
 export type ListObjectsError =
@@ -2749,15 +2771,22 @@ export type ListObjectsError =
   | InvalidRoute
   | NoRoute;
 
-export const listObjects: API.OperationMethod<
+export const listObjects: API.PaginatedOperationMethod<
   ListObjectsRequest,
   ListObjectsResponse,
   ListObjectsError,
   Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
   input: ListObjectsRequest,
   output: ListObjectsResponse,
   errors: [NoSuchBucket, InvalidRoute, NoRoute],
+  pagination: {
+    mode: "cursor",
+    inputToken: "cursor",
+    outputToken: "resultInfo.cursor",
+    items: "result",
+    pageSize: "perPage",
+  } as const,
 }));
 
 export interface PutObjectRequest {

--- a/packages/cloudflare/src/services/radar.ts
+++ b/packages/cloudflare/src/services/radar.ts
@@ -9688,12 +9688,12 @@ export interface ListBgpHijackEventsResponse {
         }[]
       | null;
   };
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListBgpHijackEventsResponse =
@@ -9777,18 +9777,25 @@ export const ListBgpHijackEventsResponse =
         ]),
       ),
     }),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -10088,12 +10095,12 @@ export interface ListBgpLeakEventsResponse {
         }[]
       | null;
   };
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListBgpLeakEventsResponse =
@@ -10157,18 +10164,25 @@ export const ListBgpLeakEventsResponse =
         ]),
       ),
     }),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/rate-limits.ts
+++ b/packages/cloudflare/src/services/rate-limits.ts
@@ -257,12 +257,12 @@ export interface ListRateLimitsResponse {
     period?: number | null;
     threshold?: number | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListRateLimitsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
@@ -402,18 +402,25 @@ export const ListRateLimitsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
         threshold: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
       }),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   },
 ).pipe(

--- a/packages/cloudflare/src/services/resource-sharing.ts
+++ b/packages/cloudflare/src/services/resource-sharing.ts
@@ -168,12 +168,12 @@ export interface ListRecipientsResponse {
         }[]
       | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListRecipientsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
@@ -221,18 +221,25 @@ export const ListRecipientsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   },
 ).pipe(
@@ -635,12 +642,12 @@ export interface ListResourcesResponse {
     resourceVersion: number;
     status: "active" | "deleting" | "deleted";
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListResourcesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -676,18 +683,23 @@ export const ListResourcesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -1314,12 +1326,12 @@ export interface ListResourceSharingsResponse {
         }[]
       | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListResourceSharingsResponse =
@@ -1407,18 +1419,25 @@ export const ListResourceSharingsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/rules.ts
+++ b/packages/cloudflare/src/services/rules.ts
@@ -655,7 +655,7 @@ export interface ListListItemsResponse {
         comment?: string | null;
       }
   )[];
-  resultInfo: { cursors?: { after?: string | null } | null };
+  resultInfo?: { cursors?: { after?: string | null } | null } | null;
 }
 
 export const ListListItemsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -764,16 +764,23 @@ export const ListListItemsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       ),
     ]),
   ),
-  resultInfo: Schema.Struct({
-    cursors: Schema.optional(
-      Schema.Union([
-        Schema.Struct({
-          after: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-        }),
-        Schema.Null,
-      ]),
-    ),
-  }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        cursors: Schema.optional(
+          Schema.Union([
+            Schema.Struct({
+              after: Schema.optional(
+                Schema.Union([Schema.String, Schema.Null]),
+              ),
+            }),
+            Schema.Null,
+          ]),
+        ),
+      }),
+      Schema.Null,
+    ]),
+  ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
 ) as unknown as Schema.Schema<ListListItemsResponse>;

--- a/packages/cloudflare/src/services/rulesets.ts
+++ b/packages/cloudflare/src/services/rulesets.ts
@@ -27309,11 +27309,11 @@ export interface ListRulesetsResponse {
     version: string;
     description?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     cursor?: string | null;
     perPage?: number | null;
-  };
+  } | null;
 }
 
 export const ListRulesetsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -27362,16 +27362,21 @@ export const ListRulesetsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    cursor: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      cursor: "cursor",
-      perPage: "per_page",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        cursor: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          cursor: "cursor",
+          perPage: "per_page",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/rum.ts
+++ b/packages/cloudflare/src/services/rum.ts
@@ -664,12 +664,12 @@ export interface ListSiteInfosResponse {
     siteToken?: string | null;
     snippet?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListSiteInfosResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -752,18 +752,23 @@ export const ListSiteInfosResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/schema-validation.ts
+++ b/packages/cloudflare/src/services/schema-validation.ts
@@ -118,12 +118,12 @@ export interface ListSchemasResponse {
     source: string;
     validationEnabled?: boolean | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListSchemasResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -148,18 +148,23 @@ export const ListSchemasResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -639,12 +644,12 @@ export const ListSettingOperationsRequest =
 
 export interface ListSettingOperationsResponse {
   result: { mitigationAction: "log" | "block" | "none"; operationId: string }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListSettingOperationsResponse =
@@ -660,18 +665,25 @@ export const ListSettingOperationsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/secrets-store.ts
+++ b/packages/cloudflare/src/services/secrets-store.ts
@@ -165,12 +165,12 @@ export const ListStoresRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export interface ListStoresResponse {
   result: { id: string; created: string; modified: string; name: string }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListStoresResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -182,18 +182,23 @@ export const ListStoresResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       name: Schema.String,
     }),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -456,12 +461,12 @@ export interface ListStoreSecretsResponse {
     storeId: string;
     comment?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListStoreSecretsResponse =
@@ -487,18 +492,25 @@ export const ListStoreSecretsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/security-center.ts
+++ b/packages/cloudflare/src/services/security-center.ts
@@ -62,12 +62,12 @@ export interface ListInsightsResponse {
         }[]
       | null;
   };
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListInsightsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -178,18 +178,23 @@ export const ListInsightsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       ]),
     ),
   }),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/snippets.ts
+++ b/packages/cloudflare/src/services/snippets.ts
@@ -335,12 +335,12 @@ export interface ListSnippetsResponse {
     snippetName: string;
     modifiedOn?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListSnippetsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -357,18 +357,23 @@ export const ListSnippetsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/spectrum.ts
+++ b/packages/cloudflare/src/services/spectrum.ts
@@ -721,12 +721,12 @@ export interface ListAppsResponse {
         originDirect?: string[] | null;
       }
   )[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAppsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -856,18 +856,23 @@ export const ListAppsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       ),
     ]),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/speed.ts
+++ b/packages/cloudflare/src/services/speed.ts
@@ -1470,12 +1470,12 @@ export interface ListPageTestsResponse {
     scheduleFrequency?: "DAILY" | "WEEKLY" | null;
     url?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListPageTestsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -1639,18 +1639,23 @@ export const ListPageTestsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       url: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
     }),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/token-validation.ts
+++ b/packages/cloudflare/src/services/token-validation.ts
@@ -199,12 +199,12 @@ export interface ListConfigurationsResponse {
     tokenSources: string[];
     tokenType: "JWT";
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListConfigurationsResponse =
@@ -267,18 +267,25 @@ export const ListConfigurationsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -1014,12 +1021,12 @@ export interface ListRulesResponse {
     createdAt?: string | null;
     lastUpdated?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListRulesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -1073,18 +1080,23 @@ export const ListRulesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/turnstile.ts
+++ b/packages/cloudflare/src/services/turnstile.ts
@@ -253,12 +253,12 @@ export interface ListWidgetsResponse {
     region: "world" | "china";
     sitekey: string;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListWidgetsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -296,18 +296,23 @@ export const ListWidgetsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/user.ts
+++ b/packages/cloudflare/src/services/user.ts
@@ -80,12 +80,12 @@ export interface ListAuditLogsResponse {
     resource?: { id?: string | null; type?: string | null } | null;
     when?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAuditLogsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -143,18 +143,23 @@ export const ListAuditLogsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       when: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
     }),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -202,12 +207,12 @@ export interface ListBillingHistoriesResponse {
     type: string;
     zone: { name?: string | null };
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListBillingHistoriesResponse =
@@ -237,18 +242,25 @@ export const ListBillingHistoriesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -766,12 +778,12 @@ export interface ListOrganizationsResponse {
     roles?: string[] | null;
     status?: "member" | "invited" | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListOrganizationsResponse =
@@ -791,18 +803,25 @@ export const ListOrganizationsResponse =
         ),
       }),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -1345,12 +1364,12 @@ export interface ListTokensResponse {
       | null;
     status?: "active" | "disabled" | "expired" | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListTokensResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -1444,18 +1463,23 @@ export const ListTokensResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/waiting-rooms.ts
+++ b/packages/cloudflare/src/services/waiting-rooms.ts
@@ -200,12 +200,12 @@ export interface ListEventsResponse {
       | "visible_managed"
       | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListEventsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -284,18 +284,23 @@ export const ListEventsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -2231,12 +2236,12 @@ export interface ListWaitingRoomsResponse {
       | "visible_managed"
       | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListWaitingRoomsResponse =
@@ -2420,18 +2425,25 @@ export const ListWaitingRoomsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -379,12 +379,12 @@ export const ListBetaWorkersRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 
 export interface ListBetaWorkersResponse {
   result: { id: string; name: string }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListBetaWorkersResponse =
@@ -395,18 +395,25 @@ export const ListBetaWorkersResponse =
         name: Schema.String,
       }),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -1813,12 +1820,12 @@ export interface ListBetaWorkerVersionsResponse {
     startupTimeMs?: number | null;
     usageModel?: "standard" | "bundled" | "unbound" | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListBetaWorkerVersionsResponse =
@@ -2373,18 +2380,25 @@ export const ListBetaWorkerVersionsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -13183,12 +13197,12 @@ export interface ListScriptVersionsResponse {
         }[]
       | null;
   };
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListScriptVersionsResponse =
@@ -13256,18 +13270,25 @@ export const ListScriptVersionsResponse =
         ]),
       ),
     }),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/workflows.ts
+++ b/packages/cloudflare/src/services/workflows.ts
@@ -346,12 +346,12 @@ export interface ListInstancesResponse {
     versionId: string;
     workflowId: string;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListInstancesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -387,18 +387,23 @@ export const ListInstancesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -885,12 +890,12 @@ export interface ListVersionsResponse {
     modifiedOn: string;
     workflowId: string;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListVersionsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -911,18 +916,23 @@ export const ListVersionsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -1075,12 +1085,12 @@ export interface ListWorkflowsResponse {
     scriptName: string;
     triggeredOn: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListWorkflowsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -1118,18 +1128,23 @@ export const ListWorkflowsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/zero-trust.ts
+++ b/packages/cloudflare/src/services/zero-trust.ts
@@ -78,12 +78,12 @@ export interface ListAccessAiControlMcpPortalsResponse {
     modifiedAt?: string | null;
     modifiedBy?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAccessAiControlMcpPortalsResponse =
@@ -113,18 +113,25 @@ export const ListAccessAiControlMcpPortalsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -652,12 +659,12 @@ export interface ListAccessAiControlMcpServersResponse {
     modifiedBy?: string | null;
     status?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAccessAiControlMcpServersResponse =
@@ -699,18 +706,25 @@ export const ListAccessAiControlMcpServersResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -10537,12 +10551,12 @@ export interface ListAccessApplicationsResponse {
         tags?: string[] | null;
       }
   )[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAccessApplicationsResponse =
@@ -16815,18 +16829,25 @@ export const ListAccessApplicationsResponse =
         ),
       ]),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -33260,12 +33281,12 @@ export interface ListAccessApplicationCasResponse {
     aud?: string | null;
     publicKey?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAccessApplicationCasResponse =
@@ -33279,18 +33300,25 @@ export const ListAccessApplicationCasResponse =
         Schema.encodeKeys({ id: "id", aud: "aud", publicKey: "public_key" }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -34457,12 +34485,12 @@ export interface ListAccessApplicationPoliciesResponse {
     sessionDuration?: string | null;
     updatedAt?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAccessApplicationPoliciesResponse =
@@ -35128,18 +35156,25 @@ export const ListAccessApplicationPoliciesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -38007,12 +38042,12 @@ export interface ListAccessApplicationPolicyTestUsersResponse {
     name?: string | null;
     status?: "approved" | "blocked" | "error" | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAccessApplicationPolicyTestUsersResponse =
@@ -38030,18 +38065,25 @@ export const ListAccessApplicationPolicyTestUsersResponse =
         ),
       }),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -38729,12 +38771,12 @@ export interface ListAccessCertificatesResponse {
     fingerprint?: string | null;
     name?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAccessCertificatesResponse =
@@ -38760,18 +38802,25 @@ export const ListAccessCertificatesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -39218,12 +39267,12 @@ export interface ListAccessCustomPagesResponse {
     type: "identity_denied" | "forbidden";
     uid?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAccessCustomPagesResponse =
@@ -39235,18 +39284,25 @@ export const ListAccessCustomPagesResponse =
         uid: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
       }),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -40818,12 +40874,12 @@ export interface ListAccessGroupsResponse {
         )[]
       | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAccessGroupsResponse =
@@ -41631,18 +41687,25 @@ export const ListAccessGroupsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -45383,12 +45446,12 @@ export interface ListAccessInfrastructureTargetsResponse {
     };
     modifiedAt: string;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAccessInfrastructureTargetsResponse =
@@ -45447,18 +45510,25 @@ export const ListAccessInfrastructureTargetsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -46183,12 +46253,12 @@ export interface ListAccessLogScimUpdatesResponse {
     resourceUserEmail?: string | null;
     status?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAccessLogScimUpdatesResponse =
@@ -46238,18 +46308,25 @@ export const ListAccessLogScimUpdatesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -47340,12 +47417,12 @@ export interface ListAccessPoliciesResponse {
     sessionDuration?: string | null;
     updatedAt?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAccessPoliciesResponse =
@@ -48015,18 +48092,25 @@ export const ListAccessPoliciesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -51383,12 +51467,12 @@ export interface ListAccessServiceTokensResponse {
     expiresAt?: string | null;
     name?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAccessServiceTokensResponse =
@@ -51410,18 +51494,25 @@ export const ListAccessServiceTokensResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -51868,12 +51959,12 @@ export const ListAccessTagsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export interface ListAccessTagsResponse {
   result: { name: string }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAccessTagsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
@@ -51883,18 +51974,25 @@ export const ListAccessTagsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
         name: Schema.String,
       }),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   },
 ).pipe(
@@ -52095,12 +52193,12 @@ export interface ListAccessUsersResponse {
     uid?: string | null;
     updatedAt?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListAccessUsersResponse =
@@ -52142,18 +52240,25 @@ export const ListAccessUsersResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -53319,11 +53424,11 @@ export interface ListDeviceDevicesResponse {
     publicIp?: string | null;
     serialNumber?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     cursor?: string | null;
     perPage?: number | null;
-  };
+  } | null;
 }
 
 export const ListDeviceDevicesResponse =
@@ -53418,16 +53523,21 @@ export const ListDeviceDevicesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      cursor: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        cursor: "cursor",
-        perPage: "per_page",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          cursor: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            cursor: "cursor",
+            perPage: "per_page",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -62326,11 +62436,11 @@ export interface ListDeviceRegistrationsResponse {
       name?: string | null;
     } | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     cursor?: string | null;
     perPage?: number | null;
-  };
+  } | null;
 }
 
 export const ListDeviceRegistrationsResponse =
@@ -62408,16 +62518,21 @@ export const ListDeviceRegistrationsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      cursor: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        cursor: "cursor",
-        perPage: "per_page",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          cursor: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            cursor: "cursor",
+            perPage: "per_page",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -63339,12 +63454,12 @@ export interface ListDexCommandsResponse {
         }[]
       | null;
   };
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListDexCommandsResponse =
@@ -63404,18 +63519,25 @@ export const ListDexCommandsResponse =
         ]),
       ),
     }),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -63621,12 +63743,12 @@ export interface ListDexCommandDevicesResponse {
         }[]
       | null;
   };
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListDexCommandDevicesResponse =
@@ -63678,18 +63800,25 @@ export const ListDexCommandDevicesResponse =
         ]),
       ),
     }),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -64148,12 +64277,12 @@ export interface ListDexFleetStatusDevicesResponse {
     switchLocked?: boolean | null;
     wifiStrengthDbm?: number | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListDexFleetStatusDevicesResponse =
@@ -64529,18 +64658,25 @@ export const ListDexFleetStatusDevicesResponse =
         ),
       }),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -65093,12 +65229,12 @@ export interface ListDexTestsResponse {
         }[]
       | null;
   };
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListDexTestsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -65314,18 +65450,23 @@ export const ListDexTestsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       ]),
     ),
   }),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -89495,12 +89636,12 @@ export interface ListIdentityProvidersResponse {
         } | null;
       }
   )[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListIdentityProvidersResponse =
@@ -90457,18 +90598,25 @@ export const ListIdentityProvidersResponse =
         ),
       ]),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -93581,12 +93729,12 @@ export interface ListIdentityProviderScimGroupsResponse {
     meta?: { created?: string | null; lastModified?: string | null } | null;
     schemas?: string[] | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListIdentityProviderScimGroupsResponse =
@@ -93616,18 +93764,25 @@ export const ListIdentityProviderScimGroupsResponse =
         ),
       }),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -93713,12 +93868,12 @@ export interface ListIdentityProviderScimUsersResponse {
     meta?: { created?: string | null; lastModified?: string | null } | null;
     schemas?: string[] | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListIdentityProviderScimUsersResponse =
@@ -93767,18 +93922,25 @@ export const ListIdentityProviderScimUsersResponse =
         ),
       }),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -93927,12 +94089,12 @@ export interface ListNetworkHostnameRoutesResponse {
     tunnelId?: string | null;
     tunnelName?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListNetworkHostnameRoutesResponse =
@@ -93958,18 +94120,25 @@ export const ListNetworkHostnameRoutesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -94406,12 +94575,12 @@ export interface ListNetworkRoutesResponse {
     virtualNetworkId?: string | null;
     virtualNetworkName?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListNetworkRoutesResponse =
@@ -94460,18 +94629,25 @@ export const ListNetworkRoutesResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -95207,12 +95383,12 @@ export interface ListNetworkSubnetsResponse {
     network?: string | null;
     subnetType?: "cloudflare_source" | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListNetworkSubnetsResponse =
@@ -95244,18 +95420,25 @@ export const ListNetworkSubnetsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -98565,12 +98748,12 @@ export interface ListTunnelsResponse {
           | null;
       }
   )[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListTunnelsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -98766,18 +98949,23 @@ export const ListTunnelsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       ),
     ]),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -99071,12 +99259,12 @@ export interface ListTunnelCloudflaredsResponse {
       | "cni"
       | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListTunnelCloudflaredsResponse =
@@ -99181,18 +99369,25 @@ export const ListTunnelCloudflaredsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
@@ -101048,12 +101243,12 @@ export interface ListTunnelWarpConnectorsResponse {
       | "cni"
       | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListTunnelWarpConnectorsResponse =
@@ -101150,18 +101345,25 @@ export const ListTunnelWarpConnectorsResponse =
         }),
       ),
     ),
-    resultInfo: Schema.Struct({
-      count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-      totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    }).pipe(
-      Schema.encodeKeys({
-        count: "count",
-        page: "page",
-        perPage: "per_page",
-        totalCount: "total_count",
-      }),
+    resultInfo: Schema.optional(
+      Schema.Union([
+        Schema.Struct({
+          count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+          totalCount: Schema.optional(
+            Schema.Union([Schema.Number, Schema.Null]),
+          ),
+        }).pipe(
+          Schema.encodeKeys({
+            count: "count",
+            page: "page",
+            perPage: "per_page",
+            totalCount: "total_count",
+          }),
+        ),
+        Schema.Null,
+      ]),
     ),
   }).pipe(
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),

--- a/packages/cloudflare/src/services/zones.ts
+++ b/packages/cloudflare/src/services/zones.ts
@@ -4598,12 +4598,12 @@ export interface ListZonesResponse {
     vanityNameServers?: string[] | null;
     verificationKey?: string | null;
   }[];
-  resultInfo: {
+  resultInfo?: {
     count?: number | null;
     page?: number | null;
     perPage?: number | null;
     totalCount?: number | null;
-  };
+  } | null;
 }
 
 export const ListZonesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -4759,18 +4759,23 @@ export const ListZonesResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       }),
     ),
   ),
-  resultInfo: Schema.Struct({
-    count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-    totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
-  }).pipe(
-    Schema.encodeKeys({
-      count: "count",
-      page: "page",
-      perPage: "per_page",
-      totalCount: "total_count",
-    }),
+  resultInfo: Schema.optional(
+    Schema.Union([
+      Schema.Struct({
+        count: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        page: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        perPage: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+        totalCount: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+      }).pipe(
+        Schema.encodeKeys({
+          count: "count",
+          page: "page",
+          perPage: "per_page",
+          totalCount: "total_count",
+        }),
+      ),
+      Schema.Null,
+    ]),
   ),
 }).pipe(
   Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),


### PR DESCRIPTION
Adds two REST operations on `/accounts/{account_id}/r2/buckets/{bucketName}/objects` so callers can paginate-then-bulk-delete a bucket's contents without dropping into the S3-compatible endpoint.

```ts
// page through every object
let cursor: string | undefined;
do {
  const page = yield* r2.listObjects({ accountId, bucketName, cursor, perPage: 1000 });
  if (page.result?.length) {
    yield* r2.deleteObjects({
      accountId,
      bucketName,
      body: page.result.map((o) => o.key!),
    });
  }
  cursor = page.resultInfo?.isTruncated ? page.resultInfo.cursor : undefined;
} while (cursor);
```

`deleteObjects` also accepts `?prefix=` (with an empty body) for the async prefix-delete job described by the Cloudflare API; the response shape is `{ key }[] | R2PrefixDeleteJob`.

Sourced from the upstream `r2-list-objects` / `r2-delete-objects` Cloudflare API schemas. Added to `cloudflare-patch` because the Cloudflare TS SDK doesn't expose them.

The `src/services/r2.ts` diff is mostly generator-format churn (the codegen now emits single-line `Schema.Struct({...})` definitions); the meaningful additions are `listObjects`, `deleteObjects`, and their request/response types.
