### PR TITLE
fix(aws): surface SSO portal errors instead of TypeError

### DIFF
--- a/packages/aws/src/auth.ts
+++ b/packages/aws/src/auth.ts
@@ -15,6 +15,7 @@ import {
   InvalidSSOProfile,
   InvalidSSOToken,
   ProfileNotFound,
+  SsoPortalError,
   SsoRegion,
   SsoStartUrl,
   type CredentialsError,
@@ -229,16 +230,31 @@ export const makeAuthService = () =>
           },
         );
 
-        const credentials = (
-          (yield* response.json) as {
-            roleCredentials: {
-              accessKeyId: string;
-              secretAccessKey: string;
-              sessionToken: string;
-              expiration: number;
-            };
-          }
-        ).roleCredentials;
+        const body = (yield* response.json) as {
+          roleCredentials?: {
+            accessKeyId: string;
+            secretAccessKey: string;
+            sessionToken: string;
+            expiration: number;
+          };
+          message?: string;
+          __type?: string;
+        };
+
+        // On non-200 responses (e.g. ForbiddenException when an IAM Identity
+        // Center role assignment is in a stale state) the portal returns a
+        // body without `roleCredentials`. Surface the real error instead of
+        // letting `.accessKeyId` throw `undefined is not an object`.
+        if (!body.roleCredentials) {
+          return yield* new SsoPortalError({
+            message: `AWS SSO portal did not return roleCredentials for profile=${profileName} (account=${profile.sso_account_id} role=${profile.sso_role_name}, status=${response.status}${body.message ? `, ${body.message}` : ""}${body.__type ? `, ${body.__type}` : ""}). ${REFRESH_MESSAGE}`,
+            profile: profileName,
+            account_id: profile.sso_account_id,
+            role_name: profile.sso_role_name,
+            status: response.status,
+          });
+        }
+        const credentials = body.roleCredentials;
 
         yield* fs.writeFileString(
           cachedCredsFilePath,

--- a/packages/aws/src/credentials.ts
+++ b/packages/aws/src/credentials.ts
@@ -53,6 +53,7 @@ export type CredentialsError =
   | ExpiredSSOToken
   | ConflictingSSORegion
   | ConflictingSSOStartUrl
+  | SsoPortalError
   | HttpClientError
   | PlatformError;
 
@@ -276,6 +277,21 @@ export class AwsCredentialProviderError extends Data.TaggedError(
   provider: string;
   cause?: unknown;
   hints?: ReadonlyArray<string>;
+}> {}
+
+/**
+ * The AWS SSO portal returned a response with no `roleCredentials`, e.g. a
+ * `ForbiddenException` when an IAM Identity Center role assignment is in a
+ * stale state.
+ */
+export class SsoPortalError extends Data.TaggedError(
+  "Alchemy::AWS::SsoPortalError",
+)<{
+  message: string;
+  profile: string;
+  account_id?: string;
+  role_name?: string;
+  status?: number;
 }> {}
 
 /**


### PR DESCRIPTION
When the SSO federation/credentials endpoint returns a body with no `roleCredentials` (e.g. `ForbiddenException` when an IAM Identity Center role assignment is in a stale state — `aws sso list-account-roles` may still list it), `credentials.accessKeyId` throws `undefined is not an object` deep in the pipeline.

Check for `roleCredentials` and emit a tagged `SsoPortalError` instead.

```diff lang="ts"
-const credentials = ((yield* response.json) as { roleCredentials: { … } }).roleCredentials;
+const body = (yield* response.json) as {
+  roleCredentials?: { … };
+  message?: string;
+  __type?: string;
+};
+if (!body.roleCredentials) {
+  return yield* new SsoPortalError({
+    message: `AWS SSO portal did not return roleCredentials for profile=${profileName} (status=${response.status}, ${body.message}, ${body.__type}). ${REFRESH_MESSAGE}`,
+    profile: profileName,
+    account_id: profile.sso_account_id,
+    role_name: profile.sso_role_name,
+    status: response.status,
+  });
+}
+const credentials = body.roleCredentials;
```

Before:

```
TypeError: undefined is not an object (evaluating 'credentials.accessKeyId')
    at .../@distilled.cloud/aws/src/auth.ts:246:26
```

After:

```
SsoPortalError: AWS SSO portal did not return roleCredentials for profile=default
(account=391965393224 role=AdministratorAccess, status=403, No access,
com.amazonaws.switchboard.portal#ForbiddenException). To refresh this SSO session
run 'aws sso login' with the corresponding profile.
```
