### PR TITLE
fix(cloudflare): split account-or-zone scoped operations into per-scope variants

### DIFF
--- a/packages/cloudflare/scripts/generate.ts
+++ b/packages/cloudflare/scripts/generate.ts
@@ -1892,17 +1892,25 @@ function generateAccountOrZoneOperationSchema(
     baseInterfaceLines.push(`  ${quotePropKey(propName)}${optMark}: ${tsType};`);
   }
 
+  // Emit a shared base interface containing all non-scope fields, then have
+  // each variant interface extend it with just its scope field. This avoids
+  // duplicating large body field declarations across both variants.
+  const baseInterfaceName = `${pascalOpName}BaseRequest`;
+  lines.push(`interface ${baseInterfaceName} {`);
+  if (baseInterfaceLines.length > 0) {
+    lines.push(baseInterfaceLines.join("\n"));
+  }
+  lines.push(`}`);
+  lines.push("");
+
   const emitVariantInterface = (
     name: string,
     scopeFieldName: "accountId" | "zoneId",
     description: string,
   ): void => {
-    lines.push(`export interface ${name} {`);
+    lines.push(`export interface ${name} extends ${baseInterfaceName} {`);
     lines.push(`  /** ${description} */`);
     lines.push(`  ${scopeFieldName}: string;`);
-    if (baseInterfaceLines.length > 0) {
-      lines.push(baseInterfaceLines.join("\n"));
-    }
     lines.push(`}`);
     lines.push("");
   };

--- a/packages/cloudflare/scripts/generate.ts
+++ b/packages/cloudflare/scripts/generate.ts
@@ -99,6 +99,51 @@ const getSyntheticHeaderParams = (op: ParsedOperation): ParamInfo[] =>
     : [];
 
 /**
+ * Names of the synthetic scope path-param placeholders in the upstream URL
+ * template (e.g. `/{accountOrZone}/{accountOrZoneId}/rulesets/...`). When an
+ * operation contains both, we split the operation into account- and
+ * zone-scoped variants at codegen time. These names are excluded from the
+ * "missing path param" synthesis logic because they are handled by the split.
+ */
+const ACCOUNT_OR_ZONE_SCOPE_PATH_PARAMS = new Set([
+  "accountOrZone",
+  "accountOrZoneId",
+]);
+
+/** True if the operation's URL template contains the accountOrZone scope. */
+const isAccountOrZoneScoped = (op: ParsedOperation): boolean =>
+  op.urlPathParams.includes("accountOrZone") &&
+  op.urlPathParams.includes("accountOrZoneId");
+
+/**
+ * Some Cloudflare URL templates contain `{rulesetPhase}` (and similar) that
+ * never appear as a parameter on the params interface. Synthesize them as
+ * required string path params so they actually get bound to the URL.
+ *
+ * The accountOrZone scope placeholders are intentionally excluded — they are
+ * replaced by concrete account/zone path params via the operation-split flow.
+ */
+const withMissingUrlPathParams = (op: ParsedOperation): ParamInfo[] => {
+  const existing = new Set(op.pathParams.map((param) => param.name));
+  const missing = op.urlPathParams.filter(
+    (name) =>
+      !existing.has(name) && !ACCOUNT_OR_ZONE_SCOPE_PATH_PARAMS.has(name),
+  );
+  if (missing.length === 0) return op.pathParams;
+  return [
+    ...op.pathParams,
+    ...missing.map(
+      (name): ParamInfo => ({
+        name,
+        type: { kind: "primitive", value: "string" },
+        location: "path",
+        required: true,
+      }),
+    ),
+  ];
+};
+
+/**
  * Patch file structure (mirrors src/expr.ts OperationPatch).
  * Defined here to avoid cross-project imports.
  */
@@ -554,9 +599,10 @@ function resolveOperationModel(
   patch?: OperationPatch,
 ): ResolvedOperationModel {
   const syntheticHeaderParams = getSyntheticHeaderParams(op);
+  const effectivePathParams = withMissingUrlPathParams(op);
 
   const nonBodyParamNames = new Set([
-    ...op.pathParams.map((p) => toCamelCase(p.name)),
+    ...effectivePathParams.map((p) => toCamelCase(p.name)),
     ...op.queryParams.map((p) => toCamelCase(p.name)),
     ...op.headerParams.map((p) => toCamelCase(p.name)),
     ...syntheticHeaderParams.map((p) => toCamelCase(p.name)),
@@ -567,7 +613,7 @@ function resolveOperationModel(
   );
 
   const allParams = [
-    ...op.pathParams,
+    ...effectivePathParams,
     ...op.queryParams,
     ...op.headerParams,
     ...syntheticHeaderParams,
@@ -577,7 +623,7 @@ function resolveOperationModel(
     type: resolveOperationTypeInfo(op, param.type),
   }));
 
-  const resolvedPathParams = op.pathParams.map((p) => ({
+  const resolvedPathParams = effectivePathParams.map((p) => ({
     ...p,
     type: resolveOperationTypeInfo(op, p.type),
   }));
@@ -1248,9 +1294,10 @@ function generateOperationSchemaAst(
   }
 
   const syntheticHeaderParams = getSyntheticHeaderParams(op);
+  const effectivePathParams = withMissingUrlPathParams(op);
 
   const nonBodyParamNames = new Set([
-    ...op.pathParams.map((p) => toCamelCase(p.name)),
+    ...effectivePathParams.map((p) => toCamelCase(p.name)),
     ...op.queryParams.map((p) => toCamelCase(p.name)),
     ...op.headerParams.map((p) => toCamelCase(p.name)),
     ...syntheticHeaderParams.map((p) => toCamelCase(p.name)),
@@ -1261,7 +1308,7 @@ function generateOperationSchemaAst(
   );
 
   const allParams = [
-    ...op.pathParams,
+    ...effectivePathParams,
     ...op.queryParams,
     ...op.headerParams,
     ...syntheticHeaderParams,
@@ -1271,7 +1318,7 @@ function generateOperationSchemaAst(
     type: resolveTypeInfoDeep(param.type, op.registry!),
   }));
 
-  const resolvedPathParams = op.pathParams.map((p) => ({
+  const resolvedPathParams = effectivePathParams.map((p) => ({
     ...p,
     type: resolveTypeInfoDeep(p.type, op.registry!),
   }));
@@ -1351,7 +1398,10 @@ function generateOperationSchemaAst(
   for (const param of resolvedPathParams) {
     const propName = toCamelCase(param.name);
     const wireName = param.name;
-    const schema = typeInfoToSchema(param.type);
+    let schema = typeInfoToSchema(param.type);
+    if (!param.required) {
+      schema = `Schema.optional(${schema})`;
+    }
     requestProps.push(
       `  ${quotePropKey(propName)}: ${schema}.pipe(T.HttpPath("${wireName}"))`,
     );
@@ -1651,10 +1701,439 @@ function generateOperationSchemaAst(
  * level by generateServiceFile. This function only references the error tag
  * names from the patch in the operation's type signature and errors array.
  */
+/**
+ * Generate two concrete operations + a thin wrapper for an
+ * accountOrZone-scoped Cloudflare operation.
+ *
+ * The upstream OpenAPI lies about `/{accountOrZone}/{accountOrZoneId}/...` —
+ * it claims `account_id` AND `zone_id` are both required path params, when in
+ * reality the literal first segment is one of `accounts`/`zones` and the
+ * caller picks exactly one of the two IDs. We split that into two real
+ * operations (`*ForAccount`, `*ForZone`) with concrete URLs, and a wrapper
+ * (`*`) that dispatches based on which scope ID is present in the input.
+ */
+function generateAccountOrZoneOperationSchema(
+  op: ParsedOperation,
+  patch?: OperationPatch,
+): string {
+  const normalizedOpName = op.operationName;
+  const pascalOpName = toPascalCase(normalizedOpName);
+  const baseFieldsConstName = `${pascalOpName}BaseFields`;
+  const accountOpName = `${normalizedOpName}ForAccount`;
+  const zoneOpName = `${normalizedOpName}ForZone`;
+  const accountRequestType = `${pascalOpName}ForAccountRequest`;
+  const zoneRequestType = `${pascalOpName}ForZoneRequest`;
+  const requestUnionType = `${pascalOpName}Request`;
+  const responseTypeName = `${pascalOpName}Response`;
+  const errorTypeName = `${pascalOpName}Error`;
+
+  const lines: string[] = [];
+  const errorClassNames: string[] = [];
+  for (const errorDef of getOperationErrors(op, patch)) {
+    errorClassNames.push(errorDef.tag);
+  }
+
+  const resolved = resolveOperationModel(op, patch);
+
+  // Strip `account_id` and `zone_id` from path params — the spec lies and
+  // declares them both required. They are replaced by per-variant scope path
+  // params (accountId for the For-Account variant, zoneId for the For-Zone
+  // variant).
+  const SCOPE_PARAM_NAMES = new Set(["accountId", "zoneId"]);
+  const isScopeParam = (p: { name: string }): boolean =>
+    SCOPE_PARAM_NAMES.has(toCamelCase(p.name));
+
+  const nonScopePathParams = resolved.pathParams.filter((p) => !isScopeParam(p));
+  const queryParams = resolved.queryParams;
+  const headerParams = resolved.headerParams;
+  const bodyParams = resolved.bodyParams.filter((p) => !isScopeParam(p));
+
+  // ---- shared base fields (everything except the scope path param) ----
+  const baseFieldEntries: string[] = [];
+
+  for (const param of nonScopePathParams) {
+    const propName = toCamelCase(param.name);
+    const wireName = param.name;
+    let schema = typeInfoToSchema(param.type);
+    if (!param.required) {
+      schema = `Schema.optional(${schema})`;
+    }
+    baseFieldEntries.push(
+      `  ${quotePropKey(propName)}: ${schema}.pipe(T.HttpPath("${wireName}"))`,
+    );
+  }
+  for (const param of queryParams) {
+    const propName = toCamelCase(param.name);
+    const wireName = param.name;
+    let schema = typeInfoToSchema(param.type);
+    if (!param.required) {
+      schema = `Schema.optional(${schema})`;
+    }
+    baseFieldEntries.push(
+      `  ${quotePropKey(propName)}: ${schema}.pipe(T.HttpQuery("${wireName}"))`,
+    );
+  }
+  for (const param of headerParams) {
+    const propName = toCamelCase(param.name);
+    let schema = typeInfoToSchema(param.type);
+    if (!param.required) {
+      schema = `Schema.optional(${schema})`;
+    }
+    const headerName = param.headerName || param.name;
+    baseFieldEntries.push(
+      `  ${quotePropKey(propName)}: ${schema}.pipe(T.HttpHeader("${headerName}"))`,
+    );
+  }
+
+  const encodeKeysMap: Record<string, string> = {};
+  let hasRenamedBodyKey = false;
+  let bodyAsHttpBodyEntry: string | undefined;
+  for (const param of bodyParams) {
+    const propName = toCamelCase(param.name);
+    const wireName = param.name;
+    let schema = typeInfoToSchema(param.type);
+    if (!param.required) {
+      schema = `Schema.optional(${schema})`;
+    }
+    if (wireName === "body" && bodyParams.length === 1) {
+      bodyAsHttpBodyEntry = `  ${quotePropKey(propName)}: ${schema}.pipe(T.HttpBody())`;
+    } else {
+      encodeKeysMap[propName] = wireName;
+      if (propName !== wireName) {
+        hasRenamedBodyKey = true;
+      }
+      baseFieldEntries.push(`  ${quotePropKey(propName)}: ${schema}`);
+    }
+  }
+  if (bodyAsHttpBodyEntry) {
+    baseFieldEntries.push(bodyAsHttpBodyEntry);
+  }
+
+  // Emit BaseFields const
+  lines.push(`const ${baseFieldsConstName} = {`);
+  if (baseFieldEntries.length > 0) {
+    lines.push(baseFieldEntries.join(",\n") + ",");
+  }
+  lines.push(`} as const;`);
+  lines.push("");
+
+  // Compute path strings for each variant by replacing the scope placeholders
+  // in the upstream URL template.
+  const accountPath = op.urlTemplate
+    .replace("{accountOrZone}", "accounts")
+    .replace("{accountOrZoneId}", "{account_id}");
+  const zonePath = op.urlTemplate
+    .replace("{accountOrZone}", "zones")
+    .replace("{accountOrZoneId}", "{zone_id}");
+
+  const hasFiles = operationHasFiles(op);
+  const isMultipart = hasFiles || op.isMultipart;
+  const buildHttpTrait = (path: string): string =>
+    isMultipart
+      ? `T.Http({ method: "${op.httpMethod}", path: "${path}", contentType: "multipart" })`
+      : `T.Http({ method: "${op.httpMethod}", path: "${path}" })`;
+
+  const buildPipes = (httpTrait: string): string => {
+    const pipes: string[] = [];
+    if (hasRenamedBodyKey) {
+      const encodeKeysEntries = Object.entries(encodeKeysMap)
+        .map(([k, v]) => `${quotePropKey(k)}: "${v}"`)
+        .join(", ");
+      pipes.push(`Schema.encodeKeys({ ${encodeKeysEntries} })`);
+    }
+    pipes.push(httpTrait);
+    return pipes.join(", ");
+  };
+
+  // ---- emit interfaces ----
+  const baseInterfaceLines: string[] = [];
+  for (const param of nonScopePathParams) {
+    const propName = toCamelCase(param.name);
+    const tsType = typeInfoToTsType(param.type);
+    const optMark = param.required ? "" : "?";
+    if (param.description) {
+      baseInterfaceLines.push(
+        `  /** ${param.description.replace(/\n/g, " ").slice(0, 200)} */`,
+      );
+    }
+    baseInterfaceLines.push(`  ${quotePropKey(propName)}${optMark}: ${tsType};`);
+  }
+  for (const param of queryParams) {
+    const propName = toCamelCase(param.name);
+    const tsType = typeInfoToTsType(param.type);
+    const optMark = param.required ? "" : "?";
+    if (param.description) {
+      baseInterfaceLines.push(
+        `  /** ${param.description.replace(/\n/g, " ").slice(0, 200)} */`,
+      );
+    }
+    baseInterfaceLines.push(`  ${quotePropKey(propName)}${optMark}: ${tsType};`);
+  }
+  for (const param of headerParams) {
+    const propName = toCamelCase(param.name);
+    const tsType = typeInfoToTsType(param.type);
+    const optMark = param.required ? "" : "?";
+    if (param.description) {
+      baseInterfaceLines.push(
+        `  /** ${param.description.replace(/\n/g, " ").slice(0, 200)} */`,
+      );
+    }
+    baseInterfaceLines.push(`  ${quotePropKey(propName)}${optMark}: ${tsType};`);
+  }
+  for (const param of bodyParams) {
+    const propName = toCamelCase(param.name);
+    const tsType = typeInfoToTsType(param.type);
+    const optMark = param.required ? "" : "?";
+    if (param.description) {
+      baseInterfaceLines.push(
+        `  /** ${param.description.replace(/\n/g, " ").slice(0, 200)} */`,
+      );
+    }
+    baseInterfaceLines.push(`  ${quotePropKey(propName)}${optMark}: ${tsType};`);
+  }
+
+  const emitVariantInterface = (
+    name: string,
+    scopeFieldName: "accountId" | "zoneId",
+    description: string,
+  ): void => {
+    lines.push(`export interface ${name} {`);
+    lines.push(`  /** ${description} */`);
+    lines.push(`  ${scopeFieldName}: string;`);
+    if (baseInterfaceLines.length > 0) {
+      lines.push(baseInterfaceLines.join("\n"));
+    }
+    lines.push(`}`);
+    lines.push("");
+  };
+
+  emitVariantInterface(
+    accountRequestType,
+    "accountId",
+    "Path param: The Account ID to use for this endpoint.",
+  );
+  emitVariantInterface(
+    zoneRequestType,
+    "zoneId",
+    "Path param: The Zone ID to use for this endpoint.",
+  );
+
+  lines.push(
+    `export type ${requestUnionType} = ${accountRequestType} | ${zoneRequestType};`,
+  );
+  lines.push("");
+
+  // ---- emit Request schemas ----
+  lines.push(
+    `export const ${accountRequestType} = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({`,
+  );
+  lines.push(`  accountId: Schema.String.pipe(T.HttpPath("account_id")),`);
+  lines.push(`  ...${baseFieldsConstName},`);
+  lines.push(`})`);
+  lines.push(
+    `  .pipe(${buildPipes(buildHttpTrait(accountPath))}) as unknown as Schema.Schema<${accountRequestType}>;`,
+  );
+  lines.push("");
+
+  lines.push(
+    `export const ${zoneRequestType} = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({`,
+  );
+  lines.push(`  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),`);
+  lines.push(`  ...${baseFieldsConstName},`);
+  lines.push(`})`);
+  lines.push(
+    `  .pipe(${buildPipes(buildHttpTrait(zonePath))}) as unknown as Schema.Schema<${zoneRequestType}>;`,
+  );
+  lines.push("");
+
+  // ---- emit shared response ----
+  const resolvedResponseType = resolved.responseType;
+  const isTypeAlias = resolved.isTypeAlias;
+  const responsePath = resolved.responsePath;
+
+  if (isTypeAlias && resolvedResponseType) {
+    const tsType = typeInfoToTsType(resolvedResponseType, 0, true);
+    const schema = typeInfoToSchema(resolvedResponseType, "", 0, true);
+    const responsePathPipe = responsePath
+      ? `.pipe(T.ResponsePath("${responsePath}"))`
+      : "";
+    lines.push(`export type ${responseTypeName} = ${tsType};`);
+    lines.push("");
+    lines.push(
+      `export const ${responseTypeName} = /*@__PURE__*/ /*#__PURE__*/ ${schema}${responsePathPipe} as unknown as Schema.Schema<${responseTypeName}>;`,
+    );
+    lines.push("");
+  } else if (
+    resolvedResponseType &&
+    resolvedResponseType.kind === "object" &&
+    resolvedResponseType.properties
+  ) {
+    lines.push(`export interface ${responseTypeName} {`);
+    for (const prop of resolvedResponseType.properties) {
+      const propName = toCamelCase(prop.name);
+      const tsType = typeInfoToTsType(prop.type, 0, true);
+      const optMark = prop.required ? "" : "?";
+      const nullableSuffix =
+        !prop.required && !typeIncludesNull(prop.type) ? " | null" : "";
+      if (prop.description) {
+        lines.push(
+          `  /** ${prop.description.replace(/\n/g, " ").slice(0, 200)} */`,
+        );
+      }
+      lines.push(
+        `  ${quotePropKey(propName)}${optMark}: ${tsType}${nullableSuffix};`,
+      );
+    }
+    lines.push(`}`);
+    lines.push("");
+
+    const responseEncodeKeysMap: Record<string, string> = {};
+    let hasRenamedResponseKey = false;
+    const responseProps = resolvedResponseType.properties.map((prop) => {
+      const wireName = prop.wireKey ?? prop.name;
+      const propName = toCamelCase(prop.name);
+      let schema = typeInfoToSchema(prop.type, "", 0, true);
+      if (!prop.required) {
+        if (!typeIncludesNull(prop.type)) {
+          schema = `Schema.Union([${schema}, Schema.Null])`;
+        }
+        schema = `Schema.optional(${schema})`;
+      }
+      responseEncodeKeysMap[propName] = wireName;
+      if (propName !== wireName) {
+        hasRenamedResponseKey = true;
+      }
+      return `  ${quotePropKey(propName)}: ${schema}`;
+    });
+
+    const responseEncodeKeysPipe = hasRenamedResponseKey
+      ? `.pipe(Schema.encodeKeys({ ${Object.entries(responseEncodeKeysMap)
+          .map(([k, v]) => `${quotePropKey(k)}: "${v}"`)
+          .join(", ")} }))`
+      : "";
+    const responsePathPipe = responsePath
+      ? `.pipe(T.ResponsePath("${responsePath}"))`
+      : "";
+
+    lines.push(
+      `export const ${responseTypeName} = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({`,
+    );
+    if (responseProps.length > 0) {
+      lines.push(responseProps.join(",\n"));
+    }
+    lines.push(
+      `})${responseEncodeKeysPipe}${responsePathPipe} as unknown as Schema.Schema<${responseTypeName}>;`,
+    );
+    lines.push("");
+  } else {
+    const responsePathPipe = responsePath
+      ? `.pipe(T.ResponsePath("${responsePath}"))`
+      : "";
+    lines.push(`export type ${responseTypeName} = unknown;`);
+    lines.push("");
+    lines.push(
+      `export const ${responseTypeName} = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown${responsePathPipe} as unknown as Schema.Schema<${responseTypeName}>;`,
+    );
+    lines.push("");
+  }
+
+  // ---- error type ----
+  const errorsArray =
+    errorClassNames.length > 0 ? `[${errorClassNames.join(", ")}]` : "[]";
+  const errorUnionMembers =
+    errorClassNames.length > 0
+      ? ["DefaultErrors", ...errorClassNames]
+      : ["DefaultErrors"];
+  lines.push(
+    `export type ${errorTypeName} =\n  | ${errorUnionMembers.join("\n  | ")};\n`,
+  );
+
+  // ---- emit operations ----
+  const paginatedItemType = resolved.paginatedItemType;
+  const isPaginated = !!(op.paginationClassName && paginatedItemType);
+
+  const emitOperation = (opName: string, requestType: string): void => {
+    if (isPaginated) {
+      const pagination = getPaginationTrait(op.paginationClassName!);
+      lines.push(`export const ${opName}: API.PaginatedOperationMethod<`);
+      lines.push(`  ${requestType},`);
+      lines.push(`  ${responseTypeName},`);
+      lines.push(`  ${errorTypeName},`);
+      lines.push(`  Credentials | HttpClient.HttpClient`);
+      lines.push(`> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({`);
+      lines.push(`  input: ${requestType},`);
+      lines.push(`  output: ${responseTypeName},`);
+      lines.push(`  errors: ${errorsArray},`);
+      lines.push(`  pagination: {`);
+      lines.push(`    mode: "${pagination.mode}",`);
+      if (pagination.inputToken) {
+        lines.push(`    inputToken: "${pagination.inputToken}",`);
+      }
+      if (pagination.outputToken) {
+        lines.push(`    outputToken: "${pagination.outputToken}",`);
+      }
+      lines.push(`    items: "${pagination.items}",`);
+      if (pagination.pageSize) {
+        lines.push(`    pageSize: "${pagination.pageSize}",`);
+      }
+      lines.push(`  } as const,`);
+      lines.push(`}));`);
+    } else {
+      lines.push(`export const ${opName}: API.OperationMethod<`);
+      lines.push(`  ${requestType},`);
+      lines.push(`  ${responseTypeName},`);
+      lines.push(`  ${errorTypeName},`);
+      lines.push(`  Credentials | HttpClient.HttpClient`);
+      lines.push(`> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({`);
+      lines.push(`  input: ${requestType},`);
+      lines.push(`  output: ${responseTypeName},`);
+      lines.push(`  errors: ${errorsArray},`);
+      lines.push(`}));`);
+    }
+    lines.push("");
+  };
+
+  emitOperation(accountOpName, accountRequestType);
+  emitOperation(zoneOpName, zoneRequestType);
+
+  // ---- emit wrapper ----
+  if (isPaginated) {
+    // Paginated: wrapper returns Stream.Stream<...>
+    lines.push(
+      `export const ${normalizedOpName} = (`,
+    );
+    lines.push(`  input: ${requestUnionType},`);
+    lines.push(
+      `): stream.Stream<${responseTypeName}, ${errorTypeName}, Credentials | HttpClient.HttpClient> =>`,
+    );
+    lines.push(
+      `  "accountId" in input ? ${accountOpName}.pages(input) : ${zoneOpName}.pages(input);`,
+    );
+    lines.push("");
+  } else {
+    lines.push(
+      `export const ${normalizedOpName} = (`,
+    );
+    lines.push(`  input: ${requestUnionType},`);
+    lines.push(
+      `): Effect.Effect<${responseTypeName}, ${errorTypeName}, Credentials | HttpClient.HttpClient> =>`,
+    );
+    lines.push(
+      `  "accountId" in input ? ${accountOpName}(input) : ${zoneOpName}(input);`,
+    );
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
 function generateOperationSchema(
   op: ParsedOperation,
   patch?: OperationPatch,
 ): string {
+  if (isAccountOrZoneScoped(op)) {
+    return generateAccountOrZoneOperationSchema(op, patch);
+  }
   if (op.source === "ast") {
     return generateOperationSchemaAst(op, patch);
   }
@@ -1699,7 +2178,10 @@ function generateOperationSchema(
   for (const param of resolvedPathParams) {
     const propName = toCamelCase(param.name);
     const wireName = param.name;
-    const schema = typeInfoToSchema(param.type);
+    let schema = typeInfoToSchema(param.type);
+    if (!param.required) {
+      schema = `Schema.optional(${schema})`;
+    }
     requestProps.push(
       `  ${quotePropKey(propName)}: ${schema}.pipe(T.HttpPath("${wireName}"))`,
     );

--- a/packages/cloudflare/scripts/generate.ts
+++ b/packages/cloudflare/scripts/generate.ts
@@ -1702,15 +1702,18 @@ function generateOperationSchemaAst(
  * names from the patch in the operation's type signature and errors array.
  */
 /**
- * Generate two concrete operations + a thin wrapper for an
- * accountOrZone-scoped Cloudflare operation.
+ * Generate two concrete operations for an accountOrZone-scoped Cloudflare
+ * operation.
  *
  * The upstream OpenAPI lies about `/{accountOrZone}/{accountOrZoneId}/...` —
  * it claims `account_id` AND `zone_id` are both required path params, when in
  * reality the literal first segment is one of `accounts`/`zones` and the
  * caller picks exactly one of the two IDs. We split that into two real
- * operations (`*ForAccount`, `*ForZone`) with concrete URLs, and a wrapper
- * (`*`) that dispatches based on which scope ID is present in the input.
+ * operations (`*ForAccount`, `*ForZone`) with concrete URLs. Callers pick the
+ * variant matching the scope they intend to address — there is no convenience
+ * wrapper that accepts a scope-discriminated union, since hiding which scope
+ * is being targeted behind a runtime check loses tree-shakability and
+ * produces noisier types.
  */
 function generateAccountOrZoneOperationSchema(
   op: ParsedOperation,
@@ -1723,7 +1726,6 @@ function generateAccountOrZoneOperationSchema(
   const zoneOpName = `${normalizedOpName}ForZone`;
   const accountRequestType = `${pascalOpName}ForAccountRequest`;
   const zoneRequestType = `${pascalOpName}ForZoneRequest`;
-  const requestUnionType = `${pascalOpName}Request`;
   const responseTypeName = `${pascalOpName}Response`;
   const errorTypeName = `${pascalOpName}Error`;
 
@@ -1926,11 +1928,6 @@ function generateAccountOrZoneOperationSchema(
     "Path param: The Zone ID to use for this endpoint.",
   );
 
-  lines.push(
-    `export type ${requestUnionType} = ${accountRequestType} | ${zoneRequestType};`,
-  );
-  lines.push("");
-
   // ---- emit Request schemas ----
   lines.push(
     `export const ${accountRequestType} = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({`,
@@ -2103,34 +2100,6 @@ function generateAccountOrZoneOperationSchema(
 
   emitOperation(accountOpName, accountRequestType);
   emitOperation(zoneOpName, zoneRequestType);
-
-  // ---- emit wrapper ----
-  if (isPaginated) {
-    // Paginated: wrapper returns Stream.Stream<...>
-    lines.push(
-      `export const ${normalizedOpName} = (`,
-    );
-    lines.push(`  input: ${requestUnionType},`);
-    lines.push(
-      `): stream.Stream<${responseTypeName}, ${errorTypeName}, Credentials | HttpClient.HttpClient> =>`,
-    );
-    lines.push(
-      `  "accountId" in input ? ${accountOpName}.pages(input) : ${zoneOpName}.pages(input);`,
-    );
-    lines.push("");
-  } else {
-    lines.push(
-      `export const ${normalizedOpName} = (`,
-    );
-    lines.push(`  input: ${requestUnionType},`);
-    lines.push(
-      `): Effect.Effect<${responseTypeName}, ${errorTypeName}, Credentials | HttpClient.HttpClient> =>`,
-    );
-    lines.push(
-      `  "accountId" in input ? ${accountOpName}(input) : ${zoneOpName}(input);`,
-    );
-    lines.push("");
-  }
 
   return lines.join("\n");
 }

--- a/packages/cloudflare/specs/cloudflare/intel.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/intel.openapi.yml
@@ -20,6 +20,11 @@ paths:
           description: Identifier.
           schema:
             type: string
+        - name: asn
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: Success
@@ -39,6 +44,11 @@ paths:
           in: path
           required: true
           description: Identifier.
+          schema:
+            type: string
+        - name: asn
+          in: path
+          required: true
           schema:
             type: string
       responses:

--- a/packages/cloudflare/specs/cloudflare/rulesets.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/rulesets.openapi.yml
@@ -9,6 +9,12 @@ paths:
   /{accountOrZone}/{accountOrZoneId}/rulesets/phases/{rulesetPhase}/entrypoint:
     get:
       operationId: getPhas
+      parameters:
+        - name: rulesetPhase
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: Success
@@ -2721,6 +2727,11 @@ paths:
           required: true
           description: "Path param: The Zone ID to use for this endpoint. Mutually
             exclusive with the Account ID."
+          schema:
+            type: string
+        - name: rulesetPhase
+          in: path
+          required: true
           schema:
             type: string
       requestBody:
@@ -7803,6 +7814,11 @@ paths:
           required: true
           schema:
             type: string
+        - name: rulesetPhase
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: Success
@@ -10499,6 +10515,12 @@ paths:
   /{accountOrZone}/{accountOrZoneId}/rulesets/phases/{rulesetPhase}/entrypoint/versions:
     get:
       operationId: listPhasVersions
+      parameters:
+        - name: rulesetPhase
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: Success

--- a/packages/cloudflare/specs/cloudflare/zero-trust.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/zero-trust.openapi.yml
@@ -903,6 +903,12 @@ paths:
   /{accountOrZone}/{accountOrZoneId}/access/apps/{appId}:
     get:
       operationId: getAccessApplication
+      parameters:
+        - name: appId
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: Success
@@ -14538,6 +14544,11 @@ paths:
           required: true
           description: "Path param: The Zone ID to use for this endpoint. Mutually
             exclusive with the Account ID."
+          schema:
+            type: string
+        - name: appId
+          in: path
+          required: true
           schema:
             type: string
       requestBody:
@@ -28737,6 +28748,12 @@ paths:
       x-distilled-response-path: result
     delete:
       operationId: deleteAccessApplication
+      parameters:
+        - name: appId
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: Success
@@ -62409,6 +62426,11 @@ paths:
             exclusive with the Account ID."
           schema:
             type: string
+        - name: appId
+          in: path
+          required: true
+          schema:
+            type: string
       requestBody:
         required: false
         content:
@@ -62458,6 +62480,11 @@ paths:
             exclusive with the Account ID."
           schema:
             type: string
+        - name: appId
+          in: path
+          required: true
+          schema:
+            type: string
       requestBody:
         required: false
         content:
@@ -62489,6 +62516,12 @@ paths:
   /{accountOrZone}/{accountOrZoneId}/access/apps/{appId}/user_policy_checks:
     get:
       operationId: listAccessApplicationUserPolicyChecks
+      parameters:
+        - name: appId
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: Success
@@ -118744,6 +118777,12 @@ paths:
   /{accountOrZone}/{accountOrZoneId}/access/apps/{appId}/revoke_tokens:
     post:
       operationId: revokeTokensAccessApplication
+      parameters:
+        - name: appId
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: Success

--- a/packages/cloudflare/src/services/custom-pages.ts
+++ b/packages/cloudflare/src/services/custom-pages.ts
@@ -33,9 +33,7 @@ const GetCustomPageBaseFields = {
   ]).pipe(T.HttpPath("identifier")),
 } as const;
 
-export interface GetCustomPageForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface GetCustomPageBaseRequest {
   identifier:
     | "1000_errors"
     | "500_errors"
@@ -49,20 +47,14 @@ export interface GetCustomPageForAccountRequest {
     | "waf_challenge";
 }
 
-export interface GetCustomPageForZoneRequest {
+export interface GetCustomPageForAccountRequest extends GetCustomPageBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetCustomPageForZoneRequest extends GetCustomPageBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  identifier:
-    | "1000_errors"
-    | "500_errors"
-    | "basic_challenge"
-    | "country_challenge"
-    | "ip_block"
-    | "managed_challenge"
-    | "ratelimit_block"
-    | "under_attack"
-    | "waf_block"
-    | "waf_challenge";
 }
 
 export type GetCustomPageRequest =
@@ -171,12 +163,14 @@ export const getCustomPage = (
 
 const ListCustomPagesBaseFields = {} as const;
 
-export interface ListCustomPagesForAccountRequest {
+interface ListCustomPagesBaseRequest {}
+
+export interface ListCustomPagesForAccountRequest extends ListCustomPagesBaseRequest {
   /** Path param: The Account ID to use for this endpoint. */
   accountId: string;
 }
 
-export interface ListCustomPagesForZoneRequest {
+export interface ListCustomPagesForZoneRequest extends ListCustomPagesBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
@@ -312,9 +306,7 @@ const PutCustomPageBaseFields = {
   url: Schema.String,
 } as const;
 
-export interface PutCustomPageForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface PutCustomPageBaseRequest {
   identifier:
     | "1000_errors"
     | "500_errors"
@@ -332,24 +324,14 @@ export interface PutCustomPageForAccountRequest {
   url: string;
 }
 
-export interface PutCustomPageForZoneRequest {
+export interface PutCustomPageForAccountRequest extends PutCustomPageBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface PutCustomPageForZoneRequest extends PutCustomPageBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  identifier:
-    | "1000_errors"
-    | "500_errors"
-    | "basic_challenge"
-    | "country_challenge"
-    | "ip_block"
-    | "managed_challenge"
-    | "ratelimit_block"
-    | "under_attack"
-    | "waf_block"
-    | "waf_challenge";
-  /** Body param: The custom page state. */
-  state: "default" | "customized";
-  /** Body param: The URL associated with the custom page. */
-  url: string;
 }
 
 export type PutCustomPageRequest =

--- a/packages/cloudflare/src/services/custom-pages.ts
+++ b/packages/cloudflare/src/services/custom-pages.ts
@@ -5,6 +5,8 @@
  * DO NOT EDIT - regenerate with: bun scripts/generate.ts --service custom-pages
  */
 
+import * as Effect from "effect/Effect";
+import * as stream from "effect/Stream";
 import * as Schema from "effect/Schema";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
@@ -16,7 +18,24 @@ import { type DefaultErrors } from "../errors.ts";
 // CustomPage
 // =============================================================================
 
-export interface GetCustomPageRequest {
+const GetCustomPageBaseFields = {
+  identifier: Schema.Literals([
+    "1000_errors",
+    "500_errors",
+    "basic_challenge",
+    "country_challenge",
+    "ip_block",
+    "managed_challenge",
+    "ratelimit_block",
+    "under_attack",
+    "waf_block",
+    "waf_challenge",
+  ]).pipe(T.HttpPath("identifier")),
+} as const;
+
+export interface GetCustomPageForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   identifier:
     | "1000_errors"
     | "500_errors"
@@ -30,25 +49,47 @@ export interface GetCustomPageRequest {
     | "waf_challenge";
 }
 
-export const GetCustomPageRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  identifier: Schema.Literals([
-    "1000_errors",
-    "500_errors",
-    "basic_challenge",
-    "country_challenge",
-    "ip_block",
-    "managed_challenge",
-    "ratelimit_block",
-    "under_attack",
-    "waf_block",
-    "waf_challenge",
-  ]).pipe(T.HttpPath("identifier")),
-}).pipe(
-  T.Http({
-    method: "GET",
-    path: "/{accountOrZone}/{accountOrZoneId}/custom_pages/{identifier}",
-  }),
-) as unknown as Schema.Schema<GetCustomPageRequest>;
+export interface GetCustomPageForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  identifier:
+    | "1000_errors"
+    | "500_errors"
+    | "basic_challenge"
+    | "country_challenge"
+    | "ip_block"
+    | "managed_challenge"
+    | "ratelimit_block"
+    | "under_attack"
+    | "waf_block"
+    | "waf_challenge";
+}
+
+export type GetCustomPageRequest =
+  | GetCustomPageForAccountRequest
+  | GetCustomPageForZoneRequest;
+
+export const GetCustomPageForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetCustomPageBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/custom_pages/{identifier}",
+    }),
+  ) as unknown as Schema.Schema<GetCustomPageForAccountRequest>;
+
+export const GetCustomPageForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...GetCustomPageBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/custom_pages/{identifier}",
+    }),
+  ) as unknown as Schema.Schema<GetCustomPageForZoneRequest>;
 
 export interface GetCustomPageResponse {
   id?: string | null;
@@ -95,27 +136,70 @@ export const GetCustomPageResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type GetCustomPageError = DefaultErrors;
 
-export const getCustomPage: API.OperationMethod<
-  GetCustomPageRequest,
+export const getCustomPageForAccount: API.OperationMethod<
+  GetCustomPageForAccountRequest,
   GetCustomPageResponse,
   GetCustomPageError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: GetCustomPageRequest,
+  input: GetCustomPageForAccountRequest,
   output: GetCustomPageResponse,
   errors: [],
 }));
 
-export interface ListCustomPagesRequest {}
+export const getCustomPageForZone: API.OperationMethod<
+  GetCustomPageForZoneRequest,
+  GetCustomPageResponse,
+  GetCustomPageError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetCustomPageForZoneRequest,
+  output: GetCustomPageResponse,
+  errors: [],
+}));
 
-export const ListCustomPagesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {},
-).pipe(
-  T.Http({
-    method: "GET",
-    path: "/{accountOrZone}/{accountOrZoneId}/custom_pages",
-  }),
-) as unknown as Schema.Schema<ListCustomPagesRequest>;
+export const getCustomPage = (
+  input: GetCustomPageRequest,
+): Effect.Effect<
+  GetCustomPageResponse,
+  GetCustomPageError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? getCustomPageForAccount(input)
+    : getCustomPageForZone(input);
+
+const ListCustomPagesBaseFields = {} as const;
+
+export interface ListCustomPagesForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface ListCustomPagesForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+}
+
+export type ListCustomPagesRequest =
+  | ListCustomPagesForAccountRequest
+  | ListCustomPagesForZoneRequest;
+
+export const ListCustomPagesForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...ListCustomPagesBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/accounts/{account_id}/custom_pages" }),
+  ) as unknown as Schema.Schema<ListCustomPagesForAccountRequest>;
+
+export const ListCustomPagesForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...ListCustomPagesBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/zones/{zone_id}/custom_pages" }),
+  ) as unknown as Schema.Schema<ListCustomPagesForZoneRequest>;
 
 export interface ListCustomPagesResponse {
   result: {
@@ -170,13 +254,13 @@ export const ListCustomPagesResponse =
 
 export type ListCustomPagesError = DefaultErrors;
 
-export const listCustomPages: API.PaginatedOperationMethod<
-  ListCustomPagesRequest,
+export const listCustomPagesForAccount: API.PaginatedOperationMethod<
+  ListCustomPagesForAccountRequest,
   ListCustomPagesResponse,
   ListCustomPagesError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
-  input: ListCustomPagesRequest,
+  input: ListCustomPagesForAccountRequest,
   output: ListCustomPagesResponse,
   errors: [],
   pagination: {
@@ -185,29 +269,33 @@ export const listCustomPages: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export interface PutCustomPageRequest {
-  identifier:
-    | "1000_errors"
-    | "500_errors"
-    | "basic_challenge"
-    | "country_challenge"
-    | "ip_block"
-    | "managed_challenge"
-    | "ratelimit_block"
-    | "under_attack"
-    | "waf_block"
-    | "waf_challenge";
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
-  /** Body param: The custom page state. */
-  state: "default" | "customized";
-  /** Body param: The URL associated with the custom page. */
-  url: string;
-}
+export const listCustomPagesForZone: API.PaginatedOperationMethod<
+  ListCustomPagesForZoneRequest,
+  ListCustomPagesResponse,
+  ListCustomPagesError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+  input: ListCustomPagesForZoneRequest,
+  output: ListCustomPagesResponse,
+  errors: [],
+  pagination: {
+    mode: "single",
+    items: "result",
+  } as const,
+}));
 
-export const PutCustomPageRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+export const listCustomPages = (
+  input: ListCustomPagesRequest,
+): stream.Stream<
+  ListCustomPagesResponse,
+  ListCustomPagesError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? listCustomPagesForAccount.pages(input)
+    : listCustomPagesForZone.pages(input);
+
+const PutCustomPageBaseFields = {
   identifier: Schema.Literals([
     "1000_errors",
     "500_errors",
@@ -220,16 +308,75 @@ export const PutCustomPageRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     "waf_block",
     "waf_challenge",
   ]).pipe(T.HttpPath("identifier")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
   state: Schema.Literals(["default", "customized"]),
   url: Schema.String,
-}).pipe(
-  T.Http({
-    method: "PUT",
-    path: "/{accountOrZone}/{accountOrZoneId}/custom_pages/{identifier}",
-  }),
-) as unknown as Schema.Schema<PutCustomPageRequest>;
+} as const;
+
+export interface PutCustomPageForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  identifier:
+    | "1000_errors"
+    | "500_errors"
+    | "basic_challenge"
+    | "country_challenge"
+    | "ip_block"
+    | "managed_challenge"
+    | "ratelimit_block"
+    | "under_attack"
+    | "waf_block"
+    | "waf_challenge";
+  /** Body param: The custom page state. */
+  state: "default" | "customized";
+  /** Body param: The URL associated with the custom page. */
+  url: string;
+}
+
+export interface PutCustomPageForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  identifier:
+    | "1000_errors"
+    | "500_errors"
+    | "basic_challenge"
+    | "country_challenge"
+    | "ip_block"
+    | "managed_challenge"
+    | "ratelimit_block"
+    | "under_attack"
+    | "waf_block"
+    | "waf_challenge";
+  /** Body param: The custom page state. */
+  state: "default" | "customized";
+  /** Body param: The URL associated with the custom page. */
+  url: string;
+}
+
+export type PutCustomPageRequest =
+  | PutCustomPageForAccountRequest
+  | PutCustomPageForZoneRequest;
+
+export const PutCustomPageForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...PutCustomPageBaseFields,
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/accounts/{account_id}/custom_pages/{identifier}",
+    }),
+  ) as unknown as Schema.Schema<PutCustomPageForAccountRequest>;
+
+export const PutCustomPageForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...PutCustomPageBaseFields,
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/zones/{zone_id}/custom_pages/{identifier}",
+    }),
+  ) as unknown as Schema.Schema<PutCustomPageForZoneRequest>;
 
 export interface PutCustomPageResponse {
   id?: string | null;
@@ -276,13 +423,35 @@ export const PutCustomPageResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type PutCustomPageError = DefaultErrors;
 
-export const putCustomPage: API.OperationMethod<
-  PutCustomPageRequest,
+export const putCustomPageForAccount: API.OperationMethod<
+  PutCustomPageForAccountRequest,
   PutCustomPageResponse,
   PutCustomPageError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: PutCustomPageRequest,
+  input: PutCustomPageForAccountRequest,
   output: PutCustomPageResponse,
   errors: [],
 }));
+
+export const putCustomPageForZone: API.OperationMethod<
+  PutCustomPageForZoneRequest,
+  PutCustomPageResponse,
+  PutCustomPageError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: PutCustomPageForZoneRequest,
+  output: PutCustomPageResponse,
+  errors: [],
+}));
+
+export const putCustomPage = (
+  input: PutCustomPageRequest,
+): Effect.Effect<
+  PutCustomPageResponse,
+  PutCustomPageError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? putCustomPageForAccount(input)
+    : putCustomPageForZone(input);

--- a/packages/cloudflare/src/services/custom-pages.ts
+++ b/packages/cloudflare/src/services/custom-pages.ts
@@ -5,8 +5,6 @@
  * DO NOT EDIT - regenerate with: bun scripts/generate.ts --service custom-pages
  */
 
-import * as Effect from "effect/Effect";
-import * as stream from "effect/Stream";
 import * as Schema from "effect/Schema";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
@@ -56,10 +54,6 @@ export interface GetCustomPageForZoneRequest extends GetCustomPageBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type GetCustomPageRequest =
-  | GetCustomPageForAccountRequest
-  | GetCustomPageForZoneRequest;
 
 export const GetCustomPageForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -150,17 +144,6 @@ export const getCustomPageForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const getCustomPage = (
-  input: GetCustomPageRequest,
-): Effect.Effect<
-  GetCustomPageResponse,
-  GetCustomPageError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? getCustomPageForAccount(input)
-    : getCustomPageForZone(input);
-
 const ListCustomPagesBaseFields = {} as const;
 
 interface ListCustomPagesBaseRequest {}
@@ -174,10 +157,6 @@ export interface ListCustomPagesForZoneRequest extends ListCustomPagesBaseReques
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type ListCustomPagesRequest =
-  | ListCustomPagesForAccountRequest
-  | ListCustomPagesForZoneRequest;
 
 export const ListCustomPagesForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -278,17 +257,6 @@ export const listCustomPagesForZone: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export const listCustomPages = (
-  input: ListCustomPagesRequest,
-): stream.Stream<
-  ListCustomPagesResponse,
-  ListCustomPagesError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? listCustomPagesForAccount.pages(input)
-    : listCustomPagesForZone.pages(input);
-
 const PutCustomPageBaseFields = {
   identifier: Schema.Literals([
     "1000_errors",
@@ -333,10 +301,6 @@ export interface PutCustomPageForZoneRequest extends PutCustomPageBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type PutCustomPageRequest =
-  | PutCustomPageForAccountRequest
-  | PutCustomPageForZoneRequest;
 
 export const PutCustomPageForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -426,14 +390,3 @@ export const putCustomPageForZone: API.OperationMethod<
   output: PutCustomPageResponse,
   errors: [],
 }));
-
-export const putCustomPage = (
-  input: PutCustomPageRequest,
-): Effect.Effect<
-  PutCustomPageResponse,
-  PutCustomPageError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? putCustomPageForAccount(input)
-    : putCustomPageForZone(input);

--- a/packages/cloudflare/src/services/firewall.ts
+++ b/packages/cloudflare/src/services/firewall.ts
@@ -5,6 +5,8 @@
  * DO NOT EDIT - regenerate with: bun scripts/generate.ts --service firewall
  */
 
+import * as Effect from "effect/Effect";
+import * as stream from "effect/Stream";
 import * as Schema from "effect/Schema";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
@@ -16,18 +18,47 @@ import { type DefaultErrors } from "../errors.ts";
 // AccessRule
 // =============================================================================
 
-export interface GetAccessRuleRequest {
+const GetAccessRuleBaseFields = {
+  ruleId: Schema.String.pipe(T.HttpPath("ruleId")),
+} as const;
+
+export interface GetAccessRuleForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   ruleId: string;
 }
 
-export const GetAccessRuleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  ruleId: Schema.String.pipe(T.HttpPath("ruleId")),
-}).pipe(
-  T.Http({
-    method: "GET",
-    path: "/{accountOrZone}/{accountOrZoneId}/firewall/access_rules/rules/{ruleId}",
-  }),
-) as unknown as Schema.Schema<GetAccessRuleRequest>;
+export interface GetAccessRuleForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  ruleId: string;
+}
+
+export type GetAccessRuleRequest =
+  | GetAccessRuleForAccountRequest
+  | GetAccessRuleForZoneRequest;
+
+export const GetAccessRuleForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetAccessRuleBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/firewall/access_rules/rules/{ruleId}",
+    }),
+  ) as unknown as Schema.Schema<GetAccessRuleForAccountRequest>;
+
+export const GetAccessRuleForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...GetAccessRuleBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/firewall/access_rules/rules/{ruleId}",
+    }),
+  ) as unknown as Schema.Schema<GetAccessRuleForZoneRequest>;
 
 export interface GetAccessRuleResponse {
   /** The unique identifier of the IP Access rule. */
@@ -155,27 +186,76 @@ export const GetAccessRuleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type GetAccessRuleError = DefaultErrors;
 
-export const getAccessRule: API.OperationMethod<
-  GetAccessRuleRequest,
+export const getAccessRuleForAccount: API.OperationMethod<
+  GetAccessRuleForAccountRequest,
   GetAccessRuleResponse,
   GetAccessRuleError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: GetAccessRuleRequest,
+  input: GetAccessRuleForAccountRequest,
   output: GetAccessRuleResponse,
   errors: [],
 }));
 
-export interface ListAccessRulesRequest {}
+export const getAccessRuleForZone: API.OperationMethod<
+  GetAccessRuleForZoneRequest,
+  GetAccessRuleResponse,
+  GetAccessRuleError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetAccessRuleForZoneRequest,
+  output: GetAccessRuleResponse,
+  errors: [],
+}));
 
-export const ListAccessRulesRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {},
-).pipe(
-  T.Http({
-    method: "GET",
-    path: "/{accountOrZone}/{accountOrZoneId}/firewall/access_rules/rules",
-  }),
-) as unknown as Schema.Schema<ListAccessRulesRequest>;
+export const getAccessRule = (
+  input: GetAccessRuleRequest,
+): Effect.Effect<
+  GetAccessRuleResponse,
+  GetAccessRuleError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? getAccessRuleForAccount(input)
+    : getAccessRuleForZone(input);
+
+const ListAccessRulesBaseFields = {} as const;
+
+export interface ListAccessRulesForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface ListAccessRulesForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+}
+
+export type ListAccessRulesRequest =
+  | ListAccessRulesForAccountRequest
+  | ListAccessRulesForZoneRequest;
+
+export const ListAccessRulesForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...ListAccessRulesBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/firewall/access_rules/rules",
+    }),
+  ) as unknown as Schema.Schema<ListAccessRulesForAccountRequest>;
+
+export const ListAccessRulesForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...ListAccessRulesBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/firewall/access_rules/rules",
+    }),
+  ) as unknown as Schema.Schema<ListAccessRulesForZoneRequest>;
 
 export interface ListAccessRulesResponse {
   result: {
@@ -328,13 +408,13 @@ export const ListAccessRulesResponse =
 
 export type ListAccessRulesError = DefaultErrors;
 
-export const listAccessRules: API.PaginatedOperationMethod<
-  ListAccessRulesRequest,
+export const listAccessRulesForAccount: API.PaginatedOperationMethod<
+  ListAccessRulesForAccountRequest,
   ListAccessRulesResponse,
   ListAccessRulesError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
-  input: ListAccessRulesRequest,
+  input: ListAccessRulesForAccountRequest,
   output: ListAccessRulesResponse,
   errors: [],
   pagination: {
@@ -346,11 +426,71 @@ export const listAccessRules: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export interface CreateAccessRuleRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
+export const listAccessRulesForZone: API.PaginatedOperationMethod<
+  ListAccessRulesForZoneRequest,
+  ListAccessRulesResponse,
+  ListAccessRulesError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+  input: ListAccessRulesForZoneRequest,
+  output: ListAccessRulesResponse,
+  errors: [],
+  pagination: {
+    mode: "page",
+    inputToken: "page",
+    outputToken: "resultInfo.page",
+    items: "result",
+    pageSize: "perPage",
+  } as const,
+}));
+
+export const listAccessRules = (
+  input: ListAccessRulesRequest,
+): stream.Stream<
+  ListAccessRulesResponse,
+  ListAccessRulesError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? listAccessRulesForAccount.pages(input)
+    : listAccessRulesForZone.pages(input);
+
+const CreateAccessRuleBaseFields = {
+  configuration: Schema.Union([
+    Schema.Struct({
+      target: Schema.optional(Schema.Literal("ip")),
+      value: Schema.optional(Schema.String),
+    }),
+    Schema.Struct({
+      target: Schema.optional(Schema.Literal("ip6")),
+      value: Schema.optional(Schema.String),
+    }),
+    Schema.Struct({
+      target: Schema.optional(Schema.Literal("ip_range")),
+      value: Schema.optional(Schema.String),
+    }),
+    Schema.Struct({
+      target: Schema.optional(Schema.Literal("asn")),
+      value: Schema.optional(Schema.String),
+    }),
+    Schema.Struct({
+      target: Schema.optional(Schema.Literal("country")),
+      value: Schema.optional(Schema.String),
+    }),
+  ]),
+  mode: Schema.Literals([
+    "block",
+    "challenge",
+    "whitelist",
+    "js_challenge",
+    "managed_challenge",
+  ]),
+  notes: Schema.optional(Schema.String),
+} as const;
+
+export interface CreateAccessRuleForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   /** Body param: The rule configuration. */
   configuration:
     | { target?: "ip"; value?: string }
@@ -369,46 +509,52 @@ export interface CreateAccessRuleRequest {
   notes?: string;
 }
 
-export const CreateAccessRuleRequest =
+export interface CreateAccessRuleForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  /** Body param: The rule configuration. */
+  configuration:
+    | { target?: "ip"; value?: string }
+    | { target?: "ip6"; value?: string }
+    | { target?: "ip_range"; value?: string }
+    | { target?: "asn"; value?: string }
+    | { target?: "country"; value?: string };
+  /** Body param: The action to apply to a matched request. */
+  mode:
+    | "block"
+    | "challenge"
+    | "whitelist"
+    | "js_challenge"
+    | "managed_challenge";
+  /** Body param: An informative summary of the rule, typically used as a reminder or explanation. */
+  notes?: string;
+}
+
+export type CreateAccessRuleRequest =
+  | CreateAccessRuleForAccountRequest
+  | CreateAccessRuleForZoneRequest;
+
+export const CreateAccessRuleForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    configuration: Schema.Union([
-      Schema.Struct({
-        target: Schema.optional(Schema.Literal("ip")),
-        value: Schema.optional(Schema.String),
-      }),
-      Schema.Struct({
-        target: Schema.optional(Schema.Literal("ip6")),
-        value: Schema.optional(Schema.String),
-      }),
-      Schema.Struct({
-        target: Schema.optional(Schema.Literal("ip_range")),
-        value: Schema.optional(Schema.String),
-      }),
-      Schema.Struct({
-        target: Schema.optional(Schema.Literal("asn")),
-        value: Schema.optional(Schema.String),
-      }),
-      Schema.Struct({
-        target: Schema.optional(Schema.Literal("country")),
-        value: Schema.optional(Schema.String),
-      }),
-    ]),
-    mode: Schema.Literals([
-      "block",
-      "challenge",
-      "whitelist",
-      "js_challenge",
-      "managed_challenge",
-    ]),
-    notes: Schema.optional(Schema.String),
+    ...CreateAccessRuleBaseFields,
   }).pipe(
     T.Http({
       method: "POST",
-      path: "/{accountOrZone}/{accountOrZoneId}/firewall/access_rules/rules",
+      path: "/accounts/{account_id}/firewall/access_rules/rules",
     }),
-  ) as unknown as Schema.Schema<CreateAccessRuleRequest>;
+  ) as unknown as Schema.Schema<CreateAccessRuleForAccountRequest>;
+
+export const CreateAccessRuleForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...CreateAccessRuleBaseFields,
+  }).pipe(
+    T.Http({
+      method: "POST",
+      path: "/zones/{zone_id}/firewall/access_rules/rules",
+    }),
+  ) as unknown as Schema.Schema<CreateAccessRuleForZoneRequest>;
 
 export interface CreateAccessRuleResponse {
   /** The unique identifier of the IP Access rule. */
@@ -537,23 +683,77 @@ export const CreateAccessRuleResponse =
 
 export type CreateAccessRuleError = DefaultErrors;
 
-export const createAccessRule: API.OperationMethod<
-  CreateAccessRuleRequest,
+export const createAccessRuleForAccount: API.OperationMethod<
+  CreateAccessRuleForAccountRequest,
   CreateAccessRuleResponse,
   CreateAccessRuleError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: CreateAccessRuleRequest,
+  input: CreateAccessRuleForAccountRequest,
   output: CreateAccessRuleResponse,
   errors: [],
 }));
 
-export interface PatchAccessRuleRequest {
+export const createAccessRuleForZone: API.OperationMethod<
+  CreateAccessRuleForZoneRequest,
+  CreateAccessRuleResponse,
+  CreateAccessRuleError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: CreateAccessRuleForZoneRequest,
+  output: CreateAccessRuleResponse,
+  errors: [],
+}));
+
+export const createAccessRule = (
+  input: CreateAccessRuleRequest,
+): Effect.Effect<
+  CreateAccessRuleResponse,
+  CreateAccessRuleError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? createAccessRuleForAccount(input)
+    : createAccessRuleForZone(input);
+
+const PatchAccessRuleBaseFields = {
+  ruleId: Schema.String.pipe(T.HttpPath("ruleId")),
+  configuration: Schema.Union([
+    Schema.Struct({
+      target: Schema.optional(Schema.Literal("ip")),
+      value: Schema.optional(Schema.String),
+    }),
+    Schema.Struct({
+      target: Schema.optional(Schema.Literal("ip6")),
+      value: Schema.optional(Schema.String),
+    }),
+    Schema.Struct({
+      target: Schema.optional(Schema.Literal("ip_range")),
+      value: Schema.optional(Schema.String),
+    }),
+    Schema.Struct({
+      target: Schema.optional(Schema.Literal("asn")),
+      value: Schema.optional(Schema.String),
+    }),
+    Schema.Struct({
+      target: Schema.optional(Schema.Literal("country")),
+      value: Schema.optional(Schema.String),
+    }),
+  ]),
+  mode: Schema.Literals([
+    "block",
+    "challenge",
+    "whitelist",
+    "js_challenge",
+    "managed_challenge",
+  ]),
+  notes: Schema.optional(Schema.String),
+} as const;
+
+export interface PatchAccessRuleForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   ruleId: string;
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
   /** Body param: The rule configuration. */
   configuration:
     | { target?: "ip"; value?: string }
@@ -572,48 +772,53 @@ export interface PatchAccessRuleRequest {
   notes?: string;
 }
 
-export const PatchAccessRuleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {
-    ruleId: Schema.String.pipe(T.HttpPath("ruleId")),
+export interface PatchAccessRuleForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  ruleId: string;
+  /** Body param: The rule configuration. */
+  configuration:
+    | { target?: "ip"; value?: string }
+    | { target?: "ip6"; value?: string }
+    | { target?: "ip_range"; value?: string }
+    | { target?: "asn"; value?: string }
+    | { target?: "country"; value?: string };
+  /** Body param: The action to apply to a matched request. */
+  mode:
+    | "block"
+    | "challenge"
+    | "whitelist"
+    | "js_challenge"
+    | "managed_challenge";
+  /** Body param: An informative summary of the rule, typically used as a reminder or explanation. */
+  notes?: string;
+}
+
+export type PatchAccessRuleRequest =
+  | PatchAccessRuleForAccountRequest
+  | PatchAccessRuleForZoneRequest;
+
+export const PatchAccessRuleForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...PatchAccessRuleBaseFields,
+  }).pipe(
+    T.Http({
+      method: "PATCH",
+      path: "/accounts/{account_id}/firewall/access_rules/rules/{ruleId}",
+    }),
+  ) as unknown as Schema.Schema<PatchAccessRuleForAccountRequest>;
+
+export const PatchAccessRuleForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    configuration: Schema.Union([
-      Schema.Struct({
-        target: Schema.optional(Schema.Literal("ip")),
-        value: Schema.optional(Schema.String),
-      }),
-      Schema.Struct({
-        target: Schema.optional(Schema.Literal("ip6")),
-        value: Schema.optional(Schema.String),
-      }),
-      Schema.Struct({
-        target: Schema.optional(Schema.Literal("ip_range")),
-        value: Schema.optional(Schema.String),
-      }),
-      Schema.Struct({
-        target: Schema.optional(Schema.Literal("asn")),
-        value: Schema.optional(Schema.String),
-      }),
-      Schema.Struct({
-        target: Schema.optional(Schema.Literal("country")),
-        value: Schema.optional(Schema.String),
-      }),
-    ]),
-    mode: Schema.Literals([
-      "block",
-      "challenge",
-      "whitelist",
-      "js_challenge",
-      "managed_challenge",
-    ]),
-    notes: Schema.optional(Schema.String),
-  },
-).pipe(
-  T.Http({
-    method: "PATCH",
-    path: "/{accountOrZone}/{accountOrZoneId}/firewall/access_rules/rules/{ruleId}",
-  }),
-) as unknown as Schema.Schema<PatchAccessRuleRequest>;
+    ...PatchAccessRuleBaseFields,
+  }).pipe(
+    T.Http({
+      method: "PATCH",
+      path: "/zones/{zone_id}/firewall/access_rules/rules/{ruleId}",
+    }),
+  ) as unknown as Schema.Schema<PatchAccessRuleForZoneRequest>;
 
 export interface PatchAccessRuleResponse {
   /** The unique identifier of the IP Access rule. */
@@ -742,30 +947,80 @@ export const PatchAccessRuleResponse =
 
 export type PatchAccessRuleError = DefaultErrors;
 
-export const patchAccessRule: API.OperationMethod<
-  PatchAccessRuleRequest,
+export const patchAccessRuleForAccount: API.OperationMethod<
+  PatchAccessRuleForAccountRequest,
   PatchAccessRuleResponse,
   PatchAccessRuleError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: PatchAccessRuleRequest,
+  input: PatchAccessRuleForAccountRequest,
   output: PatchAccessRuleResponse,
   errors: [],
 }));
 
-export interface DeleteAccessRuleRequest {
+export const patchAccessRuleForZone: API.OperationMethod<
+  PatchAccessRuleForZoneRequest,
+  PatchAccessRuleResponse,
+  PatchAccessRuleError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: PatchAccessRuleForZoneRequest,
+  output: PatchAccessRuleResponse,
+  errors: [],
+}));
+
+export const patchAccessRule = (
+  input: PatchAccessRuleRequest,
+): Effect.Effect<
+  PatchAccessRuleResponse,
+  PatchAccessRuleError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? patchAccessRuleForAccount(input)
+    : patchAccessRuleForZone(input);
+
+const DeleteAccessRuleBaseFields = {
+  ruleId: Schema.String.pipe(T.HttpPath("ruleId")),
+} as const;
+
+export interface DeleteAccessRuleForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   ruleId: string;
 }
 
-export const DeleteAccessRuleRequest =
+export interface DeleteAccessRuleForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  ruleId: string;
+}
+
+export type DeleteAccessRuleRequest =
+  | DeleteAccessRuleForAccountRequest
+  | DeleteAccessRuleForZoneRequest;
+
+export const DeleteAccessRuleForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    ruleId: Schema.String.pipe(T.HttpPath("ruleId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...DeleteAccessRuleBaseFields,
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "/{accountOrZone}/{accountOrZoneId}/firewall/access_rules/rules/{ruleId}",
+      path: "/accounts/{account_id}/firewall/access_rules/rules/{ruleId}",
     }),
-  ) as unknown as Schema.Schema<DeleteAccessRuleRequest>;
+  ) as unknown as Schema.Schema<DeleteAccessRuleForAccountRequest>;
+
+export const DeleteAccessRuleForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...DeleteAccessRuleBaseFields,
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/zones/{zone_id}/firewall/access_rules/rules/{ruleId}",
+    }),
+  ) as unknown as Schema.Schema<DeleteAccessRuleForZoneRequest>;
 
 export interface DeleteAccessRuleResponse {
   /** Defines an identifier. */
@@ -781,16 +1036,38 @@ export const DeleteAccessRuleResponse =
 
 export type DeleteAccessRuleError = DefaultErrors;
 
-export const deleteAccessRule: API.OperationMethod<
-  DeleteAccessRuleRequest,
+export const deleteAccessRuleForAccount: API.OperationMethod<
+  DeleteAccessRuleForAccountRequest,
   DeleteAccessRuleResponse,
   DeleteAccessRuleError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: DeleteAccessRuleRequest,
+  input: DeleteAccessRuleForAccountRequest,
   output: DeleteAccessRuleResponse,
   errors: [],
 }));
+
+export const deleteAccessRuleForZone: API.OperationMethod<
+  DeleteAccessRuleForZoneRequest,
+  DeleteAccessRuleResponse,
+  DeleteAccessRuleError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: DeleteAccessRuleForZoneRequest,
+  output: DeleteAccessRuleResponse,
+  errors: [],
+}));
+
+export const deleteAccessRule = (
+  input: DeleteAccessRuleRequest,
+): Effect.Effect<
+  DeleteAccessRuleResponse,
+  DeleteAccessRuleError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? deleteAccessRuleForAccount(input)
+    : deleteAccessRuleForZone(input);
 
 // =============================================================================
 // Lockdown

--- a/packages/cloudflare/src/services/firewall.ts
+++ b/packages/cloudflare/src/services/firewall.ts
@@ -5,8 +5,6 @@
  * DO NOT EDIT - regenerate with: bun scripts/generate.ts --service firewall
  */
 
-import * as Effect from "effect/Effect";
-import * as stream from "effect/Stream";
 import * as Schema from "effect/Schema";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
@@ -35,10 +33,6 @@ export interface GetAccessRuleForZoneRequest extends GetAccessRuleBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type GetAccessRuleRequest =
-  | GetAccessRuleForAccountRequest
-  | GetAccessRuleForZoneRequest;
 
 export const GetAccessRuleForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -210,17 +204,6 @@ export const getAccessRuleForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const getAccessRule = (
-  input: GetAccessRuleRequest,
-): Effect.Effect<
-  GetAccessRuleResponse,
-  GetAccessRuleError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? getAccessRuleForAccount(input)
-    : getAccessRuleForZone(input);
-
 const ListAccessRulesBaseFields = {} as const;
 
 interface ListAccessRulesBaseRequest {}
@@ -234,10 +217,6 @@ export interface ListAccessRulesForZoneRequest extends ListAccessRulesBaseReques
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type ListAccessRulesRequest =
-  | ListAccessRulesForAccountRequest
-  | ListAccessRulesForZoneRequest;
 
 export const ListAccessRulesForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -448,17 +427,6 @@ export const listAccessRulesForZone: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export const listAccessRules = (
-  input: ListAccessRulesRequest,
-): stream.Stream<
-  ListAccessRulesResponse,
-  ListAccessRulesError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? listAccessRulesForAccount.pages(input)
-    : listAccessRulesForZone.pages(input);
-
 const CreateAccessRuleBaseFields = {
   configuration: Schema.Union([
     Schema.Struct({
@@ -520,10 +488,6 @@ export interface CreateAccessRuleForZoneRequest extends CreateAccessRuleBaseRequ
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type CreateAccessRuleRequest =
-  | CreateAccessRuleForAccountRequest
-  | CreateAccessRuleForZoneRequest;
 
 export const CreateAccessRuleForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -696,17 +660,6 @@ export const createAccessRuleForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const createAccessRule = (
-  input: CreateAccessRuleRequest,
-): Effect.Effect<
-  CreateAccessRuleResponse,
-  CreateAccessRuleError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? createAccessRuleForAccount(input)
-    : createAccessRuleForZone(input);
-
 const PatchAccessRuleBaseFields = {
   ruleId: Schema.String.pipe(T.HttpPath("ruleId")),
   configuration: Schema.Union([
@@ -770,10 +723,6 @@ export interface PatchAccessRuleForZoneRequest extends PatchAccessRuleBaseReques
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type PatchAccessRuleRequest =
-  | PatchAccessRuleForAccountRequest
-  | PatchAccessRuleForZoneRequest;
 
 export const PatchAccessRuleForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -946,17 +895,6 @@ export const patchAccessRuleForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const patchAccessRule = (
-  input: PatchAccessRuleRequest,
-): Effect.Effect<
-  PatchAccessRuleResponse,
-  PatchAccessRuleError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? patchAccessRuleForAccount(input)
-    : patchAccessRuleForZone(input);
-
 const DeleteAccessRuleBaseFields = {
   ruleId: Schema.String.pipe(T.HttpPath("ruleId")),
 } as const;
@@ -974,10 +912,6 @@ export interface DeleteAccessRuleForZoneRequest extends DeleteAccessRuleBaseRequ
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type DeleteAccessRuleRequest =
-  | DeleteAccessRuleForAccountRequest
-  | DeleteAccessRuleForZoneRequest;
 
 export const DeleteAccessRuleForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -1036,17 +970,6 @@ export const deleteAccessRuleForZone: API.OperationMethod<
   output: DeleteAccessRuleResponse,
   errors: [],
 }));
-
-export const deleteAccessRule = (
-  input: DeleteAccessRuleRequest,
-): Effect.Effect<
-  DeleteAccessRuleResponse,
-  DeleteAccessRuleError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? deleteAccessRuleForAccount(input)
-    : deleteAccessRuleForZone(input);
 
 // =============================================================================
 // Lockdown

--- a/packages/cloudflare/src/services/firewall.ts
+++ b/packages/cloudflare/src/services/firewall.ts
@@ -22,16 +22,18 @@ const GetAccessRuleBaseFields = {
   ruleId: Schema.String.pipe(T.HttpPath("ruleId")),
 } as const;
 
-export interface GetAccessRuleForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface GetAccessRuleBaseRequest {
   ruleId: string;
 }
 
-export interface GetAccessRuleForZoneRequest {
+export interface GetAccessRuleForAccountRequest extends GetAccessRuleBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetAccessRuleForZoneRequest extends GetAccessRuleBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  ruleId: string;
 }
 
 export type GetAccessRuleRequest =
@@ -221,12 +223,14 @@ export const getAccessRule = (
 
 const ListAccessRulesBaseFields = {} as const;
 
-export interface ListAccessRulesForAccountRequest {
+interface ListAccessRulesBaseRequest {}
+
+export interface ListAccessRulesForAccountRequest extends ListAccessRulesBaseRequest {
   /** Path param: The Account ID to use for this endpoint. */
   accountId: string;
 }
 
-export interface ListAccessRulesForZoneRequest {
+export interface ListAccessRulesForZoneRequest extends ListAccessRulesBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
@@ -488,9 +492,7 @@ const CreateAccessRuleBaseFields = {
   notes: Schema.optional(Schema.String),
 } as const;
 
-export interface CreateAccessRuleForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface CreateAccessRuleBaseRequest {
   /** Body param: The rule configuration. */
   configuration:
     | { target?: "ip"; value?: string }
@@ -509,25 +511,14 @@ export interface CreateAccessRuleForAccountRequest {
   notes?: string;
 }
 
-export interface CreateAccessRuleForZoneRequest {
+export interface CreateAccessRuleForAccountRequest extends CreateAccessRuleBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface CreateAccessRuleForZoneRequest extends CreateAccessRuleBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  /** Body param: The rule configuration. */
-  configuration:
-    | { target?: "ip"; value?: string }
-    | { target?: "ip6"; value?: string }
-    | { target?: "ip_range"; value?: string }
-    | { target?: "asn"; value?: string }
-    | { target?: "country"; value?: string };
-  /** Body param: The action to apply to a matched request. */
-  mode:
-    | "block"
-    | "challenge"
-    | "whitelist"
-    | "js_challenge"
-    | "managed_challenge";
-  /** Body param: An informative summary of the rule, typically used as a reminder or explanation. */
-  notes?: string;
 }
 
 export type CreateAccessRuleRequest =
@@ -750,9 +741,7 @@ const PatchAccessRuleBaseFields = {
   notes: Schema.optional(Schema.String),
 } as const;
 
-export interface PatchAccessRuleForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface PatchAccessRuleBaseRequest {
   ruleId: string;
   /** Body param: The rule configuration. */
   configuration:
@@ -772,26 +761,14 @@ export interface PatchAccessRuleForAccountRequest {
   notes?: string;
 }
 
-export interface PatchAccessRuleForZoneRequest {
+export interface PatchAccessRuleForAccountRequest extends PatchAccessRuleBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface PatchAccessRuleForZoneRequest extends PatchAccessRuleBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  ruleId: string;
-  /** Body param: The rule configuration. */
-  configuration:
-    | { target?: "ip"; value?: string }
-    | { target?: "ip6"; value?: string }
-    | { target?: "ip_range"; value?: string }
-    | { target?: "asn"; value?: string }
-    | { target?: "country"; value?: string };
-  /** Body param: The action to apply to a matched request. */
-  mode:
-    | "block"
-    | "challenge"
-    | "whitelist"
-    | "js_challenge"
-    | "managed_challenge";
-  /** Body param: An informative summary of the rule, typically used as a reminder or explanation. */
-  notes?: string;
 }
 
 export type PatchAccessRuleRequest =
@@ -984,16 +961,18 @@ const DeleteAccessRuleBaseFields = {
   ruleId: Schema.String.pipe(T.HttpPath("ruleId")),
 } as const;
 
-export interface DeleteAccessRuleForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface DeleteAccessRuleBaseRequest {
   ruleId: string;
 }
 
-export interface DeleteAccessRuleForZoneRequest {
+export interface DeleteAccessRuleForAccountRequest extends DeleteAccessRuleBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface DeleteAccessRuleForZoneRequest extends DeleteAccessRuleBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  ruleId: string;
 }
 
 export type DeleteAccessRuleRequest =

--- a/packages/cloudflare/src/services/intel.ts
+++ b/packages/cloudflare/src/services/intel.ts
@@ -19,10 +19,12 @@ import { type DefaultErrors } from "../errors.ts";
 export interface GetAsnRequest {
   /** Identifier. */
   accountId: string;
+  asn: string;
 }
 
 export const GetAsnRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  asn: Schema.String.pipe(T.HttpPath("asn")),
 }).pipe(
   T.Http({ method: "GET", path: "/accounts/{account_id}/intel/asn/{asn}" }),
 ) as unknown as Schema.Schema<GetAsnRequest>;
@@ -53,10 +55,12 @@ export const getAsn: API.OperationMethod<
 export interface GetAsnSubnetRequest {
   /** Identifier. */
   accountId: string;
+  asn: string;
 }
 
 export const GetAsnSubnetRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   accountId: Schema.String.pipe(T.HttpPath("account_id")),
+  asn: Schema.String.pipe(T.HttpPath("asn")),
 }).pipe(
   T.Http({
     method: "GET",

--- a/packages/cloudflare/src/services/logpush.ts
+++ b/packages/cloudflare/src/services/logpush.ts
@@ -5,8 +5,6 @@
  * DO NOT EDIT - regenerate with: bun scripts/generate.ts --service logpush
  */
 
-import * as Effect from "effect/Effect";
-import * as stream from "effect/Stream";
 import * as Schema from "effect/Schema";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
@@ -99,10 +97,6 @@ export interface GetDatasetFieldForZoneRequest extends GetDatasetFieldBaseReques
   zoneId: string;
 }
 
-export type GetDatasetFieldRequest =
-  | GetDatasetFieldForAccountRequest
-  | GetDatasetFieldForZoneRequest;
-
 export const GetDatasetFieldForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
@@ -155,17 +149,6 @@ export const getDatasetFieldForZone: API.OperationMethod<
   output: GetDatasetFieldResponse,
   errors: [],
 }));
-
-export const getDatasetField = (
-  input: GetDatasetFieldRequest,
-): Effect.Effect<
-  GetDatasetFieldResponse,
-  GetDatasetFieldError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? getDatasetFieldForAccount(input)
-    : getDatasetFieldForZone(input);
 
 // =============================================================================
 // DatasetJob
@@ -251,10 +234,6 @@ export interface GetDatasetJobForZoneRequest extends GetDatasetJobBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type GetDatasetJobRequest =
-  | GetDatasetJobForAccountRequest
-  | GetDatasetJobForZoneRequest;
 
 export const GetDatasetJobForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -533,17 +512,6 @@ export const getDatasetJobForZone: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export const getDatasetJob = (
-  input: GetDatasetJobRequest,
-): stream.Stream<
-  GetDatasetJobResponse,
-  GetDatasetJobError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? getDatasetJobForAccount.pages(input)
-    : getDatasetJobForZone.pages(input);
-
 // =============================================================================
 // Edge
 // =============================================================================
@@ -700,10 +668,6 @@ export interface DestinationExistsValidateForZoneRequest extends DestinationExis
   zoneId: string;
 }
 
-export type DestinationExistsValidateRequest =
-  | DestinationExistsValidateForAccountRequest
-  | DestinationExistsValidateForZoneRequest;
-
 export const DestinationExistsValidateForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
@@ -763,17 +727,6 @@ export const destinationExistsValidateForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const destinationExistsValidate = (
-  input: DestinationExistsValidateRequest,
-): Effect.Effect<
-  DestinationExistsValidateResponse,
-  DestinationExistsValidateError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? destinationExistsValidateForAccount(input)
-    : destinationExistsValidateForZone(input);
-
 // =============================================================================
 // Job
 // =============================================================================
@@ -795,8 +748,6 @@ export interface GetJobForZoneRequest extends GetJobBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type GetJobRequest = GetJobForAccountRequest | GetJobForZoneRequest;
 
 export const GetJobForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -1057,14 +1008,6 @@ export const getJobForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const getJob = (
-  input: GetJobRequest,
-): Effect.Effect<
-  GetJobResponse,
-  GetJobError,
-  Credentials | HttpClient.HttpClient
-> => ("accountId" in input ? getJobForAccount(input) : getJobForZone(input));
-
 const ListJobsBaseFields = {} as const;
 
 interface ListJobsBaseRequest {}
@@ -1078,10 +1021,6 @@ export interface ListJobsForZoneRequest extends ListJobsBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type ListJobsRequest =
-  | ListJobsForAccountRequest
-  | ListJobsForZoneRequest;
 
 export const ListJobsForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -1355,17 +1294,6 @@ export const listJobsForZone: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export const listJobs = (
-  input: ListJobsRequest,
-): stream.Stream<
-  ListJobsResponse,
-  ListJobsError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? listJobsForAccount.pages(input)
-    : listJobsForZone.pages(input);
-
 const CreateJobBaseFields = {
   destinationConf: Schema.String,
   dataset: Schema.optional(
@@ -1557,10 +1485,6 @@ export interface CreateJobForZoneRequest extends CreateJobBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type CreateJobRequest =
-  | CreateJobForAccountRequest
-  | CreateJobForZoneRequest;
 
 export const CreateJobForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -1851,15 +1775,6 @@ export const createJobForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const createJob = (
-  input: CreateJobRequest,
-): Effect.Effect<
-  CreateJobResponse,
-  CreateJobError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input ? createJobForAccount(input) : createJobForZone(input);
-
 const UpdateJobBaseFields = {
   jobId: Schema.Number.pipe(T.HttpPath("jobId")),
   destinationConf: Schema.optional(Schema.String),
@@ -1985,10 +1900,6 @@ export interface UpdateJobForZoneRequest extends UpdateJobBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type UpdateJobRequest =
-  | UpdateJobForAccountRequest
-  | UpdateJobForZoneRequest;
 
 export const UpdateJobForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -2280,15 +2191,6 @@ export const updateJobForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const updateJob = (
-  input: UpdateJobRequest,
-): Effect.Effect<
-  UpdateJobResponse,
-  UpdateJobError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input ? updateJobForAccount(input) : updateJobForZone(input);
-
 const DeleteJobBaseFields = {
   jobId: Schema.Number.pipe(T.HttpPath("jobId")),
 } as const;
@@ -2306,10 +2208,6 @@ export interface DeleteJobForZoneRequest extends DeleteJobBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type DeleteJobRequest =
-  | DeleteJobForAccountRequest
-  | DeleteJobForZoneRequest;
 
 export const DeleteJobForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -2365,15 +2263,6 @@ export const deleteJobForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const deleteJob = (
-  input: DeleteJobRequest,
-): Effect.Effect<
-  DeleteJobResponse,
-  DeleteJobError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input ? deleteJobForAccount(input) : deleteJobForZone(input);
-
 // =============================================================================
 // Ownership
 // =============================================================================
@@ -2396,10 +2285,6 @@ export interface CreateOwnershipForZoneRequest extends CreateOwnershipBaseReques
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type CreateOwnershipRequest =
-  | CreateOwnershipForAccountRequest
-  | CreateOwnershipForZoneRequest;
 
 export const CreateOwnershipForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -2461,17 +2346,6 @@ export const createOwnershipForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const createOwnership = (
-  input: CreateOwnershipRequest,
-): Effect.Effect<
-  CreateOwnershipResponse,
-  CreateOwnershipError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? createOwnershipForAccount(input)
-    : createOwnershipForZone(input);
-
 const ValidateOwnershipBaseFields = {
   destinationConf: Schema.String,
   ownershipChallenge: Schema.String,
@@ -2493,10 +2367,6 @@ export interface ValidateOwnershipForZoneRequest extends ValidateOwnershipBaseRe
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type ValidateOwnershipRequest =
-  | ValidateOwnershipForAccountRequest
-  | ValidateOwnershipForZoneRequest;
 
 export const ValidateOwnershipForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -2563,17 +2433,6 @@ export const validateOwnershipForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const validateOwnership = (
-  input: ValidateOwnershipRequest,
-): Effect.Effect<
-  ValidateOwnershipResponse,
-  ValidateOwnershipError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? validateOwnershipForAccount(input)
-    : validateOwnershipForZone(input);
-
 // =============================================================================
 // Validate
 // =============================================================================
@@ -2596,10 +2455,6 @@ export interface DestinationValidateForZoneRequest extends DestinationValidateBa
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type DestinationValidateRequest =
-  | DestinationValidateForAccountRequest
-  | DestinationValidateForZoneRequest;
 
 export const DestinationValidateForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -2662,17 +2517,6 @@ export const destinationValidateForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const destinationValidate = (
-  input: DestinationValidateRequest,
-): Effect.Effect<
-  DestinationValidateResponse,
-  DestinationValidateError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? destinationValidateForAccount(input)
-    : destinationValidateForZone(input);
-
 const OriginValidateBaseFields = {
   logpullOptions: Schema.Union([Schema.String, Schema.Null]),
 } as const;
@@ -2691,10 +2535,6 @@ export interface OriginValidateForZoneRequest extends OriginValidateBaseRequest 
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type OriginValidateRequest =
-  | OriginValidateForAccountRequest
-  | OriginValidateForZoneRequest;
 
 export const OriginValidateForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -2757,14 +2597,3 @@ export const originValidateForZone: API.OperationMethod<
   output: OriginValidateResponse,
   errors: [],
 }));
-
-export const originValidate = (
-  input: OriginValidateRequest,
-): Effect.Effect<
-  OriginValidateResponse,
-  OriginValidateError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? originValidateForAccount(input)
-    : originValidateForZone(input);

--- a/packages/cloudflare/src/services/logpush.ts
+++ b/packages/cloudflare/src/services/logpush.ts
@@ -5,6 +5,8 @@
  * DO NOT EDIT - regenerate with: bun scripts/generate.ts --service logpush
  */
 
+import * as Effect from "effect/Effect";
+import * as stream from "effect/Stream";
 import * as Schema from "effect/Schema";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
@@ -16,144 +18,7 @@ import { type DefaultErrors } from "../errors.ts";
 // DatasetField
 // =============================================================================
 
-export interface GetDatasetFieldRequest {
-  datasetId:
-    | "access_requests"
-    | "audit_logs"
-    | "audit_logs_v2"
-    | "biso_user_actions"
-    | "casb_findings"
-    | "device_posture_results"
-    | "dex_application_tests"
-    | "dex_device_state_events"
-    | "dlp_forensic_copies"
-    | "dns_firewall_logs"
-    | "dns_logs"
-    | "email_security_alerts"
-    | "firewall_events"
-    | "gateway_dns"
-    | "gateway_http"
-    | "gateway_network"
-    | "http_requests"
-    | "ipsec_logs"
-    | "magic_ids_detections"
-    | "nel_reports"
-    | "network_analytics_logs"
-    | "page_shield_events"
-    | "sinkhole_http_logs"
-    | "spectrum_events"
-    | "ssh_logs"
-    | "warp_config_changes"
-    | "warp_toggle_changes"
-    | "workers_trace_events"
-    | "zaraz_events"
-    | "zero_trust_network_sessions"
-    | null;
-}
-
-export const GetDatasetFieldRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {
-    datasetId: Schema.Union([
-      Schema.Literal("access_requests"),
-      Schema.Literal("audit_logs"),
-      Schema.Literal("audit_logs_v2"),
-      Schema.Literal("biso_user_actions"),
-      Schema.Literal("casb_findings"),
-      Schema.Literal("device_posture_results"),
-      Schema.Literal("dex_application_tests"),
-      Schema.Literal("dex_device_state_events"),
-      Schema.Literal("dlp_forensic_copies"),
-      Schema.Literal("dns_firewall_logs"),
-      Schema.Literal("dns_logs"),
-      Schema.Literal("email_security_alerts"),
-      Schema.Literal("firewall_events"),
-      Schema.Literal("gateway_dns"),
-      Schema.Literal("gateway_http"),
-      Schema.Literal("gateway_network"),
-      Schema.Literal("http_requests"),
-      Schema.Literal("ipsec_logs"),
-      Schema.Literal("magic_ids_detections"),
-      Schema.Literal("nel_reports"),
-      Schema.Literal("network_analytics_logs"),
-      Schema.Literal("page_shield_events"),
-      Schema.Literal("sinkhole_http_logs"),
-      Schema.Literal("spectrum_events"),
-      Schema.Literal("ssh_logs"),
-      Schema.Literal("warp_config_changes"),
-      Schema.Literal("warp_toggle_changes"),
-      Schema.Literal("workers_trace_events"),
-      Schema.Literal("zaraz_events"),
-      Schema.Literal("zero_trust_network_sessions"),
-      Schema.Null,
-    ]).pipe(T.HttpPath("datasetId")),
-  },
-).pipe(
-  T.Http({
-    method: "GET",
-    path: "/{accountOrZone}/{accountOrZoneId}/logpush/datasets/{datasetId}/fields",
-  }),
-) as unknown as Schema.Schema<GetDatasetFieldRequest>;
-
-export type GetDatasetFieldResponse = unknown;
-
-export const GetDatasetFieldResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
-    T.ResponsePath("result"),
-  ) as unknown as Schema.Schema<GetDatasetFieldResponse>;
-
-export type GetDatasetFieldError = DefaultErrors;
-
-export const getDatasetField: API.OperationMethod<
-  GetDatasetFieldRequest,
-  GetDatasetFieldResponse,
-  GetDatasetFieldError,
-  Credentials | HttpClient.HttpClient
-> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: GetDatasetFieldRequest,
-  output: GetDatasetFieldResponse,
-  errors: [],
-}));
-
-// =============================================================================
-// DatasetJob
-// =============================================================================
-
-export interface GetDatasetJobRequest {
-  datasetId:
-    | "access_requests"
-    | "audit_logs"
-    | "audit_logs_v2"
-    | "biso_user_actions"
-    | "casb_findings"
-    | "device_posture_results"
-    | "dex_application_tests"
-    | "dex_device_state_events"
-    | "dlp_forensic_copies"
-    | "dns_firewall_logs"
-    | "dns_logs"
-    | "email_security_alerts"
-    | "firewall_events"
-    | "gateway_dns"
-    | "gateway_http"
-    | "gateway_network"
-    | "http_requests"
-    | "ipsec_logs"
-    | "magic_ids_detections"
-    | "nel_reports"
-    | "network_analytics_logs"
-    | "page_shield_events"
-    | "sinkhole_http_logs"
-    | "spectrum_events"
-    | "ssh_logs"
-    | "warp_config_changes"
-    | "warp_toggle_changes"
-    | "workers_trace_events"
-    | "zaraz_events"
-    | "zero_trust_network_sessions"
-    | null;
-}
-
-export const GetDatasetJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+const GetDatasetFieldBaseFields = {
   datasetId: Schema.Union([
     Schema.Literal("access_requests"),
     Schema.Literal("audit_logs"),
@@ -187,12 +52,289 @@ export const GetDatasetJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     Schema.Literal("zero_trust_network_sessions"),
     Schema.Null,
   ]).pipe(T.HttpPath("datasetId")),
-}).pipe(
-  T.Http({
-    method: "GET",
-    path: "/{accountOrZone}/{accountOrZoneId}/logpush/datasets/{datasetId}/jobs",
-  }),
-) as unknown as Schema.Schema<GetDatasetJobRequest>;
+} as const;
+
+export interface GetDatasetFieldForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  datasetId:
+    | "access_requests"
+    | "audit_logs"
+    | "audit_logs_v2"
+    | "biso_user_actions"
+    | "casb_findings"
+    | "device_posture_results"
+    | "dex_application_tests"
+    | "dex_device_state_events"
+    | "dlp_forensic_copies"
+    | "dns_firewall_logs"
+    | "dns_logs"
+    | "email_security_alerts"
+    | "firewall_events"
+    | "gateway_dns"
+    | "gateway_http"
+    | "gateway_network"
+    | "http_requests"
+    | "ipsec_logs"
+    | "magic_ids_detections"
+    | "nel_reports"
+    | "network_analytics_logs"
+    | "page_shield_events"
+    | "sinkhole_http_logs"
+    | "spectrum_events"
+    | "ssh_logs"
+    | "warp_config_changes"
+    | "warp_toggle_changes"
+    | "workers_trace_events"
+    | "zaraz_events"
+    | "zero_trust_network_sessions"
+    | null;
+}
+
+export interface GetDatasetFieldForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  datasetId:
+    | "access_requests"
+    | "audit_logs"
+    | "audit_logs_v2"
+    | "biso_user_actions"
+    | "casb_findings"
+    | "device_posture_results"
+    | "dex_application_tests"
+    | "dex_device_state_events"
+    | "dlp_forensic_copies"
+    | "dns_firewall_logs"
+    | "dns_logs"
+    | "email_security_alerts"
+    | "firewall_events"
+    | "gateway_dns"
+    | "gateway_http"
+    | "gateway_network"
+    | "http_requests"
+    | "ipsec_logs"
+    | "magic_ids_detections"
+    | "nel_reports"
+    | "network_analytics_logs"
+    | "page_shield_events"
+    | "sinkhole_http_logs"
+    | "spectrum_events"
+    | "ssh_logs"
+    | "warp_config_changes"
+    | "warp_toggle_changes"
+    | "workers_trace_events"
+    | "zaraz_events"
+    | "zero_trust_network_sessions"
+    | null;
+}
+
+export type GetDatasetFieldRequest =
+  | GetDatasetFieldForAccountRequest
+  | GetDatasetFieldForZoneRequest;
+
+export const GetDatasetFieldForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetDatasetFieldBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/logpush/datasets/{datasetId}/fields",
+    }),
+  ) as unknown as Schema.Schema<GetDatasetFieldForAccountRequest>;
+
+export const GetDatasetFieldForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...GetDatasetFieldBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/logpush/datasets/{datasetId}/fields",
+    }),
+  ) as unknown as Schema.Schema<GetDatasetFieldForZoneRequest>;
+
+export type GetDatasetFieldResponse = unknown;
+
+export const GetDatasetFieldResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<GetDatasetFieldResponse>;
+
+export type GetDatasetFieldError = DefaultErrors;
+
+export const getDatasetFieldForAccount: API.OperationMethod<
+  GetDatasetFieldForAccountRequest,
+  GetDatasetFieldResponse,
+  GetDatasetFieldError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetDatasetFieldForAccountRequest,
+  output: GetDatasetFieldResponse,
+  errors: [],
+}));
+
+export const getDatasetFieldForZone: API.OperationMethod<
+  GetDatasetFieldForZoneRequest,
+  GetDatasetFieldResponse,
+  GetDatasetFieldError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetDatasetFieldForZoneRequest,
+  output: GetDatasetFieldResponse,
+  errors: [],
+}));
+
+export const getDatasetField = (
+  input: GetDatasetFieldRequest,
+): Effect.Effect<
+  GetDatasetFieldResponse,
+  GetDatasetFieldError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? getDatasetFieldForAccount(input)
+    : getDatasetFieldForZone(input);
+
+// =============================================================================
+// DatasetJob
+// =============================================================================
+
+const GetDatasetJobBaseFields = {
+  datasetId: Schema.Union([
+    Schema.Literal("access_requests"),
+    Schema.Literal("audit_logs"),
+    Schema.Literal("audit_logs_v2"),
+    Schema.Literal("biso_user_actions"),
+    Schema.Literal("casb_findings"),
+    Schema.Literal("device_posture_results"),
+    Schema.Literal("dex_application_tests"),
+    Schema.Literal("dex_device_state_events"),
+    Schema.Literal("dlp_forensic_copies"),
+    Schema.Literal("dns_firewall_logs"),
+    Schema.Literal("dns_logs"),
+    Schema.Literal("email_security_alerts"),
+    Schema.Literal("firewall_events"),
+    Schema.Literal("gateway_dns"),
+    Schema.Literal("gateway_http"),
+    Schema.Literal("gateway_network"),
+    Schema.Literal("http_requests"),
+    Schema.Literal("ipsec_logs"),
+    Schema.Literal("magic_ids_detections"),
+    Schema.Literal("nel_reports"),
+    Schema.Literal("network_analytics_logs"),
+    Schema.Literal("page_shield_events"),
+    Schema.Literal("sinkhole_http_logs"),
+    Schema.Literal("spectrum_events"),
+    Schema.Literal("ssh_logs"),
+    Schema.Literal("warp_config_changes"),
+    Schema.Literal("warp_toggle_changes"),
+    Schema.Literal("workers_trace_events"),
+    Schema.Literal("zaraz_events"),
+    Schema.Literal("zero_trust_network_sessions"),
+    Schema.Null,
+  ]).pipe(T.HttpPath("datasetId")),
+} as const;
+
+export interface GetDatasetJobForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  datasetId:
+    | "access_requests"
+    | "audit_logs"
+    | "audit_logs_v2"
+    | "biso_user_actions"
+    | "casb_findings"
+    | "device_posture_results"
+    | "dex_application_tests"
+    | "dex_device_state_events"
+    | "dlp_forensic_copies"
+    | "dns_firewall_logs"
+    | "dns_logs"
+    | "email_security_alerts"
+    | "firewall_events"
+    | "gateway_dns"
+    | "gateway_http"
+    | "gateway_network"
+    | "http_requests"
+    | "ipsec_logs"
+    | "magic_ids_detections"
+    | "nel_reports"
+    | "network_analytics_logs"
+    | "page_shield_events"
+    | "sinkhole_http_logs"
+    | "spectrum_events"
+    | "ssh_logs"
+    | "warp_config_changes"
+    | "warp_toggle_changes"
+    | "workers_trace_events"
+    | "zaraz_events"
+    | "zero_trust_network_sessions"
+    | null;
+}
+
+export interface GetDatasetJobForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  datasetId:
+    | "access_requests"
+    | "audit_logs"
+    | "audit_logs_v2"
+    | "biso_user_actions"
+    | "casb_findings"
+    | "device_posture_results"
+    | "dex_application_tests"
+    | "dex_device_state_events"
+    | "dlp_forensic_copies"
+    | "dns_firewall_logs"
+    | "dns_logs"
+    | "email_security_alerts"
+    | "firewall_events"
+    | "gateway_dns"
+    | "gateway_http"
+    | "gateway_network"
+    | "http_requests"
+    | "ipsec_logs"
+    | "magic_ids_detections"
+    | "nel_reports"
+    | "network_analytics_logs"
+    | "page_shield_events"
+    | "sinkhole_http_logs"
+    | "spectrum_events"
+    | "ssh_logs"
+    | "warp_config_changes"
+    | "warp_toggle_changes"
+    | "workers_trace_events"
+    | "zaraz_events"
+    | "zero_trust_network_sessions"
+    | null;
+}
+
+export type GetDatasetJobRequest =
+  | GetDatasetJobForAccountRequest
+  | GetDatasetJobForZoneRequest;
+
+export const GetDatasetJobForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetDatasetJobBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/logpush/datasets/{datasetId}/jobs",
+    }),
+  ) as unknown as Schema.Schema<GetDatasetJobForAccountRequest>;
+
+export const GetDatasetJobForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...GetDatasetJobBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/logpush/datasets/{datasetId}/jobs",
+    }),
+  ) as unknown as Schema.Schema<GetDatasetJobForZoneRequest>;
 
 export interface GetDatasetJobResponse {
   result: ({
@@ -419,13 +561,13 @@ export const GetDatasetJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type GetDatasetJobError = DefaultErrors;
 
-export const getDatasetJob: API.PaginatedOperationMethod<
-  GetDatasetJobRequest,
+export const getDatasetJobForAccount: API.PaginatedOperationMethod<
+  GetDatasetJobForAccountRequest,
   GetDatasetJobResponse,
   GetDatasetJobError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
-  input: GetDatasetJobRequest,
+  input: GetDatasetJobForAccountRequest,
   output: GetDatasetJobResponse,
   errors: [],
   pagination: {
@@ -433,6 +575,32 @@ export const getDatasetJob: API.PaginatedOperationMethod<
     items: "result",
   } as const,
 }));
+
+export const getDatasetJobForZone: API.PaginatedOperationMethod<
+  GetDatasetJobForZoneRequest,
+  GetDatasetJobResponse,
+  GetDatasetJobError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+  input: GetDatasetJobForZoneRequest,
+  output: GetDatasetJobResponse,
+  errors: [],
+  pagination: {
+    mode: "single",
+    items: "result",
+  } as const,
+}));
+
+export const getDatasetJob = (
+  input: GetDatasetJobRequest,
+): stream.Stream<
+  GetDatasetJobResponse,
+  GetDatasetJobError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? getDatasetJobForAccount.pages(input)
+    : getDatasetJobForZone.pages(input);
 
 // =============================================================================
 // Edge
@@ -571,27 +739,51 @@ export const createEdge: API.OperationMethod<
 // ExistsValidate
 // =============================================================================
 
-export interface DestinationExistsValidateRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
+const DestinationExistsValidateBaseFields = {
+  destinationConf: Schema.String,
+} as const;
+
+export interface DestinationExistsValidateForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
   destinationConf: string;
 }
 
-export const DestinationExistsValidateRequest =
+export interface DestinationExistsValidateForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
+  destinationConf: string;
+}
+
+export type DestinationExistsValidateRequest =
+  | DestinationExistsValidateForAccountRequest
+  | DestinationExistsValidateForZoneRequest;
+
+export const DestinationExistsValidateForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    destinationConf: Schema.String,
+    ...DestinationExistsValidateBaseFields,
   }).pipe(
     Schema.encodeKeys({ destinationConf: "destination_conf" }),
     T.Http({
       method: "POST",
-      path: "/{accountOrZone}/{accountOrZoneId}/logpush/validate/destination/exists",
+      path: "/accounts/{account_id}/logpush/validate/destination/exists",
     }),
-  ) as unknown as Schema.Schema<DestinationExistsValidateRequest>;
+  ) as unknown as Schema.Schema<DestinationExistsValidateForAccountRequest>;
+
+export const DestinationExistsValidateForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...DestinationExistsValidateBaseFields,
+  }).pipe(
+    Schema.encodeKeys({ destinationConf: "destination_conf" }),
+    T.Http({
+      method: "POST",
+      path: "/zones/{zone_id}/logpush/validate/destination/exists",
+    }),
+  ) as unknown as Schema.Schema<DestinationExistsValidateForZoneRequest>;
 
 export interface DestinationExistsValidateResponse {
   exists?: boolean | null;
@@ -606,33 +798,78 @@ export const DestinationExistsValidateResponse =
 
 export type DestinationExistsValidateError = DefaultErrors;
 
-export const destinationExistsValidate: API.OperationMethod<
-  DestinationExistsValidateRequest,
+export const destinationExistsValidateForAccount: API.OperationMethod<
+  DestinationExistsValidateForAccountRequest,
   DestinationExistsValidateResponse,
   DestinationExistsValidateError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: DestinationExistsValidateRequest,
+  input: DestinationExistsValidateForAccountRequest,
   output: DestinationExistsValidateResponse,
   errors: [],
 }));
+
+export const destinationExistsValidateForZone: API.OperationMethod<
+  DestinationExistsValidateForZoneRequest,
+  DestinationExistsValidateResponse,
+  DestinationExistsValidateError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: DestinationExistsValidateForZoneRequest,
+  output: DestinationExistsValidateResponse,
+  errors: [],
+}));
+
+export const destinationExistsValidate = (
+  input: DestinationExistsValidateRequest,
+): Effect.Effect<
+  DestinationExistsValidateResponse,
+  DestinationExistsValidateError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? destinationExistsValidateForAccount(input)
+    : destinationExistsValidateForZone(input);
 
 // =============================================================================
 // Job
 // =============================================================================
 
-export interface GetJobRequest {
+const GetJobBaseFields = {
+  jobId: Schema.Number.pipe(T.HttpPath("jobId")),
+} as const;
+
+export interface GetJobForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   jobId: number;
 }
 
-export const GetJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  jobId: Schema.Number.pipe(T.HttpPath("jobId")),
+export interface GetJobForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  jobId: number;
+}
+
+export type GetJobRequest = GetJobForAccountRequest | GetJobForZoneRequest;
+
+export const GetJobForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetJobBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/logpush/jobs/{jobId}",
+    }),
+  ) as unknown as Schema.Schema<GetJobForAccountRequest>;
+
+export const GetJobForZoneRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+  ...GetJobBaseFields,
 }).pipe(
-  T.Http({
-    method: "GET",
-    path: "/{accountOrZone}/{accountOrZoneId}/logpush/jobs/{jobId}",
-  }),
-) as unknown as Schema.Schema<GetJobRequest>;
+  T.Http({ method: "GET", path: "/zones/{zone_id}/logpush/jobs/{jobId}" }),
+) as unknown as Schema.Schema<GetJobForZoneRequest>;
 
 export interface GetJobResponse {
   /** Unique id of the job. */
@@ -853,27 +1090,68 @@ export const GetJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type GetJobError = DefaultErrors;
 
-export const getJob: API.OperationMethod<
-  GetJobRequest,
+export const getJobForAccount: API.OperationMethod<
+  GetJobForAccountRequest,
   GetJobResponse,
   GetJobError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: GetJobRequest,
+  input: GetJobForAccountRequest,
   output: GetJobResponse,
   errors: [],
 }));
 
-export interface ListJobsRequest {}
+export const getJobForZone: API.OperationMethod<
+  GetJobForZoneRequest,
+  GetJobResponse,
+  GetJobError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetJobForZoneRequest,
+  output: GetJobResponse,
+  errors: [],
+}));
 
-export const ListJobsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {},
+export const getJob = (
+  input: GetJobRequest,
+): Effect.Effect<
+  GetJobResponse,
+  GetJobError,
+  Credentials | HttpClient.HttpClient
+> => ("accountId" in input ? getJobForAccount(input) : getJobForZone(input));
+
+const ListJobsBaseFields = {} as const;
+
+export interface ListJobsForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface ListJobsForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+}
+
+export type ListJobsRequest =
+  | ListJobsForAccountRequest
+  | ListJobsForZoneRequest;
+
+export const ListJobsForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...ListJobsBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/accounts/{account_id}/logpush/jobs" }),
+  ) as unknown as Schema.Schema<ListJobsForAccountRequest>;
+
+export const ListJobsForZoneRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
+  {
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...ListJobsBaseFields,
+  },
 ).pipe(
-  T.Http({
-    method: "GET",
-    path: "/{accountOrZone}/{accountOrZoneId}/logpush/jobs",
-  }),
-) as unknown as Schema.Schema<ListJobsRequest>;
+  T.Http({ method: "GET", path: "/zones/{zone_id}/logpush/jobs" }),
+) as unknown as Schema.Schema<ListJobsForZoneRequest>;
 
 export interface ListJobsResponse {
   result: ({
@@ -1100,13 +1378,13 @@ export const ListJobsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type ListJobsError = DefaultErrors;
 
-export const listJobs: API.PaginatedOperationMethod<
-  ListJobsRequest,
+export const listJobsForAccount: API.PaginatedOperationMethod<
+  ListJobsForAccountRequest,
   ListJobsResponse,
   ListJobsError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
-  input: ListJobsRequest,
+  input: ListJobsForAccountRequest,
   output: ListJobsResponse,
   errors: [],
   pagination: {
@@ -1115,86 +1393,33 @@ export const listJobs: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export interface CreateJobRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
-  /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
-  destinationConf: string;
-  /** Body param: Name of the dataset. A list of supported datasets can be found on the [Developer Docs](https://developers.cloudflare.com/logs/reference/log-fields/). */
-  dataset?:
-    | "access_requests"
-    | "audit_logs"
-    | "audit_logs_v2"
-    | "biso_user_actions"
-    | "casb_findings"
-    | "device_posture_results"
-    | "dex_application_tests"
-    | "dex_device_state_events"
-    | "dlp_forensic_copies"
-    | "dns_firewall_logs"
-    | "dns_logs"
-    | "email_security_alerts"
-    | "firewall_events"
-    | "gateway_dns"
-    | "gateway_http"
-    | "gateway_network"
-    | "http_requests"
-    | "ipsec_logs"
-    | "magic_ids_detections"
-    | "nel_reports"
-    | "network_analytics_logs"
-    | "page_shield_events"
-    | "sinkhole_http_logs"
-    | "spectrum_events"
-    | "ssh_logs"
-    | "warp_config_changes"
-    | "warp_toggle_changes"
-    | "workers_trace_events"
-    | "zaraz_events"
-    | "zero_trust_network_sessions"
-    | null;
-  /** Body param: Flag that indicates if the job is enabled. */
-  enabled?: boolean;
-  /** Body param: The filters to select the events to include and/or remove from your logs. For more information, refer to [Filters](https://developers.cloudflare.com/logs/reference/filters/). */
-  filter?: string | null;
-  /** @deprecated Body param: This field is deprecated. Please use `max_upload_ ` parameters instead. . The frequency at which Cloudflare sends batches of logs to your destination. Setting frequency to high */
-  frequency?: "high" | "low" | null;
-  /** Body param: The kind parameter (optional) is used to differentiate between Logpush and Edge Log Delivery jobs (when supported by the dataset). */
-  kind?: "" | "edge";
-  /** @deprecated Body param: This field is deprecated. Use `output_options` instead. Configuration string. It specifies things like requested fields and timestamp formats. If migrating from the logpull api */
-  logpullOptions?: string | null;
-  /** Body param: The maximum uncompressed file size of a batch of logs. This setting value must be between `5 MB` and `1 GB`, or `0` to disable it. Note that you cannot set a minimum file size; this means  */
-  maxUploadBytes?: "0" | number | null;
-  /** Body param: The maximum interval in seconds for log batches. This setting must be between 30 and 300 seconds (5 minutes), or `0` to disable it. Note that you cannot specify a minimum interval for log  */
-  maxUploadIntervalSeconds?: "0" | number | null;
-  /** Body param: The maximum number of log lines per batch. This setting must be between 1000 and 1,000,000 lines, or `0` to disable it. Note that you cannot specify a minimum number of log lines per batch */
-  maxUploadRecords?: "0" | number | null;
-  /** Body param: Optional human readable job name. Not unique. Cloudflare suggests. that you set this to a meaningful string, like the domain name, to make it easier to identify your job. */
-  name?: string | null;
-  /** Body param: The structured replacement for `logpull_options`. When including this field, the `logpull_option` field will be ignored. */
-  outputOptions?: {
-    batchPrefix?: string | null;
-    batchSuffix?: string | null;
-    "cve-2021-44228"?: boolean | null;
-    fieldDelimiter?: string | null;
-    fieldNames?: string[];
-    outputType?: "ndjson" | "csv";
-    recordDelimiter?: string | null;
-    recordPrefix?: string | null;
-    recordSuffix?: string | null;
-    recordTemplate?: string | null;
-    sampleRate?: number | null;
-    timestampFormat?: "unixnano" | "unix" | "rfc3339";
-  } | null;
-  /** Body param: Ownership challenge token to prove destination ownership. */
-  ownershipChallenge?: string;
-}
+export const listJobsForZone: API.PaginatedOperationMethod<
+  ListJobsForZoneRequest,
+  ListJobsResponse,
+  ListJobsError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+  input: ListJobsForZoneRequest,
+  output: ListJobsResponse,
+  errors: [],
+  pagination: {
+    mode: "single",
+    items: "result",
+  } as const,
+}));
 
-export const CreateJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+export const listJobs = (
+  input: ListJobsRequest,
+): stream.Stream<
+  ListJobsResponse,
+  ListJobsError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? listJobsForAccount.pages(input)
+    : listJobsForZone.pages(input);
+
+const CreateJobBaseFields = {
   destinationConf: Schema.String,
   dataset: Schema.optional(
     Schema.Union([
@@ -1301,27 +1526,207 @@ export const CreateJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     ]),
   ),
   ownershipChallenge: Schema.optional(Schema.String),
-}).pipe(
-  Schema.encodeKeys({
-    destinationConf: "destination_conf",
-    dataset: "dataset",
-    enabled: "enabled",
-    filter: "filter",
-    frequency: "frequency",
-    kind: "kind",
-    logpullOptions: "logpull_options",
-    maxUploadBytes: "max_upload_bytes",
-    maxUploadIntervalSeconds: "max_upload_interval_seconds",
-    maxUploadRecords: "max_upload_records",
-    name: "name",
-    outputOptions: "output_options",
-    ownershipChallenge: "ownership_challenge",
-  }),
-  T.Http({
-    method: "POST",
-    path: "/{accountOrZone}/{accountOrZoneId}/logpush/jobs",
-  }),
-) as unknown as Schema.Schema<CreateJobRequest>;
+} as const;
+
+export interface CreateJobForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
+  destinationConf: string;
+  /** Body param: Name of the dataset. A list of supported datasets can be found on the [Developer Docs](https://developers.cloudflare.com/logs/reference/log-fields/). */
+  dataset?:
+    | "access_requests"
+    | "audit_logs"
+    | "audit_logs_v2"
+    | "biso_user_actions"
+    | "casb_findings"
+    | "device_posture_results"
+    | "dex_application_tests"
+    | "dex_device_state_events"
+    | "dlp_forensic_copies"
+    | "dns_firewall_logs"
+    | "dns_logs"
+    | "email_security_alerts"
+    | "firewall_events"
+    | "gateway_dns"
+    | "gateway_http"
+    | "gateway_network"
+    | "http_requests"
+    | "ipsec_logs"
+    | "magic_ids_detections"
+    | "nel_reports"
+    | "network_analytics_logs"
+    | "page_shield_events"
+    | "sinkhole_http_logs"
+    | "spectrum_events"
+    | "ssh_logs"
+    | "warp_config_changes"
+    | "warp_toggle_changes"
+    | "workers_trace_events"
+    | "zaraz_events"
+    | "zero_trust_network_sessions"
+    | null;
+  /** Body param: Flag that indicates if the job is enabled. */
+  enabled?: boolean;
+  /** Body param: The filters to select the events to include and/or remove from your logs. For more information, refer to [Filters](https://developers.cloudflare.com/logs/reference/filters/). */
+  filter?: string | null;
+  /** @deprecated Body param: This field is deprecated. Please use `max_upload_ ` parameters instead. . The frequency at which Cloudflare sends batches of logs to your destination. Setting frequency to high */
+  frequency?: "high" | "low" | null;
+  /** Body param: The kind parameter (optional) is used to differentiate between Logpush and Edge Log Delivery jobs (when supported by the dataset). */
+  kind?: "" | "edge";
+  /** @deprecated Body param: This field is deprecated. Use `output_options` instead. Configuration string. It specifies things like requested fields and timestamp formats. If migrating from the logpull api */
+  logpullOptions?: string | null;
+  /** Body param: The maximum uncompressed file size of a batch of logs. This setting value must be between `5 MB` and `1 GB`, or `0` to disable it. Note that you cannot set a minimum file size; this means  */
+  maxUploadBytes?: "0" | number | null;
+  /** Body param: The maximum interval in seconds for log batches. This setting must be between 30 and 300 seconds (5 minutes), or `0` to disable it. Note that you cannot specify a minimum interval for log  */
+  maxUploadIntervalSeconds?: "0" | number | null;
+  /** Body param: The maximum number of log lines per batch. This setting must be between 1000 and 1,000,000 lines, or `0` to disable it. Note that you cannot specify a minimum number of log lines per batch */
+  maxUploadRecords?: "0" | number | null;
+  /** Body param: Optional human readable job name. Not unique. Cloudflare suggests. that you set this to a meaningful string, like the domain name, to make it easier to identify your job. */
+  name?: string | null;
+  /** Body param: The structured replacement for `logpull_options`. When including this field, the `logpull_option` field will be ignored. */
+  outputOptions?: {
+    batchPrefix?: string | null;
+    batchSuffix?: string | null;
+    "cve-2021-44228"?: boolean | null;
+    fieldDelimiter?: string | null;
+    fieldNames?: string[];
+    outputType?: "ndjson" | "csv";
+    recordDelimiter?: string | null;
+    recordPrefix?: string | null;
+    recordSuffix?: string | null;
+    recordTemplate?: string | null;
+    sampleRate?: number | null;
+    timestampFormat?: "unixnano" | "unix" | "rfc3339";
+  } | null;
+  /** Body param: Ownership challenge token to prove destination ownership. */
+  ownershipChallenge?: string;
+}
+
+export interface CreateJobForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
+  destinationConf: string;
+  /** Body param: Name of the dataset. A list of supported datasets can be found on the [Developer Docs](https://developers.cloudflare.com/logs/reference/log-fields/). */
+  dataset?:
+    | "access_requests"
+    | "audit_logs"
+    | "audit_logs_v2"
+    | "biso_user_actions"
+    | "casb_findings"
+    | "device_posture_results"
+    | "dex_application_tests"
+    | "dex_device_state_events"
+    | "dlp_forensic_copies"
+    | "dns_firewall_logs"
+    | "dns_logs"
+    | "email_security_alerts"
+    | "firewall_events"
+    | "gateway_dns"
+    | "gateway_http"
+    | "gateway_network"
+    | "http_requests"
+    | "ipsec_logs"
+    | "magic_ids_detections"
+    | "nel_reports"
+    | "network_analytics_logs"
+    | "page_shield_events"
+    | "sinkhole_http_logs"
+    | "spectrum_events"
+    | "ssh_logs"
+    | "warp_config_changes"
+    | "warp_toggle_changes"
+    | "workers_trace_events"
+    | "zaraz_events"
+    | "zero_trust_network_sessions"
+    | null;
+  /** Body param: Flag that indicates if the job is enabled. */
+  enabled?: boolean;
+  /** Body param: The filters to select the events to include and/or remove from your logs. For more information, refer to [Filters](https://developers.cloudflare.com/logs/reference/filters/). */
+  filter?: string | null;
+  /** @deprecated Body param: This field is deprecated. Please use `max_upload_ ` parameters instead. . The frequency at which Cloudflare sends batches of logs to your destination. Setting frequency to high */
+  frequency?: "high" | "low" | null;
+  /** Body param: The kind parameter (optional) is used to differentiate between Logpush and Edge Log Delivery jobs (when supported by the dataset). */
+  kind?: "" | "edge";
+  /** @deprecated Body param: This field is deprecated. Use `output_options` instead. Configuration string. It specifies things like requested fields and timestamp formats. If migrating from the logpull api */
+  logpullOptions?: string | null;
+  /** Body param: The maximum uncompressed file size of a batch of logs. This setting value must be between `5 MB` and `1 GB`, or `0` to disable it. Note that you cannot set a minimum file size; this means  */
+  maxUploadBytes?: "0" | number | null;
+  /** Body param: The maximum interval in seconds for log batches. This setting must be between 30 and 300 seconds (5 minutes), or `0` to disable it. Note that you cannot specify a minimum interval for log  */
+  maxUploadIntervalSeconds?: "0" | number | null;
+  /** Body param: The maximum number of log lines per batch. This setting must be between 1000 and 1,000,000 lines, or `0` to disable it. Note that you cannot specify a minimum number of log lines per batch */
+  maxUploadRecords?: "0" | number | null;
+  /** Body param: Optional human readable job name. Not unique. Cloudflare suggests. that you set this to a meaningful string, like the domain name, to make it easier to identify your job. */
+  name?: string | null;
+  /** Body param: The structured replacement for `logpull_options`. When including this field, the `logpull_option` field will be ignored. */
+  outputOptions?: {
+    batchPrefix?: string | null;
+    batchSuffix?: string | null;
+    "cve-2021-44228"?: boolean | null;
+    fieldDelimiter?: string | null;
+    fieldNames?: string[];
+    outputType?: "ndjson" | "csv";
+    recordDelimiter?: string | null;
+    recordPrefix?: string | null;
+    recordSuffix?: string | null;
+    recordTemplate?: string | null;
+    sampleRate?: number | null;
+    timestampFormat?: "unixnano" | "unix" | "rfc3339";
+  } | null;
+  /** Body param: Ownership challenge token to prove destination ownership. */
+  ownershipChallenge?: string;
+}
+
+export type CreateJobRequest =
+  | CreateJobForAccountRequest
+  | CreateJobForZoneRequest;
+
+export const CreateJobForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...CreateJobBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      destinationConf: "destination_conf",
+      dataset: "dataset",
+      enabled: "enabled",
+      filter: "filter",
+      frequency: "frequency",
+      kind: "kind",
+      logpullOptions: "logpull_options",
+      maxUploadBytes: "max_upload_bytes",
+      maxUploadIntervalSeconds: "max_upload_interval_seconds",
+      maxUploadRecords: "max_upload_records",
+      name: "name",
+      outputOptions: "output_options",
+      ownershipChallenge: "ownership_challenge",
+    }),
+    T.Http({ method: "POST", path: "/accounts/{account_id}/logpush/jobs" }),
+  ) as unknown as Schema.Schema<CreateJobForAccountRequest>;
+
+export const CreateJobForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...CreateJobBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      destinationConf: "destination_conf",
+      dataset: "dataset",
+      enabled: "enabled",
+      filter: "filter",
+      frequency: "frequency",
+      kind: "kind",
+      logpullOptions: "logpull_options",
+      maxUploadBytes: "max_upload_bytes",
+      maxUploadIntervalSeconds: "max_upload_interval_seconds",
+      maxUploadRecords: "max_upload_records",
+      name: "name",
+      outputOptions: "output_options",
+      ownershipChallenge: "ownership_challenge",
+    }),
+    T.Http({ method: "POST", path: "/zones/{zone_id}/logpush/jobs" }),
+  ) as unknown as Schema.Schema<CreateJobForZoneRequest>;
 
 export interface CreateJobResponse {
   /** Unique id of the job. */
@@ -1544,66 +1949,39 @@ export const CreateJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type CreateJobError = DefaultErrors;
 
-export const createJob: API.OperationMethod<
-  CreateJobRequest,
+export const createJobForAccount: API.OperationMethod<
+  CreateJobForAccountRequest,
   CreateJobResponse,
   CreateJobError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: CreateJobRequest,
+  input: CreateJobForAccountRequest,
   output: CreateJobResponse,
   errors: [],
 }));
 
-export interface UpdateJobRequest {
-  jobId: number;
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
-  /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
-  destinationConf?: string;
-  /** Body param: Flag that indicates if the job is enabled. */
-  enabled?: boolean;
-  /** Body param: The filters to select the events to include and/or remove from your logs. For more information, refer to [Filters](https://developers.cloudflare.com/logs/reference/filters/). */
-  filter?: string | null;
-  /** @deprecated Body param: This field is deprecated. Please use `max_upload_ ` parameters instead. . The frequency at which Cloudflare sends batches of logs to your destination. Setting frequency to high */
-  frequency?: "high" | "low" | null;
-  /** Body param: The kind parameter (optional) is used to differentiate between Logpush and Edge Log Delivery jobs (when supported by the dataset). */
-  kind?: "" | "edge";
-  /** @deprecated Body param: This field is deprecated. Use `output_options` instead. Configuration string. It specifies things like requested fields and timestamp formats. If migrating from the logpull api */
-  logpullOptions?: string | null;
-  /** Body param: The maximum uncompressed file size of a batch of logs. This setting value must be between `5 MB` and `1 GB`, or `0` to disable it. Note that you cannot set a minimum file size; this means  */
-  maxUploadBytes?: "0" | number | null;
-  /** Body param: The maximum interval in seconds for log batches. This setting must be between 30 and 300 seconds (5 minutes), or `0` to disable it. Note that you cannot specify a minimum interval for log  */
-  maxUploadIntervalSeconds?: "0" | number | null;
-  /** Body param: The maximum number of log lines per batch. This setting must be between 1000 and 1,000,000 lines, or `0` to disable it. Note that you cannot specify a minimum number of log lines per batch */
-  maxUploadRecords?: "0" | number | null;
-  /** Body param: Optional human readable job name. Not unique. Cloudflare suggests. that you set this to a meaningful string, like the domain name, to make it easier to identify your job. */
-  name?: string | null;
-  /** Body param: The structured replacement for `logpull_options`. When including this field, the `logpull_option` field will be ignored. */
-  outputOptions?: {
-    batchPrefix?: string | null;
-    batchSuffix?: string | null;
-    "cve-2021-44228"?: boolean | null;
-    fieldDelimiter?: string | null;
-    fieldNames?: string[];
-    outputType?: "ndjson" | "csv";
-    recordDelimiter?: string | null;
-    recordPrefix?: string | null;
-    recordSuffix?: string | null;
-    recordTemplate?: string | null;
-    sampleRate?: number | null;
-    timestampFormat?: "unixnano" | "unix" | "rfc3339";
-  } | null;
-  /** Body param: Ownership challenge token to prove destination ownership. */
-  ownershipChallenge?: string;
-}
+export const createJobForZone: API.OperationMethod<
+  CreateJobForZoneRequest,
+  CreateJobResponse,
+  CreateJobError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: CreateJobForZoneRequest,
+  output: CreateJobResponse,
+  errors: [],
+}));
 
-export const UpdateJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+export const createJob = (
+  input: CreateJobRequest,
+): Effect.Effect<
+  CreateJobResponse,
+  CreateJobError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input ? createJobForAccount(input) : createJobForZone(input);
+
+const UpdateJobBaseFields = {
   jobId: Schema.Number.pipe(T.HttpPath("jobId")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
   destinationConf: Schema.optional(Schema.String),
   enabled: Schema.optional(Schema.Boolean),
   filter: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
@@ -1675,26 +2053,144 @@ export const UpdateJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     ]),
   ),
   ownershipChallenge: Schema.optional(Schema.String),
-}).pipe(
-  Schema.encodeKeys({
-    destinationConf: "destination_conf",
-    enabled: "enabled",
-    filter: "filter",
-    frequency: "frequency",
-    kind: "kind",
-    logpullOptions: "logpull_options",
-    maxUploadBytes: "max_upload_bytes",
-    maxUploadIntervalSeconds: "max_upload_interval_seconds",
-    maxUploadRecords: "max_upload_records",
-    name: "name",
-    outputOptions: "output_options",
-    ownershipChallenge: "ownership_challenge",
-  }),
-  T.Http({
-    method: "PUT",
-    path: "/{accountOrZone}/{accountOrZoneId}/logpush/jobs/{jobId}",
-  }),
-) as unknown as Schema.Schema<UpdateJobRequest>;
+} as const;
+
+export interface UpdateJobForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  jobId: number;
+  /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
+  destinationConf?: string;
+  /** Body param: Flag that indicates if the job is enabled. */
+  enabled?: boolean;
+  /** Body param: The filters to select the events to include and/or remove from your logs. For more information, refer to [Filters](https://developers.cloudflare.com/logs/reference/filters/). */
+  filter?: string | null;
+  /** @deprecated Body param: This field is deprecated. Please use `max_upload_ ` parameters instead. . The frequency at which Cloudflare sends batches of logs to your destination. Setting frequency to high */
+  frequency?: "high" | "low" | null;
+  /** Body param: The kind parameter (optional) is used to differentiate between Logpush and Edge Log Delivery jobs (when supported by the dataset). */
+  kind?: "" | "edge";
+  /** @deprecated Body param: This field is deprecated. Use `output_options` instead. Configuration string. It specifies things like requested fields and timestamp formats. If migrating from the logpull api */
+  logpullOptions?: string | null;
+  /** Body param: The maximum uncompressed file size of a batch of logs. This setting value must be between `5 MB` and `1 GB`, or `0` to disable it. Note that you cannot set a minimum file size; this means  */
+  maxUploadBytes?: "0" | number | null;
+  /** Body param: The maximum interval in seconds for log batches. This setting must be between 30 and 300 seconds (5 minutes), or `0` to disable it. Note that you cannot specify a minimum interval for log  */
+  maxUploadIntervalSeconds?: "0" | number | null;
+  /** Body param: The maximum number of log lines per batch. This setting must be between 1000 and 1,000,000 lines, or `0` to disable it. Note that you cannot specify a minimum number of log lines per batch */
+  maxUploadRecords?: "0" | number | null;
+  /** Body param: Optional human readable job name. Not unique. Cloudflare suggests. that you set this to a meaningful string, like the domain name, to make it easier to identify your job. */
+  name?: string | null;
+  /** Body param: The structured replacement for `logpull_options`. When including this field, the `logpull_option` field will be ignored. */
+  outputOptions?: {
+    batchPrefix?: string | null;
+    batchSuffix?: string | null;
+    "cve-2021-44228"?: boolean | null;
+    fieldDelimiter?: string | null;
+    fieldNames?: string[];
+    outputType?: "ndjson" | "csv";
+    recordDelimiter?: string | null;
+    recordPrefix?: string | null;
+    recordSuffix?: string | null;
+    recordTemplate?: string | null;
+    sampleRate?: number | null;
+    timestampFormat?: "unixnano" | "unix" | "rfc3339";
+  } | null;
+  /** Body param: Ownership challenge token to prove destination ownership. */
+  ownershipChallenge?: string;
+}
+
+export interface UpdateJobForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  jobId: number;
+  /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
+  destinationConf?: string;
+  /** Body param: Flag that indicates if the job is enabled. */
+  enabled?: boolean;
+  /** Body param: The filters to select the events to include and/or remove from your logs. For more information, refer to [Filters](https://developers.cloudflare.com/logs/reference/filters/). */
+  filter?: string | null;
+  /** @deprecated Body param: This field is deprecated. Please use `max_upload_ ` parameters instead. . The frequency at which Cloudflare sends batches of logs to your destination. Setting frequency to high */
+  frequency?: "high" | "low" | null;
+  /** Body param: The kind parameter (optional) is used to differentiate between Logpush and Edge Log Delivery jobs (when supported by the dataset). */
+  kind?: "" | "edge";
+  /** @deprecated Body param: This field is deprecated. Use `output_options` instead. Configuration string. It specifies things like requested fields and timestamp formats. If migrating from the logpull api */
+  logpullOptions?: string | null;
+  /** Body param: The maximum uncompressed file size of a batch of logs. This setting value must be between `5 MB` and `1 GB`, or `0` to disable it. Note that you cannot set a minimum file size; this means  */
+  maxUploadBytes?: "0" | number | null;
+  /** Body param: The maximum interval in seconds for log batches. This setting must be between 30 and 300 seconds (5 minutes), or `0` to disable it. Note that you cannot specify a minimum interval for log  */
+  maxUploadIntervalSeconds?: "0" | number | null;
+  /** Body param: The maximum number of log lines per batch. This setting must be between 1000 and 1,000,000 lines, or `0` to disable it. Note that you cannot specify a minimum number of log lines per batch */
+  maxUploadRecords?: "0" | number | null;
+  /** Body param: Optional human readable job name. Not unique. Cloudflare suggests. that you set this to a meaningful string, like the domain name, to make it easier to identify your job. */
+  name?: string | null;
+  /** Body param: The structured replacement for `logpull_options`. When including this field, the `logpull_option` field will be ignored. */
+  outputOptions?: {
+    batchPrefix?: string | null;
+    batchSuffix?: string | null;
+    "cve-2021-44228"?: boolean | null;
+    fieldDelimiter?: string | null;
+    fieldNames?: string[];
+    outputType?: "ndjson" | "csv";
+    recordDelimiter?: string | null;
+    recordPrefix?: string | null;
+    recordSuffix?: string | null;
+    recordTemplate?: string | null;
+    sampleRate?: number | null;
+    timestampFormat?: "unixnano" | "unix" | "rfc3339";
+  } | null;
+  /** Body param: Ownership challenge token to prove destination ownership. */
+  ownershipChallenge?: string;
+}
+
+export type UpdateJobRequest =
+  | UpdateJobForAccountRequest
+  | UpdateJobForZoneRequest;
+
+export const UpdateJobForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...UpdateJobBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      destinationConf: "destination_conf",
+      enabled: "enabled",
+      filter: "filter",
+      frequency: "frequency",
+      kind: "kind",
+      logpullOptions: "logpull_options",
+      maxUploadBytes: "max_upload_bytes",
+      maxUploadIntervalSeconds: "max_upload_interval_seconds",
+      maxUploadRecords: "max_upload_records",
+      name: "name",
+      outputOptions: "output_options",
+      ownershipChallenge: "ownership_challenge",
+    }),
+    T.Http({
+      method: "PUT",
+      path: "/accounts/{account_id}/logpush/jobs/{jobId}",
+    }),
+  ) as unknown as Schema.Schema<UpdateJobForAccountRequest>;
+
+export const UpdateJobForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...UpdateJobBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      destinationConf: "destination_conf",
+      enabled: "enabled",
+      filter: "filter",
+      frequency: "frequency",
+      kind: "kind",
+      logpullOptions: "logpull_options",
+      maxUploadBytes: "max_upload_bytes",
+      maxUploadIntervalSeconds: "max_upload_interval_seconds",
+      maxUploadRecords: "max_upload_records",
+      name: "name",
+      outputOptions: "output_options",
+      ownershipChallenge: "ownership_challenge",
+    }),
+    T.Http({ method: "PUT", path: "/zones/{zone_id}/logpush/jobs/{jobId}" }),
+  ) as unknown as Schema.Schema<UpdateJobForZoneRequest>;
 
 export interface UpdateJobResponse {
   /** Unique id of the job. */
@@ -1917,29 +2413,75 @@ export const UpdateJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type UpdateJobError = DefaultErrors;
 
-export const updateJob: API.OperationMethod<
-  UpdateJobRequest,
+export const updateJobForAccount: API.OperationMethod<
+  UpdateJobForAccountRequest,
   UpdateJobResponse,
   UpdateJobError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: UpdateJobRequest,
+  input: UpdateJobForAccountRequest,
   output: UpdateJobResponse,
   errors: [],
 }));
 
-export interface DeleteJobRequest {
+export const updateJobForZone: API.OperationMethod<
+  UpdateJobForZoneRequest,
+  UpdateJobResponse,
+  UpdateJobError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: UpdateJobForZoneRequest,
+  output: UpdateJobResponse,
+  errors: [],
+}));
+
+export const updateJob = (
+  input: UpdateJobRequest,
+): Effect.Effect<
+  UpdateJobResponse,
+  UpdateJobError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input ? updateJobForAccount(input) : updateJobForZone(input);
+
+const DeleteJobBaseFields = {
+  jobId: Schema.Number.pipe(T.HttpPath("jobId")),
+} as const;
+
+export interface DeleteJobForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   jobId: number;
 }
 
-export const DeleteJobRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  jobId: Schema.Number.pipe(T.HttpPath("jobId")),
-}).pipe(
-  T.Http({
-    method: "DELETE",
-    path: "/{accountOrZone}/{accountOrZoneId}/logpush/jobs/{jobId}",
-  }),
-) as unknown as Schema.Schema<DeleteJobRequest>;
+export interface DeleteJobForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  jobId: number;
+}
+
+export type DeleteJobRequest =
+  | DeleteJobForAccountRequest
+  | DeleteJobForZoneRequest;
+
+export const DeleteJobForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...DeleteJobBaseFields,
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/accounts/{account_id}/logpush/jobs/{jobId}",
+    }),
+  ) as unknown as Schema.Schema<DeleteJobForAccountRequest>;
+
+export const DeleteJobForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...DeleteJobBaseFields,
+  }).pipe(
+    T.Http({ method: "DELETE", path: "/zones/{zone_id}/logpush/jobs/{jobId}" }),
+  ) as unknown as Schema.Schema<DeleteJobForZoneRequest>;
 
 export interface DeleteJobResponse {
   /** Unique id of the job. */
@@ -1954,43 +2496,83 @@ export const DeleteJobResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type DeleteJobError = DefaultErrors;
 
-export const deleteJob: API.OperationMethod<
-  DeleteJobRequest,
+export const deleteJobForAccount: API.OperationMethod<
+  DeleteJobForAccountRequest,
   DeleteJobResponse,
   DeleteJobError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: DeleteJobRequest,
+  input: DeleteJobForAccountRequest,
   output: DeleteJobResponse,
   errors: [],
 }));
+
+export const deleteJobForZone: API.OperationMethod<
+  DeleteJobForZoneRequest,
+  DeleteJobResponse,
+  DeleteJobError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: DeleteJobForZoneRequest,
+  output: DeleteJobResponse,
+  errors: [],
+}));
+
+export const deleteJob = (
+  input: DeleteJobRequest,
+): Effect.Effect<
+  DeleteJobResponse,
+  DeleteJobError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input ? deleteJobForAccount(input) : deleteJobForZone(input);
 
 // =============================================================================
 // Ownership
 // =============================================================================
 
-export interface CreateOwnershipRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
+const CreateOwnershipBaseFields = {
+  destinationConf: Schema.String,
+} as const;
+
+export interface CreateOwnershipForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
   destinationConf: string;
 }
 
-export const CreateOwnershipRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {
+export interface CreateOwnershipForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
+  destinationConf: string;
+}
+
+export type CreateOwnershipRequest =
+  | CreateOwnershipForAccountRequest
+  | CreateOwnershipForZoneRequest;
+
+export const CreateOwnershipForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...CreateOwnershipBaseFields,
+  }).pipe(
+    Schema.encodeKeys({ destinationConf: "destination_conf" }),
+    T.Http({
+      method: "POST",
+      path: "/accounts/{account_id}/logpush/ownership",
+    }),
+  ) as unknown as Schema.Schema<CreateOwnershipForAccountRequest>;
+
+export const CreateOwnershipForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    destinationConf: Schema.String,
-  },
-).pipe(
-  Schema.encodeKeys({ destinationConf: "destination_conf" }),
-  T.Http({
-    method: "POST",
-    path: "/{accountOrZone}/{accountOrZoneId}/logpush/ownership",
-  }),
-) as unknown as Schema.Schema<CreateOwnershipRequest>;
+    ...CreateOwnershipBaseFields,
+  }).pipe(
+    Schema.encodeKeys({ destinationConf: "destination_conf" }),
+    T.Http({ method: "POST", path: "/zones/{zone_id}/logpush/ownership" }),
+  ) as unknown as Schema.Schema<CreateOwnershipForZoneRequest>;
 
 export interface CreateOwnershipResponse {
   filename?: string | null;
@@ -2009,34 +2591,70 @@ export const CreateOwnershipResponse =
 
 export type CreateOwnershipError = DefaultErrors;
 
-export const createOwnership: API.OperationMethod<
-  CreateOwnershipRequest,
+export const createOwnershipForAccount: API.OperationMethod<
+  CreateOwnershipForAccountRequest,
   CreateOwnershipResponse,
   CreateOwnershipError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: CreateOwnershipRequest,
+  input: CreateOwnershipForAccountRequest,
   output: CreateOwnershipResponse,
   errors: [],
 }));
 
-export interface ValidateOwnershipRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
+export const createOwnershipForZone: API.OperationMethod<
+  CreateOwnershipForZoneRequest,
+  CreateOwnershipResponse,
+  CreateOwnershipError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: CreateOwnershipForZoneRequest,
+  output: CreateOwnershipResponse,
+  errors: [],
+}));
+
+export const createOwnership = (
+  input: CreateOwnershipRequest,
+): Effect.Effect<
+  CreateOwnershipResponse,
+  CreateOwnershipError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? createOwnershipForAccount(input)
+    : createOwnershipForZone(input);
+
+const ValidateOwnershipBaseFields = {
+  destinationConf: Schema.String,
+  ownershipChallenge: Schema.String,
+} as const;
+
+export interface ValidateOwnershipForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
   destinationConf: string;
   /** Body param: Ownership challenge token to prove destination ownership. */
   ownershipChallenge: string;
 }
 
-export const ValidateOwnershipRequest =
+export interface ValidateOwnershipForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
+  destinationConf: string;
+  /** Body param: Ownership challenge token to prove destination ownership. */
+  ownershipChallenge: string;
+}
+
+export type ValidateOwnershipRequest =
+  | ValidateOwnershipForAccountRequest
+  | ValidateOwnershipForZoneRequest;
+
+export const ValidateOwnershipForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    destinationConf: Schema.String,
-    ownershipChallenge: Schema.String,
+    ...ValidateOwnershipBaseFields,
   }).pipe(
     Schema.encodeKeys({
       destinationConf: "destination_conf",
@@ -2044,9 +2662,24 @@ export const ValidateOwnershipRequest =
     }),
     T.Http({
       method: "POST",
-      path: "/{accountOrZone}/{accountOrZoneId}/logpush/ownership/validate",
+      path: "/accounts/{account_id}/logpush/ownership/validate",
     }),
-  ) as unknown as Schema.Schema<ValidateOwnershipRequest>;
+  ) as unknown as Schema.Schema<ValidateOwnershipForAccountRequest>;
+
+export const ValidateOwnershipForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...ValidateOwnershipBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      destinationConf: "destination_conf",
+      ownershipChallenge: "ownership_challenge",
+    }),
+    T.Http({
+      method: "POST",
+      path: "/zones/{zone_id}/logpush/ownership/validate",
+    }),
+  ) as unknown as Schema.Schema<ValidateOwnershipForZoneRequest>;
 
 export interface ValidateOwnershipResponse {
   valid?: boolean | null;
@@ -2061,42 +2694,88 @@ export const ValidateOwnershipResponse =
 
 export type ValidateOwnershipError = DefaultErrors;
 
-export const validateOwnership: API.OperationMethod<
-  ValidateOwnershipRequest,
+export const validateOwnershipForAccount: API.OperationMethod<
+  ValidateOwnershipForAccountRequest,
   ValidateOwnershipResponse,
   ValidateOwnershipError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: ValidateOwnershipRequest,
+  input: ValidateOwnershipForAccountRequest,
   output: ValidateOwnershipResponse,
   errors: [],
 }));
+
+export const validateOwnershipForZone: API.OperationMethod<
+  ValidateOwnershipForZoneRequest,
+  ValidateOwnershipResponse,
+  ValidateOwnershipError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: ValidateOwnershipForZoneRequest,
+  output: ValidateOwnershipResponse,
+  errors: [],
+}));
+
+export const validateOwnership = (
+  input: ValidateOwnershipRequest,
+): Effect.Effect<
+  ValidateOwnershipResponse,
+  ValidateOwnershipError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? validateOwnershipForAccount(input)
+    : validateOwnershipForZone(input);
 
 // =============================================================================
 // Validate
 // =============================================================================
 
-export interface DestinationValidateRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
+const DestinationValidateBaseFields = {
+  destinationConf: Schema.String,
+} as const;
+
+export interface DestinationValidateForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
   destinationConf: string;
 }
 
-export const DestinationValidateRequest =
+export interface DestinationValidateForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
+  destinationConf: string;
+}
+
+export type DestinationValidateRequest =
+  | DestinationValidateForAccountRequest
+  | DestinationValidateForZoneRequest;
+
+export const DestinationValidateForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    destinationConf: Schema.String,
+    ...DestinationValidateBaseFields,
   }).pipe(
     Schema.encodeKeys({ destinationConf: "destination_conf" }),
     T.Http({
       method: "POST",
-      path: "/{accountOrZone}/{accountOrZoneId}/logpush/validate/destination",
+      path: "/accounts/{account_id}/logpush/validate/destination",
     }),
-  ) as unknown as Schema.Schema<DestinationValidateRequest>;
+  ) as unknown as Schema.Schema<DestinationValidateForAccountRequest>;
+
+export const DestinationValidateForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...DestinationValidateBaseFields,
+  }).pipe(
+    Schema.encodeKeys({ destinationConf: "destination_conf" }),
+    T.Http({
+      method: "POST",
+      path: "/zones/{zone_id}/logpush/validate/destination",
+    }),
+  ) as unknown as Schema.Schema<DestinationValidateForZoneRequest>;
 
 export interface DestinationValidateResponse {
   message?: string | null;
@@ -2113,37 +2792,84 @@ export const DestinationValidateResponse =
 
 export type DestinationValidateError = DefaultErrors;
 
-export const destinationValidate: API.OperationMethod<
-  DestinationValidateRequest,
+export const destinationValidateForAccount: API.OperationMethod<
+  DestinationValidateForAccountRequest,
   DestinationValidateResponse,
   DestinationValidateError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: DestinationValidateRequest,
+  input: DestinationValidateForAccountRequest,
   output: DestinationValidateResponse,
   errors: [],
 }));
 
-export interface OriginValidateRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
+export const destinationValidateForZone: API.OperationMethod<
+  DestinationValidateForZoneRequest,
+  DestinationValidateResponse,
+  DestinationValidateError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: DestinationValidateForZoneRequest,
+  output: DestinationValidateResponse,
+  errors: [],
+}));
+
+export const destinationValidate = (
+  input: DestinationValidateRequest,
+): Effect.Effect<
+  DestinationValidateResponse,
+  DestinationValidateError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? destinationValidateForAccount(input)
+    : destinationValidateForZone(input);
+
+const OriginValidateBaseFields = {
+  logpullOptions: Schema.Union([Schema.String, Schema.Null]),
+} as const;
+
+export interface OriginValidateForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   /** @deprecated Body param: This field is deprecated. Use `output_options` instead. Configuration string. It specifies things like requested fields and timestamp formats. If migrating from the logpull api */
   logpullOptions: string | null;
 }
 
-export const OriginValidateRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-  logpullOptions: Schema.Union([Schema.String, Schema.Null]),
-}).pipe(
-  Schema.encodeKeys({ logpullOptions: "logpull_options" }),
-  T.Http({
-    method: "POST",
-    path: "/{accountOrZone}/{accountOrZoneId}/logpush/validate/origin",
-  }),
-) as unknown as Schema.Schema<OriginValidateRequest>;
+export interface OriginValidateForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  /** @deprecated Body param: This field is deprecated. Use `output_options` instead. Configuration string. It specifies things like requested fields and timestamp formats. If migrating from the logpull api */
+  logpullOptions: string | null;
+}
+
+export type OriginValidateRequest =
+  | OriginValidateForAccountRequest
+  | OriginValidateForZoneRequest;
+
+export const OriginValidateForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...OriginValidateBaseFields,
+  }).pipe(
+    Schema.encodeKeys({ logpullOptions: "logpull_options" }),
+    T.Http({
+      method: "POST",
+      path: "/accounts/{account_id}/logpush/validate/origin",
+    }),
+  ) as unknown as Schema.Schema<OriginValidateForAccountRequest>;
+
+export const OriginValidateForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...OriginValidateBaseFields,
+  }).pipe(
+    Schema.encodeKeys({ logpullOptions: "logpull_options" }),
+    T.Http({
+      method: "POST",
+      path: "/zones/{zone_id}/logpush/validate/origin",
+    }),
+  ) as unknown as Schema.Schema<OriginValidateForZoneRequest>;
 
 export interface OriginValidateResponse {
   message?: string | null;
@@ -2161,13 +2887,35 @@ export const OriginValidateResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 
 export type OriginValidateError = DefaultErrors;
 
-export const originValidate: API.OperationMethod<
-  OriginValidateRequest,
+export const originValidateForAccount: API.OperationMethod<
+  OriginValidateForAccountRequest,
   OriginValidateResponse,
   OriginValidateError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: OriginValidateRequest,
+  input: OriginValidateForAccountRequest,
   output: OriginValidateResponse,
   errors: [],
 }));
+
+export const originValidateForZone: API.OperationMethod<
+  OriginValidateForZoneRequest,
+  OriginValidateResponse,
+  OriginValidateError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: OriginValidateForZoneRequest,
+  output: OriginValidateResponse,
+  errors: [],
+}));
+
+export const originValidate = (
+  input: OriginValidateRequest,
+): Effect.Effect<
+  OriginValidateResponse,
+  OriginValidateError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? originValidateForAccount(input)
+    : originValidateForZone(input);

--- a/packages/cloudflare/src/services/logpush.ts
+++ b/packages/cloudflare/src/services/logpush.ts
@@ -54,9 +54,7 @@ const GetDatasetFieldBaseFields = {
   ]).pipe(T.HttpPath("datasetId")),
 } as const;
 
-export interface GetDatasetFieldForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface GetDatasetFieldBaseRequest {
   datasetId:
     | "access_requests"
     | "audit_logs"
@@ -91,41 +89,14 @@ export interface GetDatasetFieldForAccountRequest {
     | null;
 }
 
-export interface GetDatasetFieldForZoneRequest {
+export interface GetDatasetFieldForAccountRequest extends GetDatasetFieldBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetDatasetFieldForZoneRequest extends GetDatasetFieldBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  datasetId:
-    | "access_requests"
-    | "audit_logs"
-    | "audit_logs_v2"
-    | "biso_user_actions"
-    | "casb_findings"
-    | "device_posture_results"
-    | "dex_application_tests"
-    | "dex_device_state_events"
-    | "dlp_forensic_copies"
-    | "dns_firewall_logs"
-    | "dns_logs"
-    | "email_security_alerts"
-    | "firewall_events"
-    | "gateway_dns"
-    | "gateway_http"
-    | "gateway_network"
-    | "http_requests"
-    | "ipsec_logs"
-    | "magic_ids_detections"
-    | "nel_reports"
-    | "network_analytics_logs"
-    | "page_shield_events"
-    | "sinkhole_http_logs"
-    | "spectrum_events"
-    | "ssh_logs"
-    | "warp_config_changes"
-    | "warp_toggle_changes"
-    | "workers_trace_events"
-    | "zaraz_events"
-    | "zero_trust_network_sessions"
-    | null;
 }
 
 export type GetDatasetFieldRequest =
@@ -236,9 +207,7 @@ const GetDatasetJobBaseFields = {
   ]).pipe(T.HttpPath("datasetId")),
 } as const;
 
-export interface GetDatasetJobForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface GetDatasetJobBaseRequest {
   datasetId:
     | "access_requests"
     | "audit_logs"
@@ -273,41 +242,14 @@ export interface GetDatasetJobForAccountRequest {
     | null;
 }
 
-export interface GetDatasetJobForZoneRequest {
+export interface GetDatasetJobForAccountRequest extends GetDatasetJobBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetDatasetJobForZoneRequest extends GetDatasetJobBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  datasetId:
-    | "access_requests"
-    | "audit_logs"
-    | "audit_logs_v2"
-    | "biso_user_actions"
-    | "casb_findings"
-    | "device_posture_results"
-    | "dex_application_tests"
-    | "dex_device_state_events"
-    | "dlp_forensic_copies"
-    | "dns_firewall_logs"
-    | "dns_logs"
-    | "email_security_alerts"
-    | "firewall_events"
-    | "gateway_dns"
-    | "gateway_http"
-    | "gateway_network"
-    | "http_requests"
-    | "ipsec_logs"
-    | "magic_ids_detections"
-    | "nel_reports"
-    | "network_analytics_logs"
-    | "page_shield_events"
-    | "sinkhole_http_logs"
-    | "spectrum_events"
-    | "ssh_logs"
-    | "warp_config_changes"
-    | "warp_toggle_changes"
-    | "workers_trace_events"
-    | "zaraz_events"
-    | "zero_trust_network_sessions"
-    | null;
 }
 
 export type GetDatasetJobRequest =
@@ -743,18 +685,19 @@ const DestinationExistsValidateBaseFields = {
   destinationConf: Schema.String,
 } as const;
 
-export interface DestinationExistsValidateForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface DestinationExistsValidateBaseRequest {
   /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
   destinationConf: string;
 }
 
-export interface DestinationExistsValidateForZoneRequest {
+export interface DestinationExistsValidateForAccountRequest extends DestinationExistsValidateBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface DestinationExistsValidateForZoneRequest extends DestinationExistsValidateBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
-  destinationConf: string;
 }
 
 export type DestinationExistsValidateRequest =
@@ -839,16 +782,18 @@ const GetJobBaseFields = {
   jobId: Schema.Number.pipe(T.HttpPath("jobId")),
 } as const;
 
-export interface GetJobForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface GetJobBaseRequest {
   jobId: number;
 }
 
-export interface GetJobForZoneRequest {
+export interface GetJobForAccountRequest extends GetJobBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetJobForZoneRequest extends GetJobBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  jobId: number;
 }
 
 export type GetJobRequest = GetJobForAccountRequest | GetJobForZoneRequest;
@@ -1122,12 +1067,14 @@ export const getJob = (
 
 const ListJobsBaseFields = {} as const;
 
-export interface ListJobsForAccountRequest {
+interface ListJobsBaseRequest {}
+
+export interface ListJobsForAccountRequest extends ListJobsBaseRequest {
   /** Path param: The Account ID to use for this endpoint. */
   accountId: string;
 }
 
-export interface ListJobsForZoneRequest {
+export interface ListJobsForZoneRequest extends ListJobsBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
@@ -1528,9 +1475,7 @@ const CreateJobBaseFields = {
   ownershipChallenge: Schema.optional(Schema.String),
 } as const;
 
-export interface CreateJobForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface CreateJobBaseRequest {
   /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
   destinationConf: string;
   /** Body param: Name of the dataset. A list of supported datasets can be found on the [Developer Docs](https://developers.cloudflare.com/logs/reference/log-fields/). */
@@ -1603,79 +1548,14 @@ export interface CreateJobForAccountRequest {
   ownershipChallenge?: string;
 }
 
-export interface CreateJobForZoneRequest {
+export interface CreateJobForAccountRequest extends CreateJobBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface CreateJobForZoneRequest extends CreateJobBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
-  destinationConf: string;
-  /** Body param: Name of the dataset. A list of supported datasets can be found on the [Developer Docs](https://developers.cloudflare.com/logs/reference/log-fields/). */
-  dataset?:
-    | "access_requests"
-    | "audit_logs"
-    | "audit_logs_v2"
-    | "biso_user_actions"
-    | "casb_findings"
-    | "device_posture_results"
-    | "dex_application_tests"
-    | "dex_device_state_events"
-    | "dlp_forensic_copies"
-    | "dns_firewall_logs"
-    | "dns_logs"
-    | "email_security_alerts"
-    | "firewall_events"
-    | "gateway_dns"
-    | "gateway_http"
-    | "gateway_network"
-    | "http_requests"
-    | "ipsec_logs"
-    | "magic_ids_detections"
-    | "nel_reports"
-    | "network_analytics_logs"
-    | "page_shield_events"
-    | "sinkhole_http_logs"
-    | "spectrum_events"
-    | "ssh_logs"
-    | "warp_config_changes"
-    | "warp_toggle_changes"
-    | "workers_trace_events"
-    | "zaraz_events"
-    | "zero_trust_network_sessions"
-    | null;
-  /** Body param: Flag that indicates if the job is enabled. */
-  enabled?: boolean;
-  /** Body param: The filters to select the events to include and/or remove from your logs. For more information, refer to [Filters](https://developers.cloudflare.com/logs/reference/filters/). */
-  filter?: string | null;
-  /** @deprecated Body param: This field is deprecated. Please use `max_upload_ ` parameters instead. . The frequency at which Cloudflare sends batches of logs to your destination. Setting frequency to high */
-  frequency?: "high" | "low" | null;
-  /** Body param: The kind parameter (optional) is used to differentiate between Logpush and Edge Log Delivery jobs (when supported by the dataset). */
-  kind?: "" | "edge";
-  /** @deprecated Body param: This field is deprecated. Use `output_options` instead. Configuration string. It specifies things like requested fields and timestamp formats. If migrating from the logpull api */
-  logpullOptions?: string | null;
-  /** Body param: The maximum uncompressed file size of a batch of logs. This setting value must be between `5 MB` and `1 GB`, or `0` to disable it. Note that you cannot set a minimum file size; this means  */
-  maxUploadBytes?: "0" | number | null;
-  /** Body param: The maximum interval in seconds for log batches. This setting must be between 30 and 300 seconds (5 minutes), or `0` to disable it. Note that you cannot specify a minimum interval for log  */
-  maxUploadIntervalSeconds?: "0" | number | null;
-  /** Body param: The maximum number of log lines per batch. This setting must be between 1000 and 1,000,000 lines, or `0` to disable it. Note that you cannot specify a minimum number of log lines per batch */
-  maxUploadRecords?: "0" | number | null;
-  /** Body param: Optional human readable job name. Not unique. Cloudflare suggests. that you set this to a meaningful string, like the domain name, to make it easier to identify your job. */
-  name?: string | null;
-  /** Body param: The structured replacement for `logpull_options`. When including this field, the `logpull_option` field will be ignored. */
-  outputOptions?: {
-    batchPrefix?: string | null;
-    batchSuffix?: string | null;
-    "cve-2021-44228"?: boolean | null;
-    fieldDelimiter?: string | null;
-    fieldNames?: string[];
-    outputType?: "ndjson" | "csv";
-    recordDelimiter?: string | null;
-    recordPrefix?: string | null;
-    recordSuffix?: string | null;
-    recordTemplate?: string | null;
-    sampleRate?: number | null;
-    timestampFormat?: "unixnano" | "unix" | "rfc3339";
-  } | null;
-  /** Body param: Ownership challenge token to prove destination ownership. */
-  ownershipChallenge?: string;
 }
 
 export type CreateJobRequest =
@@ -2055,9 +1935,7 @@ const UpdateJobBaseFields = {
   ownershipChallenge: Schema.optional(Schema.String),
 } as const;
 
-export interface UpdateJobForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface UpdateJobBaseRequest {
   jobId: number;
   /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
   destinationConf?: string;
@@ -2098,47 +1976,14 @@ export interface UpdateJobForAccountRequest {
   ownershipChallenge?: string;
 }
 
-export interface UpdateJobForZoneRequest {
+export interface UpdateJobForAccountRequest extends UpdateJobBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface UpdateJobForZoneRequest extends UpdateJobBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  jobId: number;
-  /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
-  destinationConf?: string;
-  /** Body param: Flag that indicates if the job is enabled. */
-  enabled?: boolean;
-  /** Body param: The filters to select the events to include and/or remove from your logs. For more information, refer to [Filters](https://developers.cloudflare.com/logs/reference/filters/). */
-  filter?: string | null;
-  /** @deprecated Body param: This field is deprecated. Please use `max_upload_ ` parameters instead. . The frequency at which Cloudflare sends batches of logs to your destination. Setting frequency to high */
-  frequency?: "high" | "low" | null;
-  /** Body param: The kind parameter (optional) is used to differentiate between Logpush and Edge Log Delivery jobs (when supported by the dataset). */
-  kind?: "" | "edge";
-  /** @deprecated Body param: This field is deprecated. Use `output_options` instead. Configuration string. It specifies things like requested fields and timestamp formats. If migrating from the logpull api */
-  logpullOptions?: string | null;
-  /** Body param: The maximum uncompressed file size of a batch of logs. This setting value must be between `5 MB` and `1 GB`, or `0` to disable it. Note that you cannot set a minimum file size; this means  */
-  maxUploadBytes?: "0" | number | null;
-  /** Body param: The maximum interval in seconds for log batches. This setting must be between 30 and 300 seconds (5 minutes), or `0` to disable it. Note that you cannot specify a minimum interval for log  */
-  maxUploadIntervalSeconds?: "0" | number | null;
-  /** Body param: The maximum number of log lines per batch. This setting must be between 1000 and 1,000,000 lines, or `0` to disable it. Note that you cannot specify a minimum number of log lines per batch */
-  maxUploadRecords?: "0" | number | null;
-  /** Body param: Optional human readable job name. Not unique. Cloudflare suggests. that you set this to a meaningful string, like the domain name, to make it easier to identify your job. */
-  name?: string | null;
-  /** Body param: The structured replacement for `logpull_options`. When including this field, the `logpull_option` field will be ignored. */
-  outputOptions?: {
-    batchPrefix?: string | null;
-    batchSuffix?: string | null;
-    "cve-2021-44228"?: boolean | null;
-    fieldDelimiter?: string | null;
-    fieldNames?: string[];
-    outputType?: "ndjson" | "csv";
-    recordDelimiter?: string | null;
-    recordPrefix?: string | null;
-    recordSuffix?: string | null;
-    recordTemplate?: string | null;
-    sampleRate?: number | null;
-    timestampFormat?: "unixnano" | "unix" | "rfc3339";
-  } | null;
-  /** Body param: Ownership challenge token to prove destination ownership. */
-  ownershipChallenge?: string;
 }
 
 export type UpdateJobRequest =
@@ -2448,16 +2293,18 @@ const DeleteJobBaseFields = {
   jobId: Schema.Number.pipe(T.HttpPath("jobId")),
 } as const;
 
-export interface DeleteJobForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface DeleteJobBaseRequest {
   jobId: number;
 }
 
-export interface DeleteJobForZoneRequest {
+export interface DeleteJobForAccountRequest extends DeleteJobBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface DeleteJobForZoneRequest extends DeleteJobBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  jobId: number;
 }
 
 export type DeleteJobRequest =
@@ -2535,18 +2382,19 @@ const CreateOwnershipBaseFields = {
   destinationConf: Schema.String,
 } as const;
 
-export interface CreateOwnershipForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface CreateOwnershipBaseRequest {
   /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
   destinationConf: string;
 }
 
-export interface CreateOwnershipForZoneRequest {
+export interface CreateOwnershipForAccountRequest extends CreateOwnershipBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface CreateOwnershipForZoneRequest extends CreateOwnershipBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
-  destinationConf: string;
 }
 
 export type CreateOwnershipRequest =
@@ -2629,22 +2477,21 @@ const ValidateOwnershipBaseFields = {
   ownershipChallenge: Schema.String,
 } as const;
 
-export interface ValidateOwnershipForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface ValidateOwnershipBaseRequest {
   /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
   destinationConf: string;
   /** Body param: Ownership challenge token to prove destination ownership. */
   ownershipChallenge: string;
 }
 
-export interface ValidateOwnershipForZoneRequest {
+export interface ValidateOwnershipForAccountRequest extends ValidateOwnershipBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface ValidateOwnershipForZoneRequest extends ValidateOwnershipBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
-  destinationConf: string;
-  /** Body param: Ownership challenge token to prove destination ownership. */
-  ownershipChallenge: string;
 }
 
 export type ValidateOwnershipRequest =
@@ -2735,18 +2582,19 @@ const DestinationValidateBaseFields = {
   destinationConf: Schema.String,
 } as const;
 
-export interface DestinationValidateForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface DestinationValidateBaseRequest {
   /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
   destinationConf: string;
 }
 
-export interface DestinationValidateForZoneRequest {
+export interface DestinationValidateForAccountRequest extends DestinationValidateBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface DestinationValidateForZoneRequest extends DestinationValidateBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  /** Body param: Uniquely identifies a resource (such as an s3 bucket) where data. will be pushed. Additional configuration parameters supported by the destination may be included. */
-  destinationConf: string;
 }
 
 export type DestinationValidateRequest =
@@ -2829,18 +2677,19 @@ const OriginValidateBaseFields = {
   logpullOptions: Schema.Union([Schema.String, Schema.Null]),
 } as const;
 
-export interface OriginValidateForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface OriginValidateBaseRequest {
   /** @deprecated Body param: This field is deprecated. Use `output_options` instead. Configuration string. It specifies things like requested fields and timestamp formats. If migrating from the logpull api */
   logpullOptions: string | null;
 }
 
-export interface OriginValidateForZoneRequest {
+export interface OriginValidateForAccountRequest extends OriginValidateBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface OriginValidateForZoneRequest extends OriginValidateBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  /** @deprecated Body param: This field is deprecated. Use `output_options` instead. Configuration string. It specifies things like requested fields and timestamp formats. If migrating from the logpull api */
-  logpullOptions: string | null;
 }
 
 export type OriginValidateRequest =

--- a/packages/cloudflare/src/services/rulesets.ts
+++ b/packages/cloudflare/src/services/rulesets.ts
@@ -23,16 +23,18 @@ const GetPhasBaseFields = {
   rulesetPhase: Schema.String.pipe(T.HttpPath("rulesetPhase")),
 } as const;
 
-export interface GetPhasForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface GetPhasBaseRequest {
   rulesetPhase: string;
 }
 
-export interface GetPhasForZoneRequest {
+export interface GetPhasForAccountRequest extends GetPhasBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetPhasForZoneRequest extends GetPhasBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  rulesetPhase: string;
 }
 
 export type GetPhasRequest = GetPhasForAccountRequest | GetPhasForZoneRequest;
@@ -5265,9 +5267,7 @@ const PutPhasBaseFields = {
   ),
 } as const;
 
-export interface PutPhasForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface PutPhasBaseRequest {
   rulesetPhase: string;
   /** Body param: An informative description of the ruleset. */
   description?: string;
@@ -5893,632 +5893,14 @@ export interface PutPhasForAccountRequest {
   )[];
 }
 
-export interface PutPhasForZoneRequest {
+export interface PutPhasForAccountRequest extends PutPhasBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface PutPhasForZoneRequest extends PutPhasBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  rulesetPhase: string;
-  /** Body param: An informative description of the ruleset. */
-  description?: string;
-  /** Body param: The human-readable name of the ruleset. */
-  name?: string;
-  /** Body param: The list of rules in the ruleset. */
-  rules?: (
-    | {
-        id?: string;
-        action?: "block";
-        actionParameters?: {
-          response?: {
-            content: string;
-            contentType: string;
-            statusCode: number;
-          };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "challenge";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "compress_response";
-        actionParameters?: {
-          algorithms: {
-            name?: "none" | "auto" | "default" | "gzip" | "brotli" | "zstd";
-          }[];
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "ddos_dynamic";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "execute";
-        actionParameters?: {
-          id: string;
-          matchedData?: { publicKey: string };
-          overrides?: {
-            action?: string;
-            categories?: {
-              category: string;
-              action?: string;
-              enabled?: boolean;
-              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
-            }[];
-            enabled?: boolean;
-            rules?: {
-              id: string;
-              action?: string;
-              enabled?: boolean;
-              scoreThreshold?: number;
-              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
-            }[];
-            sensitivityLevel?: "default" | "medium" | "low" | "eoff";
-          };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "force_connection_close";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "js_challenge";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "log";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "log_custom_field";
-        actionParameters?: {
-          cookieFields?: { name: string }[];
-          rawResponseFields?: { name: string; preserveDuplicates?: boolean }[];
-          requestFields?: { name: string }[];
-          responseFields?: { name: string; preserveDuplicates?: boolean }[];
-          transformedRequestFields?: { name: string }[];
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "managed_challenge";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "redirect";
-        actionParameters?: {
-          fromList?: { key: string; name: string };
-          fromValue?: {
-            targetUrl: { expression?: string; value?: string };
-            preserveQueryString?: boolean;
-            statusCode?: "301" | "302" | "303" | "307" | "308";
-          };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "rewrite";
-        actionParameters?: {
-          headers?: Record<string, unknown>;
-          uri?:
-            | { path: { expression?: string; value?: string } }
-            | { query: { expression?: string; value?: string } };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "route";
-        actionParameters?: {
-          hostHeader?: string;
-          origin?: { host?: string; port?: number };
-          sni?: { value: string };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "score";
-        actionParameters?: { increment: number };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "serve_error";
-        actionParameters?:
-          | {
-              content: string;
-              contentType?:
-                | "application/json"
-                | "text/html"
-                | "text/plain"
-                | "text/xml";
-              statusCode?: number;
-            }
-          | {
-              assetName: string;
-              contentType?:
-                | "application/json"
-                | "text/html"
-                | "text/plain"
-                | "text/xml";
-              statusCode?: number;
-            };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "set_cache_settings";
-        actionParameters?: {
-          additionalCacheablePorts?: number[];
-          browserTtl?: {
-            mode:
-              | "respect_origin"
-              | "bypass_by_default"
-              | "override_origin"
-              | "bypass";
-            default?: number;
-          };
-          cache?: boolean;
-          cacheKey?: {
-            cacheByDeviceType?: boolean;
-            cacheDeceptionArmor?: boolean;
-            customKey?: {
-              cookie?: { checkPresence?: string[]; include?: string[] };
-              header?: {
-                checkPresence?: string[];
-                contains?: Record<string, unknown>;
-                excludeOrigin?: boolean;
-                include?: string[];
-              };
-              host?: { resolved?: boolean };
-              queryString?: {
-                exclude?: { all?: true; list?: string[] };
-                include?: { all?: true; list?: string[] };
-              };
-              user?: { deviceType?: boolean; geo?: boolean; lang?: boolean };
-            };
-            ignoreQueryStringsOrder?: boolean;
-          };
-          cacheReserve?: { eligible: boolean; minimumFileSize?: number };
-          edgeTtl?: {
-            mode: "respect_origin" | "bypass_by_default" | "override_origin";
-            default?: number;
-            statusCodeTtl?: {
-              value: number;
-              statusCode?: number;
-              statusCodeRange?: { from?: number; to?: number };
-            }[];
-          };
-          originCacheControl?: boolean;
-          originErrorPagePassthru?: boolean;
-          readTimeout?: number;
-          respectStrongEtags?: boolean;
-          serveStale?: { disableStaleWhileUpdating?: boolean };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "set_config";
-        actionParameters?: {
-          automaticHttpsRewrites?: boolean;
-          autominify?: { css?: boolean; html?: boolean; js?: boolean };
-          bic?: boolean;
-          disableApps?: true;
-          disablePayPerCrawl?: true;
-          disableRum?: true;
-          disableZaraz?: true;
-          emailObfuscation?: boolean;
-          fonts?: boolean;
-          hotlinkProtection?: boolean;
-          mirage?: boolean;
-          opportunisticEncryption?: boolean;
-          polish?: "off" | "lossless" | "lossy" | "webp";
-          requestBodyBuffering?: "none" | "standard" | "full";
-          responseBodyBuffering?: "none" | "standard";
-          rocketLoader?: boolean;
-          securityLevel?:
-            | "off"
-            | "essentially_off"
-            | "low"
-            | "medium"
-            | "high"
-            | "under_attack";
-          serverSideExcludes?: boolean;
-          ssl?: "off" | "flexible" | "full" | "strict" | "origin_pull";
-          sxg?: boolean;
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "skip";
-        actionParameters?: {
-          phase?: "current";
-          phases?: (
-            | "ddos_l4"
-            | "ddos_l7"
-            | "http_config_settings"
-            | "http_custom_errors"
-            | "http_log_custom_fields"
-            | "http_ratelimit"
-            | "http_request_cache_settings"
-            | "http_request_dynamic_redirect"
-            | "http_request_firewall_custom"
-            | "http_request_firewall_managed"
-            | "http_request_late_transform"
-            | "http_request_origin"
-            | "http_request_redirect"
-            | "http_request_sanitize"
-            | "http_request_sbfm"
-            | "http_request_transform"
-            | "http_response_compression"
-            | "http_response_firewall_managed"
-            | "http_response_headers_transform"
-            | "magic_transit"
-            | "magic_transit_ids_managed"
-            | "magic_transit_managed"
-            | "magic_transit_ratelimit"
-          )[];
-          products?: (
-            | "bic"
-            | "hot"
-            | "rateLimit"
-            | "securityLevel"
-            | "uaBlock"
-            | "waf"
-            | "zoneLockdown"
-          )[];
-          rules?: Record<string, unknown>;
-          ruleset?: "current";
-          rulesets?: string[];
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-  )[];
 }
 
 export type PutPhasRequest = PutPhasForAccountRequest | PutPhasForZoneRequest;
@@ -10055,18 +9437,19 @@ const GetPhasVersionBaseFields = {
   rulesetPhase: Schema.String.pipe(T.HttpPath("rulesetPhase")),
 } as const;
 
-export interface GetPhasVersionForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface GetPhasVersionBaseRequest {
   rulesetVersion: string;
   rulesetPhase: string;
 }
 
-export interface GetPhasVersionForZoneRequest {
+export interface GetPhasVersionForAccountRequest extends GetPhasVersionBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetPhasVersionForZoneRequest extends GetPhasVersionBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  rulesetVersion: string;
-  rulesetPhase: string;
 }
 
 export type GetPhasVersionRequest =
@@ -13658,16 +13041,18 @@ const ListPhasVersionsBaseFields = {
   rulesetPhase: Schema.String.pipe(T.HttpPath("rulesetPhase")),
 } as const;
 
-export interface ListPhasVersionsForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface ListPhasVersionsBaseRequest {
   rulesetPhase: string;
 }
 
-export interface ListPhasVersionsForZoneRequest {
+export interface ListPhasVersionsForAccountRequest extends ListPhasVersionsBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface ListPhasVersionsForZoneRequest extends ListPhasVersionsBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  rulesetPhase: string;
 }
 
 export type ListPhasVersionsRequest =
@@ -13908,9 +13293,7 @@ const CreateRuleBaseFields = {
   ref: Schema.optional(Schema.String),
 } as const;
 
-export interface CreateRuleForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface CreateRuleBaseRequest {
   rulesetId: string;
   /** Body param: The unique ID of the rule. */
   id?: string;
@@ -13950,46 +13333,14 @@ export interface CreateRuleForAccountRequest {
   ref?: string;
 }
 
-export interface CreateRuleForZoneRequest {
+export interface CreateRuleForAccountRequest extends CreateRuleBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface CreateRuleForZoneRequest extends CreateRuleBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  rulesetId: string;
-  /** Body param: The unique ID of the rule. */
-  id?: string;
-  /** Body param: The action to perform when the rule matches. */
-  action?: "block";
-  /** Body param: The parameters configuring the rule's action. */
-  actionParameters?: {
-    response?: { content: string; contentType: string; statusCode: number };
-  };
-  /** Body param: An informative description of the rule. */
-  description?: string;
-  /** Body param: Whether the rule should be executed. */
-  enabled?: boolean;
-  /** Body param: Configuration for exposed credential checking. */
-  exposedCredentialCheck?: {
-    passwordExpression: string;
-    usernameExpression: string;
-  };
-  /** Body param: The expression defining which traffic will match the rule. */
-  expression?: string;
-  /** Body param: An object configuring the rule's logging behavior. */
-  logging?: { enabled: boolean };
-  /** Body param: An object configuring where the rule will be placed. */
-  position?: { before?: string } | { after?: string } | { index?: number };
-  /** Body param: An object configuring the rule's rate limit behavior. */
-  ratelimit?: {
-    characteristics: string[];
-    period: number;
-    countingExpression?: string;
-    mitigationTimeout?: number;
-    requestsPerPeriod?: number;
-    requestsToOrigin?: boolean;
-    scorePerPeriod?: number;
-    scoreResponseHeaderName?: string;
-  };
-  /** Body param: The reference of the rule (the rule's ID by default). */
-  ref?: string;
 }
 
 export type CreateRuleRequest =
@@ -17629,9 +16980,7 @@ const PatchRuleBaseFields = {
   ref: Schema.optional(Schema.String),
 } as const;
 
-export interface PatchRuleForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface PatchRuleBaseRequest {
   rulesetId: string;
   ruleId: string;
   /** Body param: The unique ID of the rule. */
@@ -17672,47 +17021,14 @@ export interface PatchRuleForAccountRequest {
   ref?: string;
 }
 
-export interface PatchRuleForZoneRequest {
+export interface PatchRuleForAccountRequest extends PatchRuleBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface PatchRuleForZoneRequest extends PatchRuleBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  rulesetId: string;
-  ruleId: string;
-  /** Body param: The unique ID of the rule. */
-  id?: string;
-  /** Body param: The action to perform when the rule matches. */
-  action?: "block";
-  /** Body param: The parameters configuring the rule's action. */
-  actionParameters?: {
-    response?: { content: string; contentType: string; statusCode: number };
-  };
-  /** Body param: An informative description of the rule. */
-  description?: string;
-  /** Body param: Whether the rule should be executed. */
-  enabled?: boolean;
-  /** Body param: Configuration for exposed credential checking. */
-  exposedCredentialCheck?: {
-    passwordExpression: string;
-    usernameExpression: string;
-  };
-  /** Body param: The expression defining which traffic will match the rule. */
-  expression?: string;
-  /** Body param: An object configuring the rule's logging behavior. */
-  logging?: { enabled: boolean };
-  /** Body param: An object configuring where the rule will be placed. */
-  position?: { before?: string } | { after?: string } | { index?: number };
-  /** Body param: An object configuring the rule's rate limit behavior. */
-  ratelimit?: {
-    characteristics: string[];
-    period: number;
-    countingExpression?: string;
-    mitigationTimeout?: number;
-    requestsPerPeriod?: number;
-    requestsToOrigin?: boolean;
-    scorePerPeriod?: number;
-    scoreResponseHeaderName?: string;
-  };
-  /** Body param: The reference of the rule (the rule's ID by default). */
-  ref?: string;
 }
 
 export type PatchRuleRequest =
@@ -21277,18 +20593,19 @@ const DeleteRuleBaseFields = {
   ruleId: Schema.String.pipe(T.HttpPath("ruleId")),
 } as const;
 
-export interface DeleteRuleForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface DeleteRuleBaseRequest {
   rulesetId: string;
   ruleId: string;
 }
 
-export interface DeleteRuleForZoneRequest {
+export interface DeleteRuleForAccountRequest extends DeleteRuleBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface DeleteRuleForZoneRequest extends DeleteRuleBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  rulesetId: string;
-  ruleId: string;
 }
 
 export type DeleteRuleRequest =
@@ -24830,16 +24147,18 @@ const GetRulesetBaseFields = {
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
 } as const;
 
-export interface GetRulesetForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface GetRulesetBaseRequest {
   rulesetId: string;
 }
 
-export interface GetRulesetForZoneRequest {
+export interface GetRulesetForAccountRequest extends GetRulesetBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetRulesetForZoneRequest extends GetRulesetBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  rulesetId: string;
 }
 
 export type GetRulesetRequest =
@@ -28372,12 +27691,14 @@ export const getRuleset = (
 
 const ListRulesetsBaseFields = {} as const;
 
-export interface ListRulesetsForAccountRequest {
+interface ListRulesetsBaseRequest {}
+
+export interface ListRulesetsForAccountRequest extends ListRulesetsBaseRequest {
   /** Path param: The Account ID to use for this endpoint. */
   accountId: string;
 }
 
-export interface ListRulesetsForZoneRequest {
+export interface ListRulesetsForZoneRequest extends ListRulesetsBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
@@ -30287,9 +29608,7 @@ const CreateRulesetBaseFields = {
   ),
 } as const;
 
-export interface CreateRulesetForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface CreateRulesetBaseRequest {
   /** Body param: The kind of the ruleset. */
   kind: "managed" | "custom" | "root" | "zone";
   /** Body param: The human-readable name of the ruleset. */
@@ -30941,658 +30260,14 @@ export interface CreateRulesetForAccountRequest {
   )[];
 }
 
-export interface CreateRulesetForZoneRequest {
+export interface CreateRulesetForAccountRequest extends CreateRulesetBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface CreateRulesetForZoneRequest extends CreateRulesetBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  /** Body param: The kind of the ruleset. */
-  kind: "managed" | "custom" | "root" | "zone";
-  /** Body param: The human-readable name of the ruleset. */
-  name: string;
-  /** Body param: The phase of the ruleset. */
-  phase:
-    | "ddos_l4"
-    | "ddos_l7"
-    | "http_config_settings"
-    | "http_custom_errors"
-    | "http_log_custom_fields"
-    | "http_ratelimit"
-    | "http_request_cache_settings"
-    | "http_request_dynamic_redirect"
-    | "http_request_firewall_custom"
-    | "http_request_firewall_managed"
-    | "http_request_late_transform"
-    | "http_request_origin"
-    | "http_request_redirect"
-    | "http_request_sanitize"
-    | "http_request_sbfm"
-    | "http_request_transform"
-    | "http_response_compression"
-    | "http_response_firewall_managed"
-    | "http_response_headers_transform"
-    | "magic_transit"
-    | "magic_transit_ids_managed"
-    | "magic_transit_managed"
-    | "magic_transit_ratelimit";
-  /** Body param: An informative description of the ruleset. */
-  description?: string;
-  /** Body param: The list of rules in the ruleset. */
-  rules?: (
-    | {
-        id?: string;
-        action?: "block";
-        actionParameters?: {
-          response?: {
-            content: string;
-            contentType: string;
-            statusCode: number;
-          };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "challenge";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "compress_response";
-        actionParameters?: {
-          algorithms: {
-            name?: "none" | "auto" | "default" | "gzip" | "brotli" | "zstd";
-          }[];
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "ddos_dynamic";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "execute";
-        actionParameters?: {
-          id: string;
-          matchedData?: { publicKey: string };
-          overrides?: {
-            action?: string;
-            categories?: {
-              category: string;
-              action?: string;
-              enabled?: boolean;
-              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
-            }[];
-            enabled?: boolean;
-            rules?: {
-              id: string;
-              action?: string;
-              enabled?: boolean;
-              scoreThreshold?: number;
-              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
-            }[];
-            sensitivityLevel?: "default" | "medium" | "low" | "eoff";
-          };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "force_connection_close";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "js_challenge";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "log";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "log_custom_field";
-        actionParameters?: {
-          cookieFields?: { name: string }[];
-          rawResponseFields?: { name: string; preserveDuplicates?: boolean }[];
-          requestFields?: { name: string }[];
-          responseFields?: { name: string; preserveDuplicates?: boolean }[];
-          transformedRequestFields?: { name: string }[];
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "managed_challenge";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "redirect";
-        actionParameters?: {
-          fromList?: { key: string; name: string };
-          fromValue?: {
-            targetUrl: { expression?: string; value?: string };
-            preserveQueryString?: boolean;
-            statusCode?: "301" | "302" | "303" | "307" | "308";
-          };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "rewrite";
-        actionParameters?: {
-          headers?: Record<string, unknown>;
-          uri?:
-            | { path: { expression?: string; value?: string } }
-            | { query: { expression?: string; value?: string } };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "route";
-        actionParameters?: {
-          hostHeader?: string;
-          origin?: { host?: string; port?: number };
-          sni?: { value: string };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "score";
-        actionParameters?: { increment: number };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "serve_error";
-        actionParameters?:
-          | {
-              content: string;
-              contentType?:
-                | "application/json"
-                | "text/html"
-                | "text/plain"
-                | "text/xml";
-              statusCode?: number;
-            }
-          | {
-              assetName: string;
-              contentType?:
-                | "application/json"
-                | "text/html"
-                | "text/plain"
-                | "text/xml";
-              statusCode?: number;
-            };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "set_cache_settings";
-        actionParameters?: {
-          additionalCacheablePorts?: number[];
-          browserTtl?: {
-            mode:
-              | "respect_origin"
-              | "bypass_by_default"
-              | "override_origin"
-              | "bypass";
-            default?: number;
-          };
-          cache?: boolean;
-          cacheKey?: {
-            cacheByDeviceType?: boolean;
-            cacheDeceptionArmor?: boolean;
-            customKey?: {
-              cookie?: { checkPresence?: string[]; include?: string[] };
-              header?: {
-                checkPresence?: string[];
-                contains?: Record<string, unknown>;
-                excludeOrigin?: boolean;
-                include?: string[];
-              };
-              host?: { resolved?: boolean };
-              queryString?: {
-                exclude?: { all?: true; list?: string[] };
-                include?: { all?: true; list?: string[] };
-              };
-              user?: { deviceType?: boolean; geo?: boolean; lang?: boolean };
-            };
-            ignoreQueryStringsOrder?: boolean;
-          };
-          cacheReserve?: { eligible: boolean; minimumFileSize?: number };
-          edgeTtl?: {
-            mode: "respect_origin" | "bypass_by_default" | "override_origin";
-            default?: number;
-            statusCodeTtl?: {
-              value: number;
-              statusCode?: number;
-              statusCodeRange?: { from?: number; to?: number };
-            }[];
-          };
-          originCacheControl?: boolean;
-          originErrorPagePassthru?: boolean;
-          readTimeout?: number;
-          respectStrongEtags?: boolean;
-          serveStale?: { disableStaleWhileUpdating?: boolean };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "set_config";
-        actionParameters?: {
-          automaticHttpsRewrites?: boolean;
-          autominify?: { css?: boolean; html?: boolean; js?: boolean };
-          bic?: boolean;
-          disableApps?: true;
-          disablePayPerCrawl?: true;
-          disableRum?: true;
-          disableZaraz?: true;
-          emailObfuscation?: boolean;
-          fonts?: boolean;
-          hotlinkProtection?: boolean;
-          mirage?: boolean;
-          opportunisticEncryption?: boolean;
-          polish?: "off" | "lossless" | "lossy" | "webp";
-          requestBodyBuffering?: "none" | "standard" | "full";
-          responseBodyBuffering?: "none" | "standard";
-          rocketLoader?: boolean;
-          securityLevel?:
-            | "off"
-            | "essentially_off"
-            | "low"
-            | "medium"
-            | "high"
-            | "under_attack";
-          serverSideExcludes?: boolean;
-          ssl?: "off" | "flexible" | "full" | "strict" | "origin_pull";
-          sxg?: boolean;
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "skip";
-        actionParameters?: {
-          phase?: "current";
-          phases?: (
-            | "ddos_l4"
-            | "ddos_l7"
-            | "http_config_settings"
-            | "http_custom_errors"
-            | "http_log_custom_fields"
-            | "http_ratelimit"
-            | "http_request_cache_settings"
-            | "http_request_dynamic_redirect"
-            | "http_request_firewall_custom"
-            | "http_request_firewall_managed"
-            | "http_request_late_transform"
-            | "http_request_origin"
-            | "http_request_redirect"
-            | "http_request_sanitize"
-            | "http_request_sbfm"
-            | "http_request_transform"
-            | "http_response_compression"
-            | "http_response_firewall_managed"
-            | "http_response_headers_transform"
-            | "magic_transit"
-            | "magic_transit_ids_managed"
-            | "magic_transit_managed"
-            | "magic_transit_ratelimit"
-          )[];
-          products?: (
-            | "bic"
-            | "hot"
-            | "rateLimit"
-            | "securityLevel"
-            | "uaBlock"
-            | "waf"
-            | "zoneLockdown"
-          )[];
-          rules?: Record<string, unknown>;
-          ruleset?: "current";
-          rulesets?: string[];
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-  )[];
 }
 
 export type CreateRulesetRequest =
@@ -36855,9 +35530,7 @@ const UpdateRulesetBaseFields = {
   ),
 } as const;
 
-export interface UpdateRulesetForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface UpdateRulesetBaseRequest {
   rulesetId: string;
   /** Body param: An informative description of the ruleset. */
   description?: string;
@@ -37510,659 +36183,14 @@ export interface UpdateRulesetForAccountRequest {
   )[];
 }
 
-export interface UpdateRulesetForZoneRequest {
+export interface UpdateRulesetForAccountRequest extends UpdateRulesetBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface UpdateRulesetForZoneRequest extends UpdateRulesetBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  rulesetId: string;
-  /** Body param: An informative description of the ruleset. */
-  description?: string;
-  /** Body param: The kind of the ruleset. */
-  kind?: "managed" | "custom" | "root" | "zone";
-  /** Body param: The human-readable name of the ruleset. */
-  name?: string;
-  /** Body param: The phase of the ruleset. */
-  phase?:
-    | "ddos_l4"
-    | "ddos_l7"
-    | "http_config_settings"
-    | "http_custom_errors"
-    | "http_log_custom_fields"
-    | "http_ratelimit"
-    | "http_request_cache_settings"
-    | "http_request_dynamic_redirect"
-    | "http_request_firewall_custom"
-    | "http_request_firewall_managed"
-    | "http_request_late_transform"
-    | "http_request_origin"
-    | "http_request_redirect"
-    | "http_request_sanitize"
-    | "http_request_sbfm"
-    | "http_request_transform"
-    | "http_response_compression"
-    | "http_response_firewall_managed"
-    | "http_response_headers_transform"
-    | "magic_transit"
-    | "magic_transit_ids_managed"
-    | "magic_transit_managed"
-    | "magic_transit_ratelimit";
-  /** Body param: The list of rules in the ruleset. */
-  rules?: (
-    | {
-        id?: string;
-        action?: "block";
-        actionParameters?: {
-          response?: {
-            content: string;
-            contentType: string;
-            statusCode: number;
-          };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "challenge";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "compress_response";
-        actionParameters?: {
-          algorithms: {
-            name?: "none" | "auto" | "default" | "gzip" | "brotli" | "zstd";
-          }[];
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "ddos_dynamic";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "execute";
-        actionParameters?: {
-          id: string;
-          matchedData?: { publicKey: string };
-          overrides?: {
-            action?: string;
-            categories?: {
-              category: string;
-              action?: string;
-              enabled?: boolean;
-              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
-            }[];
-            enabled?: boolean;
-            rules?: {
-              id: string;
-              action?: string;
-              enabled?: boolean;
-              scoreThreshold?: number;
-              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
-            }[];
-            sensitivityLevel?: "default" | "medium" | "low" | "eoff";
-          };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "force_connection_close";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "js_challenge";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "log";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "log_custom_field";
-        actionParameters?: {
-          cookieFields?: { name: string }[];
-          rawResponseFields?: { name: string; preserveDuplicates?: boolean }[];
-          requestFields?: { name: string }[];
-          responseFields?: { name: string; preserveDuplicates?: boolean }[];
-          transformedRequestFields?: { name: string }[];
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "managed_challenge";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "redirect";
-        actionParameters?: {
-          fromList?: { key: string; name: string };
-          fromValue?: {
-            targetUrl: { expression?: string; value?: string };
-            preserveQueryString?: boolean;
-            statusCode?: "301" | "302" | "303" | "307" | "308";
-          };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "rewrite";
-        actionParameters?: {
-          headers?: Record<string, unknown>;
-          uri?:
-            | { path: { expression?: string; value?: string } }
-            | { query: { expression?: string; value?: string } };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "route";
-        actionParameters?: {
-          hostHeader?: string;
-          origin?: { host?: string; port?: number };
-          sni?: { value: string };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "score";
-        actionParameters?: { increment: number };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "serve_error";
-        actionParameters?:
-          | {
-              content: string;
-              contentType?:
-                | "application/json"
-                | "text/html"
-                | "text/plain"
-                | "text/xml";
-              statusCode?: number;
-            }
-          | {
-              assetName: string;
-              contentType?:
-                | "application/json"
-                | "text/html"
-                | "text/plain"
-                | "text/xml";
-              statusCode?: number;
-            };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "set_cache_settings";
-        actionParameters?: {
-          additionalCacheablePorts?: number[];
-          browserTtl?: {
-            mode:
-              | "respect_origin"
-              | "bypass_by_default"
-              | "override_origin"
-              | "bypass";
-            default?: number;
-          };
-          cache?: boolean;
-          cacheKey?: {
-            cacheByDeviceType?: boolean;
-            cacheDeceptionArmor?: boolean;
-            customKey?: {
-              cookie?: { checkPresence?: string[]; include?: string[] };
-              header?: {
-                checkPresence?: string[];
-                contains?: Record<string, unknown>;
-                excludeOrigin?: boolean;
-                include?: string[];
-              };
-              host?: { resolved?: boolean };
-              queryString?: {
-                exclude?: { all?: true; list?: string[] };
-                include?: { all?: true; list?: string[] };
-              };
-              user?: { deviceType?: boolean; geo?: boolean; lang?: boolean };
-            };
-            ignoreQueryStringsOrder?: boolean;
-          };
-          cacheReserve?: { eligible: boolean; minimumFileSize?: number };
-          edgeTtl?: {
-            mode: "respect_origin" | "bypass_by_default" | "override_origin";
-            default?: number;
-            statusCodeTtl?: {
-              value: number;
-              statusCode?: number;
-              statusCodeRange?: { from?: number; to?: number };
-            }[];
-          };
-          originCacheControl?: boolean;
-          originErrorPagePassthru?: boolean;
-          readTimeout?: number;
-          respectStrongEtags?: boolean;
-          serveStale?: { disableStaleWhileUpdating?: boolean };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "set_config";
-        actionParameters?: {
-          automaticHttpsRewrites?: boolean;
-          autominify?: { css?: boolean; html?: boolean; js?: boolean };
-          bic?: boolean;
-          disableApps?: true;
-          disablePayPerCrawl?: true;
-          disableRum?: true;
-          disableZaraz?: true;
-          emailObfuscation?: boolean;
-          fonts?: boolean;
-          hotlinkProtection?: boolean;
-          mirage?: boolean;
-          opportunisticEncryption?: boolean;
-          polish?: "off" | "lossless" | "lossy" | "webp";
-          requestBodyBuffering?: "none" | "standard" | "full";
-          responseBodyBuffering?: "none" | "standard";
-          rocketLoader?: boolean;
-          securityLevel?:
-            | "off"
-            | "essentially_off"
-            | "low"
-            | "medium"
-            | "high"
-            | "under_attack";
-          serverSideExcludes?: boolean;
-          ssl?: "off" | "flexible" | "full" | "strict" | "origin_pull";
-          sxg?: boolean;
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "skip";
-        actionParameters?: {
-          phase?: "current";
-          phases?: (
-            | "ddos_l4"
-            | "ddos_l7"
-            | "http_config_settings"
-            | "http_custom_errors"
-            | "http_log_custom_fields"
-            | "http_ratelimit"
-            | "http_request_cache_settings"
-            | "http_request_dynamic_redirect"
-            | "http_request_firewall_custom"
-            | "http_request_firewall_managed"
-            | "http_request_late_transform"
-            | "http_request_origin"
-            | "http_request_redirect"
-            | "http_request_sanitize"
-            | "http_request_sbfm"
-            | "http_request_transform"
-            | "http_response_compression"
-            | "http_response_firewall_managed"
-            | "http_response_headers_transform"
-            | "magic_transit"
-            | "magic_transit_ids_managed"
-            | "magic_transit_managed"
-            | "magic_transit_ratelimit"
-          )[];
-          products?: (
-            | "bic"
-            | "hot"
-            | "rateLimit"
-            | "securityLevel"
-            | "uaBlock"
-            | "waf"
-            | "zoneLockdown"
-          )[];
-          rules?: Record<string, unknown>;
-          ruleset?: "current";
-          rulesets?: string[];
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-  )[];
 }
 
 export type UpdateRulesetRequest =
@@ -41699,16 +39727,18 @@ const DeleteRulesetBaseFields = {
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
 } as const;
 
-export interface DeleteRulesetForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface DeleteRulesetBaseRequest {
   rulesetId: string;
 }
 
-export interface DeleteRulesetForZoneRequest {
+export interface DeleteRulesetForAccountRequest extends DeleteRulesetBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface DeleteRulesetForZoneRequest extends DeleteRulesetBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  rulesetId: string;
 }
 
 export type DeleteRulesetRequest =
@@ -41783,18 +39813,19 @@ const GetVersionBaseFields = {
   rulesetVersion: Schema.String.pipe(T.HttpPath("rulesetVersion")),
 } as const;
 
-export interface GetVersionForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface GetVersionBaseRequest {
   rulesetId: string;
   rulesetVersion: string;
 }
 
-export interface GetVersionForZoneRequest {
+export interface GetVersionForAccountRequest extends GetVersionBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetVersionForZoneRequest extends GetVersionBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  rulesetId: string;
-  rulesetVersion: string;
 }
 
 export type GetVersionRequest =
@@ -45332,16 +43363,18 @@ const ListVersionsBaseFields = {
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
 } as const;
 
-export interface ListVersionsForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface ListVersionsBaseRequest {
   rulesetId: string;
 }
 
-export interface ListVersionsForZoneRequest {
+export interface ListVersionsForAccountRequest extends ListVersionsBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface ListVersionsForZoneRequest extends ListVersionsBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  rulesetId: string;
 }
 
 export type ListVersionsRequest =
@@ -45501,18 +43534,19 @@ const DeleteVersionBaseFields = {
   rulesetVersion: Schema.String.pipe(T.HttpPath("rulesetVersion")),
 } as const;
 
-export interface DeleteVersionForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface DeleteVersionBaseRequest {
   rulesetId: string;
   rulesetVersion: string;
 }
 
-export interface DeleteVersionForZoneRequest {
+export interface DeleteVersionForAccountRequest extends DeleteVersionBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface DeleteVersionForZoneRequest extends DeleteVersionBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  rulesetId: string;
-  rulesetVersion: string;
 }
 
 export type DeleteVersionRequest =

--- a/packages/cloudflare/src/services/rulesets.ts
+++ b/packages/cloudflare/src/services/rulesets.ts
@@ -5,6 +5,8 @@
  * DO NOT EDIT - regenerate with: bun scripts/generate.ts --service rulesets
  */
 
+import * as Effect from "effect/Effect";
+import * as stream from "effect/Stream";
 import * as Schema from "effect/Schema";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
@@ -17,16 +19,44 @@ import { SensitiveString } from "../sensitive.ts";
 // Pha
 // =============================================================================
 
-export interface GetPhasRequest {}
+const GetPhasBaseFields = {
+  rulesetPhase: Schema.String.pipe(T.HttpPath("rulesetPhase")),
+} as const;
 
-export const GetPhasRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {},
-).pipe(
+export interface GetPhasForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  rulesetPhase: string;
+}
+
+export interface GetPhasForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  rulesetPhase: string;
+}
+
+export type GetPhasRequest = GetPhasForAccountRequest | GetPhasForZoneRequest;
+
+export const GetPhasForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetPhasBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/rulesets/phases/{rulesetPhase}/entrypoint",
+    }),
+  ) as unknown as Schema.Schema<GetPhasForAccountRequest>;
+
+export const GetPhasForZoneRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+  ...GetPhasBaseFields,
+}).pipe(
   T.Http({
     method: "GET",
-    path: "/{accountOrZone}/{accountOrZoneId}/rulesets/phases/{rulesetPhase}/entrypoint",
+    path: "/zones/{zone_id}/rulesets/phases/{rulesetPhase}/entrypoint",
   }),
-) as unknown as Schema.Schema<GetPhasRequest>;
+) as unknown as Schema.Schema<GetPhasForZoneRequest>;
 
 export interface GetPhasResponse {
   /** The unique ID of the ruleset. */
@@ -3500,649 +3530,38 @@ export const GetPhasResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type GetPhasError = DefaultErrors;
 
-export const getPhas: API.OperationMethod<
-  GetPhasRequest,
+export const getPhasForAccount: API.OperationMethod<
+  GetPhasForAccountRequest,
   GetPhasResponse,
   GetPhasError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: GetPhasRequest,
+  input: GetPhasForAccountRequest,
   output: GetPhasResponse,
   errors: [],
 }));
 
-export interface PutPhasRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
-  /** Body param: An informative description of the ruleset. */
-  description?: string;
-  /** Body param: The human-readable name of the ruleset. */
-  name?: string;
-  /** Body param: The list of rules in the ruleset. */
-  rules?: (
-    | {
-        id?: string;
-        action?: "block";
-        actionParameters?: {
-          response?: {
-            content: string;
-            contentType: string;
-            statusCode: number;
-          };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "challenge";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "compress_response";
-        actionParameters?: {
-          algorithms: {
-            name?: "none" | "auto" | "default" | "gzip" | "brotli" | "zstd";
-          }[];
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "ddos_dynamic";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "execute";
-        actionParameters?: {
-          id: string;
-          matchedData?: { publicKey: string };
-          overrides?: {
-            action?: string;
-            categories?: {
-              category: string;
-              action?: string;
-              enabled?: boolean;
-              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
-            }[];
-            enabled?: boolean;
-            rules?: {
-              id: string;
-              action?: string;
-              enabled?: boolean;
-              scoreThreshold?: number;
-              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
-            }[];
-            sensitivityLevel?: "default" | "medium" | "low" | "eoff";
-          };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "force_connection_close";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "js_challenge";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "log";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "log_custom_field";
-        actionParameters?: {
-          cookieFields?: { name: string }[];
-          rawResponseFields?: { name: string; preserveDuplicates?: boolean }[];
-          requestFields?: { name: string }[];
-          responseFields?: { name: string; preserveDuplicates?: boolean }[];
-          transformedRequestFields?: { name: string }[];
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "managed_challenge";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "redirect";
-        actionParameters?: {
-          fromList?: { key: string; name: string };
-          fromValue?: {
-            targetUrl: { expression?: string; value?: string };
-            preserveQueryString?: boolean;
-            statusCode?: "301" | "302" | "303" | "307" | "308";
-          };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "rewrite";
-        actionParameters?: {
-          headers?: Record<string, unknown>;
-          uri?:
-            | { path: { expression?: string; value?: string } }
-            | { query: { expression?: string; value?: string } };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "route";
-        actionParameters?: {
-          hostHeader?: string;
-          origin?: { host?: string; port?: number };
-          sni?: { value: string };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "score";
-        actionParameters?: { increment: number };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "serve_error";
-        actionParameters?:
-          | {
-              content: string;
-              contentType?:
-                | "application/json"
-                | "text/html"
-                | "text/plain"
-                | "text/xml";
-              statusCode?: number;
-            }
-          | {
-              assetName: string;
-              contentType?:
-                | "application/json"
-                | "text/html"
-                | "text/plain"
-                | "text/xml";
-              statusCode?: number;
-            };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "set_cache_settings";
-        actionParameters?: {
-          additionalCacheablePorts?: number[];
-          browserTtl?: {
-            mode:
-              | "respect_origin"
-              | "bypass_by_default"
-              | "override_origin"
-              | "bypass";
-            default?: number;
-          };
-          cache?: boolean;
-          cacheKey?: {
-            cacheByDeviceType?: boolean;
-            cacheDeceptionArmor?: boolean;
-            customKey?: {
-              cookie?: { checkPresence?: string[]; include?: string[] };
-              header?: {
-                checkPresence?: string[];
-                contains?: Record<string, unknown>;
-                excludeOrigin?: boolean;
-                include?: string[];
-              };
-              host?: { resolved?: boolean };
-              queryString?: {
-                exclude?: { all?: true; list?: string[] };
-                include?: { all?: true; list?: string[] };
-              };
-              user?: { deviceType?: boolean; geo?: boolean; lang?: boolean };
-            };
-            ignoreQueryStringsOrder?: boolean;
-          };
-          cacheReserve?: { eligible: boolean; minimumFileSize?: number };
-          edgeTtl?: {
-            mode: "respect_origin" | "bypass_by_default" | "override_origin";
-            default?: number;
-            statusCodeTtl?: {
-              value: number;
-              statusCode?: number;
-              statusCodeRange?: { from?: number; to?: number };
-            }[];
-          };
-          originCacheControl?: boolean;
-          originErrorPagePassthru?: boolean;
-          readTimeout?: number;
-          respectStrongEtags?: boolean;
-          serveStale?: { disableStaleWhileUpdating?: boolean };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "set_config";
-        actionParameters?: {
-          automaticHttpsRewrites?: boolean;
-          autominify?: { css?: boolean; html?: boolean; js?: boolean };
-          bic?: boolean;
-          disableApps?: true;
-          disablePayPerCrawl?: true;
-          disableRum?: true;
-          disableZaraz?: true;
-          emailObfuscation?: boolean;
-          fonts?: boolean;
-          hotlinkProtection?: boolean;
-          mirage?: boolean;
-          opportunisticEncryption?: boolean;
-          polish?: "off" | "lossless" | "lossy" | "webp";
-          requestBodyBuffering?: "none" | "standard" | "full";
-          responseBodyBuffering?: "none" | "standard";
-          rocketLoader?: boolean;
-          securityLevel?:
-            | "off"
-            | "essentially_off"
-            | "low"
-            | "medium"
-            | "high"
-            | "under_attack";
-          serverSideExcludes?: boolean;
-          ssl?: "off" | "flexible" | "full" | "strict" | "origin_pull";
-          sxg?: boolean;
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "skip";
-        actionParameters?: {
-          phase?: "current";
-          phases?: (
-            | "ddos_l4"
-            | "ddos_l7"
-            | "http_config_settings"
-            | "http_custom_errors"
-            | "http_log_custom_fields"
-            | "http_ratelimit"
-            | "http_request_cache_settings"
-            | "http_request_dynamic_redirect"
-            | "http_request_firewall_custom"
-            | "http_request_firewall_managed"
-            | "http_request_late_transform"
-            | "http_request_origin"
-            | "http_request_redirect"
-            | "http_request_sanitize"
-            | "http_request_sbfm"
-            | "http_request_transform"
-            | "http_response_compression"
-            | "http_response_firewall_managed"
-            | "http_response_headers_transform"
-            | "magic_transit"
-            | "magic_transit_ids_managed"
-            | "magic_transit_managed"
-            | "magic_transit_ratelimit"
-          )[];
-          products?: (
-            | "bic"
-            | "hot"
-            | "rateLimit"
-            | "securityLevel"
-            | "uaBlock"
-            | "waf"
-            | "zoneLockdown"
-          )[];
-          rules?: Record<string, unknown>;
-          ruleset?: "current";
-          rulesets?: string[];
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-  )[];
-}
+export const getPhasForZone: API.OperationMethod<
+  GetPhasForZoneRequest,
+  GetPhasResponse,
+  GetPhasError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetPhasForZoneRequest,
+  output: GetPhasResponse,
+  errors: [],
+}));
 
-export const PutPhasRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+export const getPhas = (
+  input: GetPhasRequest,
+): Effect.Effect<
+  GetPhasResponse,
+  GetPhasError,
+  Credentials | HttpClient.HttpClient
+> => ("accountId" in input ? getPhasForAccount(input) : getPhasForZone(input));
+
+const PutPhasBaseFields = {
+  rulesetPhase: Schema.String.pipe(T.HttpPath("rulesetPhase")),
   description: Schema.optional(Schema.String),
   name: Schema.optional(Schema.String),
   rules: Schema.optional(
@@ -5844,12 +5263,1286 @@ export const PutPhasRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       ]),
     ),
   ),
+} as const;
+
+export interface PutPhasForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  rulesetPhase: string;
+  /** Body param: An informative description of the ruleset. */
+  description?: string;
+  /** Body param: The human-readable name of the ruleset. */
+  name?: string;
+  /** Body param: The list of rules in the ruleset. */
+  rules?: (
+    | {
+        id?: string;
+        action?: "block";
+        actionParameters?: {
+          response?: {
+            content: string;
+            contentType: string;
+            statusCode: number;
+          };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "challenge";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "compress_response";
+        actionParameters?: {
+          algorithms: {
+            name?: "none" | "auto" | "default" | "gzip" | "brotli" | "zstd";
+          }[];
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "ddos_dynamic";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "execute";
+        actionParameters?: {
+          id: string;
+          matchedData?: { publicKey: string };
+          overrides?: {
+            action?: string;
+            categories?: {
+              category: string;
+              action?: string;
+              enabled?: boolean;
+              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
+            }[];
+            enabled?: boolean;
+            rules?: {
+              id: string;
+              action?: string;
+              enabled?: boolean;
+              scoreThreshold?: number;
+              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
+            }[];
+            sensitivityLevel?: "default" | "medium" | "low" | "eoff";
+          };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "force_connection_close";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "js_challenge";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "log";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "log_custom_field";
+        actionParameters?: {
+          cookieFields?: { name: string }[];
+          rawResponseFields?: { name: string; preserveDuplicates?: boolean }[];
+          requestFields?: { name: string }[];
+          responseFields?: { name: string; preserveDuplicates?: boolean }[];
+          transformedRequestFields?: { name: string }[];
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "managed_challenge";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "redirect";
+        actionParameters?: {
+          fromList?: { key: string; name: string };
+          fromValue?: {
+            targetUrl: { expression?: string; value?: string };
+            preserveQueryString?: boolean;
+            statusCode?: "301" | "302" | "303" | "307" | "308";
+          };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "rewrite";
+        actionParameters?: {
+          headers?: Record<string, unknown>;
+          uri?:
+            | { path: { expression?: string; value?: string } }
+            | { query: { expression?: string; value?: string } };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "route";
+        actionParameters?: {
+          hostHeader?: string;
+          origin?: { host?: string; port?: number };
+          sni?: { value: string };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "score";
+        actionParameters?: { increment: number };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "serve_error";
+        actionParameters?:
+          | {
+              content: string;
+              contentType?:
+                | "application/json"
+                | "text/html"
+                | "text/plain"
+                | "text/xml";
+              statusCode?: number;
+            }
+          | {
+              assetName: string;
+              contentType?:
+                | "application/json"
+                | "text/html"
+                | "text/plain"
+                | "text/xml";
+              statusCode?: number;
+            };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "set_cache_settings";
+        actionParameters?: {
+          additionalCacheablePorts?: number[];
+          browserTtl?: {
+            mode:
+              | "respect_origin"
+              | "bypass_by_default"
+              | "override_origin"
+              | "bypass";
+            default?: number;
+          };
+          cache?: boolean;
+          cacheKey?: {
+            cacheByDeviceType?: boolean;
+            cacheDeceptionArmor?: boolean;
+            customKey?: {
+              cookie?: { checkPresence?: string[]; include?: string[] };
+              header?: {
+                checkPresence?: string[];
+                contains?: Record<string, unknown>;
+                excludeOrigin?: boolean;
+                include?: string[];
+              };
+              host?: { resolved?: boolean };
+              queryString?: {
+                exclude?: { all?: true; list?: string[] };
+                include?: { all?: true; list?: string[] };
+              };
+              user?: { deviceType?: boolean; geo?: boolean; lang?: boolean };
+            };
+            ignoreQueryStringsOrder?: boolean;
+          };
+          cacheReserve?: { eligible: boolean; minimumFileSize?: number };
+          edgeTtl?: {
+            mode: "respect_origin" | "bypass_by_default" | "override_origin";
+            default?: number;
+            statusCodeTtl?: {
+              value: number;
+              statusCode?: number;
+              statusCodeRange?: { from?: number; to?: number };
+            }[];
+          };
+          originCacheControl?: boolean;
+          originErrorPagePassthru?: boolean;
+          readTimeout?: number;
+          respectStrongEtags?: boolean;
+          serveStale?: { disableStaleWhileUpdating?: boolean };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "set_config";
+        actionParameters?: {
+          automaticHttpsRewrites?: boolean;
+          autominify?: { css?: boolean; html?: boolean; js?: boolean };
+          bic?: boolean;
+          disableApps?: true;
+          disablePayPerCrawl?: true;
+          disableRum?: true;
+          disableZaraz?: true;
+          emailObfuscation?: boolean;
+          fonts?: boolean;
+          hotlinkProtection?: boolean;
+          mirage?: boolean;
+          opportunisticEncryption?: boolean;
+          polish?: "off" | "lossless" | "lossy" | "webp";
+          requestBodyBuffering?: "none" | "standard" | "full";
+          responseBodyBuffering?: "none" | "standard";
+          rocketLoader?: boolean;
+          securityLevel?:
+            | "off"
+            | "essentially_off"
+            | "low"
+            | "medium"
+            | "high"
+            | "under_attack";
+          serverSideExcludes?: boolean;
+          ssl?: "off" | "flexible" | "full" | "strict" | "origin_pull";
+          sxg?: boolean;
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "skip";
+        actionParameters?: {
+          phase?: "current";
+          phases?: (
+            | "ddos_l4"
+            | "ddos_l7"
+            | "http_config_settings"
+            | "http_custom_errors"
+            | "http_log_custom_fields"
+            | "http_ratelimit"
+            | "http_request_cache_settings"
+            | "http_request_dynamic_redirect"
+            | "http_request_firewall_custom"
+            | "http_request_firewall_managed"
+            | "http_request_late_transform"
+            | "http_request_origin"
+            | "http_request_redirect"
+            | "http_request_sanitize"
+            | "http_request_sbfm"
+            | "http_request_transform"
+            | "http_response_compression"
+            | "http_response_firewall_managed"
+            | "http_response_headers_transform"
+            | "magic_transit"
+            | "magic_transit_ids_managed"
+            | "magic_transit_managed"
+            | "magic_transit_ratelimit"
+          )[];
+          products?: (
+            | "bic"
+            | "hot"
+            | "rateLimit"
+            | "securityLevel"
+            | "uaBlock"
+            | "waf"
+            | "zoneLockdown"
+          )[];
+          rules?: Record<string, unknown>;
+          ruleset?: "current";
+          rulesets?: string[];
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+  )[];
+}
+
+export interface PutPhasForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  rulesetPhase: string;
+  /** Body param: An informative description of the ruleset. */
+  description?: string;
+  /** Body param: The human-readable name of the ruleset. */
+  name?: string;
+  /** Body param: The list of rules in the ruleset. */
+  rules?: (
+    | {
+        id?: string;
+        action?: "block";
+        actionParameters?: {
+          response?: {
+            content: string;
+            contentType: string;
+            statusCode: number;
+          };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "challenge";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "compress_response";
+        actionParameters?: {
+          algorithms: {
+            name?: "none" | "auto" | "default" | "gzip" | "brotli" | "zstd";
+          }[];
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "ddos_dynamic";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "execute";
+        actionParameters?: {
+          id: string;
+          matchedData?: { publicKey: string };
+          overrides?: {
+            action?: string;
+            categories?: {
+              category: string;
+              action?: string;
+              enabled?: boolean;
+              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
+            }[];
+            enabled?: boolean;
+            rules?: {
+              id: string;
+              action?: string;
+              enabled?: boolean;
+              scoreThreshold?: number;
+              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
+            }[];
+            sensitivityLevel?: "default" | "medium" | "low" | "eoff";
+          };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "force_connection_close";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "js_challenge";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "log";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "log_custom_field";
+        actionParameters?: {
+          cookieFields?: { name: string }[];
+          rawResponseFields?: { name: string; preserveDuplicates?: boolean }[];
+          requestFields?: { name: string }[];
+          responseFields?: { name: string; preserveDuplicates?: boolean }[];
+          transformedRequestFields?: { name: string }[];
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "managed_challenge";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "redirect";
+        actionParameters?: {
+          fromList?: { key: string; name: string };
+          fromValue?: {
+            targetUrl: { expression?: string; value?: string };
+            preserveQueryString?: boolean;
+            statusCode?: "301" | "302" | "303" | "307" | "308";
+          };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "rewrite";
+        actionParameters?: {
+          headers?: Record<string, unknown>;
+          uri?:
+            | { path: { expression?: string; value?: string } }
+            | { query: { expression?: string; value?: string } };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "route";
+        actionParameters?: {
+          hostHeader?: string;
+          origin?: { host?: string; port?: number };
+          sni?: { value: string };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "score";
+        actionParameters?: { increment: number };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "serve_error";
+        actionParameters?:
+          | {
+              content: string;
+              contentType?:
+                | "application/json"
+                | "text/html"
+                | "text/plain"
+                | "text/xml";
+              statusCode?: number;
+            }
+          | {
+              assetName: string;
+              contentType?:
+                | "application/json"
+                | "text/html"
+                | "text/plain"
+                | "text/xml";
+              statusCode?: number;
+            };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "set_cache_settings";
+        actionParameters?: {
+          additionalCacheablePorts?: number[];
+          browserTtl?: {
+            mode:
+              | "respect_origin"
+              | "bypass_by_default"
+              | "override_origin"
+              | "bypass";
+            default?: number;
+          };
+          cache?: boolean;
+          cacheKey?: {
+            cacheByDeviceType?: boolean;
+            cacheDeceptionArmor?: boolean;
+            customKey?: {
+              cookie?: { checkPresence?: string[]; include?: string[] };
+              header?: {
+                checkPresence?: string[];
+                contains?: Record<string, unknown>;
+                excludeOrigin?: boolean;
+                include?: string[];
+              };
+              host?: { resolved?: boolean };
+              queryString?: {
+                exclude?: { all?: true; list?: string[] };
+                include?: { all?: true; list?: string[] };
+              };
+              user?: { deviceType?: boolean; geo?: boolean; lang?: boolean };
+            };
+            ignoreQueryStringsOrder?: boolean;
+          };
+          cacheReserve?: { eligible: boolean; minimumFileSize?: number };
+          edgeTtl?: {
+            mode: "respect_origin" | "bypass_by_default" | "override_origin";
+            default?: number;
+            statusCodeTtl?: {
+              value: number;
+              statusCode?: number;
+              statusCodeRange?: { from?: number; to?: number };
+            }[];
+          };
+          originCacheControl?: boolean;
+          originErrorPagePassthru?: boolean;
+          readTimeout?: number;
+          respectStrongEtags?: boolean;
+          serveStale?: { disableStaleWhileUpdating?: boolean };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "set_config";
+        actionParameters?: {
+          automaticHttpsRewrites?: boolean;
+          autominify?: { css?: boolean; html?: boolean; js?: boolean };
+          bic?: boolean;
+          disableApps?: true;
+          disablePayPerCrawl?: true;
+          disableRum?: true;
+          disableZaraz?: true;
+          emailObfuscation?: boolean;
+          fonts?: boolean;
+          hotlinkProtection?: boolean;
+          mirage?: boolean;
+          opportunisticEncryption?: boolean;
+          polish?: "off" | "lossless" | "lossy" | "webp";
+          requestBodyBuffering?: "none" | "standard" | "full";
+          responseBodyBuffering?: "none" | "standard";
+          rocketLoader?: boolean;
+          securityLevel?:
+            | "off"
+            | "essentially_off"
+            | "low"
+            | "medium"
+            | "high"
+            | "under_attack";
+          serverSideExcludes?: boolean;
+          ssl?: "off" | "flexible" | "full" | "strict" | "origin_pull";
+          sxg?: boolean;
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "skip";
+        actionParameters?: {
+          phase?: "current";
+          phases?: (
+            | "ddos_l4"
+            | "ddos_l7"
+            | "http_config_settings"
+            | "http_custom_errors"
+            | "http_log_custom_fields"
+            | "http_ratelimit"
+            | "http_request_cache_settings"
+            | "http_request_dynamic_redirect"
+            | "http_request_firewall_custom"
+            | "http_request_firewall_managed"
+            | "http_request_late_transform"
+            | "http_request_origin"
+            | "http_request_redirect"
+            | "http_request_sanitize"
+            | "http_request_sbfm"
+            | "http_request_transform"
+            | "http_response_compression"
+            | "http_response_firewall_managed"
+            | "http_response_headers_transform"
+            | "magic_transit"
+            | "magic_transit_ids_managed"
+            | "magic_transit_managed"
+            | "magic_transit_ratelimit"
+          )[];
+          products?: (
+            | "bic"
+            | "hot"
+            | "rateLimit"
+            | "securityLevel"
+            | "uaBlock"
+            | "waf"
+            | "zoneLockdown"
+          )[];
+          rules?: Record<string, unknown>;
+          ruleset?: "current";
+          rulesets?: string[];
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+  )[];
+}
+
+export type PutPhasRequest = PutPhasForAccountRequest | PutPhasForZoneRequest;
+
+export const PutPhasForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...PutPhasBaseFields,
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/accounts/{account_id}/rulesets/phases/{rulesetPhase}/entrypoint",
+    }),
+  ) as unknown as Schema.Schema<PutPhasForAccountRequest>;
+
+export const PutPhasForZoneRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+  ...PutPhasBaseFields,
 }).pipe(
   T.Http({
     method: "PUT",
-    path: "/{accountOrZone}/{accountOrZoneId}/rulesets/phases/{rulesetPhase}/entrypoint",
+    path: "/zones/{zone_id}/rulesets/phases/{rulesetPhase}/entrypoint",
   }),
-) as unknown as Schema.Schema<PutPhasRequest>;
+) as unknown as Schema.Schema<PutPhasForZoneRequest>;
 
 export interface PutPhasResponse {
   /** The unique ID of the ruleset. */
@@ -9323,33 +10016,84 @@ export const PutPhasResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type PutPhasError = DefaultErrors;
 
-export const putPhas: API.OperationMethod<
-  PutPhasRequest,
+export const putPhasForAccount: API.OperationMethod<
+  PutPhasForAccountRequest,
   PutPhasResponse,
   PutPhasError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: PutPhasRequest,
+  input: PutPhasForAccountRequest,
   output: PutPhasResponse,
   errors: [],
 }));
+
+export const putPhasForZone: API.OperationMethod<
+  PutPhasForZoneRequest,
+  PutPhasResponse,
+  PutPhasError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: PutPhasForZoneRequest,
+  output: PutPhasResponse,
+  errors: [],
+}));
+
+export const putPhas = (
+  input: PutPhasRequest,
+): Effect.Effect<
+  PutPhasResponse,
+  PutPhasError,
+  Credentials | HttpClient.HttpClient
+> => ("accountId" in input ? putPhasForAccount(input) : putPhasForZone(input));
 
 // =============================================================================
 // PhasVersion
 // =============================================================================
 
-export interface GetPhasVersionRequest {
+const GetPhasVersionBaseFields = {
+  rulesetVersion: Schema.String.pipe(T.HttpPath("rulesetVersion")),
+  rulesetPhase: Schema.String.pipe(T.HttpPath("rulesetPhase")),
+} as const;
+
+export interface GetPhasVersionForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   rulesetVersion: string;
+  rulesetPhase: string;
 }
 
-export const GetPhasVersionRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  rulesetVersion: Schema.String.pipe(T.HttpPath("rulesetVersion")),
-}).pipe(
-  T.Http({
-    method: "GET",
-    path: "/{accountOrZone}/{accountOrZoneId}/rulesets/phases/{rulesetPhase}/entrypoint/versions/{rulesetVersion}",
-  }),
-) as unknown as Schema.Schema<GetPhasVersionRequest>;
+export interface GetPhasVersionForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  rulesetVersion: string;
+  rulesetPhase: string;
+}
+
+export type GetPhasVersionRequest =
+  | GetPhasVersionForAccountRequest
+  | GetPhasVersionForZoneRequest;
+
+export const GetPhasVersionForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetPhasVersionBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/rulesets/phases/{rulesetPhase}/entrypoint/versions/{rulesetVersion}",
+    }),
+  ) as unknown as Schema.Schema<GetPhasVersionForAccountRequest>;
+
+export const GetPhasVersionForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...GetPhasVersionBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/rulesets/phases/{rulesetPhase}/entrypoint/versions/{rulesetVersion}",
+    }),
+  ) as unknown as Schema.Schema<GetPhasVersionForZoneRequest>;
 
 export interface GetPhasVersionResponse {
   /** The unique ID of the ruleset. */
@@ -12877,26 +13621,80 @@ export const GetPhasVersionResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 
 export type GetPhasVersionError = DefaultErrors;
 
-export const getPhasVersion: API.OperationMethod<
-  GetPhasVersionRequest,
+export const getPhasVersionForAccount: API.OperationMethod<
+  GetPhasVersionForAccountRequest,
   GetPhasVersionResponse,
   GetPhasVersionError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: GetPhasVersionRequest,
+  input: GetPhasVersionForAccountRequest,
   output: GetPhasVersionResponse,
   errors: [],
 }));
 
-export interface ListPhasVersionsRequest {}
+export const getPhasVersionForZone: API.OperationMethod<
+  GetPhasVersionForZoneRequest,
+  GetPhasVersionResponse,
+  GetPhasVersionError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetPhasVersionForZoneRequest,
+  output: GetPhasVersionResponse,
+  errors: [],
+}));
 
-export const ListPhasVersionsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
+export const getPhasVersion = (
+  input: GetPhasVersionRequest,
+): Effect.Effect<
+  GetPhasVersionResponse,
+  GetPhasVersionError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? getPhasVersionForAccount(input)
+    : getPhasVersionForZone(input);
+
+const ListPhasVersionsBaseFields = {
+  rulesetPhase: Schema.String.pipe(T.HttpPath("rulesetPhase")),
+} as const;
+
+export interface ListPhasVersionsForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  rulesetPhase: string;
+}
+
+export interface ListPhasVersionsForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  rulesetPhase: string;
+}
+
+export type ListPhasVersionsRequest =
+  | ListPhasVersionsForAccountRequest
+  | ListPhasVersionsForZoneRequest;
+
+export const ListPhasVersionsForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...ListPhasVersionsBaseFields,
+  }).pipe(
     T.Http({
       method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/rulesets/phases/{rulesetPhase}/entrypoint/versions",
+      path: "/accounts/{account_id}/rulesets/phases/{rulesetPhase}/entrypoint/versions",
     }),
-  ) as unknown as Schema.Schema<ListPhasVersionsRequest>;
+  ) as unknown as Schema.Schema<ListPhasVersionsForAccountRequest>;
+
+export const ListPhasVersionsForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...ListPhasVersionsBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/rulesets/phases/{rulesetPhase}/entrypoint/versions",
+    }),
+  ) as unknown as Schema.Schema<ListPhasVersionsForZoneRequest>;
 
 export interface ListPhasVersionsResponse {
   result: {
@@ -12986,13 +13784,13 @@ export const ListPhasVersionsResponse =
 
 export type ListPhasVersionsError = DefaultErrors;
 
-export const listPhasVersions: API.PaginatedOperationMethod<
-  ListPhasVersionsRequest,
+export const listPhasVersionsForAccount: API.PaginatedOperationMethod<
+  ListPhasVersionsForAccountRequest,
   ListPhasVersionsResponse,
   ListPhasVersionsError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
-  input: ListPhasVersionsRequest,
+  input: ListPhasVersionsForAccountRequest,
   output: ListPhasVersionsResponse,
   errors: [],
   pagination: {
@@ -13001,58 +13799,38 @@ export const listPhasVersions: API.PaginatedOperationMethod<
   } as const,
 }));
 
+export const listPhasVersionsForZone: API.PaginatedOperationMethod<
+  ListPhasVersionsForZoneRequest,
+  ListPhasVersionsResponse,
+  ListPhasVersionsError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+  input: ListPhasVersionsForZoneRequest,
+  output: ListPhasVersionsResponse,
+  errors: [],
+  pagination: {
+    mode: "single",
+    items: "result",
+  } as const,
+}));
+
+export const listPhasVersions = (
+  input: ListPhasVersionsRequest,
+): stream.Stream<
+  ListPhasVersionsResponse,
+  ListPhasVersionsError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? listPhasVersionsForAccount.pages(input)
+    : listPhasVersionsForZone.pages(input);
+
 // =============================================================================
 // Rule
 // =============================================================================
 
-export interface CreateRuleRequest {
-  rulesetId: string;
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
-  /** Body param: The unique ID of the rule. */
-  id?: string;
-  /** Body param: The action to perform when the rule matches. */
-  action?: "block";
-  /** Body param: The parameters configuring the rule's action. */
-  actionParameters?: {
-    response?: { content: string; contentType: string; statusCode: number };
-  };
-  /** Body param: An informative description of the rule. */
-  description?: string;
-  /** Body param: Whether the rule should be executed. */
-  enabled?: boolean;
-  /** Body param: Configuration for exposed credential checking. */
-  exposedCredentialCheck?: {
-    passwordExpression: string;
-    usernameExpression: string;
-  };
-  /** Body param: The expression defining which traffic will match the rule. */
-  expression?: string;
-  /** Body param: An object configuring the rule's logging behavior. */
-  logging?: { enabled: boolean };
-  /** Body param: An object configuring where the rule will be placed. */
-  position?: { before?: string } | { after?: string } | { index?: number };
-  /** Body param: An object configuring the rule's rate limit behavior. */
-  ratelimit?: {
-    characteristics: string[];
-    period: number;
-    countingExpression?: string;
-    mitigationTimeout?: number;
-    requestsPerPeriod?: number;
-    requestsToOrigin?: boolean;
-    scorePerPeriod?: number;
-    scoreResponseHeaderName?: string;
-  };
-  /** Body param: The reference of the rule (the rule's ID by default). */
-  ref?: string;
-}
-
-export const CreateRuleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+const CreateRuleBaseFields = {
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
   id: Schema.optional(Schema.String),
   action: Schema.optional(Schema.Literal("block")),
   actionParameters: Schema.optional(
@@ -13128,25 +13906,143 @@ export const CreateRuleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     ),
   ),
   ref: Schema.optional(Schema.String),
-}).pipe(
-  Schema.encodeKeys({
-    id: "id",
-    action: "action",
-    actionParameters: "action_parameters",
-    description: "description",
-    enabled: "enabled",
-    exposedCredentialCheck: "exposed_credential_check",
-    expression: "expression",
-    logging: "logging",
-    position: "position",
-    ratelimit: "ratelimit",
-    ref: "ref",
-  }),
-  T.Http({
-    method: "POST",
-    path: "/{accountOrZone}/{accountOrZoneId}/rulesets/{rulesetId}/rules",
-  }),
-) as unknown as Schema.Schema<CreateRuleRequest>;
+} as const;
+
+export interface CreateRuleForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  rulesetId: string;
+  /** Body param: The unique ID of the rule. */
+  id?: string;
+  /** Body param: The action to perform when the rule matches. */
+  action?: "block";
+  /** Body param: The parameters configuring the rule's action. */
+  actionParameters?: {
+    response?: { content: string; contentType: string; statusCode: number };
+  };
+  /** Body param: An informative description of the rule. */
+  description?: string;
+  /** Body param: Whether the rule should be executed. */
+  enabled?: boolean;
+  /** Body param: Configuration for exposed credential checking. */
+  exposedCredentialCheck?: {
+    passwordExpression: string;
+    usernameExpression: string;
+  };
+  /** Body param: The expression defining which traffic will match the rule. */
+  expression?: string;
+  /** Body param: An object configuring the rule's logging behavior. */
+  logging?: { enabled: boolean };
+  /** Body param: An object configuring where the rule will be placed. */
+  position?: { before?: string } | { after?: string } | { index?: number };
+  /** Body param: An object configuring the rule's rate limit behavior. */
+  ratelimit?: {
+    characteristics: string[];
+    period: number;
+    countingExpression?: string;
+    mitigationTimeout?: number;
+    requestsPerPeriod?: number;
+    requestsToOrigin?: boolean;
+    scorePerPeriod?: number;
+    scoreResponseHeaderName?: string;
+  };
+  /** Body param: The reference of the rule (the rule's ID by default). */
+  ref?: string;
+}
+
+export interface CreateRuleForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  rulesetId: string;
+  /** Body param: The unique ID of the rule. */
+  id?: string;
+  /** Body param: The action to perform when the rule matches. */
+  action?: "block";
+  /** Body param: The parameters configuring the rule's action. */
+  actionParameters?: {
+    response?: { content: string; contentType: string; statusCode: number };
+  };
+  /** Body param: An informative description of the rule. */
+  description?: string;
+  /** Body param: Whether the rule should be executed. */
+  enabled?: boolean;
+  /** Body param: Configuration for exposed credential checking. */
+  exposedCredentialCheck?: {
+    passwordExpression: string;
+    usernameExpression: string;
+  };
+  /** Body param: The expression defining which traffic will match the rule. */
+  expression?: string;
+  /** Body param: An object configuring the rule's logging behavior. */
+  logging?: { enabled: boolean };
+  /** Body param: An object configuring where the rule will be placed. */
+  position?: { before?: string } | { after?: string } | { index?: number };
+  /** Body param: An object configuring the rule's rate limit behavior. */
+  ratelimit?: {
+    characteristics: string[];
+    period: number;
+    countingExpression?: string;
+    mitigationTimeout?: number;
+    requestsPerPeriod?: number;
+    requestsToOrigin?: boolean;
+    scorePerPeriod?: number;
+    scoreResponseHeaderName?: string;
+  };
+  /** Body param: The reference of the rule (the rule's ID by default). */
+  ref?: string;
+}
+
+export type CreateRuleRequest =
+  | CreateRuleForAccountRequest
+  | CreateRuleForZoneRequest;
+
+export const CreateRuleForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...CreateRuleBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      id: "id",
+      action: "action",
+      actionParameters: "action_parameters",
+      description: "description",
+      enabled: "enabled",
+      exposedCredentialCheck: "exposed_credential_check",
+      expression: "expression",
+      logging: "logging",
+      position: "position",
+      ratelimit: "ratelimit",
+      ref: "ref",
+    }),
+    T.Http({
+      method: "POST",
+      path: "/accounts/{account_id}/rulesets/{rulesetId}/rules",
+    }),
+  ) as unknown as Schema.Schema<CreateRuleForAccountRequest>;
+
+export const CreateRuleForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...CreateRuleBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      id: "id",
+      action: "action",
+      actionParameters: "action_parameters",
+      description: "description",
+      enabled: "enabled",
+      exposedCredentialCheck: "exposed_credential_check",
+      expression: "expression",
+      logging: "logging",
+      position: "position",
+      ratelimit: "ratelimit",
+      ref: "ref",
+    }),
+    T.Http({
+      method: "POST",
+      path: "/zones/{zone_id}/rulesets/{rulesetId}/rules",
+    }),
+  ) as unknown as Schema.Schema<CreateRuleForZoneRequest>;
 
 export interface CreateRuleResponse {
   /** The unique ID of the ruleset. */
@@ -16622,67 +17518,40 @@ export const CreateRuleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type CreateRuleError = DefaultErrors;
 
-export const createRule: API.OperationMethod<
-  CreateRuleRequest,
+export const createRuleForAccount: API.OperationMethod<
+  CreateRuleForAccountRequest,
   CreateRuleResponse,
   CreateRuleError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: CreateRuleRequest,
+  input: CreateRuleForAccountRequest,
   output: CreateRuleResponse,
   errors: [],
 }));
 
-export interface PatchRuleRequest {
-  rulesetId: string;
-  ruleId: string;
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
-  /** Body param: The unique ID of the rule. */
-  id?: string;
-  /** Body param: The action to perform when the rule matches. */
-  action?: "block";
-  /** Body param: The parameters configuring the rule's action. */
-  actionParameters?: {
-    response?: { content: string; contentType: string; statusCode: number };
-  };
-  /** Body param: An informative description of the rule. */
-  description?: string;
-  /** Body param: Whether the rule should be executed. */
-  enabled?: boolean;
-  /** Body param: Configuration for exposed credential checking. */
-  exposedCredentialCheck?: {
-    passwordExpression: string;
-    usernameExpression: string;
-  };
-  /** Body param: The expression defining which traffic will match the rule. */
-  expression?: string;
-  /** Body param: An object configuring the rule's logging behavior. */
-  logging?: { enabled: boolean };
-  /** Body param: An object configuring where the rule will be placed. */
-  position?: { before?: string } | { after?: string } | { index?: number };
-  /** Body param: An object configuring the rule's rate limit behavior. */
-  ratelimit?: {
-    characteristics: string[];
-    period: number;
-    countingExpression?: string;
-    mitigationTimeout?: number;
-    requestsPerPeriod?: number;
-    requestsToOrigin?: boolean;
-    scorePerPeriod?: number;
-    scoreResponseHeaderName?: string;
-  };
-  /** Body param: The reference of the rule (the rule's ID by default). */
-  ref?: string;
-}
+export const createRuleForZone: API.OperationMethod<
+  CreateRuleForZoneRequest,
+  CreateRuleResponse,
+  CreateRuleError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: CreateRuleForZoneRequest,
+  output: CreateRuleResponse,
+  errors: [],
+}));
 
-export const PatchRuleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+export const createRule = (
+  input: CreateRuleRequest,
+): Effect.Effect<
+  CreateRuleResponse,
+  CreateRuleError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input ? createRuleForAccount(input) : createRuleForZone(input);
+
+const PatchRuleBaseFields = {
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
   ruleId: Schema.String.pipe(T.HttpPath("ruleId")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
   id: Schema.optional(Schema.String),
   action: Schema.optional(Schema.Literal("block")),
   actionParameters: Schema.optional(
@@ -16758,25 +17627,145 @@ export const PatchRuleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     ),
   ),
   ref: Schema.optional(Schema.String),
-}).pipe(
-  Schema.encodeKeys({
-    id: "id",
-    action: "action",
-    actionParameters: "action_parameters",
-    description: "description",
-    enabled: "enabled",
-    exposedCredentialCheck: "exposed_credential_check",
-    expression: "expression",
-    logging: "logging",
-    position: "position",
-    ratelimit: "ratelimit",
-    ref: "ref",
-  }),
-  T.Http({
-    method: "PATCH",
-    path: "/{accountOrZone}/{accountOrZoneId}/rulesets/{rulesetId}/rules/{ruleId}",
-  }),
-) as unknown as Schema.Schema<PatchRuleRequest>;
+} as const;
+
+export interface PatchRuleForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  rulesetId: string;
+  ruleId: string;
+  /** Body param: The unique ID of the rule. */
+  id?: string;
+  /** Body param: The action to perform when the rule matches. */
+  action?: "block";
+  /** Body param: The parameters configuring the rule's action. */
+  actionParameters?: {
+    response?: { content: string; contentType: string; statusCode: number };
+  };
+  /** Body param: An informative description of the rule. */
+  description?: string;
+  /** Body param: Whether the rule should be executed. */
+  enabled?: boolean;
+  /** Body param: Configuration for exposed credential checking. */
+  exposedCredentialCheck?: {
+    passwordExpression: string;
+    usernameExpression: string;
+  };
+  /** Body param: The expression defining which traffic will match the rule. */
+  expression?: string;
+  /** Body param: An object configuring the rule's logging behavior. */
+  logging?: { enabled: boolean };
+  /** Body param: An object configuring where the rule will be placed. */
+  position?: { before?: string } | { after?: string } | { index?: number };
+  /** Body param: An object configuring the rule's rate limit behavior. */
+  ratelimit?: {
+    characteristics: string[];
+    period: number;
+    countingExpression?: string;
+    mitigationTimeout?: number;
+    requestsPerPeriod?: number;
+    requestsToOrigin?: boolean;
+    scorePerPeriod?: number;
+    scoreResponseHeaderName?: string;
+  };
+  /** Body param: The reference of the rule (the rule's ID by default). */
+  ref?: string;
+}
+
+export interface PatchRuleForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  rulesetId: string;
+  ruleId: string;
+  /** Body param: The unique ID of the rule. */
+  id?: string;
+  /** Body param: The action to perform when the rule matches. */
+  action?: "block";
+  /** Body param: The parameters configuring the rule's action. */
+  actionParameters?: {
+    response?: { content: string; contentType: string; statusCode: number };
+  };
+  /** Body param: An informative description of the rule. */
+  description?: string;
+  /** Body param: Whether the rule should be executed. */
+  enabled?: boolean;
+  /** Body param: Configuration for exposed credential checking. */
+  exposedCredentialCheck?: {
+    passwordExpression: string;
+    usernameExpression: string;
+  };
+  /** Body param: The expression defining which traffic will match the rule. */
+  expression?: string;
+  /** Body param: An object configuring the rule's logging behavior. */
+  logging?: { enabled: boolean };
+  /** Body param: An object configuring where the rule will be placed. */
+  position?: { before?: string } | { after?: string } | { index?: number };
+  /** Body param: An object configuring the rule's rate limit behavior. */
+  ratelimit?: {
+    characteristics: string[];
+    period: number;
+    countingExpression?: string;
+    mitigationTimeout?: number;
+    requestsPerPeriod?: number;
+    requestsToOrigin?: boolean;
+    scorePerPeriod?: number;
+    scoreResponseHeaderName?: string;
+  };
+  /** Body param: The reference of the rule (the rule's ID by default). */
+  ref?: string;
+}
+
+export type PatchRuleRequest =
+  | PatchRuleForAccountRequest
+  | PatchRuleForZoneRequest;
+
+export const PatchRuleForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...PatchRuleBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      id: "id",
+      action: "action",
+      actionParameters: "action_parameters",
+      description: "description",
+      enabled: "enabled",
+      exposedCredentialCheck: "exposed_credential_check",
+      expression: "expression",
+      logging: "logging",
+      position: "position",
+      ratelimit: "ratelimit",
+      ref: "ref",
+    }),
+    T.Http({
+      method: "PATCH",
+      path: "/accounts/{account_id}/rulesets/{rulesetId}/rules/{ruleId}",
+    }),
+  ) as unknown as Schema.Schema<PatchRuleForAccountRequest>;
+
+export const PatchRuleForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...PatchRuleBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      id: "id",
+      action: "action",
+      actionParameters: "action_parameters",
+      description: "description",
+      enabled: "enabled",
+      exposedCredentialCheck: "exposed_credential_check",
+      expression: "expression",
+      logging: "logging",
+      position: "position",
+      ratelimit: "ratelimit",
+      ref: "ref",
+    }),
+    T.Http({
+      method: "PATCH",
+      path: "/zones/{zone_id}/rulesets/{rulesetId}/rules/{ruleId}",
+    }),
+  ) as unknown as Schema.Schema<PatchRuleForZoneRequest>;
 
 export interface PatchRuleResponse {
   /** The unique ID of the ruleset. */
@@ -20252,31 +21241,81 @@ export const PatchRuleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type PatchRuleError = DefaultErrors;
 
-export const patchRule: API.OperationMethod<
-  PatchRuleRequest,
+export const patchRuleForAccount: API.OperationMethod<
+  PatchRuleForAccountRequest,
   PatchRuleResponse,
   PatchRuleError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: PatchRuleRequest,
+  input: PatchRuleForAccountRequest,
   output: PatchRuleResponse,
   errors: [],
 }));
 
-export interface DeleteRuleRequest {
+export const patchRuleForZone: API.OperationMethod<
+  PatchRuleForZoneRequest,
+  PatchRuleResponse,
+  PatchRuleError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: PatchRuleForZoneRequest,
+  output: PatchRuleResponse,
+  errors: [],
+}));
+
+export const patchRule = (
+  input: PatchRuleRequest,
+): Effect.Effect<
+  PatchRuleResponse,
+  PatchRuleError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input ? patchRuleForAccount(input) : patchRuleForZone(input);
+
+const DeleteRuleBaseFields = {
+  rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
+  ruleId: Schema.String.pipe(T.HttpPath("ruleId")),
+} as const;
+
+export interface DeleteRuleForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   rulesetId: string;
   ruleId: string;
 }
 
-export const DeleteRuleRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
-  ruleId: Schema.String.pipe(T.HttpPath("ruleId")),
-}).pipe(
-  T.Http({
-    method: "DELETE",
-    path: "/{accountOrZone}/{accountOrZoneId}/rulesets/{rulesetId}/rules/{ruleId}",
-  }),
-) as unknown as Schema.Schema<DeleteRuleRequest>;
+export interface DeleteRuleForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  rulesetId: string;
+  ruleId: string;
+}
+
+export type DeleteRuleRequest =
+  | DeleteRuleForAccountRequest
+  | DeleteRuleForZoneRequest;
+
+export const DeleteRuleForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...DeleteRuleBaseFields,
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/accounts/{account_id}/rulesets/{rulesetId}/rules/{ruleId}",
+    }),
+  ) as unknown as Schema.Schema<DeleteRuleForAccountRequest>;
+
+export const DeleteRuleForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...DeleteRuleBaseFields,
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/zones/{zone_id}/rulesets/{rulesetId}/rules/{ruleId}",
+    }),
+  ) as unknown as Schema.Schema<DeleteRuleForZoneRequest>;
 
 export interface DeleteRuleResponse {
   /** The unique ID of the ruleset. */
@@ -23752,33 +24791,79 @@ export const DeleteRuleResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type DeleteRuleError = DefaultErrors;
 
-export const deleteRule: API.OperationMethod<
-  DeleteRuleRequest,
+export const deleteRuleForAccount: API.OperationMethod<
+  DeleteRuleForAccountRequest,
   DeleteRuleResponse,
   DeleteRuleError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: DeleteRuleRequest,
+  input: DeleteRuleForAccountRequest,
   output: DeleteRuleResponse,
   errors: [],
 }));
+
+export const deleteRuleForZone: API.OperationMethod<
+  DeleteRuleForZoneRequest,
+  DeleteRuleResponse,
+  DeleteRuleError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: DeleteRuleForZoneRequest,
+  output: DeleteRuleResponse,
+  errors: [],
+}));
+
+export const deleteRule = (
+  input: DeleteRuleRequest,
+): Effect.Effect<
+  DeleteRuleResponse,
+  DeleteRuleError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input ? deleteRuleForAccount(input) : deleteRuleForZone(input);
 
 // =============================================================================
 // Ruleset
 // =============================================================================
 
-export interface GetRulesetRequest {
+const GetRulesetBaseFields = {
+  rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
+} as const;
+
+export interface GetRulesetForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   rulesetId: string;
 }
 
-export const GetRulesetRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
-}).pipe(
-  T.Http({
-    method: "GET",
-    path: "/{accountOrZone}/{accountOrZoneId}/rulesets/{rulesetId}",
-  }),
-) as unknown as Schema.Schema<GetRulesetRequest>;
+export interface GetRulesetForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  rulesetId: string;
+}
+
+export type GetRulesetRequest =
+  | GetRulesetForAccountRequest
+  | GetRulesetForZoneRequest;
+
+export const GetRulesetForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetRulesetBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/rulesets/{rulesetId}",
+    }),
+  ) as unknown as Schema.Schema<GetRulesetForAccountRequest>;
+
+export const GetRulesetForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...GetRulesetBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/zones/{zone_id}/rulesets/{rulesetId}" }),
+  ) as unknown as Schema.Schema<GetRulesetForZoneRequest>;
 
 export interface GetRulesetResponse {
   /** The unique ID of the ruleset. */
@@ -27254,27 +28339,68 @@ export const GetRulesetResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type GetRulesetError = DefaultErrors;
 
-export const getRuleset: API.OperationMethod<
-  GetRulesetRequest,
+export const getRulesetForAccount: API.OperationMethod<
+  GetRulesetForAccountRequest,
   GetRulesetResponse,
   GetRulesetError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: GetRulesetRequest,
+  input: GetRulesetForAccountRequest,
   output: GetRulesetResponse,
   errors: [],
 }));
 
-export interface ListRulesetsRequest {}
+export const getRulesetForZone: API.OperationMethod<
+  GetRulesetForZoneRequest,
+  GetRulesetResponse,
+  GetRulesetError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetRulesetForZoneRequest,
+  output: GetRulesetResponse,
+  errors: [],
+}));
 
-export const ListRulesetsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {},
-).pipe(
-  T.Http({
-    method: "GET",
-    path: "/{accountOrZone}/{accountOrZoneId}/rulesets",
-  }),
-) as unknown as Schema.Schema<ListRulesetsRequest>;
+export const getRuleset = (
+  input: GetRulesetRequest,
+): Effect.Effect<
+  GetRulesetResponse,
+  GetRulesetError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input ? getRulesetForAccount(input) : getRulesetForZone(input);
+
+const ListRulesetsBaseFields = {} as const;
+
+export interface ListRulesetsForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface ListRulesetsForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+}
+
+export type ListRulesetsRequest =
+  | ListRulesetsForAccountRequest
+  | ListRulesetsForZoneRequest;
+
+export const ListRulesetsForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...ListRulesetsBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/accounts/{account_id}/rulesets" }),
+  ) as unknown as Schema.Schema<ListRulesetsForAccountRequest>;
+
+export const ListRulesetsForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...ListRulesetsBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/zones/{zone_id}/rulesets" }),
+  ) as unknown as Schema.Schema<ListRulesetsForZoneRequest>;
 
 export interface ListRulesetsResponse {
   result: {
@@ -27384,13 +28510,13 @@ export const ListRulesetsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type ListRulesetsError = DefaultErrors;
 
-export const listRulesets: API.PaginatedOperationMethod<
-  ListRulesetsRequest,
+export const listRulesetsForAccount: API.PaginatedOperationMethod<
+  ListRulesetsForAccountRequest,
   ListRulesetsResponse,
   ListRulesetsError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
-  input: ListRulesetsRequest,
+  input: ListRulesetsForAccountRequest,
   output: ListRulesetsResponse,
   errors: [],
   pagination: {
@@ -27402,665 +28528,36 @@ export const listRulesets: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export interface CreateRulesetRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
-  /** Body param: The kind of the ruleset. */
-  kind: "managed" | "custom" | "root" | "zone";
-  /** Body param: The human-readable name of the ruleset. */
-  name: string;
-  /** Body param: The phase of the ruleset. */
-  phase:
-    | "ddos_l4"
-    | "ddos_l7"
-    | "http_config_settings"
-    | "http_custom_errors"
-    | "http_log_custom_fields"
-    | "http_ratelimit"
-    | "http_request_cache_settings"
-    | "http_request_dynamic_redirect"
-    | "http_request_firewall_custom"
-    | "http_request_firewall_managed"
-    | "http_request_late_transform"
-    | "http_request_origin"
-    | "http_request_redirect"
-    | "http_request_sanitize"
-    | "http_request_sbfm"
-    | "http_request_transform"
-    | "http_response_compression"
-    | "http_response_firewall_managed"
-    | "http_response_headers_transform"
-    | "magic_transit"
-    | "magic_transit_ids_managed"
-    | "magic_transit_managed"
-    | "magic_transit_ratelimit";
-  /** Body param: An informative description of the ruleset. */
-  description?: string;
-  /** Body param: The list of rules in the ruleset. */
-  rules?: (
-    | {
-        id?: string;
-        action?: "block";
-        actionParameters?: {
-          response?: {
-            content: string;
-            contentType: string;
-            statusCode: number;
-          };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "challenge";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "compress_response";
-        actionParameters?: {
-          algorithms: {
-            name?: "none" | "auto" | "default" | "gzip" | "brotli" | "zstd";
-          }[];
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "ddos_dynamic";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "execute";
-        actionParameters?: {
-          id: string;
-          matchedData?: { publicKey: string };
-          overrides?: {
-            action?: string;
-            categories?: {
-              category: string;
-              action?: string;
-              enabled?: boolean;
-              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
-            }[];
-            enabled?: boolean;
-            rules?: {
-              id: string;
-              action?: string;
-              enabled?: boolean;
-              scoreThreshold?: number;
-              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
-            }[];
-            sensitivityLevel?: "default" | "medium" | "low" | "eoff";
-          };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "force_connection_close";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "js_challenge";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "log";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "log_custom_field";
-        actionParameters?: {
-          cookieFields?: { name: string }[];
-          rawResponseFields?: { name: string; preserveDuplicates?: boolean }[];
-          requestFields?: { name: string }[];
-          responseFields?: { name: string; preserveDuplicates?: boolean }[];
-          transformedRequestFields?: { name: string }[];
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "managed_challenge";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "redirect";
-        actionParameters?: {
-          fromList?: { key: string; name: string };
-          fromValue?: {
-            targetUrl: { expression?: string; value?: string };
-            preserveQueryString?: boolean;
-            statusCode?: "301" | "302" | "303" | "307" | "308";
-          };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "rewrite";
-        actionParameters?: {
-          headers?: Record<string, unknown>;
-          uri?:
-            | { path: { expression?: string; value?: string } }
-            | { query: { expression?: string; value?: string } };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "route";
-        actionParameters?: {
-          hostHeader?: string;
-          origin?: { host?: string; port?: number };
-          sni?: { value: string };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "score";
-        actionParameters?: { increment: number };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "serve_error";
-        actionParameters?:
-          | {
-              content: string;
-              contentType?:
-                | "application/json"
-                | "text/html"
-                | "text/plain"
-                | "text/xml";
-              statusCode?: number;
-            }
-          | {
-              assetName: string;
-              contentType?:
-                | "application/json"
-                | "text/html"
-                | "text/plain"
-                | "text/xml";
-              statusCode?: number;
-            };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "set_cache_settings";
-        actionParameters?: {
-          additionalCacheablePorts?: number[];
-          browserTtl?: {
-            mode:
-              | "respect_origin"
-              | "bypass_by_default"
-              | "override_origin"
-              | "bypass";
-            default?: number;
-          };
-          cache?: boolean;
-          cacheKey?: {
-            cacheByDeviceType?: boolean;
-            cacheDeceptionArmor?: boolean;
-            customKey?: {
-              cookie?: { checkPresence?: string[]; include?: string[] };
-              header?: {
-                checkPresence?: string[];
-                contains?: Record<string, unknown>;
-                excludeOrigin?: boolean;
-                include?: string[];
-              };
-              host?: { resolved?: boolean };
-              queryString?: {
-                exclude?: { all?: true; list?: string[] };
-                include?: { all?: true; list?: string[] };
-              };
-              user?: { deviceType?: boolean; geo?: boolean; lang?: boolean };
-            };
-            ignoreQueryStringsOrder?: boolean;
-          };
-          cacheReserve?: { eligible: boolean; minimumFileSize?: number };
-          edgeTtl?: {
-            mode: "respect_origin" | "bypass_by_default" | "override_origin";
-            default?: number;
-            statusCodeTtl?: {
-              value: number;
-              statusCode?: number;
-              statusCodeRange?: { from?: number; to?: number };
-            }[];
-          };
-          originCacheControl?: boolean;
-          originErrorPagePassthru?: boolean;
-          readTimeout?: number;
-          respectStrongEtags?: boolean;
-          serveStale?: { disableStaleWhileUpdating?: boolean };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "set_config";
-        actionParameters?: {
-          automaticHttpsRewrites?: boolean;
-          autominify?: { css?: boolean; html?: boolean; js?: boolean };
-          bic?: boolean;
-          disableApps?: true;
-          disablePayPerCrawl?: true;
-          disableRum?: true;
-          disableZaraz?: true;
-          emailObfuscation?: boolean;
-          fonts?: boolean;
-          hotlinkProtection?: boolean;
-          mirage?: boolean;
-          opportunisticEncryption?: boolean;
-          polish?: "off" | "lossless" | "lossy" | "webp";
-          requestBodyBuffering?: "none" | "standard" | "full";
-          responseBodyBuffering?: "none" | "standard";
-          rocketLoader?: boolean;
-          securityLevel?:
-            | "off"
-            | "essentially_off"
-            | "low"
-            | "medium"
-            | "high"
-            | "under_attack";
-          serverSideExcludes?: boolean;
-          ssl?: "off" | "flexible" | "full" | "strict" | "origin_pull";
-          sxg?: boolean;
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "skip";
-        actionParameters?: {
-          phase?: "current";
-          phases?: (
-            | "ddos_l4"
-            | "ddos_l7"
-            | "http_config_settings"
-            | "http_custom_errors"
-            | "http_log_custom_fields"
-            | "http_ratelimit"
-            | "http_request_cache_settings"
-            | "http_request_dynamic_redirect"
-            | "http_request_firewall_custom"
-            | "http_request_firewall_managed"
-            | "http_request_late_transform"
-            | "http_request_origin"
-            | "http_request_redirect"
-            | "http_request_sanitize"
-            | "http_request_sbfm"
-            | "http_request_transform"
-            | "http_response_compression"
-            | "http_response_firewall_managed"
-            | "http_response_headers_transform"
-            | "magic_transit"
-            | "magic_transit_ids_managed"
-            | "magic_transit_managed"
-            | "magic_transit_ratelimit"
-          )[];
-          products?: (
-            | "bic"
-            | "hot"
-            | "rateLimit"
-            | "securityLevel"
-            | "uaBlock"
-            | "waf"
-            | "zoneLockdown"
-          )[];
-          rules?: Record<string, unknown>;
-          ruleset?: "current";
-          rulesets?: string[];
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-  )[];
-}
+export const listRulesetsForZone: API.PaginatedOperationMethod<
+  ListRulesetsForZoneRequest,
+  ListRulesetsResponse,
+  ListRulesetsError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+  input: ListRulesetsForZoneRequest,
+  output: ListRulesetsResponse,
+  errors: [],
+  pagination: {
+    mode: "cursor",
+    inputToken: "cursor",
+    outputToken: "resultInfo.cursor",
+    items: "result",
+    pageSize: "perPage",
+  } as const,
+}));
 
-export const CreateRulesetRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+export const listRulesets = (
+  input: ListRulesetsRequest,
+): stream.Stream<
+  ListRulesetsResponse,
+  ListRulesetsError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? listRulesetsForAccount.pages(input)
+    : listRulesetsForZone.pages(input);
+
+const CreateRulesetBaseFields = {
   kind: Schema.Literals(["managed", "custom", "root", "zone"]),
   name: Schema.String,
   phase: Schema.Literals([
@@ -29788,12 +30285,1335 @@ export const CreateRulesetRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       ]),
     ),
   ),
-}).pipe(
-  T.Http({
-    method: "POST",
-    path: "/{accountOrZone}/{accountOrZoneId}/rulesets",
-  }),
-) as unknown as Schema.Schema<CreateRulesetRequest>;
+} as const;
+
+export interface CreateRulesetForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  /** Body param: The kind of the ruleset. */
+  kind: "managed" | "custom" | "root" | "zone";
+  /** Body param: The human-readable name of the ruleset. */
+  name: string;
+  /** Body param: The phase of the ruleset. */
+  phase:
+    | "ddos_l4"
+    | "ddos_l7"
+    | "http_config_settings"
+    | "http_custom_errors"
+    | "http_log_custom_fields"
+    | "http_ratelimit"
+    | "http_request_cache_settings"
+    | "http_request_dynamic_redirect"
+    | "http_request_firewall_custom"
+    | "http_request_firewall_managed"
+    | "http_request_late_transform"
+    | "http_request_origin"
+    | "http_request_redirect"
+    | "http_request_sanitize"
+    | "http_request_sbfm"
+    | "http_request_transform"
+    | "http_response_compression"
+    | "http_response_firewall_managed"
+    | "http_response_headers_transform"
+    | "magic_transit"
+    | "magic_transit_ids_managed"
+    | "magic_transit_managed"
+    | "magic_transit_ratelimit";
+  /** Body param: An informative description of the ruleset. */
+  description?: string;
+  /** Body param: The list of rules in the ruleset. */
+  rules?: (
+    | {
+        id?: string;
+        action?: "block";
+        actionParameters?: {
+          response?: {
+            content: string;
+            contentType: string;
+            statusCode: number;
+          };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "challenge";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "compress_response";
+        actionParameters?: {
+          algorithms: {
+            name?: "none" | "auto" | "default" | "gzip" | "brotli" | "zstd";
+          }[];
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "ddos_dynamic";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "execute";
+        actionParameters?: {
+          id: string;
+          matchedData?: { publicKey: string };
+          overrides?: {
+            action?: string;
+            categories?: {
+              category: string;
+              action?: string;
+              enabled?: boolean;
+              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
+            }[];
+            enabled?: boolean;
+            rules?: {
+              id: string;
+              action?: string;
+              enabled?: boolean;
+              scoreThreshold?: number;
+              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
+            }[];
+            sensitivityLevel?: "default" | "medium" | "low" | "eoff";
+          };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "force_connection_close";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "js_challenge";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "log";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "log_custom_field";
+        actionParameters?: {
+          cookieFields?: { name: string }[];
+          rawResponseFields?: { name: string; preserveDuplicates?: boolean }[];
+          requestFields?: { name: string }[];
+          responseFields?: { name: string; preserveDuplicates?: boolean }[];
+          transformedRequestFields?: { name: string }[];
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "managed_challenge";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "redirect";
+        actionParameters?: {
+          fromList?: { key: string; name: string };
+          fromValue?: {
+            targetUrl: { expression?: string; value?: string };
+            preserveQueryString?: boolean;
+            statusCode?: "301" | "302" | "303" | "307" | "308";
+          };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "rewrite";
+        actionParameters?: {
+          headers?: Record<string, unknown>;
+          uri?:
+            | { path: { expression?: string; value?: string } }
+            | { query: { expression?: string; value?: string } };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "route";
+        actionParameters?: {
+          hostHeader?: string;
+          origin?: { host?: string; port?: number };
+          sni?: { value: string };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "score";
+        actionParameters?: { increment: number };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "serve_error";
+        actionParameters?:
+          | {
+              content: string;
+              contentType?:
+                | "application/json"
+                | "text/html"
+                | "text/plain"
+                | "text/xml";
+              statusCode?: number;
+            }
+          | {
+              assetName: string;
+              contentType?:
+                | "application/json"
+                | "text/html"
+                | "text/plain"
+                | "text/xml";
+              statusCode?: number;
+            };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "set_cache_settings";
+        actionParameters?: {
+          additionalCacheablePorts?: number[];
+          browserTtl?: {
+            mode:
+              | "respect_origin"
+              | "bypass_by_default"
+              | "override_origin"
+              | "bypass";
+            default?: number;
+          };
+          cache?: boolean;
+          cacheKey?: {
+            cacheByDeviceType?: boolean;
+            cacheDeceptionArmor?: boolean;
+            customKey?: {
+              cookie?: { checkPresence?: string[]; include?: string[] };
+              header?: {
+                checkPresence?: string[];
+                contains?: Record<string, unknown>;
+                excludeOrigin?: boolean;
+                include?: string[];
+              };
+              host?: { resolved?: boolean };
+              queryString?: {
+                exclude?: { all?: true; list?: string[] };
+                include?: { all?: true; list?: string[] };
+              };
+              user?: { deviceType?: boolean; geo?: boolean; lang?: boolean };
+            };
+            ignoreQueryStringsOrder?: boolean;
+          };
+          cacheReserve?: { eligible: boolean; minimumFileSize?: number };
+          edgeTtl?: {
+            mode: "respect_origin" | "bypass_by_default" | "override_origin";
+            default?: number;
+            statusCodeTtl?: {
+              value: number;
+              statusCode?: number;
+              statusCodeRange?: { from?: number; to?: number };
+            }[];
+          };
+          originCacheControl?: boolean;
+          originErrorPagePassthru?: boolean;
+          readTimeout?: number;
+          respectStrongEtags?: boolean;
+          serveStale?: { disableStaleWhileUpdating?: boolean };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "set_config";
+        actionParameters?: {
+          automaticHttpsRewrites?: boolean;
+          autominify?: { css?: boolean; html?: boolean; js?: boolean };
+          bic?: boolean;
+          disableApps?: true;
+          disablePayPerCrawl?: true;
+          disableRum?: true;
+          disableZaraz?: true;
+          emailObfuscation?: boolean;
+          fonts?: boolean;
+          hotlinkProtection?: boolean;
+          mirage?: boolean;
+          opportunisticEncryption?: boolean;
+          polish?: "off" | "lossless" | "lossy" | "webp";
+          requestBodyBuffering?: "none" | "standard" | "full";
+          responseBodyBuffering?: "none" | "standard";
+          rocketLoader?: boolean;
+          securityLevel?:
+            | "off"
+            | "essentially_off"
+            | "low"
+            | "medium"
+            | "high"
+            | "under_attack";
+          serverSideExcludes?: boolean;
+          ssl?: "off" | "flexible" | "full" | "strict" | "origin_pull";
+          sxg?: boolean;
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "skip";
+        actionParameters?: {
+          phase?: "current";
+          phases?: (
+            | "ddos_l4"
+            | "ddos_l7"
+            | "http_config_settings"
+            | "http_custom_errors"
+            | "http_log_custom_fields"
+            | "http_ratelimit"
+            | "http_request_cache_settings"
+            | "http_request_dynamic_redirect"
+            | "http_request_firewall_custom"
+            | "http_request_firewall_managed"
+            | "http_request_late_transform"
+            | "http_request_origin"
+            | "http_request_redirect"
+            | "http_request_sanitize"
+            | "http_request_sbfm"
+            | "http_request_transform"
+            | "http_response_compression"
+            | "http_response_firewall_managed"
+            | "http_response_headers_transform"
+            | "magic_transit"
+            | "magic_transit_ids_managed"
+            | "magic_transit_managed"
+            | "magic_transit_ratelimit"
+          )[];
+          products?: (
+            | "bic"
+            | "hot"
+            | "rateLimit"
+            | "securityLevel"
+            | "uaBlock"
+            | "waf"
+            | "zoneLockdown"
+          )[];
+          rules?: Record<string, unknown>;
+          ruleset?: "current";
+          rulesets?: string[];
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+  )[];
+}
+
+export interface CreateRulesetForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  /** Body param: The kind of the ruleset. */
+  kind: "managed" | "custom" | "root" | "zone";
+  /** Body param: The human-readable name of the ruleset. */
+  name: string;
+  /** Body param: The phase of the ruleset. */
+  phase:
+    | "ddos_l4"
+    | "ddos_l7"
+    | "http_config_settings"
+    | "http_custom_errors"
+    | "http_log_custom_fields"
+    | "http_ratelimit"
+    | "http_request_cache_settings"
+    | "http_request_dynamic_redirect"
+    | "http_request_firewall_custom"
+    | "http_request_firewall_managed"
+    | "http_request_late_transform"
+    | "http_request_origin"
+    | "http_request_redirect"
+    | "http_request_sanitize"
+    | "http_request_sbfm"
+    | "http_request_transform"
+    | "http_response_compression"
+    | "http_response_firewall_managed"
+    | "http_response_headers_transform"
+    | "magic_transit"
+    | "magic_transit_ids_managed"
+    | "magic_transit_managed"
+    | "magic_transit_ratelimit";
+  /** Body param: An informative description of the ruleset. */
+  description?: string;
+  /** Body param: The list of rules in the ruleset. */
+  rules?: (
+    | {
+        id?: string;
+        action?: "block";
+        actionParameters?: {
+          response?: {
+            content: string;
+            contentType: string;
+            statusCode: number;
+          };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "challenge";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "compress_response";
+        actionParameters?: {
+          algorithms: {
+            name?: "none" | "auto" | "default" | "gzip" | "brotli" | "zstd";
+          }[];
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "ddos_dynamic";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "execute";
+        actionParameters?: {
+          id: string;
+          matchedData?: { publicKey: string };
+          overrides?: {
+            action?: string;
+            categories?: {
+              category: string;
+              action?: string;
+              enabled?: boolean;
+              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
+            }[];
+            enabled?: boolean;
+            rules?: {
+              id: string;
+              action?: string;
+              enabled?: boolean;
+              scoreThreshold?: number;
+              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
+            }[];
+            sensitivityLevel?: "default" | "medium" | "low" | "eoff";
+          };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "force_connection_close";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "js_challenge";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "log";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "log_custom_field";
+        actionParameters?: {
+          cookieFields?: { name: string }[];
+          rawResponseFields?: { name: string; preserveDuplicates?: boolean }[];
+          requestFields?: { name: string }[];
+          responseFields?: { name: string; preserveDuplicates?: boolean }[];
+          transformedRequestFields?: { name: string }[];
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "managed_challenge";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "redirect";
+        actionParameters?: {
+          fromList?: { key: string; name: string };
+          fromValue?: {
+            targetUrl: { expression?: string; value?: string };
+            preserveQueryString?: boolean;
+            statusCode?: "301" | "302" | "303" | "307" | "308";
+          };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "rewrite";
+        actionParameters?: {
+          headers?: Record<string, unknown>;
+          uri?:
+            | { path: { expression?: string; value?: string } }
+            | { query: { expression?: string; value?: string } };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "route";
+        actionParameters?: {
+          hostHeader?: string;
+          origin?: { host?: string; port?: number };
+          sni?: { value: string };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "score";
+        actionParameters?: { increment: number };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "serve_error";
+        actionParameters?:
+          | {
+              content: string;
+              contentType?:
+                | "application/json"
+                | "text/html"
+                | "text/plain"
+                | "text/xml";
+              statusCode?: number;
+            }
+          | {
+              assetName: string;
+              contentType?:
+                | "application/json"
+                | "text/html"
+                | "text/plain"
+                | "text/xml";
+              statusCode?: number;
+            };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "set_cache_settings";
+        actionParameters?: {
+          additionalCacheablePorts?: number[];
+          browserTtl?: {
+            mode:
+              | "respect_origin"
+              | "bypass_by_default"
+              | "override_origin"
+              | "bypass";
+            default?: number;
+          };
+          cache?: boolean;
+          cacheKey?: {
+            cacheByDeviceType?: boolean;
+            cacheDeceptionArmor?: boolean;
+            customKey?: {
+              cookie?: { checkPresence?: string[]; include?: string[] };
+              header?: {
+                checkPresence?: string[];
+                contains?: Record<string, unknown>;
+                excludeOrigin?: boolean;
+                include?: string[];
+              };
+              host?: { resolved?: boolean };
+              queryString?: {
+                exclude?: { all?: true; list?: string[] };
+                include?: { all?: true; list?: string[] };
+              };
+              user?: { deviceType?: boolean; geo?: boolean; lang?: boolean };
+            };
+            ignoreQueryStringsOrder?: boolean;
+          };
+          cacheReserve?: { eligible: boolean; minimumFileSize?: number };
+          edgeTtl?: {
+            mode: "respect_origin" | "bypass_by_default" | "override_origin";
+            default?: number;
+            statusCodeTtl?: {
+              value: number;
+              statusCode?: number;
+              statusCodeRange?: { from?: number; to?: number };
+            }[];
+          };
+          originCacheControl?: boolean;
+          originErrorPagePassthru?: boolean;
+          readTimeout?: number;
+          respectStrongEtags?: boolean;
+          serveStale?: { disableStaleWhileUpdating?: boolean };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "set_config";
+        actionParameters?: {
+          automaticHttpsRewrites?: boolean;
+          autominify?: { css?: boolean; html?: boolean; js?: boolean };
+          bic?: boolean;
+          disableApps?: true;
+          disablePayPerCrawl?: true;
+          disableRum?: true;
+          disableZaraz?: true;
+          emailObfuscation?: boolean;
+          fonts?: boolean;
+          hotlinkProtection?: boolean;
+          mirage?: boolean;
+          opportunisticEncryption?: boolean;
+          polish?: "off" | "lossless" | "lossy" | "webp";
+          requestBodyBuffering?: "none" | "standard" | "full";
+          responseBodyBuffering?: "none" | "standard";
+          rocketLoader?: boolean;
+          securityLevel?:
+            | "off"
+            | "essentially_off"
+            | "low"
+            | "medium"
+            | "high"
+            | "under_attack";
+          serverSideExcludes?: boolean;
+          ssl?: "off" | "flexible" | "full" | "strict" | "origin_pull";
+          sxg?: boolean;
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "skip";
+        actionParameters?: {
+          phase?: "current";
+          phases?: (
+            | "ddos_l4"
+            | "ddos_l7"
+            | "http_config_settings"
+            | "http_custom_errors"
+            | "http_log_custom_fields"
+            | "http_ratelimit"
+            | "http_request_cache_settings"
+            | "http_request_dynamic_redirect"
+            | "http_request_firewall_custom"
+            | "http_request_firewall_managed"
+            | "http_request_late_transform"
+            | "http_request_origin"
+            | "http_request_redirect"
+            | "http_request_sanitize"
+            | "http_request_sbfm"
+            | "http_request_transform"
+            | "http_response_compression"
+            | "http_response_firewall_managed"
+            | "http_response_headers_transform"
+            | "magic_transit"
+            | "magic_transit_ids_managed"
+            | "magic_transit_managed"
+            | "magic_transit_ratelimit"
+          )[];
+          products?: (
+            | "bic"
+            | "hot"
+            | "rateLimit"
+            | "securityLevel"
+            | "uaBlock"
+            | "waf"
+            | "zoneLockdown"
+          )[];
+          rules?: Record<string, unknown>;
+          ruleset?: "current";
+          rulesets?: string[];
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+  )[];
+}
+
+export type CreateRulesetRequest =
+  | CreateRulesetForAccountRequest
+  | CreateRulesetForZoneRequest;
+
+export const CreateRulesetForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...CreateRulesetBaseFields,
+  }).pipe(
+    T.Http({ method: "POST", path: "/accounts/{account_id}/rulesets" }),
+  ) as unknown as Schema.Schema<CreateRulesetForAccountRequest>;
+
+export const CreateRulesetForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...CreateRulesetBaseFields,
+  }).pipe(
+    T.Http({ method: "POST", path: "/zones/{zone_id}/rulesets" }),
+  ) as unknown as Schema.Schema<CreateRulesetForZoneRequest>;
 
 export interface CreateRulesetResponse {
   /** The unique ID of the ruleset. */
@@ -33269,678 +35089,41 @@ export const CreateRulesetResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type CreateRulesetError = DefaultErrors;
 
-export const createRuleset: API.OperationMethod<
-  CreateRulesetRequest,
+export const createRulesetForAccount: API.OperationMethod<
+  CreateRulesetForAccountRequest,
   CreateRulesetResponse,
   CreateRulesetError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: CreateRulesetRequest,
+  input: CreateRulesetForAccountRequest,
   output: CreateRulesetResponse,
   errors: [],
 }));
 
-export interface UpdateRulesetRequest {
-  rulesetId: string;
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
-  /** Body param: An informative description of the ruleset. */
-  description?: string;
-  /** Body param: The kind of the ruleset. */
-  kind?: "managed" | "custom" | "root" | "zone";
-  /** Body param: The human-readable name of the ruleset. */
-  name?: string;
-  /** Body param: The phase of the ruleset. */
-  phase?:
-    | "ddos_l4"
-    | "ddos_l7"
-    | "http_config_settings"
-    | "http_custom_errors"
-    | "http_log_custom_fields"
-    | "http_ratelimit"
-    | "http_request_cache_settings"
-    | "http_request_dynamic_redirect"
-    | "http_request_firewall_custom"
-    | "http_request_firewall_managed"
-    | "http_request_late_transform"
-    | "http_request_origin"
-    | "http_request_redirect"
-    | "http_request_sanitize"
-    | "http_request_sbfm"
-    | "http_request_transform"
-    | "http_response_compression"
-    | "http_response_firewall_managed"
-    | "http_response_headers_transform"
-    | "magic_transit"
-    | "magic_transit_ids_managed"
-    | "magic_transit_managed"
-    | "magic_transit_ratelimit";
-  /** Body param: The list of rules in the ruleset. */
-  rules?: (
-    | {
-        id?: string;
-        action?: "block";
-        actionParameters?: {
-          response?: {
-            content: string;
-            contentType: string;
-            statusCode: number;
-          };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "challenge";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "compress_response";
-        actionParameters?: {
-          algorithms: {
-            name?: "none" | "auto" | "default" | "gzip" | "brotli" | "zstd";
-          }[];
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "ddos_dynamic";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "execute";
-        actionParameters?: {
-          id: string;
-          matchedData?: { publicKey: string };
-          overrides?: {
-            action?: string;
-            categories?: {
-              category: string;
-              action?: string;
-              enabled?: boolean;
-              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
-            }[];
-            enabled?: boolean;
-            rules?: {
-              id: string;
-              action?: string;
-              enabled?: boolean;
-              scoreThreshold?: number;
-              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
-            }[];
-            sensitivityLevel?: "default" | "medium" | "low" | "eoff";
-          };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "force_connection_close";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "js_challenge";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "log";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "log_custom_field";
-        actionParameters?: {
-          cookieFields?: { name: string }[];
-          rawResponseFields?: { name: string; preserveDuplicates?: boolean }[];
-          requestFields?: { name: string }[];
-          responseFields?: { name: string; preserveDuplicates?: boolean }[];
-          transformedRequestFields?: { name: string }[];
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "managed_challenge";
-        actionParameters?: unknown;
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "redirect";
-        actionParameters?: {
-          fromList?: { key: string; name: string };
-          fromValue?: {
-            targetUrl: { expression?: string; value?: string };
-            preserveQueryString?: boolean;
-            statusCode?: "301" | "302" | "303" | "307" | "308";
-          };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "rewrite";
-        actionParameters?: {
-          headers?: Record<string, unknown>;
-          uri?:
-            | { path: { expression?: string; value?: string } }
-            | { query: { expression?: string; value?: string } };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "route";
-        actionParameters?: {
-          hostHeader?: string;
-          origin?: { host?: string; port?: number };
-          sni?: { value: string };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "score";
-        actionParameters?: { increment: number };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "serve_error";
-        actionParameters?:
-          | {
-              content: string;
-              contentType?:
-                | "application/json"
-                | "text/html"
-                | "text/plain"
-                | "text/xml";
-              statusCode?: number;
-            }
-          | {
-              assetName: string;
-              contentType?:
-                | "application/json"
-                | "text/html"
-                | "text/plain"
-                | "text/xml";
-              statusCode?: number;
-            };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "set_cache_settings";
-        actionParameters?: {
-          additionalCacheablePorts?: number[];
-          browserTtl?: {
-            mode:
-              | "respect_origin"
-              | "bypass_by_default"
-              | "override_origin"
-              | "bypass";
-            default?: number;
-          };
-          cache?: boolean;
-          cacheKey?: {
-            cacheByDeviceType?: boolean;
-            cacheDeceptionArmor?: boolean;
-            customKey?: {
-              cookie?: { checkPresence?: string[]; include?: string[] };
-              header?: {
-                checkPresence?: string[];
-                contains?: Record<string, unknown>;
-                excludeOrigin?: boolean;
-                include?: string[];
-              };
-              host?: { resolved?: boolean };
-              queryString?: {
-                exclude?: { all?: true; list?: string[] };
-                include?: { all?: true; list?: string[] };
-              };
-              user?: { deviceType?: boolean; geo?: boolean; lang?: boolean };
-            };
-            ignoreQueryStringsOrder?: boolean;
-          };
-          cacheReserve?: { eligible: boolean; minimumFileSize?: number };
-          edgeTtl?: {
-            mode: "respect_origin" | "bypass_by_default" | "override_origin";
-            default?: number;
-            statusCodeTtl?: {
-              value: number;
-              statusCode?: number;
-              statusCodeRange?: { from?: number; to?: number };
-            }[];
-          };
-          originCacheControl?: boolean;
-          originErrorPagePassthru?: boolean;
-          readTimeout?: number;
-          respectStrongEtags?: boolean;
-          serveStale?: { disableStaleWhileUpdating?: boolean };
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "set_config";
-        actionParameters?: {
-          automaticHttpsRewrites?: boolean;
-          autominify?: { css?: boolean; html?: boolean; js?: boolean };
-          bic?: boolean;
-          disableApps?: true;
-          disablePayPerCrawl?: true;
-          disableRum?: true;
-          disableZaraz?: true;
-          emailObfuscation?: boolean;
-          fonts?: boolean;
-          hotlinkProtection?: boolean;
-          mirage?: boolean;
-          opportunisticEncryption?: boolean;
-          polish?: "off" | "lossless" | "lossy" | "webp";
-          requestBodyBuffering?: "none" | "standard" | "full";
-          responseBodyBuffering?: "none" | "standard";
-          rocketLoader?: boolean;
-          securityLevel?:
-            | "off"
-            | "essentially_off"
-            | "low"
-            | "medium"
-            | "high"
-            | "under_attack";
-          serverSideExcludes?: boolean;
-          ssl?: "off" | "flexible" | "full" | "strict" | "origin_pull";
-          sxg?: boolean;
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-    | {
-        id?: string;
-        action?: "skip";
-        actionParameters?: {
-          phase?: "current";
-          phases?: (
-            | "ddos_l4"
-            | "ddos_l7"
-            | "http_config_settings"
-            | "http_custom_errors"
-            | "http_log_custom_fields"
-            | "http_ratelimit"
-            | "http_request_cache_settings"
-            | "http_request_dynamic_redirect"
-            | "http_request_firewall_custom"
-            | "http_request_firewall_managed"
-            | "http_request_late_transform"
-            | "http_request_origin"
-            | "http_request_redirect"
-            | "http_request_sanitize"
-            | "http_request_sbfm"
-            | "http_request_transform"
-            | "http_response_compression"
-            | "http_response_firewall_managed"
-            | "http_response_headers_transform"
-            | "magic_transit"
-            | "magic_transit_ids_managed"
-            | "magic_transit_managed"
-            | "magic_transit_ratelimit"
-          )[];
-          products?: (
-            | "bic"
-            | "hot"
-            | "rateLimit"
-            | "securityLevel"
-            | "uaBlock"
-            | "waf"
-            | "zoneLockdown"
-          )[];
-          rules?: Record<string, unknown>;
-          ruleset?: "current";
-          rulesets?: string[];
-        };
-        description?: string;
-        enabled?: boolean;
-        exposedCredentialCheck?: {
-          passwordExpression: string;
-          usernameExpression: string;
-        };
-        expression?: string;
-        logging?: { enabled: boolean };
-        ratelimit?: {
-          characteristics: string[];
-          period: number;
-          countingExpression?: string;
-          mitigationTimeout?: number;
-          requestsPerPeriod?: number;
-          requestsToOrigin?: boolean;
-          scorePerPeriod?: number;
-          scoreResponseHeaderName?: string;
-        };
-        ref?: string;
-      }
-  )[];
-}
+export const createRulesetForZone: API.OperationMethod<
+  CreateRulesetForZoneRequest,
+  CreateRulesetResponse,
+  CreateRulesetError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: CreateRulesetForZoneRequest,
+  output: CreateRulesetResponse,
+  errors: [],
+}));
 
-export const UpdateRulesetRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+export const createRuleset = (
+  input: CreateRulesetRequest,
+): Effect.Effect<
+  CreateRulesetResponse,
+  CreateRulesetError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? createRulesetForAccount(input)
+    : createRulesetForZone(input);
+
+const UpdateRulesetBaseFields = {
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
   description: Schema.optional(Schema.String),
   kind: Schema.optional(Schema.Literals(["managed", "custom", "root", "zone"])),
   name: Schema.optional(Schema.String),
@@ -35670,12 +36853,1340 @@ export const UpdateRulesetRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       ]),
     ),
   ),
-}).pipe(
-  T.Http({
-    method: "PUT",
-    path: "/{accountOrZone}/{accountOrZoneId}/rulesets/{rulesetId}",
-  }),
-) as unknown as Schema.Schema<UpdateRulesetRequest>;
+} as const;
+
+export interface UpdateRulesetForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  rulesetId: string;
+  /** Body param: An informative description of the ruleset. */
+  description?: string;
+  /** Body param: The kind of the ruleset. */
+  kind?: "managed" | "custom" | "root" | "zone";
+  /** Body param: The human-readable name of the ruleset. */
+  name?: string;
+  /** Body param: The phase of the ruleset. */
+  phase?:
+    | "ddos_l4"
+    | "ddos_l7"
+    | "http_config_settings"
+    | "http_custom_errors"
+    | "http_log_custom_fields"
+    | "http_ratelimit"
+    | "http_request_cache_settings"
+    | "http_request_dynamic_redirect"
+    | "http_request_firewall_custom"
+    | "http_request_firewall_managed"
+    | "http_request_late_transform"
+    | "http_request_origin"
+    | "http_request_redirect"
+    | "http_request_sanitize"
+    | "http_request_sbfm"
+    | "http_request_transform"
+    | "http_response_compression"
+    | "http_response_firewall_managed"
+    | "http_response_headers_transform"
+    | "magic_transit"
+    | "magic_transit_ids_managed"
+    | "magic_transit_managed"
+    | "magic_transit_ratelimit";
+  /** Body param: The list of rules in the ruleset. */
+  rules?: (
+    | {
+        id?: string;
+        action?: "block";
+        actionParameters?: {
+          response?: {
+            content: string;
+            contentType: string;
+            statusCode: number;
+          };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "challenge";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "compress_response";
+        actionParameters?: {
+          algorithms: {
+            name?: "none" | "auto" | "default" | "gzip" | "brotli" | "zstd";
+          }[];
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "ddos_dynamic";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "execute";
+        actionParameters?: {
+          id: string;
+          matchedData?: { publicKey: string };
+          overrides?: {
+            action?: string;
+            categories?: {
+              category: string;
+              action?: string;
+              enabled?: boolean;
+              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
+            }[];
+            enabled?: boolean;
+            rules?: {
+              id: string;
+              action?: string;
+              enabled?: boolean;
+              scoreThreshold?: number;
+              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
+            }[];
+            sensitivityLevel?: "default" | "medium" | "low" | "eoff";
+          };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "force_connection_close";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "js_challenge";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "log";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "log_custom_field";
+        actionParameters?: {
+          cookieFields?: { name: string }[];
+          rawResponseFields?: { name: string; preserveDuplicates?: boolean }[];
+          requestFields?: { name: string }[];
+          responseFields?: { name: string; preserveDuplicates?: boolean }[];
+          transformedRequestFields?: { name: string }[];
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "managed_challenge";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "redirect";
+        actionParameters?: {
+          fromList?: { key: string; name: string };
+          fromValue?: {
+            targetUrl: { expression?: string; value?: string };
+            preserveQueryString?: boolean;
+            statusCode?: "301" | "302" | "303" | "307" | "308";
+          };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "rewrite";
+        actionParameters?: {
+          headers?: Record<string, unknown>;
+          uri?:
+            | { path: { expression?: string; value?: string } }
+            | { query: { expression?: string; value?: string } };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "route";
+        actionParameters?: {
+          hostHeader?: string;
+          origin?: { host?: string; port?: number };
+          sni?: { value: string };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "score";
+        actionParameters?: { increment: number };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "serve_error";
+        actionParameters?:
+          | {
+              content: string;
+              contentType?:
+                | "application/json"
+                | "text/html"
+                | "text/plain"
+                | "text/xml";
+              statusCode?: number;
+            }
+          | {
+              assetName: string;
+              contentType?:
+                | "application/json"
+                | "text/html"
+                | "text/plain"
+                | "text/xml";
+              statusCode?: number;
+            };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "set_cache_settings";
+        actionParameters?: {
+          additionalCacheablePorts?: number[];
+          browserTtl?: {
+            mode:
+              | "respect_origin"
+              | "bypass_by_default"
+              | "override_origin"
+              | "bypass";
+            default?: number;
+          };
+          cache?: boolean;
+          cacheKey?: {
+            cacheByDeviceType?: boolean;
+            cacheDeceptionArmor?: boolean;
+            customKey?: {
+              cookie?: { checkPresence?: string[]; include?: string[] };
+              header?: {
+                checkPresence?: string[];
+                contains?: Record<string, unknown>;
+                excludeOrigin?: boolean;
+                include?: string[];
+              };
+              host?: { resolved?: boolean };
+              queryString?: {
+                exclude?: { all?: true; list?: string[] };
+                include?: { all?: true; list?: string[] };
+              };
+              user?: { deviceType?: boolean; geo?: boolean; lang?: boolean };
+            };
+            ignoreQueryStringsOrder?: boolean;
+          };
+          cacheReserve?: { eligible: boolean; minimumFileSize?: number };
+          edgeTtl?: {
+            mode: "respect_origin" | "bypass_by_default" | "override_origin";
+            default?: number;
+            statusCodeTtl?: {
+              value: number;
+              statusCode?: number;
+              statusCodeRange?: { from?: number; to?: number };
+            }[];
+          };
+          originCacheControl?: boolean;
+          originErrorPagePassthru?: boolean;
+          readTimeout?: number;
+          respectStrongEtags?: boolean;
+          serveStale?: { disableStaleWhileUpdating?: boolean };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "set_config";
+        actionParameters?: {
+          automaticHttpsRewrites?: boolean;
+          autominify?: { css?: boolean; html?: boolean; js?: boolean };
+          bic?: boolean;
+          disableApps?: true;
+          disablePayPerCrawl?: true;
+          disableRum?: true;
+          disableZaraz?: true;
+          emailObfuscation?: boolean;
+          fonts?: boolean;
+          hotlinkProtection?: boolean;
+          mirage?: boolean;
+          opportunisticEncryption?: boolean;
+          polish?: "off" | "lossless" | "lossy" | "webp";
+          requestBodyBuffering?: "none" | "standard" | "full";
+          responseBodyBuffering?: "none" | "standard";
+          rocketLoader?: boolean;
+          securityLevel?:
+            | "off"
+            | "essentially_off"
+            | "low"
+            | "medium"
+            | "high"
+            | "under_attack";
+          serverSideExcludes?: boolean;
+          ssl?: "off" | "flexible" | "full" | "strict" | "origin_pull";
+          sxg?: boolean;
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "skip";
+        actionParameters?: {
+          phase?: "current";
+          phases?: (
+            | "ddos_l4"
+            | "ddos_l7"
+            | "http_config_settings"
+            | "http_custom_errors"
+            | "http_log_custom_fields"
+            | "http_ratelimit"
+            | "http_request_cache_settings"
+            | "http_request_dynamic_redirect"
+            | "http_request_firewall_custom"
+            | "http_request_firewall_managed"
+            | "http_request_late_transform"
+            | "http_request_origin"
+            | "http_request_redirect"
+            | "http_request_sanitize"
+            | "http_request_sbfm"
+            | "http_request_transform"
+            | "http_response_compression"
+            | "http_response_firewall_managed"
+            | "http_response_headers_transform"
+            | "magic_transit"
+            | "magic_transit_ids_managed"
+            | "magic_transit_managed"
+            | "magic_transit_ratelimit"
+          )[];
+          products?: (
+            | "bic"
+            | "hot"
+            | "rateLimit"
+            | "securityLevel"
+            | "uaBlock"
+            | "waf"
+            | "zoneLockdown"
+          )[];
+          rules?: Record<string, unknown>;
+          ruleset?: "current";
+          rulesets?: string[];
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+  )[];
+}
+
+export interface UpdateRulesetForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  rulesetId: string;
+  /** Body param: An informative description of the ruleset. */
+  description?: string;
+  /** Body param: The kind of the ruleset. */
+  kind?: "managed" | "custom" | "root" | "zone";
+  /** Body param: The human-readable name of the ruleset. */
+  name?: string;
+  /** Body param: The phase of the ruleset. */
+  phase?:
+    | "ddos_l4"
+    | "ddos_l7"
+    | "http_config_settings"
+    | "http_custom_errors"
+    | "http_log_custom_fields"
+    | "http_ratelimit"
+    | "http_request_cache_settings"
+    | "http_request_dynamic_redirect"
+    | "http_request_firewall_custom"
+    | "http_request_firewall_managed"
+    | "http_request_late_transform"
+    | "http_request_origin"
+    | "http_request_redirect"
+    | "http_request_sanitize"
+    | "http_request_sbfm"
+    | "http_request_transform"
+    | "http_response_compression"
+    | "http_response_firewall_managed"
+    | "http_response_headers_transform"
+    | "magic_transit"
+    | "magic_transit_ids_managed"
+    | "magic_transit_managed"
+    | "magic_transit_ratelimit";
+  /** Body param: The list of rules in the ruleset. */
+  rules?: (
+    | {
+        id?: string;
+        action?: "block";
+        actionParameters?: {
+          response?: {
+            content: string;
+            contentType: string;
+            statusCode: number;
+          };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "challenge";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "compress_response";
+        actionParameters?: {
+          algorithms: {
+            name?: "none" | "auto" | "default" | "gzip" | "brotli" | "zstd";
+          }[];
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "ddos_dynamic";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "execute";
+        actionParameters?: {
+          id: string;
+          matchedData?: { publicKey: string };
+          overrides?: {
+            action?: string;
+            categories?: {
+              category: string;
+              action?: string;
+              enabled?: boolean;
+              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
+            }[];
+            enabled?: boolean;
+            rules?: {
+              id: string;
+              action?: string;
+              enabled?: boolean;
+              scoreThreshold?: number;
+              sensitivityLevel?: "default" | "medium" | "low" | "eoff";
+            }[];
+            sensitivityLevel?: "default" | "medium" | "low" | "eoff";
+          };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "force_connection_close";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "js_challenge";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "log";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "log_custom_field";
+        actionParameters?: {
+          cookieFields?: { name: string }[];
+          rawResponseFields?: { name: string; preserveDuplicates?: boolean }[];
+          requestFields?: { name: string }[];
+          responseFields?: { name: string; preserveDuplicates?: boolean }[];
+          transformedRequestFields?: { name: string }[];
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "managed_challenge";
+        actionParameters?: unknown;
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "redirect";
+        actionParameters?: {
+          fromList?: { key: string; name: string };
+          fromValue?: {
+            targetUrl: { expression?: string; value?: string };
+            preserveQueryString?: boolean;
+            statusCode?: "301" | "302" | "303" | "307" | "308";
+          };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "rewrite";
+        actionParameters?: {
+          headers?: Record<string, unknown>;
+          uri?:
+            | { path: { expression?: string; value?: string } }
+            | { query: { expression?: string; value?: string } };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "route";
+        actionParameters?: {
+          hostHeader?: string;
+          origin?: { host?: string; port?: number };
+          sni?: { value: string };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "score";
+        actionParameters?: { increment: number };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "serve_error";
+        actionParameters?:
+          | {
+              content: string;
+              contentType?:
+                | "application/json"
+                | "text/html"
+                | "text/plain"
+                | "text/xml";
+              statusCode?: number;
+            }
+          | {
+              assetName: string;
+              contentType?:
+                | "application/json"
+                | "text/html"
+                | "text/plain"
+                | "text/xml";
+              statusCode?: number;
+            };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "set_cache_settings";
+        actionParameters?: {
+          additionalCacheablePorts?: number[];
+          browserTtl?: {
+            mode:
+              | "respect_origin"
+              | "bypass_by_default"
+              | "override_origin"
+              | "bypass";
+            default?: number;
+          };
+          cache?: boolean;
+          cacheKey?: {
+            cacheByDeviceType?: boolean;
+            cacheDeceptionArmor?: boolean;
+            customKey?: {
+              cookie?: { checkPresence?: string[]; include?: string[] };
+              header?: {
+                checkPresence?: string[];
+                contains?: Record<string, unknown>;
+                excludeOrigin?: boolean;
+                include?: string[];
+              };
+              host?: { resolved?: boolean };
+              queryString?: {
+                exclude?: { all?: true; list?: string[] };
+                include?: { all?: true; list?: string[] };
+              };
+              user?: { deviceType?: boolean; geo?: boolean; lang?: boolean };
+            };
+            ignoreQueryStringsOrder?: boolean;
+          };
+          cacheReserve?: { eligible: boolean; minimumFileSize?: number };
+          edgeTtl?: {
+            mode: "respect_origin" | "bypass_by_default" | "override_origin";
+            default?: number;
+            statusCodeTtl?: {
+              value: number;
+              statusCode?: number;
+              statusCodeRange?: { from?: number; to?: number };
+            }[];
+          };
+          originCacheControl?: boolean;
+          originErrorPagePassthru?: boolean;
+          readTimeout?: number;
+          respectStrongEtags?: boolean;
+          serveStale?: { disableStaleWhileUpdating?: boolean };
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "set_config";
+        actionParameters?: {
+          automaticHttpsRewrites?: boolean;
+          autominify?: { css?: boolean; html?: boolean; js?: boolean };
+          bic?: boolean;
+          disableApps?: true;
+          disablePayPerCrawl?: true;
+          disableRum?: true;
+          disableZaraz?: true;
+          emailObfuscation?: boolean;
+          fonts?: boolean;
+          hotlinkProtection?: boolean;
+          mirage?: boolean;
+          opportunisticEncryption?: boolean;
+          polish?: "off" | "lossless" | "lossy" | "webp";
+          requestBodyBuffering?: "none" | "standard" | "full";
+          responseBodyBuffering?: "none" | "standard";
+          rocketLoader?: boolean;
+          securityLevel?:
+            | "off"
+            | "essentially_off"
+            | "low"
+            | "medium"
+            | "high"
+            | "under_attack";
+          serverSideExcludes?: boolean;
+          ssl?: "off" | "flexible" | "full" | "strict" | "origin_pull";
+          sxg?: boolean;
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+    | {
+        id?: string;
+        action?: "skip";
+        actionParameters?: {
+          phase?: "current";
+          phases?: (
+            | "ddos_l4"
+            | "ddos_l7"
+            | "http_config_settings"
+            | "http_custom_errors"
+            | "http_log_custom_fields"
+            | "http_ratelimit"
+            | "http_request_cache_settings"
+            | "http_request_dynamic_redirect"
+            | "http_request_firewall_custom"
+            | "http_request_firewall_managed"
+            | "http_request_late_transform"
+            | "http_request_origin"
+            | "http_request_redirect"
+            | "http_request_sanitize"
+            | "http_request_sbfm"
+            | "http_request_transform"
+            | "http_response_compression"
+            | "http_response_firewall_managed"
+            | "http_response_headers_transform"
+            | "magic_transit"
+            | "magic_transit_ids_managed"
+            | "magic_transit_managed"
+            | "magic_transit_ratelimit"
+          )[];
+          products?: (
+            | "bic"
+            | "hot"
+            | "rateLimit"
+            | "securityLevel"
+            | "uaBlock"
+            | "waf"
+            | "zoneLockdown"
+          )[];
+          rules?: Record<string, unknown>;
+          ruleset?: "current";
+          rulesets?: string[];
+        };
+        description?: string;
+        enabled?: boolean;
+        exposedCredentialCheck?: {
+          passwordExpression: string;
+          usernameExpression: string;
+        };
+        expression?: string;
+        logging?: { enabled: boolean };
+        ratelimit?: {
+          characteristics: string[];
+          period: number;
+          countingExpression?: string;
+          mitigationTimeout?: number;
+          requestsPerPeriod?: number;
+          requestsToOrigin?: boolean;
+          scorePerPeriod?: number;
+          scoreResponseHeaderName?: string;
+        };
+        ref?: string;
+      }
+  )[];
+}
+
+export type UpdateRulesetRequest =
+  | UpdateRulesetForAccountRequest
+  | UpdateRulesetForZoneRequest;
+
+export const UpdateRulesetForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...UpdateRulesetBaseFields,
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/accounts/{account_id}/rulesets/{rulesetId}",
+    }),
+  ) as unknown as Schema.Schema<UpdateRulesetForAccountRequest>;
+
+export const UpdateRulesetForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...UpdateRulesetBaseFields,
+  }).pipe(
+    T.Http({ method: "PUT", path: "/zones/{zone_id}/rulesets/{rulesetId}" }),
+  ) as unknown as Schema.Schema<UpdateRulesetForZoneRequest>;
 
 export interface UpdateRulesetResponse {
   /** The unique ID of the ruleset. */
@@ -39151,29 +41662,77 @@ export const UpdateRulesetResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type UpdateRulesetError = DefaultErrors;
 
-export const updateRuleset: API.OperationMethod<
-  UpdateRulesetRequest,
+export const updateRulesetForAccount: API.OperationMethod<
+  UpdateRulesetForAccountRequest,
   UpdateRulesetResponse,
   UpdateRulesetError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: UpdateRulesetRequest,
+  input: UpdateRulesetForAccountRequest,
   output: UpdateRulesetResponse,
   errors: [],
 }));
 
-export interface DeleteRulesetRequest {
+export const updateRulesetForZone: API.OperationMethod<
+  UpdateRulesetForZoneRequest,
+  UpdateRulesetResponse,
+  UpdateRulesetError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: UpdateRulesetForZoneRequest,
+  output: UpdateRulesetResponse,
+  errors: [],
+}));
+
+export const updateRuleset = (
+  input: UpdateRulesetRequest,
+): Effect.Effect<
+  UpdateRulesetResponse,
+  UpdateRulesetError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? updateRulesetForAccount(input)
+    : updateRulesetForZone(input);
+
+const DeleteRulesetBaseFields = {
+  rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
+} as const;
+
+export interface DeleteRulesetForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   rulesetId: string;
 }
 
-export const DeleteRulesetRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
-}).pipe(
-  T.Http({
-    method: "DELETE",
-    path: "/{accountOrZone}/{accountOrZoneId}/rulesets/{rulesetId}",
-  }),
-) as unknown as Schema.Schema<DeleteRulesetRequest>;
+export interface DeleteRulesetForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  rulesetId: string;
+}
+
+export type DeleteRulesetRequest =
+  | DeleteRulesetForAccountRequest
+  | DeleteRulesetForZoneRequest;
+
+export const DeleteRulesetForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...DeleteRulesetBaseFields,
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/accounts/{account_id}/rulesets/{rulesetId}",
+    }),
+  ) as unknown as Schema.Schema<DeleteRulesetForAccountRequest>;
+
+export const DeleteRulesetForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...DeleteRulesetBaseFields,
+  }).pipe(
+    T.Http({ method: "DELETE", path: "/zones/{zone_id}/rulesets/{rulesetId}" }),
+  ) as unknown as Schema.Schema<DeleteRulesetForZoneRequest>;
 
 export type DeleteRulesetResponse = unknown;
 
@@ -39182,35 +41741,87 @@ export const DeleteRulesetResponse =
 
 export type DeleteRulesetError = DefaultErrors;
 
-export const deleteRuleset: API.OperationMethod<
-  DeleteRulesetRequest,
+export const deleteRulesetForAccount: API.OperationMethod<
+  DeleteRulesetForAccountRequest,
   DeleteRulesetResponse,
   DeleteRulesetError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: DeleteRulesetRequest,
+  input: DeleteRulesetForAccountRequest,
   output: DeleteRulesetResponse,
   errors: [],
 }));
+
+export const deleteRulesetForZone: API.OperationMethod<
+  DeleteRulesetForZoneRequest,
+  DeleteRulesetResponse,
+  DeleteRulesetError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: DeleteRulesetForZoneRequest,
+  output: DeleteRulesetResponse,
+  errors: [],
+}));
+
+export const deleteRuleset = (
+  input: DeleteRulesetRequest,
+): Effect.Effect<
+  DeleteRulesetResponse,
+  DeleteRulesetError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? deleteRulesetForAccount(input)
+    : deleteRulesetForZone(input);
 
 // =============================================================================
 // Version
 // =============================================================================
 
-export interface GetVersionRequest {
+const GetVersionBaseFields = {
+  rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
+  rulesetVersion: Schema.String.pipe(T.HttpPath("rulesetVersion")),
+} as const;
+
+export interface GetVersionForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   rulesetId: string;
   rulesetVersion: string;
 }
 
-export const GetVersionRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
-  rulesetVersion: Schema.String.pipe(T.HttpPath("rulesetVersion")),
-}).pipe(
-  T.Http({
-    method: "GET",
-    path: "/{accountOrZone}/{accountOrZoneId}/rulesets/{rulesetId}/versions/{rulesetVersion}",
-  }),
-) as unknown as Schema.Schema<GetVersionRequest>;
+export interface GetVersionForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  rulesetId: string;
+  rulesetVersion: string;
+}
+
+export type GetVersionRequest =
+  | GetVersionForAccountRequest
+  | GetVersionForZoneRequest;
+
+export const GetVersionForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetVersionBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/rulesets/{rulesetId}/versions/{rulesetVersion}",
+    }),
+  ) as unknown as Schema.Schema<GetVersionForAccountRequest>;
+
+export const GetVersionForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...GetVersionBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/rulesets/{rulesetId}/versions/{rulesetVersion}",
+    }),
+  ) as unknown as Schema.Schema<GetVersionForZoneRequest>;
 
 export interface GetVersionResponse {
   /** The unique ID of the ruleset. */
@@ -42686,29 +45297,78 @@ export const GetVersionResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type GetVersionError = DefaultErrors;
 
-export const getVersion: API.OperationMethod<
-  GetVersionRequest,
+export const getVersionForAccount: API.OperationMethod<
+  GetVersionForAccountRequest,
   GetVersionResponse,
   GetVersionError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: GetVersionRequest,
+  input: GetVersionForAccountRequest,
   output: GetVersionResponse,
   errors: [],
 }));
 
-export interface ListVersionsRequest {
+export const getVersionForZone: API.OperationMethod<
+  GetVersionForZoneRequest,
+  GetVersionResponse,
+  GetVersionError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetVersionForZoneRequest,
+  output: GetVersionResponse,
+  errors: [],
+}));
+
+export const getVersion = (
+  input: GetVersionRequest,
+): Effect.Effect<
+  GetVersionResponse,
+  GetVersionError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input ? getVersionForAccount(input) : getVersionForZone(input);
+
+const ListVersionsBaseFields = {
+  rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
+} as const;
+
+export interface ListVersionsForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   rulesetId: string;
 }
 
-export const ListVersionsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
-}).pipe(
-  T.Http({
-    method: "GET",
-    path: "/{accountOrZone}/{accountOrZoneId}/rulesets/{rulesetId}/versions",
-  }),
-) as unknown as Schema.Schema<ListVersionsRequest>;
+export interface ListVersionsForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  rulesetId: string;
+}
+
+export type ListVersionsRequest =
+  | ListVersionsForAccountRequest
+  | ListVersionsForZoneRequest;
+
+export const ListVersionsForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...ListVersionsBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/rulesets/{rulesetId}/versions",
+    }),
+  ) as unknown as Schema.Schema<ListVersionsForAccountRequest>;
+
+export const ListVersionsForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...ListVersionsBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/rulesets/{rulesetId}/versions",
+    }),
+  ) as unknown as Schema.Schema<ListVersionsForZoneRequest>;
 
 export interface ListVersionsResponse {
   result: {
@@ -42795,13 +45455,13 @@ export const ListVersionsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type ListVersionsError = DefaultErrors;
 
-export const listVersions: API.PaginatedOperationMethod<
-  ListVersionsRequest,
+export const listVersionsForAccount: API.PaginatedOperationMethod<
+  ListVersionsForAccountRequest,
   ListVersionsResponse,
   ListVersionsError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
-  input: ListVersionsRequest,
+  input: ListVersionsForAccountRequest,
   output: ListVersionsResponse,
   errors: [],
   pagination: {
@@ -42810,20 +45470,76 @@ export const listVersions: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export interface DeleteVersionRequest {
+export const listVersionsForZone: API.PaginatedOperationMethod<
+  ListVersionsForZoneRequest,
+  ListVersionsResponse,
+  ListVersionsError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+  input: ListVersionsForZoneRequest,
+  output: ListVersionsResponse,
+  errors: [],
+  pagination: {
+    mode: "single",
+    items: "result",
+  } as const,
+}));
+
+export const listVersions = (
+  input: ListVersionsRequest,
+): stream.Stream<
+  ListVersionsResponse,
+  ListVersionsError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? listVersionsForAccount.pages(input)
+    : listVersionsForZone.pages(input);
+
+const DeleteVersionBaseFields = {
+  rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
+  rulesetVersion: Schema.String.pipe(T.HttpPath("rulesetVersion")),
+} as const;
+
+export interface DeleteVersionForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   rulesetId: string;
   rulesetVersion: string;
 }
 
-export const DeleteVersionRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
-  rulesetVersion: Schema.String.pipe(T.HttpPath("rulesetVersion")),
-}).pipe(
-  T.Http({
-    method: "DELETE",
-    path: "/{accountOrZone}/{accountOrZoneId}/rulesets/{rulesetId}/versions/{rulesetVersion}",
-  }),
-) as unknown as Schema.Schema<DeleteVersionRequest>;
+export interface DeleteVersionForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  rulesetId: string;
+  rulesetVersion: string;
+}
+
+export type DeleteVersionRequest =
+  | DeleteVersionForAccountRequest
+  | DeleteVersionForZoneRequest;
+
+export const DeleteVersionForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...DeleteVersionBaseFields,
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/accounts/{account_id}/rulesets/{rulesetId}/versions/{rulesetVersion}",
+    }),
+  ) as unknown as Schema.Schema<DeleteVersionForAccountRequest>;
+
+export const DeleteVersionForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...DeleteVersionBaseFields,
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/zones/{zone_id}/rulesets/{rulesetId}/versions/{rulesetVersion}",
+    }),
+  ) as unknown as Schema.Schema<DeleteVersionForZoneRequest>;
 
 export type DeleteVersionResponse = unknown;
 
@@ -42832,13 +45548,35 @@ export const DeleteVersionResponse =
 
 export type DeleteVersionError = DefaultErrors;
 
-export const deleteVersion: API.OperationMethod<
-  DeleteVersionRequest,
+export const deleteVersionForAccount: API.OperationMethod<
+  DeleteVersionForAccountRequest,
   DeleteVersionResponse,
   DeleteVersionError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: DeleteVersionRequest,
+  input: DeleteVersionForAccountRequest,
   output: DeleteVersionResponse,
   errors: [],
 }));
+
+export const deleteVersionForZone: API.OperationMethod<
+  DeleteVersionForZoneRequest,
+  DeleteVersionResponse,
+  DeleteVersionError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: DeleteVersionForZoneRequest,
+  output: DeleteVersionResponse,
+  errors: [],
+}));
+
+export const deleteVersion = (
+  input: DeleteVersionRequest,
+): Effect.Effect<
+  DeleteVersionResponse,
+  DeleteVersionError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? deleteVersionForAccount(input)
+    : deleteVersionForZone(input);

--- a/packages/cloudflare/src/services/rulesets.ts
+++ b/packages/cloudflare/src/services/rulesets.ts
@@ -5,8 +5,6 @@
  * DO NOT EDIT - regenerate with: bun scripts/generate.ts --service rulesets
  */
 
-import * as Effect from "effect/Effect";
-import * as stream from "effect/Stream";
 import * as Schema from "effect/Schema";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
@@ -36,8 +34,6 @@ export interface GetPhasForZoneRequest extends GetPhasBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type GetPhasRequest = GetPhasForAccountRequest | GetPhasForZoneRequest;
 
 export const GetPhasForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -3554,14 +3550,6 @@ export const getPhasForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const getPhas = (
-  input: GetPhasRequest,
-): Effect.Effect<
-  GetPhasResponse,
-  GetPhasError,
-  Credentials | HttpClient.HttpClient
-> => ("accountId" in input ? getPhasForAccount(input) : getPhasForZone(input));
-
 const PutPhasBaseFields = {
   rulesetPhase: Schema.String.pipe(T.HttpPath("rulesetPhase")),
   description: Schema.optional(Schema.String),
@@ -5902,8 +5890,6 @@ export interface PutPhasForZoneRequest extends PutPhasBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type PutPhasRequest = PutPhasForAccountRequest | PutPhasForZoneRequest;
 
 export const PutPhasForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -9420,14 +9406,6 @@ export const putPhasForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const putPhas = (
-  input: PutPhasRequest,
-): Effect.Effect<
-  PutPhasResponse,
-  PutPhasError,
-  Credentials | HttpClient.HttpClient
-> => ("accountId" in input ? putPhasForAccount(input) : putPhasForZone(input));
-
 // =============================================================================
 // PhasVersion
 // =============================================================================
@@ -9451,10 +9429,6 @@ export interface GetPhasVersionForZoneRequest extends GetPhasVersionBaseRequest 
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type GetPhasVersionRequest =
-  | GetPhasVersionForAccountRequest
-  | GetPhasVersionForZoneRequest;
 
 export const GetPhasVersionForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -13026,17 +13000,6 @@ export const getPhasVersionForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const getPhasVersion = (
-  input: GetPhasVersionRequest,
-): Effect.Effect<
-  GetPhasVersionResponse,
-  GetPhasVersionError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? getPhasVersionForAccount(input)
-    : getPhasVersionForZone(input);
-
 const ListPhasVersionsBaseFields = {
   rulesetPhase: Schema.String.pipe(T.HttpPath("rulesetPhase")),
 } as const;
@@ -13054,10 +13017,6 @@ export interface ListPhasVersionsForZoneRequest extends ListPhasVersionsBaseRequ
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type ListPhasVersionsRequest =
-  | ListPhasVersionsForAccountRequest
-  | ListPhasVersionsForZoneRequest;
 
 export const ListPhasVersionsForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -13199,17 +13158,6 @@ export const listPhasVersionsForZone: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export const listPhasVersions = (
-  input: ListPhasVersionsRequest,
-): stream.Stream<
-  ListPhasVersionsResponse,
-  ListPhasVersionsError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? listPhasVersionsForAccount.pages(input)
-    : listPhasVersionsForZone.pages(input);
-
 // =============================================================================
 // Rule
 // =============================================================================
@@ -13342,10 +13290,6 @@ export interface CreateRuleForZoneRequest extends CreateRuleBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type CreateRuleRequest =
-  | CreateRuleForAccountRequest
-  | CreateRuleForZoneRequest;
 
 export const CreateRuleForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -16891,15 +16835,6 @@ export const createRuleForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const createRule = (
-  input: CreateRuleRequest,
-): Effect.Effect<
-  CreateRuleResponse,
-  CreateRuleError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input ? createRuleForAccount(input) : createRuleForZone(input);
-
 const PatchRuleBaseFields = {
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
   ruleId: Schema.String.pipe(T.HttpPath("ruleId")),
@@ -17030,10 +16965,6 @@ export interface PatchRuleForZoneRequest extends PatchRuleBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type PatchRuleRequest =
-  | PatchRuleForAccountRequest
-  | PatchRuleForZoneRequest;
 
 export const PatchRuleForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -20579,15 +20510,6 @@ export const patchRuleForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const patchRule = (
-  input: PatchRuleRequest,
-): Effect.Effect<
-  PatchRuleResponse,
-  PatchRuleError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input ? patchRuleForAccount(input) : patchRuleForZone(input);
-
 const DeleteRuleBaseFields = {
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
   ruleId: Schema.String.pipe(T.HttpPath("ruleId")),
@@ -20607,10 +20529,6 @@ export interface DeleteRuleForZoneRequest extends DeleteRuleBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type DeleteRuleRequest =
-  | DeleteRuleForAccountRequest
-  | DeleteRuleForZoneRequest;
 
 export const DeleteRuleForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -24130,15 +24048,6 @@ export const deleteRuleForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const deleteRule = (
-  input: DeleteRuleRequest,
-): Effect.Effect<
-  DeleteRuleResponse,
-  DeleteRuleError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input ? deleteRuleForAccount(input) : deleteRuleForZone(input);
-
 // =============================================================================
 // Ruleset
 // =============================================================================
@@ -24160,10 +24069,6 @@ export interface GetRulesetForZoneRequest extends GetRulesetBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type GetRulesetRequest =
-  | GetRulesetForAccountRequest
-  | GetRulesetForZoneRequest;
 
 export const GetRulesetForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -27680,15 +27585,6 @@ export const getRulesetForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const getRuleset = (
-  input: GetRulesetRequest,
-): Effect.Effect<
-  GetRulesetResponse,
-  GetRulesetError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input ? getRulesetForAccount(input) : getRulesetForZone(input);
-
 const ListRulesetsBaseFields = {} as const;
 
 interface ListRulesetsBaseRequest {}
@@ -27702,10 +27598,6 @@ export interface ListRulesetsForZoneRequest extends ListRulesetsBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type ListRulesetsRequest =
-  | ListRulesetsForAccountRequest
-  | ListRulesetsForZoneRequest;
 
 export const ListRulesetsForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -27866,17 +27758,6 @@ export const listRulesetsForZone: API.PaginatedOperationMethod<
     pageSize: "perPage",
   } as const,
 }));
-
-export const listRulesets = (
-  input: ListRulesetsRequest,
-): stream.Stream<
-  ListRulesetsResponse,
-  ListRulesetsError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? listRulesetsForAccount.pages(input)
-    : listRulesetsForZone.pages(input);
 
 const CreateRulesetBaseFields = {
   kind: Schema.Literals(["managed", "custom", "root", "zone"]),
@@ -30269,10 +30150,6 @@ export interface CreateRulesetForZoneRequest extends CreateRulesetBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type CreateRulesetRequest =
-  | CreateRulesetForAccountRequest
-  | CreateRulesetForZoneRequest;
 
 export const CreateRulesetForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -33786,17 +33663,6 @@ export const createRulesetForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const createRuleset = (
-  input: CreateRulesetRequest,
-): Effect.Effect<
-  CreateRulesetResponse,
-  CreateRulesetError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? createRulesetForAccount(input)
-    : createRulesetForZone(input);
-
 const UpdateRulesetBaseFields = {
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
   description: Schema.optional(Schema.String),
@@ -36192,10 +36058,6 @@ export interface UpdateRulesetForZoneRequest extends UpdateRulesetBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type UpdateRulesetRequest =
-  | UpdateRulesetForAccountRequest
-  | UpdateRulesetForZoneRequest;
 
 export const UpdateRulesetForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -39712,17 +39574,6 @@ export const updateRulesetForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const updateRuleset = (
-  input: UpdateRulesetRequest,
-): Effect.Effect<
-  UpdateRulesetResponse,
-  UpdateRulesetError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? updateRulesetForAccount(input)
-    : updateRulesetForZone(input);
-
 const DeleteRulesetBaseFields = {
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
 } as const;
@@ -39740,10 +39591,6 @@ export interface DeleteRulesetForZoneRequest extends DeleteRulesetBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type DeleteRulesetRequest =
-  | DeleteRulesetForAccountRequest
-  | DeleteRulesetForZoneRequest;
 
 export const DeleteRulesetForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -39793,17 +39640,6 @@ export const deleteRulesetForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const deleteRuleset = (
-  input: DeleteRulesetRequest,
-): Effect.Effect<
-  DeleteRulesetResponse,
-  DeleteRulesetError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? deleteRulesetForAccount(input)
-    : deleteRulesetForZone(input);
-
 // =============================================================================
 // Version
 // =============================================================================
@@ -39827,10 +39663,6 @@ export interface GetVersionForZoneRequest extends GetVersionBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type GetVersionRequest =
-  | GetVersionForAccountRequest
-  | GetVersionForZoneRequest;
 
 export const GetVersionForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -43350,15 +43182,6 @@ export const getVersionForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const getVersion = (
-  input: GetVersionRequest,
-): Effect.Effect<
-  GetVersionResponse,
-  GetVersionError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input ? getVersionForAccount(input) : getVersionForZone(input);
-
 const ListVersionsBaseFields = {
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
 } as const;
@@ -43376,10 +43199,6 @@ export interface ListVersionsForZoneRequest extends ListVersionsBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type ListVersionsRequest =
-  | ListVersionsForAccountRequest
-  | ListVersionsForZoneRequest;
 
 export const ListVersionsForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -43518,17 +43337,6 @@ export const listVersionsForZone: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export const listVersions = (
-  input: ListVersionsRequest,
-): stream.Stream<
-  ListVersionsResponse,
-  ListVersionsError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? listVersionsForAccount.pages(input)
-    : listVersionsForZone.pages(input);
-
 const DeleteVersionBaseFields = {
   rulesetId: Schema.String.pipe(T.HttpPath("rulesetId")),
   rulesetVersion: Schema.String.pipe(T.HttpPath("rulesetVersion")),
@@ -43548,10 +43356,6 @@ export interface DeleteVersionForZoneRequest extends DeleteVersionBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type DeleteVersionRequest =
-  | DeleteVersionForAccountRequest
-  | DeleteVersionForZoneRequest;
 
 export const DeleteVersionForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -43603,14 +43407,3 @@ export const deleteVersionForZone: API.OperationMethod<
   output: DeleteVersionResponse,
   errors: [],
 }));
-
-export const deleteVersion = (
-  input: DeleteVersionRequest,
-): Effect.Effect<
-  DeleteVersionResponse,
-  DeleteVersionError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? deleteVersionForAccount(input)
-    : deleteVersionForZone(input);

--- a/packages/cloudflare/src/services/security-center.ts
+++ b/packages/cloudflare/src/services/security-center.ts
@@ -20,12 +20,14 @@ import { type DefaultErrors } from "../errors.ts";
 
 const ListInsightsBaseFields = {} as const;
 
-export interface ListInsightsForAccountRequest {
+interface ListInsightsBaseRequest {}
+
+export interface ListInsightsForAccountRequest extends ListInsightsBaseRequest {
   /** Path param: The Account ID to use for this endpoint. */
   accountId: string;
 }
 
-export interface ListInsightsForZoneRequest {
+export interface ListInsightsForZoneRequest extends ListInsightsBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
@@ -283,20 +285,20 @@ const DismissInsightBaseFields = {
   dismiss: Schema.optional(Schema.Boolean),
 } as const;
 
-export interface DismissInsightForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface DismissInsightBaseRequest {
   issueId: string;
   /** Body param: */
   dismiss?: boolean;
 }
 
-export interface DismissInsightForZoneRequest {
+export interface DismissInsightForAccountRequest extends DismissInsightBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface DismissInsightForZoneRequest extends DismissInsightBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  issueId: string;
-  /** Body param: */
-  dismiss?: boolean;
 }
 
 export type DismissInsightRequest =
@@ -441,12 +443,14 @@ export const dismissInsight = (
 
 const GetInsightClassBaseFields = {} as const;
 
-export interface GetInsightClassForAccountRequest {
+interface GetInsightClassBaseRequest {}
+
+export interface GetInsightClassForAccountRequest extends GetInsightClassBaseRequest {
   /** Path param: The Account ID to use for this endpoint. */
   accountId: string;
 }
 
-export interface GetInsightClassForZoneRequest {
+export interface GetInsightClassForZoneRequest extends GetInsightClassBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
@@ -532,12 +536,14 @@ export const getInsightClass = (
 
 const GetInsightSeverityBaseFields = {} as const;
 
-export interface GetInsightSeverityForAccountRequest {
+interface GetInsightSeverityBaseRequest {}
+
+export interface GetInsightSeverityForAccountRequest extends GetInsightSeverityBaseRequest {
   /** Path param: The Account ID to use for this endpoint. */
   accountId: string;
 }
 
-export interface GetInsightSeverityForZoneRequest {
+export interface GetInsightSeverityForZoneRequest extends GetInsightSeverityBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
@@ -624,12 +630,14 @@ export const getInsightSeverity = (
 
 const GetInsightTypeBaseFields = {} as const;
 
-export interface GetInsightTypeForAccountRequest {
+interface GetInsightTypeBaseRequest {}
+
+export interface GetInsightTypeForAccountRequest extends GetInsightTypeBaseRequest {
   /** Path param: The Account ID to use for this endpoint. */
   accountId: string;
 }
 
-export interface GetInsightTypeForZoneRequest {
+export interface GetInsightTypeForZoneRequest extends GetInsightTypeBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }

--- a/packages/cloudflare/src/services/security-center.ts
+++ b/packages/cloudflare/src/services/security-center.ts
@@ -5,6 +5,8 @@
  * DO NOT EDIT - regenerate with: bun scripts/generate.ts --service security-center
  */
 
+import * as Effect from "effect/Effect";
+import * as stream from "effect/Stream";
 import * as Schema from "effect/Schema";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
@@ -16,16 +18,43 @@ import { type DefaultErrors } from "../errors.ts";
 // Insight
 // =============================================================================
 
-export interface ListInsightsRequest {}
+const ListInsightsBaseFields = {} as const;
 
-export const ListInsightsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {},
-).pipe(
-  T.Http({
-    method: "GET",
-    path: "/{accountOrZone}/{accountOrZoneId}/security-center/insights",
-  }),
-) as unknown as Schema.Schema<ListInsightsRequest>;
+export interface ListInsightsForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface ListInsightsForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+}
+
+export type ListInsightsRequest =
+  | ListInsightsForAccountRequest
+  | ListInsightsForZoneRequest;
+
+export const ListInsightsForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...ListInsightsBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/security-center/insights",
+    }),
+  ) as unknown as Schema.Schema<ListInsightsForAccountRequest>;
+
+export const ListInsightsForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...ListInsightsBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/security-center/insights",
+    }),
+  ) as unknown as Schema.Schema<ListInsightsForZoneRequest>;
 
 export interface ListInsightsResponse {
   result: {
@@ -202,13 +231,13 @@ export const ListInsightsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
 
 export type ListInsightsError = DefaultErrors;
 
-export const listInsights: API.PaginatedOperationMethod<
-  ListInsightsRequest,
+export const listInsightsForAccount: API.PaginatedOperationMethod<
+  ListInsightsForAccountRequest,
   ListInsightsResponse,
   ListInsightsError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
-  input: ListInsightsRequest,
+  input: ListInsightsForAccountRequest,
   output: ListInsightsResponse,
   errors: [],
   pagination: {
@@ -220,27 +249,81 @@ export const listInsights: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export interface DismissInsightRequest {
+export const listInsightsForZone: API.PaginatedOperationMethod<
+  ListInsightsForZoneRequest,
+  ListInsightsResponse,
+  ListInsightsError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+  input: ListInsightsForZoneRequest,
+  output: ListInsightsResponse,
+  errors: [],
+  pagination: {
+    mode: "page",
+    inputToken: "page",
+    outputToken: "resultInfo.page",
+    items: "result.items",
+    pageSize: "perPage",
+  } as const,
+}));
+
+export const listInsights = (
+  input: ListInsightsRequest,
+): stream.Stream<
+  ListInsightsResponse,
+  ListInsightsError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? listInsightsForAccount.pages(input)
+    : listInsightsForZone.pages(input);
+
+const DismissInsightBaseFields = {
+  issueId: Schema.String.pipe(T.HttpPath("issueId")),
+  dismiss: Schema.optional(Schema.Boolean),
+} as const;
+
+export interface DismissInsightForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   issueId: string;
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
   /** Body param: */
   dismiss?: boolean;
 }
 
-export const DismissInsightRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  issueId: Schema.String.pipe(T.HttpPath("issueId")),
-  accountId: Schema.String.pipe(T.HttpPath("account_id")),
-  zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-  dismiss: Schema.optional(Schema.Boolean),
-}).pipe(
-  T.Http({
-    method: "PUT",
-    path: "/{accountOrZone}/{accountOrZoneId}/security-center/insights/{issueId}/dismiss",
-  }),
-) as unknown as Schema.Schema<DismissInsightRequest>;
+export interface DismissInsightForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  issueId: string;
+  /** Body param: */
+  dismiss?: boolean;
+}
+
+export type DismissInsightRequest =
+  | DismissInsightForAccountRequest
+  | DismissInsightForZoneRequest;
+
+export const DismissInsightForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...DismissInsightBaseFields,
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/accounts/{account_id}/security-center/insights/{issueId}/dismiss",
+    }),
+  ) as unknown as Schema.Schema<DismissInsightForAccountRequest>;
+
+export const DismissInsightForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...DismissInsightBaseFields,
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/zones/{zone_id}/security-center/insights/{issueId}/dismiss",
+    }),
+  ) as unknown as Schema.Schema<DismissInsightForZoneRequest>;
 
 export interface DismissInsightResponse {
   errors: {
@@ -319,31 +402,80 @@ export const DismissInsightResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 
 export type DismissInsightError = DefaultErrors;
 
-export const dismissInsight: API.OperationMethod<
-  DismissInsightRequest,
+export const dismissInsightForAccount: API.OperationMethod<
+  DismissInsightForAccountRequest,
   DismissInsightResponse,
   DismissInsightError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: DismissInsightRequest,
+  input: DismissInsightForAccountRequest,
   output: DismissInsightResponse,
   errors: [],
 }));
+
+export const dismissInsightForZone: API.OperationMethod<
+  DismissInsightForZoneRequest,
+  DismissInsightResponse,
+  DismissInsightError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: DismissInsightForZoneRequest,
+  output: DismissInsightResponse,
+  errors: [],
+}));
+
+export const dismissInsight = (
+  input: DismissInsightRequest,
+): Effect.Effect<
+  DismissInsightResponse,
+  DismissInsightError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? dismissInsightForAccount(input)
+    : dismissInsightForZone(input);
 
 // =============================================================================
 // InsightClass
 // =============================================================================
 
-export interface GetInsightClassRequest {}
+const GetInsightClassBaseFields = {} as const;
 
-export const GetInsightClassRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {},
-).pipe(
-  T.Http({
-    method: "GET",
-    path: "/{accountOrZone}/{accountOrZoneId}/security-center/insights/class",
-  }),
-) as unknown as Schema.Schema<GetInsightClassRequest>;
+export interface GetInsightClassForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetInsightClassForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+}
+
+export type GetInsightClassRequest =
+  | GetInsightClassForAccountRequest
+  | GetInsightClassForZoneRequest;
+
+export const GetInsightClassForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetInsightClassBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/security-center/insights/class",
+    }),
+  ) as unknown as Schema.Schema<GetInsightClassForAccountRequest>;
+
+export const GetInsightClassForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...GetInsightClassBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/security-center/insights/class",
+    }),
+  ) as unknown as Schema.Schema<GetInsightClassForZoneRequest>;
 
 export type GetInsightClassResponse = {
   count?: number | null;
@@ -361,30 +493,80 @@ export const GetInsightClassResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Array(
 
 export type GetInsightClassError = DefaultErrors;
 
-export const getInsightClass: API.OperationMethod<
-  GetInsightClassRequest,
+export const getInsightClassForAccount: API.OperationMethod<
+  GetInsightClassForAccountRequest,
   GetInsightClassResponse,
   GetInsightClassError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: GetInsightClassRequest,
+  input: GetInsightClassForAccountRequest,
   output: GetInsightClassResponse,
   errors: [],
 }));
+
+export const getInsightClassForZone: API.OperationMethod<
+  GetInsightClassForZoneRequest,
+  GetInsightClassResponse,
+  GetInsightClassError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetInsightClassForZoneRequest,
+  output: GetInsightClassResponse,
+  errors: [],
+}));
+
+export const getInsightClass = (
+  input: GetInsightClassRequest,
+): Effect.Effect<
+  GetInsightClassResponse,
+  GetInsightClassError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? getInsightClassForAccount(input)
+    : getInsightClassForZone(input);
 
 // =============================================================================
 // InsightSeverity
 // =============================================================================
 
-export interface GetInsightSeverityRequest {}
+const GetInsightSeverityBaseFields = {} as const;
 
-export const GetInsightSeverityRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
+export interface GetInsightSeverityForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetInsightSeverityForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+}
+
+export type GetInsightSeverityRequest =
+  | GetInsightSeverityForAccountRequest
+  | GetInsightSeverityForZoneRequest;
+
+export const GetInsightSeverityForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetInsightSeverityBaseFields,
+  }).pipe(
     T.Http({
       method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/security-center/insights/severity",
+      path: "/accounts/{account_id}/security-center/insights/severity",
     }),
-  ) as unknown as Schema.Schema<GetInsightSeverityRequest>;
+  ) as unknown as Schema.Schema<GetInsightSeverityForAccountRequest>;
+
+export const GetInsightSeverityForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...GetInsightSeverityBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/security-center/insights/severity",
+    }),
+  ) as unknown as Schema.Schema<GetInsightSeverityForZoneRequest>;
 
 export type GetInsightSeverityResponse = {
   count?: number | null;
@@ -403,31 +585,80 @@ export const GetInsightSeverityResponse =
 
 export type GetInsightSeverityError = DefaultErrors;
 
-export const getInsightSeverity: API.OperationMethod<
-  GetInsightSeverityRequest,
+export const getInsightSeverityForAccount: API.OperationMethod<
+  GetInsightSeverityForAccountRequest,
   GetInsightSeverityResponse,
   GetInsightSeverityError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: GetInsightSeverityRequest,
+  input: GetInsightSeverityForAccountRequest,
   output: GetInsightSeverityResponse,
   errors: [],
 }));
+
+export const getInsightSeverityForZone: API.OperationMethod<
+  GetInsightSeverityForZoneRequest,
+  GetInsightSeverityResponse,
+  GetInsightSeverityError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetInsightSeverityForZoneRequest,
+  output: GetInsightSeverityResponse,
+  errors: [],
+}));
+
+export const getInsightSeverity = (
+  input: GetInsightSeverityRequest,
+): Effect.Effect<
+  GetInsightSeverityResponse,
+  GetInsightSeverityError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? getInsightSeverityForAccount(input)
+    : getInsightSeverityForZone(input);
 
 // =============================================================================
 // InsightType
 // =============================================================================
 
-export interface GetInsightTypeRequest {}
+const GetInsightTypeBaseFields = {} as const;
 
-export const GetInsightTypeRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
-  {},
-).pipe(
-  T.Http({
-    method: "GET",
-    path: "/{accountOrZone}/{accountOrZoneId}/security-center/insights/type",
-  }),
-) as unknown as Schema.Schema<GetInsightTypeRequest>;
+export interface GetInsightTypeForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetInsightTypeForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+}
+
+export type GetInsightTypeRequest =
+  | GetInsightTypeForAccountRequest
+  | GetInsightTypeForZoneRequest;
+
+export const GetInsightTypeForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetInsightTypeBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/security-center/insights/type",
+    }),
+  ) as unknown as Schema.Schema<GetInsightTypeForAccountRequest>;
+
+export const GetInsightTypeForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...GetInsightTypeBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/security-center/insights/type",
+    }),
+  ) as unknown as Schema.Schema<GetInsightTypeForZoneRequest>;
 
 export type GetInsightTypeResponse = {
   count?: number | null;
@@ -445,13 +676,35 @@ export const GetInsightTypeResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Array(
 
 export type GetInsightTypeError = DefaultErrors;
 
-export const getInsightType: API.OperationMethod<
-  GetInsightTypeRequest,
+export const getInsightTypeForAccount: API.OperationMethod<
+  GetInsightTypeForAccountRequest,
   GetInsightTypeResponse,
   GetInsightTypeError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: GetInsightTypeRequest,
+  input: GetInsightTypeForAccountRequest,
   output: GetInsightTypeResponse,
   errors: [],
 }));
+
+export const getInsightTypeForZone: API.OperationMethod<
+  GetInsightTypeForZoneRequest,
+  GetInsightTypeResponse,
+  GetInsightTypeError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetInsightTypeForZoneRequest,
+  output: GetInsightTypeResponse,
+  errors: [],
+}));
+
+export const getInsightType = (
+  input: GetInsightTypeRequest,
+): Effect.Effect<
+  GetInsightTypeResponse,
+  GetInsightTypeError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? getInsightTypeForAccount(input)
+    : getInsightTypeForZone(input);

--- a/packages/cloudflare/src/services/security-center.ts
+++ b/packages/cloudflare/src/services/security-center.ts
@@ -5,8 +5,6 @@
  * DO NOT EDIT - regenerate with: bun scripts/generate.ts --service security-center
  */
 
-import * as Effect from "effect/Effect";
-import * as stream from "effect/Stream";
 import * as Schema from "effect/Schema";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
@@ -31,10 +29,6 @@ export interface ListInsightsForZoneRequest extends ListInsightsBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type ListInsightsRequest =
-  | ListInsightsForAccountRequest
-  | ListInsightsForZoneRequest;
 
 export const ListInsightsForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -269,17 +263,6 @@ export const listInsightsForZone: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export const listInsights = (
-  input: ListInsightsRequest,
-): stream.Stream<
-  ListInsightsResponse,
-  ListInsightsError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? listInsightsForAccount.pages(input)
-    : listInsightsForZone.pages(input);
-
 const DismissInsightBaseFields = {
   issueId: Schema.String.pipe(T.HttpPath("issueId")),
   dismiss: Schema.optional(Schema.Boolean),
@@ -300,10 +283,6 @@ export interface DismissInsightForZoneRequest extends DismissInsightBaseRequest 
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type DismissInsightRequest =
-  | DismissInsightForAccountRequest
-  | DismissInsightForZoneRequest;
 
 export const DismissInsightForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -426,17 +405,6 @@ export const dismissInsightForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const dismissInsight = (
-  input: DismissInsightRequest,
-): Effect.Effect<
-  DismissInsightResponse,
-  DismissInsightError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? dismissInsightForAccount(input)
-    : dismissInsightForZone(input);
-
 // =============================================================================
 // InsightClass
 // =============================================================================
@@ -454,10 +422,6 @@ export interface GetInsightClassForZoneRequest extends GetInsightClassBaseReques
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type GetInsightClassRequest =
-  | GetInsightClassForAccountRequest
-  | GetInsightClassForZoneRequest;
 
 export const GetInsightClassForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -519,17 +483,6 @@ export const getInsightClassForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const getInsightClass = (
-  input: GetInsightClassRequest,
-): Effect.Effect<
-  GetInsightClassResponse,
-  GetInsightClassError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? getInsightClassForAccount(input)
-    : getInsightClassForZone(input);
-
 // =============================================================================
 // InsightSeverity
 // =============================================================================
@@ -547,10 +500,6 @@ export interface GetInsightSeverityForZoneRequest extends GetInsightSeverityBase
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type GetInsightSeverityRequest =
-  | GetInsightSeverityForAccountRequest
-  | GetInsightSeverityForZoneRequest;
 
 export const GetInsightSeverityForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -613,17 +562,6 @@ export const getInsightSeverityForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const getInsightSeverity = (
-  input: GetInsightSeverityRequest,
-): Effect.Effect<
-  GetInsightSeverityResponse,
-  GetInsightSeverityError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? getInsightSeverityForAccount(input)
-    : getInsightSeverityForZone(input);
-
 // =============================================================================
 // InsightType
 // =============================================================================
@@ -641,10 +579,6 @@ export interface GetInsightTypeForZoneRequest extends GetInsightTypeBaseRequest 
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type GetInsightTypeRequest =
-  | GetInsightTypeForAccountRequest
-  | GetInsightTypeForZoneRequest;
 
 export const GetInsightTypeForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -705,14 +639,3 @@ export const getInsightTypeForZone: API.OperationMethod<
   output: GetInsightTypeResponse,
   errors: [],
 }));
-
-export const getInsightType = (
-  input: GetInsightTypeRequest,
-): Effect.Effect<
-  GetInsightTypeResponse,
-  GetInsightTypeError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? getInsightTypeForAccount(input)
-    : getInsightTypeForZone(input);

--- a/packages/cloudflare/src/services/waiting-rooms.ts
+++ b/packages/cloudflare/src/services/waiting-rooms.ts
@@ -2153,12 +2153,14 @@ export const getWaitingRoom: API.OperationMethod<
 
 const ListWaitingRoomsBaseFields = {} as const;
 
-export interface ListWaitingRoomsForAccountRequest {
+interface ListWaitingRoomsBaseRequest {}
+
+export interface ListWaitingRoomsForAccountRequest extends ListWaitingRoomsBaseRequest {
   /** Path param: The Account ID to use for this endpoint. */
   accountId: string;
 }
 
-export interface ListWaitingRoomsForZoneRequest {
+export interface ListWaitingRoomsForZoneRequest extends ListWaitingRoomsBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }

--- a/packages/cloudflare/src/services/waiting-rooms.ts
+++ b/packages/cloudflare/src/services/waiting-rooms.ts
@@ -5,7 +5,6 @@
  * DO NOT EDIT - regenerate with: bun scripts/generate.ts --service waiting-rooms
  */
 
-import * as stream from "effect/Stream";
 import * as Schema from "effect/Schema";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
@@ -2165,10 +2164,6 @@ export interface ListWaitingRoomsForZoneRequest extends ListWaitingRoomsBaseRequ
   zoneId: string;
 }
 
-export type ListWaitingRoomsRequest =
-  | ListWaitingRoomsForAccountRequest
-  | ListWaitingRoomsForZoneRequest;
-
 export const ListWaitingRoomsForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
@@ -2511,17 +2506,6 @@ export const listWaitingRoomsForZone: API.PaginatedOperationMethod<
     pageSize: "perPage",
   } as const,
 }));
-
-export const listWaitingRooms = (
-  input: ListWaitingRoomsRequest,
-): stream.Stream<
-  ListWaitingRoomsResponse,
-  ListWaitingRoomsError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? listWaitingRoomsForAccount.pages(input)
-    : listWaitingRoomsForZone.pages(input);
 
 export interface CreateWaitingRoomRequest {
   /** Path param: Identifier. */

--- a/packages/cloudflare/src/services/waiting-rooms.ts
+++ b/packages/cloudflare/src/services/waiting-rooms.ts
@@ -5,6 +5,7 @@
  * DO NOT EDIT - regenerate with: bun scripts/generate.ts --service waiting-rooms
  */
 
+import * as stream from "effect/Stream";
 import * as Schema from "effect/Schema";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
@@ -2150,15 +2151,37 @@ export const getWaitingRoom: API.OperationMethod<
   errors: [],
 }));
 
-export interface ListWaitingRoomsRequest {}
+const ListWaitingRoomsBaseFields = {} as const;
 
-export const ListWaitingRoomsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
-    T.Http({
-      method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/waiting_rooms",
-    }),
-  ) as unknown as Schema.Schema<ListWaitingRoomsRequest>;
+export interface ListWaitingRoomsForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface ListWaitingRoomsForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+}
+
+export type ListWaitingRoomsRequest =
+  | ListWaitingRoomsForAccountRequest
+  | ListWaitingRoomsForZoneRequest;
+
+export const ListWaitingRoomsForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...ListWaitingRoomsBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/accounts/{account_id}/waiting_rooms" }),
+  ) as unknown as Schema.Schema<ListWaitingRoomsForAccountRequest>;
+
+export const ListWaitingRoomsForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...ListWaitingRoomsBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/zones/{zone_id}/waiting_rooms" }),
+  ) as unknown as Schema.Schema<ListWaitingRoomsForZoneRequest>;
 
 export interface ListWaitingRoomsResponse {
   result: {
@@ -2451,13 +2474,13 @@ export const ListWaitingRoomsResponse =
 
 export type ListWaitingRoomsError = DefaultErrors;
 
-export const listWaitingRooms: API.PaginatedOperationMethod<
-  ListWaitingRoomsRequest,
+export const listWaitingRoomsForAccount: API.PaginatedOperationMethod<
+  ListWaitingRoomsForAccountRequest,
   ListWaitingRoomsResponse,
   ListWaitingRoomsError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
-  input: ListWaitingRoomsRequest,
+  input: ListWaitingRoomsForAccountRequest,
   output: ListWaitingRoomsResponse,
   errors: [],
   pagination: {
@@ -2468,6 +2491,35 @@ export const listWaitingRooms: API.PaginatedOperationMethod<
     pageSize: "perPage",
   } as const,
 }));
+
+export const listWaitingRoomsForZone: API.PaginatedOperationMethod<
+  ListWaitingRoomsForZoneRequest,
+  ListWaitingRoomsResponse,
+  ListWaitingRoomsError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+  input: ListWaitingRoomsForZoneRequest,
+  output: ListWaitingRoomsResponse,
+  errors: [],
+  pagination: {
+    mode: "page",
+    inputToken: "page",
+    outputToken: "resultInfo.page",
+    items: "result",
+    pageSize: "perPage",
+  } as const,
+}));
+
+export const listWaitingRooms = (
+  input: ListWaitingRoomsRequest,
+): stream.Stream<
+  ListWaitingRoomsResponse,
+  ListWaitingRoomsError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? listWaitingRoomsForAccount.pages(input)
+    : listWaitingRoomsForZone.pages(input);
 
 export interface CreateWaitingRoomRequest {
   /** Path param: Identifier. */

--- a/packages/cloudflare/src/services/zero-trust.ts
+++ b/packages/cloudflare/src/services/zero-trust.ts
@@ -1180,16 +1180,18 @@ const GetAccessApplicationBaseFields = {
   appId: Schema.String.pipe(T.HttpPath("appId")),
 } as const;
 
-export interface GetAccessApplicationForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface GetAccessApplicationBaseRequest {
   appId: string;
 }
 
-export interface GetAccessApplicationForZoneRequest {
+export interface GetAccessApplicationForAccountRequest extends GetAccessApplicationBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetAccessApplicationForZoneRequest extends GetAccessApplicationBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  appId: string;
 }
 
 export type GetAccessApplicationRequest =
@@ -8898,12 +8900,14 @@ export const getAccessApplication = (
 
 const ListAccessApplicationsBaseFields = {} as const;
 
-export interface ListAccessApplicationsForAccountRequest {
+interface ListAccessApplicationsBaseRequest {}
+
+export interface ListAccessApplicationsForAccountRequest extends ListAccessApplicationsBaseRequest {
   /** Path param: The Account ID to use for this endpoint. */
   accountId: string;
 }
 
-export interface ListAccessApplicationsForZoneRequest {
+export interface ListAccessApplicationsForZoneRequest extends ListAccessApplicationsBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
@@ -17263,9 +17267,7 @@ const CreateAccessApplicationBaseFields = {
   tags: Schema.optional(Schema.Array(Schema.String)),
 } as const;
 
-export interface CreateAccessApplicationForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface CreateAccessApplicationBaseRequest {
   /** Body param: The primary hostname and path secured by Access. This domain will be displayed if the app is visible in the App Launcher. */
   domain: string;
   /** Body param: The application type. */
@@ -17431,172 +17433,14 @@ export interface CreateAccessApplicationForAccountRequest {
   tags?: string[];
 }
 
-export interface CreateAccessApplicationForZoneRequest {
+export interface CreateAccessApplicationForAccountRequest extends CreateAccessApplicationBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface CreateAccessApplicationForZoneRequest extends CreateAccessApplicationBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  /** Body param: The primary hostname and path secured by Access. This domain will be displayed if the app is visible in the App Launcher. */
-  domain: string;
-  /** Body param: The application type. */
-  type:
-    | "self_hosted"
-    | "saas"
-    | "ssh"
-    | "vnc"
-    | "app_launcher"
-    | "warp"
-    | "biso"
-    | "bookmark"
-    | "dash_sso"
-    | "infrastructure"
-    | "rdp"
-    | "mcp"
-    | "mcp_portal"
-    | "proxy_endpoint";
-  /** Body param: When set to true, users can authenticate to this application using their WARP session. When set to false this application will always require direct IdP authentication. This setting always */
-  allowAuthenticateViaWarp?: boolean;
-  /** Body param: Enables loading application content in an iFrame. */
-  allowIframe?: boolean;
-  /** Body param: The identity providers your users can select when connecting to this application. Defaults to all IdPs configured in your account. */
-  allowedIdps?: string[];
-  /** Body param: Displays the application in the App Launcher. */
-  appLauncherVisible?: boolean;
-  /** Body param: When set to `true`, users skip the identity provider selection step during login. You must specify only one identity provider in allowed_idps. */
-  autoRedirectToIdentity?: boolean;
-  /** Body param: */
-  corsHeaders?: {
-    allowAllHeaders?: boolean;
-    allowAllMethods?: boolean;
-    allowAllOrigins?: boolean;
-    allowCredentials?: boolean;
-    allowedHeaders?: string[];
-    allowedMethods?: (
-      | "GET"
-      | "POST"
-      | "HEAD"
-      | "PUT"
-      | "DELETE"
-      | "CONNECT"
-      | "OPTIONS"
-      | "TRACE"
-      | "PATCH"
-    )[];
-    allowedOrigins?: string[];
-    maxAge?: number;
-  };
-  /** Body param: The custom error message shown to a user when they are denied access to the application. */
-  customDenyMessage?: string;
-  /** Body param: The custom URL a user is redirected to when they are denied access to the application when failing identity-based rules. */
-  customDenyUrl?: string;
-  /** Body param: The custom URL a user is redirected to when they are denied access to the application when failing non-identity rules. */
-  customNonIdentityDenyUrl?: string;
-  /** Body param: The custom pages that will be displayed when applicable for this application */
-  customPages?: string[];
-  /** Body param: List of destinations secured by Access. This supersedes `self_hosted_domains` to allow for more flexibility in defining different types of domains. If `destinations` are provided, then `se */
-  destinations?: (
-    | { type?: "public"; uri?: string }
-    | {
-        cidr?: string;
-        hostname?: string;
-        l4Protocol?: "tcp" | "udp";
-        portRange?: string;
-        type?: "private";
-        vnetId?: string;
-      }
-    | { mcpServerId?: string; type?: "via_mcp_server_portal" }
-  )[];
-  /** Body param: Enables the binding cookie, which increases security against compromised authorization tokens and CSRF attacks. */
-  enableBindingCookie?: boolean;
-  /** Body param: Enables the HttpOnly cookie attribute, which increases security against XSS attacks. */
-  httpOnlyCookieAttribute?: boolean;
-  /** Body param: The image URL for the logo shown in the App Launcher dashboard. */
-  logoUrl?: string;
-  /** Body param: The name of the application. */
-  name?: string;
-  /** Body param: Allows options preflight requests to bypass Access authentication and go directly to the origin. Cannot turn on if cors_headers is set. */
-  optionsPreflightBypass?: boolean;
-  /** Body param: Enables cookie paths to scope an application's JWT to the application path. If disabled, the JWT will scope to the hostname by default */
-  pathCookieAttribute?: boolean;
-  /** Body param: The policies that Access applies to the application, in ascending order of precedence. Items can reference existing policies or create new policies exclusive to the application. */
-  policies?: (
-    | { id?: string; precedence?: number }
-    | string
-    | {
-        id?: string;
-        approvalGroups?: {
-          approvalsNeeded: number;
-          emailAddresses?: string[];
-          emailListUuid?: string;
-        }[];
-        approvalRequired?: boolean;
-        isolationRequired?: boolean;
-        precedence?: number;
-        purposeJustificationPrompt?: string;
-        purposeJustificationRequired?: boolean;
-        sessionDuration?: string;
-      }
-  )[];
-  /** Body param: Allows matching Access Service Tokens passed HTTP in a single header with this name. This works as an alternative to the (CF-Access-Client-Id, CF-Access-Client-Secret) pair of headers. The */
-  readServiceTokensFromHeader?: string;
-  /** Body param: Sets the SameSite cookie setting, which provides increased security against CSRF attacks. */
-  sameSiteCookieAttribute?: string;
-  /** Body param: Configuration for provisioning to this application via SCIM. This is currently in closed beta. */
-  scimConfig?: {
-    idpUid: string;
-    remoteUri: string;
-    authentication?:
-      | { password: string; scheme: "httpbasic"; user: string }
-      | { token: string; scheme: "oauthbearertoken" }
-      | {
-          authorizationUrl: string;
-          clientId: string;
-          clientSecret: string;
-          scheme: "oauth2";
-          tokenUrl: string;
-          scopes?: string[];
-        }
-      | {
-          clientId: string;
-          clientSecret: string;
-          scheme: "access_service_token";
-        }
-      | (
-          | { password: string; scheme: "httpbasic"; user: string }
-          | { token: string; scheme: "oauthbearertoken" }
-          | {
-              authorizationUrl: string;
-              clientId: string;
-              clientSecret: string;
-              scheme: "oauth2";
-              tokenUrl: string;
-              scopes?: string[];
-            }
-          | {
-              clientId: string;
-              clientSecret: string;
-              scheme: "access_service_token";
-            }
-        )[];
-    deactivateOnDelete?: boolean;
-    enabled?: boolean;
-    mappings?: {
-      schema: string;
-      enabled?: boolean;
-      filter?: string;
-      operations?: { create?: boolean; delete?: boolean; update?: boolean };
-      strictness?: "strict" | "passthrough";
-      transformJsonata?: string;
-    }[];
-  };
-  /** @deprecated Body param: List of public domains that Access will secure. This field is deprecated in favor of `destinations` and will be supported until   November 21, 2025.  If `destinations` are prov */
-  selfHostedDomains?: string[];
-  /** Body param: Returns a 401 status code when the request is blocked by a Service Auth policy. */
-  serviceAuth_401Redirect?: boolean;
-  /** Body param: The amount of time that tokens issued for this application will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. Note: unsupported for */
-  sessionDuration?: string;
-  /** Body param: Enables automatic authentication through cloudflared. */
-  skipInterstitial?: boolean;
-  /** Body param: The tags you want assigned to an application. Tags are used to filter applications in the App Launcher dashboard. */
-  tags?: string[];
 }
 
 export type CreateAccessApplicationRequest =
@@ -25647,9 +25491,7 @@ const UpdateAccessApplicationBaseFields = {
   tags: Schema.optional(Schema.Array(Schema.String)),
 } as const;
 
-export interface UpdateAccessApplicationForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface UpdateAccessApplicationBaseRequest {
   appId: string;
   /** Body param: The primary hostname and path secured by Access. This domain will be displayed if the app is visible in the App Launcher. */
   domain: string;
@@ -25816,173 +25658,14 @@ export interface UpdateAccessApplicationForAccountRequest {
   tags?: string[];
 }
 
-export interface UpdateAccessApplicationForZoneRequest {
+export interface UpdateAccessApplicationForAccountRequest extends UpdateAccessApplicationBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface UpdateAccessApplicationForZoneRequest extends UpdateAccessApplicationBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  appId: string;
-  /** Body param: The primary hostname and path secured by Access. This domain will be displayed if the app is visible in the App Launcher. */
-  domain: string;
-  /** Body param: The application type. */
-  type:
-    | "self_hosted"
-    | "saas"
-    | "ssh"
-    | "vnc"
-    | "app_launcher"
-    | "warp"
-    | "biso"
-    | "bookmark"
-    | "dash_sso"
-    | "infrastructure"
-    | "rdp"
-    | "mcp"
-    | "mcp_portal"
-    | "proxy_endpoint";
-  /** Body param: When set to true, users can authenticate to this application using their WARP session. When set to false this application will always require direct IdP authentication. This setting always */
-  allowAuthenticateViaWarp?: boolean;
-  /** Body param: Enables loading application content in an iFrame. */
-  allowIframe?: boolean;
-  /** Body param: The identity providers your users can select when connecting to this application. Defaults to all IdPs configured in your account. */
-  allowedIdps?: string[];
-  /** Body param: Displays the application in the App Launcher. */
-  appLauncherVisible?: boolean;
-  /** Body param: When set to `true`, users skip the identity provider selection step during login. You must specify only one identity provider in allowed_idps. */
-  autoRedirectToIdentity?: boolean;
-  /** Body param: */
-  corsHeaders?: {
-    allowAllHeaders?: boolean;
-    allowAllMethods?: boolean;
-    allowAllOrigins?: boolean;
-    allowCredentials?: boolean;
-    allowedHeaders?: string[];
-    allowedMethods?: (
-      | "GET"
-      | "POST"
-      | "HEAD"
-      | "PUT"
-      | "DELETE"
-      | "CONNECT"
-      | "OPTIONS"
-      | "TRACE"
-      | "PATCH"
-    )[];
-    allowedOrigins?: string[];
-    maxAge?: number;
-  };
-  /** Body param: The custom error message shown to a user when they are denied access to the application. */
-  customDenyMessage?: string;
-  /** Body param: The custom URL a user is redirected to when they are denied access to the application when failing identity-based rules. */
-  customDenyUrl?: string;
-  /** Body param: The custom URL a user is redirected to when they are denied access to the application when failing non-identity rules. */
-  customNonIdentityDenyUrl?: string;
-  /** Body param: The custom pages that will be displayed when applicable for this application */
-  customPages?: string[];
-  /** Body param: List of destinations secured by Access. This supersedes `self_hosted_domains` to allow for more flexibility in defining different types of domains. If `destinations` are provided, then `se */
-  destinations?: (
-    | { type?: "public"; uri?: string }
-    | {
-        cidr?: string;
-        hostname?: string;
-        l4Protocol?: "tcp" | "udp";
-        portRange?: string;
-        type?: "private";
-        vnetId?: string;
-      }
-    | { mcpServerId?: string; type?: "via_mcp_server_portal" }
-  )[];
-  /** Body param: Enables the binding cookie, which increases security against compromised authorization tokens and CSRF attacks. */
-  enableBindingCookie?: boolean;
-  /** Body param: Enables the HttpOnly cookie attribute, which increases security against XSS attacks. */
-  httpOnlyCookieAttribute?: boolean;
-  /** Body param: The image URL for the logo shown in the App Launcher dashboard. */
-  logoUrl?: string;
-  /** Body param: The name of the application. */
-  name?: string;
-  /** Body param: Allows options preflight requests to bypass Access authentication and go directly to the origin. Cannot turn on if cors_headers is set. */
-  optionsPreflightBypass?: boolean;
-  /** Body param: Enables cookie paths to scope an application's JWT to the application path. If disabled, the JWT will scope to the hostname by default */
-  pathCookieAttribute?: boolean;
-  /** Body param: The policies that Access applies to the application, in ascending order of precedence. Items can reference existing policies or create new policies exclusive to the application. */
-  policies?: (
-    | { id?: string; precedence?: number }
-    | string
-    | {
-        id?: string;
-        approvalGroups?: {
-          approvalsNeeded: number;
-          emailAddresses?: string[];
-          emailListUuid?: string;
-        }[];
-        approvalRequired?: boolean;
-        isolationRequired?: boolean;
-        precedence?: number;
-        purposeJustificationPrompt?: string;
-        purposeJustificationRequired?: boolean;
-        sessionDuration?: string;
-      }
-  )[];
-  /** Body param: Allows matching Access Service Tokens passed HTTP in a single header with this name. This works as an alternative to the (CF-Access-Client-Id, CF-Access-Client-Secret) pair of headers. The */
-  readServiceTokensFromHeader?: string;
-  /** Body param: Sets the SameSite cookie setting, which provides increased security against CSRF attacks. */
-  sameSiteCookieAttribute?: string;
-  /** Body param: Configuration for provisioning to this application via SCIM. This is currently in closed beta. */
-  scimConfig?: {
-    idpUid: string;
-    remoteUri: string;
-    authentication?:
-      | { password: string; scheme: "httpbasic"; user: string }
-      | { token: string; scheme: "oauthbearertoken" }
-      | {
-          authorizationUrl: string;
-          clientId: string;
-          clientSecret: string;
-          scheme: "oauth2";
-          tokenUrl: string;
-          scopes?: string[];
-        }
-      | {
-          clientId: string;
-          clientSecret: string;
-          scheme: "access_service_token";
-        }
-      | (
-          | { password: string; scheme: "httpbasic"; user: string }
-          | { token: string; scheme: "oauthbearertoken" }
-          | {
-              authorizationUrl: string;
-              clientId: string;
-              clientSecret: string;
-              scheme: "oauth2";
-              tokenUrl: string;
-              scopes?: string[];
-            }
-          | {
-              clientId: string;
-              clientSecret: string;
-              scheme: "access_service_token";
-            }
-        )[];
-    deactivateOnDelete?: boolean;
-    enabled?: boolean;
-    mappings?: {
-      schema: string;
-      enabled?: boolean;
-      filter?: string;
-      operations?: { create?: boolean; delete?: boolean; update?: boolean };
-      strictness?: "strict" | "passthrough";
-      transformJsonata?: string;
-    }[];
-  };
-  /** @deprecated Body param: List of public domains that Access will secure. This field is deprecated in favor of `destinations` and will be supported until   November 21, 2025.  If `destinations` are prov */
-  selfHostedDomains?: string[];
-  /** Body param: Returns a 401 status code when the request is blocked by a Service Auth policy. */
-  serviceAuth_401Redirect?: boolean;
-  /** Body param: The amount of time that tokens issued for this application will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. Note: unsupported for */
-  sessionDuration?: string;
-  /** Body param: Enables automatic authentication through cloudflared. */
-  skipInterstitial?: boolean;
-  /** Body param: The tags you want assigned to an application. Tags are used to filter applications in the App Launcher dashboard. */
-  tags?: string[];
 }
 
 export type UpdateAccessApplicationRequest =
@@ -33753,16 +33436,18 @@ const DeleteAccessApplicationBaseFields = {
   appId: Schema.String.pipe(T.HttpPath("appId")),
 } as const;
 
-export interface DeleteAccessApplicationForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface DeleteAccessApplicationBaseRequest {
   appId: string;
 }
 
-export interface DeleteAccessApplicationForZoneRequest {
+export interface DeleteAccessApplicationForAccountRequest extends DeleteAccessApplicationBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface DeleteAccessApplicationForZoneRequest extends DeleteAccessApplicationBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  appId: string;
 }
 
 export type DeleteAccessApplicationRequest =
@@ -33843,16 +33528,18 @@ const GetAccessApplicationCaBaseFields = {
   appId: Schema.String.pipe(T.HttpPath("appId")),
 } as const;
 
-export interface GetAccessApplicationCaForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface GetAccessApplicationCaBaseRequest {
   appId: string;
 }
 
-export interface GetAccessApplicationCaForZoneRequest {
+export interface GetAccessApplicationCaForAccountRequest extends GetAccessApplicationCaBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetAccessApplicationCaForZoneRequest extends GetAccessApplicationCaBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  appId: string;
 }
 
 export type GetAccessApplicationCaRequest =
@@ -33935,12 +33622,14 @@ export const getAccessApplicationCa = (
 
 const ListAccessApplicationCasBaseFields = {} as const;
 
-export interface ListAccessApplicationCasForAccountRequest {
+interface ListAccessApplicationCasBaseRequest {}
+
+export interface ListAccessApplicationCasForAccountRequest extends ListAccessApplicationCasBaseRequest {
   /** Path param: The Account ID to use for this endpoint. */
   accountId: string;
 }
 
-export interface ListAccessApplicationCasForZoneRequest {
+export interface ListAccessApplicationCasForZoneRequest extends ListAccessApplicationCasBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
@@ -34067,16 +33756,18 @@ const CreateAccessApplicationCaBaseFields = {
   appId: Schema.String.pipe(T.HttpPath("appId")),
 } as const;
 
-export interface CreateAccessApplicationCaForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface CreateAccessApplicationCaBaseRequest {
   appId: string;
 }
 
-export interface CreateAccessApplicationCaForZoneRequest {
+export interface CreateAccessApplicationCaForAccountRequest extends CreateAccessApplicationCaBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface CreateAccessApplicationCaForZoneRequest extends CreateAccessApplicationCaBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  appId: string;
 }
 
 export type CreateAccessApplicationCaRequest =
@@ -34161,16 +33852,18 @@ const DeleteAccessApplicationCaBaseFields = {
   appId: Schema.String.pipe(T.HttpPath("appId")),
 } as const;
 
-export interface DeleteAccessApplicationCaForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface DeleteAccessApplicationCaBaseRequest {
   appId: string;
 }
 
-export interface DeleteAccessApplicationCaForZoneRequest {
+export interface DeleteAccessApplicationCaForAccountRequest extends DeleteAccessApplicationCaBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface DeleteAccessApplicationCaForZoneRequest extends DeleteAccessApplicationCaBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  appId: string;
 }
 
 export type DeleteAccessApplicationCaRequest =
@@ -34255,18 +33948,19 @@ const GetAccessApplicationPolicyBaseFields = {
   policyId: Schema.String.pipe(T.HttpPath("policyId")),
 } as const;
 
-export interface GetAccessApplicationPolicyForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface GetAccessApplicationPolicyBaseRequest {
   appId: string;
   policyId: string;
 }
 
-export interface GetAccessApplicationPolicyForZoneRequest {
+export interface GetAccessApplicationPolicyForAccountRequest extends GetAccessApplicationPolicyBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetAccessApplicationPolicyForZoneRequest extends GetAccessApplicationPolicyBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  appId: string;
-  policyId: string;
 }
 
 export type GetAccessApplicationPolicyRequest =
@@ -35165,16 +34859,18 @@ const ListAccessApplicationPoliciesBaseFields = {
   appId: Schema.String.pipe(T.HttpPath("appId")),
 } as const;
 
-export interface ListAccessApplicationPoliciesForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface ListAccessApplicationPoliciesBaseRequest {
   appId: string;
 }
 
-export interface ListAccessApplicationPoliciesForZoneRequest {
+export interface ListAccessApplicationPoliciesForAccountRequest extends ListAccessApplicationPoliciesBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface ListAccessApplicationPoliciesForZoneRequest extends ListAccessApplicationPoliciesBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  appId: string;
 }
 
 export type ListAccessApplicationPoliciesRequest =
@@ -36149,9 +35845,7 @@ const CreateAccessApplicationPolicyBaseFields = {
   sessionDuration: Schema.optional(Schema.String),
 } as const;
 
-export interface CreateAccessApplicationPolicyForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface CreateAccessApplicationPolicyBaseRequest {
   appId: string;
   /** Body param: Administrators who can approve a temporary authentication request. */
   approvalGroups?: {
@@ -36173,28 +35867,14 @@ export interface CreateAccessApplicationPolicyForAccountRequest {
   sessionDuration?: string;
 }
 
-export interface CreateAccessApplicationPolicyForZoneRequest {
+export interface CreateAccessApplicationPolicyForAccountRequest extends CreateAccessApplicationPolicyBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface CreateAccessApplicationPolicyForZoneRequest extends CreateAccessApplicationPolicyBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  appId: string;
-  /** Body param: Administrators who can approve a temporary authentication request. */
-  approvalGroups?: {
-    approvalsNeeded: number;
-    emailAddresses?: string[];
-    emailListUuid?: string;
-  }[];
-  /** Body param: Requires the user to request access from an administrator at the start of each session. */
-  approvalRequired?: boolean;
-  /** Body param: Require this application to be served in an isolated browser for users matching this policy. 'Client Web Isolation' must be on for the account in order to use this feature. */
-  isolationRequired?: boolean;
-  /** Body param: The order of execution for this policy. Must be unique for each policy within an app. */
-  precedence?: number;
-  /** Body param: A custom message that will appear on the purpose justification screen. */
-  purposeJustificationPrompt?: string;
-  /** Body param: Require users to enter a justification when they log in to the application. */
-  purposeJustificationRequired?: boolean;
-  /** Body param: The amount of time that tokens issued for the application will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. */
-  sessionDuration?: string;
 }
 
 export type CreateAccessApplicationPolicyRequest =
@@ -37133,9 +36813,7 @@ const UpdateAccessApplicationPolicyBaseFields = {
   sessionDuration: Schema.optional(Schema.String),
 } as const;
 
-export interface UpdateAccessApplicationPolicyForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface UpdateAccessApplicationPolicyBaseRequest {
   appId: string;
   policyId: string;
   /** Body param: Administrators who can approve a temporary authentication request. */
@@ -37158,29 +36836,14 @@ export interface UpdateAccessApplicationPolicyForAccountRequest {
   sessionDuration?: string;
 }
 
-export interface UpdateAccessApplicationPolicyForZoneRequest {
+export interface UpdateAccessApplicationPolicyForAccountRequest extends UpdateAccessApplicationPolicyBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface UpdateAccessApplicationPolicyForZoneRequest extends UpdateAccessApplicationPolicyBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  appId: string;
-  policyId: string;
-  /** Body param: Administrators who can approve a temporary authentication request. */
-  approvalGroups?: {
-    approvalsNeeded: number;
-    emailAddresses?: string[];
-    emailListUuid?: string;
-  }[];
-  /** Body param: Requires the user to request access from an administrator at the start of each session. */
-  approvalRequired?: boolean;
-  /** Body param: Require this application to be served in an isolated browser for users matching this policy. 'Client Web Isolation' must be on for the account in order to use this feature. */
-  isolationRequired?: boolean;
-  /** Body param: The order of execution for this policy. Must be unique for each policy within an app. */
-  precedence?: number;
-  /** Body param: A custom message that will appear on the purpose justification screen. */
-  purposeJustificationPrompt?: string;
-  /** Body param: Require users to enter a justification when they log in to the application. */
-  purposeJustificationRequired?: boolean;
-  /** Body param: The amount of time that tokens issued for the application will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. */
-  sessionDuration?: string;
 }
 
 export type UpdateAccessApplicationPolicyRequest =
@@ -38098,18 +37761,19 @@ const DeleteAccessApplicationPolicyBaseFields = {
   policyId: Schema.String.pipe(T.HttpPath("policyId")),
 } as const;
 
-export interface DeleteAccessApplicationPolicyForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface DeleteAccessApplicationPolicyBaseRequest {
   appId: string;
   policyId: string;
 }
 
-export interface DeleteAccessApplicationPolicyForZoneRequest {
+export interface DeleteAccessApplicationPolicyForAccountRequest extends DeleteAccessApplicationPolicyBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface DeleteAccessApplicationPolicyForZoneRequest extends DeleteAccessApplicationPolicyBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  appId: string;
-  policyId: string;
 }
 
 export type DeleteAccessApplicationPolicyRequest =
@@ -39237,9 +38901,7 @@ const PutAccessApplicationSettingBaseFields = {
   skipInterstitial: Schema.optional(Schema.Boolean),
 } as const;
 
-export interface PutAccessApplicationSettingForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface PutAccessApplicationSettingBaseRequest {
   appId: string;
   /** Body param: Enables loading application content in an iFrame. */
   allowIframe?: boolean;
@@ -39247,14 +38909,14 @@ export interface PutAccessApplicationSettingForAccountRequest {
   skipInterstitial?: boolean;
 }
 
-export interface PutAccessApplicationSettingForZoneRequest {
+export interface PutAccessApplicationSettingForAccountRequest extends PutAccessApplicationSettingBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface PutAccessApplicationSettingForZoneRequest extends PutAccessApplicationSettingBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  appId: string;
-  /** Body param: Enables loading application content in an iFrame. */
-  allowIframe?: boolean;
-  /** Body param: Enables automatic authentication through cloudflared. */
-  skipInterstitial?: boolean;
 }
 
 export type PutAccessApplicationSettingRequest =
@@ -39356,9 +39018,7 @@ const PatchAccessApplicationSettingBaseFields = {
   skipInterstitial: Schema.optional(Schema.Boolean),
 } as const;
 
-export interface PatchAccessApplicationSettingForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface PatchAccessApplicationSettingBaseRequest {
   appId: string;
   /** Body param: Enables loading application content in an iFrame. */
   allowIframe?: boolean;
@@ -39366,14 +39026,14 @@ export interface PatchAccessApplicationSettingForAccountRequest {
   skipInterstitial?: boolean;
 }
 
-export interface PatchAccessApplicationSettingForZoneRequest {
+export interface PatchAccessApplicationSettingForAccountRequest extends PatchAccessApplicationSettingBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface PatchAccessApplicationSettingForZoneRequest extends PatchAccessApplicationSettingBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  appId: string;
-  /** Body param: Enables loading application content in an iFrame. */
-  allowIframe?: boolean;
-  /** Body param: Enables automatic authentication through cloudflared. */
-  skipInterstitial?: boolean;
 }
 
 export type PatchAccessApplicationSettingRequest =
@@ -39477,16 +39137,18 @@ const ListAccessApplicationUserPolicyChecksBaseFields = {
   appId: Schema.String.pipe(T.HttpPath("appId")),
 } as const;
 
-export interface ListAccessApplicationUserPolicyChecksForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface ListAccessApplicationUserPolicyChecksBaseRequest {
   appId: string;
 }
 
-export interface ListAccessApplicationUserPolicyChecksForZoneRequest {
+export interface ListAccessApplicationUserPolicyChecksForAccountRequest extends ListAccessApplicationUserPolicyChecksBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface ListAccessApplicationUserPolicyChecksForZoneRequest extends ListAccessApplicationUserPolicyChecksBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  appId: string;
 }
 
 export type ListAccessApplicationUserPolicyChecksRequest =
@@ -39975,16 +39637,18 @@ const GetAccessCertificateBaseFields = {
   certificateId: Schema.String.pipe(T.HttpPath("certificateId")),
 } as const;
 
-export interface GetAccessCertificateForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface GetAccessCertificateBaseRequest {
   certificateId: string;
 }
 
-export interface GetAccessCertificateForZoneRequest {
+export interface GetAccessCertificateForAccountRequest extends GetAccessCertificateBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetAccessCertificateForZoneRequest extends GetAccessCertificateBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  certificateId: string;
 }
 
 export type GetAccessCertificateRequest =
@@ -40085,12 +39749,14 @@ export const getAccessCertificate = (
 
 const ListAccessCertificatesBaseFields = {} as const;
 
-export interface ListAccessCertificatesForAccountRequest {
+interface ListAccessCertificatesBaseRequest {}
+
+export interface ListAccessCertificatesForAccountRequest extends ListAccessCertificatesBaseRequest {
   /** Path param: The Account ID to use for this endpoint. */
   accountId: string;
 }
 
-export interface ListAccessCertificatesForZoneRequest {
+export interface ListAccessCertificatesForZoneRequest extends ListAccessCertificatesBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
@@ -40236,9 +39902,7 @@ const CreateAccessCertificateBaseFields = {
   associatedHostnames: Schema.optional(Schema.Array(Schema.String)),
 } as const;
 
-export interface CreateAccessCertificateForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface CreateAccessCertificateBaseRequest {
   /** Body param: The certificate content. */
   certificate: string;
   /** Body param: The name of the certificate. */
@@ -40247,15 +39911,14 @@ export interface CreateAccessCertificateForAccountRequest {
   associatedHostnames?: string[];
 }
 
-export interface CreateAccessCertificateForZoneRequest {
+export interface CreateAccessCertificateForAccountRequest extends CreateAccessCertificateBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface CreateAccessCertificateForZoneRequest extends CreateAccessCertificateBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  /** Body param: The certificate content. */
-  certificate: string;
-  /** Body param: The name of the certificate. */
-  name: string;
-  /** Body param: The hostnames of the applications that will use this certificate. */
-  associatedHostnames?: string[];
 }
 
 export type CreateAccessCertificateRequest =
@@ -40367,9 +40030,7 @@ const UpdateAccessCertificateBaseFields = {
   name: Schema.optional(Schema.String),
 } as const;
 
-export interface UpdateAccessCertificateForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface UpdateAccessCertificateBaseRequest {
   certificateId: string;
   /** Body param: The hostnames of the applications that will use this certificate. */
   associatedHostnames: string[];
@@ -40377,14 +40038,14 @@ export interface UpdateAccessCertificateForAccountRequest {
   name?: string;
 }
 
-export interface UpdateAccessCertificateForZoneRequest {
+export interface UpdateAccessCertificateForAccountRequest extends UpdateAccessCertificateBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface UpdateAccessCertificateForZoneRequest extends UpdateAccessCertificateBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  certificateId: string;
-  /** Body param: The hostnames of the applications that will use this certificate. */
-  associatedHostnames: string[];
-  /** Body param: The name of the certificate. */
-  name?: string;
 }
 
 export type UpdateAccessCertificateRequest =
@@ -40495,16 +40156,18 @@ const DeleteAccessCertificateBaseFields = {
   certificateId: Schema.String.pipe(T.HttpPath("certificateId")),
 } as const;
 
-export interface DeleteAccessCertificateForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface DeleteAccessCertificateBaseRequest {
   certificateId: string;
 }
 
-export interface DeleteAccessCertificateForZoneRequest {
+export interface DeleteAccessCertificateForAccountRequest extends DeleteAccessCertificateBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface DeleteAccessCertificateForZoneRequest extends DeleteAccessCertificateBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  certificateId: string;
 }
 
 export type DeleteAccessCertificateRequest =
@@ -40586,12 +40249,14 @@ export const deleteAccessCertificate = (
 
 const GetAccessCertificateSettingBaseFields = {} as const;
 
-export interface GetAccessCertificateSettingForAccountRequest {
+interface GetAccessCertificateSettingBaseRequest {}
+
+export interface GetAccessCertificateSettingForAccountRequest extends GetAccessCertificateSettingBaseRequest {
   /** Path param: The Account ID to use for this endpoint. */
   accountId: string;
 }
 
-export interface GetAccessCertificateSettingForZoneRequest {
+export interface GetAccessCertificateSettingForZoneRequest extends GetAccessCertificateSettingBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
@@ -40706,9 +40371,7 @@ const PutAccessCertificateSettingBaseFields = {
   ),
 } as const;
 
-export interface PutAccessCertificateSettingForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface PutAccessCertificateSettingBaseRequest {
   /** Body param: */
   settings: {
     chinaNetwork: boolean;
@@ -40717,15 +40380,14 @@ export interface PutAccessCertificateSettingForAccountRequest {
   }[];
 }
 
-export interface PutAccessCertificateSettingForZoneRequest {
+export interface PutAccessCertificateSettingForAccountRequest extends PutAccessCertificateSettingBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface PutAccessCertificateSettingForZoneRequest extends PutAccessCertificateSettingBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  /** Body param: */
-  settings: {
-    chinaNetwork: boolean;
-    clientCertificateForwarding: boolean;
-    hostname: string;
-  }[];
 }
 
 export type PutAccessCertificateSettingRequest =
@@ -41278,16 +40940,18 @@ const GetAccessGroupBaseFields = {
   groupId: Schema.String.pipe(T.HttpPath("groupId")),
 } as const;
 
-export interface GetAccessGroupForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface GetAccessGroupBaseRequest {
   groupId: string;
 }
 
-export interface GetAccessGroupForZoneRequest {
+export interface GetAccessGroupForAccountRequest extends GetAccessGroupBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetAccessGroupForZoneRequest extends GetAccessGroupBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  groupId: string;
 }
 
 export type GetAccessGroupRequest =
@@ -42345,12 +42009,14 @@ export const getAccessGroup = (
 
 const ListAccessGroupsBaseFields = {} as const;
 
-export interface ListAccessGroupsForAccountRequest {
+interface ListAccessGroupsBaseRequest {}
+
+export interface ListAccessGroupsForAccountRequest extends ListAccessGroupsBaseRequest {
   /** Path param: The Account ID to use for this endpoint. */
   accountId: string;
 }
 
-export interface ListAccessGroupsForZoneRequest {
+export interface ListAccessGroupsForZoneRequest extends ListAccessGroupsBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
@@ -44023,9 +43689,7 @@ const CreateAccessGroupBaseFields = {
   ),
 } as const;
 
-export interface CreateAccessGroupForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface CreateAccessGroupBaseRequest {
   /** Body param: Rules evaluated with an OR logical operator. A user needs to meet only one of the Include rules. */
   include: (
     | { group: { id: string } }
@@ -44167,148 +43831,14 @@ export interface CreateAccessGroupForAccountRequest {
   )[];
 }
 
-export interface CreateAccessGroupForZoneRequest {
+export interface CreateAccessGroupForAccountRequest extends CreateAccessGroupBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface CreateAccessGroupForZoneRequest extends CreateAccessGroupBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  /** Body param: Rules evaluated with an OR logical operator. A user needs to meet only one of the Include rules. */
-  include: (
-    | { group: { id: string } }
-    | { anyValidServiceToken: unknown }
-    | { authContext: { id: string; acId: string; identityProviderId: string } }
-    | { authMethod: { authMethod: string } }
-    | { azureAD: { id: string; identityProviderId: string } }
-    | { certificate: unknown }
-    | { commonName: { commonName: string } }
-    | { geo: { countryCode: string } }
-    | { devicePosture: { integrationUid: string } }
-    | { emailDomain: { domain: string } }
-    | { emailList: { id: string } }
-    | { email: { email: string } }
-    | { everyone: unknown }
-    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
-    | {
-        githubOrganization: {
-          identityProviderId: string;
-          name: string;
-          team?: string;
-        };
-      }
-    | { gsuite: { email: string; identityProviderId: string } }
-    | { loginMethod: { id: string } }
-    | { ipList: { id: string } }
-    | { ip: { ip: string } }
-    | { okta: { identityProviderId: string; name: string } }
-    | {
-        saml: {
-          attributeName: string;
-          attributeValue: string;
-          identityProviderId: string;
-        };
-      }
-    | {
-        oidc: {
-          claimName: string;
-          claimValue: string;
-          identityProviderId: string;
-        };
-      }
-    | { serviceToken: { tokenId: string } }
-    | { linkedAppToken: { appUid: string } }
-  )[];
-  /** Body param: The name of the Access group. */
-  name: string;
-  /** Body param: Rules evaluated with a NOT logical operator. To match a policy, a user cannot meet any of the Exclude rules. */
-  exclude?: (
-    | { group: { id: string } }
-    | { anyValidServiceToken: unknown }
-    | { authContext: { id: string; acId: string; identityProviderId: string } }
-    | { authMethod: { authMethod: string } }
-    | { azureAD: { id: string; identityProviderId: string } }
-    | { certificate: unknown }
-    | { commonName: { commonName: string } }
-    | { geo: { countryCode: string } }
-    | { devicePosture: { integrationUid: string } }
-    | { emailDomain: { domain: string } }
-    | { emailList: { id: string } }
-    | { email: { email: string } }
-    | { everyone: unknown }
-    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
-    | {
-        githubOrganization: {
-          identityProviderId: string;
-          name: string;
-          team?: string;
-        };
-      }
-    | { gsuite: { email: string; identityProviderId: string } }
-    | { loginMethod: { id: string } }
-    | { ipList: { id: string } }
-    | { ip: { ip: string } }
-    | { okta: { identityProviderId: string; name: string } }
-    | {
-        saml: {
-          attributeName: string;
-          attributeValue: string;
-          identityProviderId: string;
-        };
-      }
-    | {
-        oidc: {
-          claimName: string;
-          claimValue: string;
-          identityProviderId: string;
-        };
-      }
-    | { serviceToken: { tokenId: string } }
-    | { linkedAppToken: { appUid: string } }
-  )[];
-  /** Body param: Whether this is the default group */
-  isDefault?: boolean;
-  /** Body param: Rules evaluated with an AND logical operator. To match a policy, a user must meet all of the Require rules. */
-  require?: (
-    | { group: { id: string } }
-    | { anyValidServiceToken: unknown }
-    | { authContext: { id: string; acId: string; identityProviderId: string } }
-    | { authMethod: { authMethod: string } }
-    | { azureAD: { id: string; identityProviderId: string } }
-    | { certificate: unknown }
-    | { commonName: { commonName: string } }
-    | { geo: { countryCode: string } }
-    | { devicePosture: { integrationUid: string } }
-    | { emailDomain: { domain: string } }
-    | { emailList: { id: string } }
-    | { email: { email: string } }
-    | { everyone: unknown }
-    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
-    | {
-        githubOrganization: {
-          identityProviderId: string;
-          name: string;
-          team?: string;
-        };
-      }
-    | { gsuite: { email: string; identityProviderId: string } }
-    | { loginMethod: { id: string } }
-    | { ipList: { id: string } }
-    | { ip: { ip: string } }
-    | { okta: { identityProviderId: string; name: string } }
-    | {
-        saml: {
-          attributeName: string;
-          attributeValue: string;
-          identityProviderId: string;
-        };
-      }
-    | {
-        oidc: {
-          claimName: string;
-          claimValue: string;
-          identityProviderId: string;
-        };
-      }
-    | { serviceToken: { tokenId: string } }
-    | { linkedAppToken: { appUid: string } }
-  )[];
 }
 
 export type CreateAccessGroupRequest =
@@ -45924,9 +45454,7 @@ const UpdateAccessGroupBaseFields = {
   ),
 } as const;
 
-export interface UpdateAccessGroupForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface UpdateAccessGroupBaseRequest {
   groupId: string;
   /** Body param: Rules evaluated with an OR logical operator. A user needs to meet only one of the Include rules. */
   include: (
@@ -46069,149 +45597,14 @@ export interface UpdateAccessGroupForAccountRequest {
   )[];
 }
 
-export interface UpdateAccessGroupForZoneRequest {
+export interface UpdateAccessGroupForAccountRequest extends UpdateAccessGroupBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface UpdateAccessGroupForZoneRequest extends UpdateAccessGroupBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  groupId: string;
-  /** Body param: Rules evaluated with an OR logical operator. A user needs to meet only one of the Include rules. */
-  include: (
-    | { group: { id: string } }
-    | { anyValidServiceToken: unknown }
-    | { authContext: { id: string; acId: string; identityProviderId: string } }
-    | { authMethod: { authMethod: string } }
-    | { azureAD: { id: string; identityProviderId: string } }
-    | { certificate: unknown }
-    | { commonName: { commonName: string } }
-    | { geo: { countryCode: string } }
-    | { devicePosture: { integrationUid: string } }
-    | { emailDomain: { domain: string } }
-    | { emailList: { id: string } }
-    | { email: { email: string } }
-    | { everyone: unknown }
-    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
-    | {
-        githubOrganization: {
-          identityProviderId: string;
-          name: string;
-          team?: string;
-        };
-      }
-    | { gsuite: { email: string; identityProviderId: string } }
-    | { loginMethod: { id: string } }
-    | { ipList: { id: string } }
-    | { ip: { ip: string } }
-    | { okta: { identityProviderId: string; name: string } }
-    | {
-        saml: {
-          attributeName: string;
-          attributeValue: string;
-          identityProviderId: string;
-        };
-      }
-    | {
-        oidc: {
-          claimName: string;
-          claimValue: string;
-          identityProviderId: string;
-        };
-      }
-    | { serviceToken: { tokenId: string } }
-    | { linkedAppToken: { appUid: string } }
-  )[];
-  /** Body param: The name of the Access group. */
-  name: string;
-  /** Body param: Rules evaluated with a NOT logical operator. To match a policy, a user cannot meet any of the Exclude rules. */
-  exclude?: (
-    | { group: { id: string } }
-    | { anyValidServiceToken: unknown }
-    | { authContext: { id: string; acId: string; identityProviderId: string } }
-    | { authMethod: { authMethod: string } }
-    | { azureAD: { id: string; identityProviderId: string } }
-    | { certificate: unknown }
-    | { commonName: { commonName: string } }
-    | { geo: { countryCode: string } }
-    | { devicePosture: { integrationUid: string } }
-    | { emailDomain: { domain: string } }
-    | { emailList: { id: string } }
-    | { email: { email: string } }
-    | { everyone: unknown }
-    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
-    | {
-        githubOrganization: {
-          identityProviderId: string;
-          name: string;
-          team?: string;
-        };
-      }
-    | { gsuite: { email: string; identityProviderId: string } }
-    | { loginMethod: { id: string } }
-    | { ipList: { id: string } }
-    | { ip: { ip: string } }
-    | { okta: { identityProviderId: string; name: string } }
-    | {
-        saml: {
-          attributeName: string;
-          attributeValue: string;
-          identityProviderId: string;
-        };
-      }
-    | {
-        oidc: {
-          claimName: string;
-          claimValue: string;
-          identityProviderId: string;
-        };
-      }
-    | { serviceToken: { tokenId: string } }
-    | { linkedAppToken: { appUid: string } }
-  )[];
-  /** Body param: Whether this is the default group */
-  isDefault?: boolean;
-  /** Body param: Rules evaluated with an AND logical operator. To match a policy, a user must meet all of the Require rules. */
-  require?: (
-    | { group: { id: string } }
-    | { anyValidServiceToken: unknown }
-    | { authContext: { id: string; acId: string; identityProviderId: string } }
-    | { authMethod: { authMethod: string } }
-    | { azureAD: { id: string; identityProviderId: string } }
-    | { certificate: unknown }
-    | { commonName: { commonName: string } }
-    | { geo: { countryCode: string } }
-    | { devicePosture: { integrationUid: string } }
-    | { emailDomain: { domain: string } }
-    | { emailList: { id: string } }
-    | { email: { email: string } }
-    | { everyone: unknown }
-    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
-    | {
-        githubOrganization: {
-          identityProviderId: string;
-          name: string;
-          team?: string;
-        };
-      }
-    | { gsuite: { email: string; identityProviderId: string } }
-    | { loginMethod: { id: string } }
-    | { ipList: { id: string } }
-    | { ip: { ip: string } }
-    | { okta: { identityProviderId: string; name: string } }
-    | {
-        saml: {
-          attributeName: string;
-          attributeValue: string;
-          identityProviderId: string;
-        };
-      }
-    | {
-        oidc: {
-          claimName: string;
-          claimValue: string;
-          identityProviderId: string;
-        };
-      }
-    | { serviceToken: { tokenId: string } }
-    | { linkedAppToken: { appUid: string } }
-  )[];
 }
 
 export type UpdateAccessGroupRequest =
@@ -47284,16 +46677,18 @@ const DeleteAccessGroupBaseFields = {
   groupId: Schema.String.pipe(T.HttpPath("groupId")),
 } as const;
 
-export interface DeleteAccessGroupForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface DeleteAccessGroupBaseRequest {
   groupId: string;
 }
 
-export interface DeleteAccessGroupForZoneRequest {
+export interface DeleteAccessGroupForAccountRequest extends DeleteAccessGroupBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface DeleteAccessGroupForZoneRequest extends DeleteAccessGroupBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  groupId: string;
 }
 
 export type DeleteAccessGroupRequest =
@@ -53544,16 +52939,18 @@ const GetAccessServiceTokenBaseFields = {
   serviceTokenId: Schema.String.pipe(T.HttpPath("serviceTokenId")),
 } as const;
 
-export interface GetAccessServiceTokenForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface GetAccessServiceTokenBaseRequest {
   serviceTokenId: string;
 }
 
-export interface GetAccessServiceTokenForZoneRequest {
+export interface GetAccessServiceTokenForAccountRequest extends GetAccessServiceTokenBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetAccessServiceTokenForZoneRequest extends GetAccessServiceTokenBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  serviceTokenId: string;
 }
 
 export type GetAccessServiceTokenRequest =
@@ -53652,12 +53049,14 @@ export const getAccessServiceToken = (
 
 const ListAccessServiceTokensBaseFields = {} as const;
 
-export interface ListAccessServiceTokensForAccountRequest {
+interface ListAccessServiceTokensBaseRequest {}
+
+export interface ListAccessServiceTokensForAccountRequest extends ListAccessServiceTokensBaseRequest {
   /** Path param: The Account ID to use for this endpoint. */
   accountId: string;
 }
 
-export interface ListAccessServiceTokensForZoneRequest {
+export interface ListAccessServiceTokensForZoneRequest extends ListAccessServiceTokensBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
@@ -53800,9 +53199,7 @@ const CreateAccessServiceTokenBaseFields = {
   previousClientSecretExpiresAt: Schema.optional(Schema.String),
 } as const;
 
-export interface CreateAccessServiceTokenForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface CreateAccessServiceTokenBaseRequest {
   /** Body param: The name of the service token. */
   name: string;
   /** Body param: A version number identifying the current `client_secret` associated with the service token. Incrementing it triggers a rotation; the previous secret will still be accepted until the time i */
@@ -53813,17 +53210,14 @@ export interface CreateAccessServiceTokenForAccountRequest {
   previousClientSecretExpiresAt?: string;
 }
 
-export interface CreateAccessServiceTokenForZoneRequest {
+export interface CreateAccessServiceTokenForAccountRequest extends CreateAccessServiceTokenBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface CreateAccessServiceTokenForZoneRequest extends CreateAccessServiceTokenBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  /** Body param: The name of the service token. */
-  name: string;
-  /** Body param: A version number identifying the current `client_secret` associated with the service token. Incrementing it triggers a rotation; the previous secret will still be accepted until the time i */
-  clientSecretVersion?: number;
-  /** Body param: The duration for how long the service token will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. The default is 1 year in hours (8760 */
-  duration?: string;
-  /** Body param: The expiration of the previous `client_secret`. This can be modified at any point after a rotation. For example, you may extend it further into the future if you need more time to update s */
-  previousClientSecretExpiresAt?: string;
 }
 
 export type CreateAccessServiceTokenRequest =
@@ -53938,9 +53332,7 @@ const UpdateAccessServiceTokenBaseFields = {
   previousClientSecretExpiresAt: Schema.optional(Schema.String),
 } as const;
 
-export interface UpdateAccessServiceTokenForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface UpdateAccessServiceTokenBaseRequest {
   serviceTokenId: string;
   /** Body param: A version number identifying the current `client_secret` associated with the service token. Incrementing it triggers a rotation; the previous secret will still be accepted until the time i */
   clientSecretVersion?: number;
@@ -53952,18 +53344,14 @@ export interface UpdateAccessServiceTokenForAccountRequest {
   previousClientSecretExpiresAt?: string;
 }
 
-export interface UpdateAccessServiceTokenForZoneRequest {
+export interface UpdateAccessServiceTokenForAccountRequest extends UpdateAccessServiceTokenBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface UpdateAccessServiceTokenForZoneRequest extends UpdateAccessServiceTokenBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  serviceTokenId: string;
-  /** Body param: A version number identifying the current `client_secret` associated with the service token. Incrementing it triggers a rotation; the previous secret will still be accepted until the time i */
-  clientSecretVersion?: number;
-  /** Body param: The duration for how long the service token will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. The default is 1 year in hours (8760 */
-  duration?: string;
-  /** Body param: The name of the service token. */
-  name?: string;
-  /** Body param: The expiration of the previous `client_secret`. This can be modified at any point after a rotation. For example, you may extend it further into the future if you need more time to update s */
-  previousClientSecretExpiresAt?: string;
 }
 
 export type UpdateAccessServiceTokenRequest =
@@ -54076,16 +53464,18 @@ const DeleteAccessServiceTokenBaseFields = {
   serviceTokenId: Schema.String.pipe(T.HttpPath("serviceTokenId")),
 } as const;
 
-export interface DeleteAccessServiceTokenForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface DeleteAccessServiceTokenBaseRequest {
   serviceTokenId: string;
 }
 
-export interface DeleteAccessServiceTokenForZoneRequest {
+export interface DeleteAccessServiceTokenForAccountRequest extends DeleteAccessServiceTokenBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface DeleteAccessServiceTokenForZoneRequest extends DeleteAccessServiceTokenBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  serviceTokenId: string;
 }
 
 export type DeleteAccessServiceTokenRequest =
@@ -90301,16 +89691,18 @@ const GetIdentityProviderBaseFields = {
   identityProviderId: Schema.String.pipe(T.HttpPath("identityProviderId")),
 } as const;
 
-export interface GetIdentityProviderForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface GetIdentityProviderBaseRequest {
   identityProviderId: string;
 }
 
-export interface GetIdentityProviderForZoneRequest {
+export interface GetIdentityProviderForAccountRequest extends GetIdentityProviderBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetIdentityProviderForZoneRequest extends GetIdentityProviderBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  identityProviderId: string;
 }
 
 export type GetIdentityProviderRequest =
@@ -91746,12 +91138,14 @@ export const getIdentityProvider = (
 
 const ListIdentityProvidersBaseFields = {} as const;
 
-export interface ListIdentityProvidersForAccountRequest {
+interface ListIdentityProvidersBaseRequest {}
+
+export interface ListIdentityProvidersForAccountRequest extends ListIdentityProvidersBaseRequest {
   /** Path param: The Account ID to use for this endpoint. */
   accountId: string;
 }
 
-export interface ListIdentityProvidersForZoneRequest {
+export interface ListIdentityProvidersForZoneRequest extends ListIdentityProvidersBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
@@ -93226,9 +92620,7 @@ const CreateIdentityProviderBaseFields = {
   ),
 } as const;
 
-export interface CreateIdentityProviderForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface CreateIdentityProviderBaseRequest {
   /** Body param: The configuration parameters for the identity provider. To view the required parameters for a specific provider, refer to our [developer documentation](https://developers.cloudflare.com/cl */
   config: {
     claims?: string[];
@@ -93267,45 +92659,14 @@ export interface CreateIdentityProviderForAccountRequest {
   };
 }
 
-export interface CreateIdentityProviderForZoneRequest {
+export interface CreateIdentityProviderForAccountRequest extends CreateIdentityProviderBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface CreateIdentityProviderForZoneRequest extends CreateIdentityProviderBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  /** Body param: The configuration parameters for the identity provider. To view the required parameters for a specific provider, refer to our [developer documentation](https://developers.cloudflare.com/cl */
-  config: {
-    claims?: string[];
-    clientId?: string;
-    clientSecret?: string;
-    conditionalAccessEnabled?: boolean;
-    directoryId?: string;
-    emailClaimName?: string;
-    prompt?: "login" | "select_account" | "none";
-    supportGroups?: boolean;
-  };
-  /** Body param: The name of the identity provider, shown to users on the login page. */
-  name: string;
-  /** Body param: The type of identity provider. To determine the value for a specific provider, refer to our [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integrat */
-  type:
-    | "onetimepin"
-    | "azureAD"
-    | "saml"
-    | "centrify"
-    | "facebook"
-    | "github"
-    | "google-apps"
-    | "google"
-    | "linkedin"
-    | "oidc"
-    | "okta"
-    | "onelogin"
-    | "pingone"
-    | "yandex";
-  /** Body param: The configuration settings for enabling a System for Cross-Domain Identity Management (SCIM) with the identity provider. */
-  scimConfig?: {
-    enabled?: boolean;
-    identityUpdateBehavior?: "automatic" | "reauth" | "no_action";
-    seatDeprovision?: boolean;
-    userDeprovision?: boolean;
-  };
 }
 
 export type CreateIdentityProviderRequest =
@@ -94812,9 +94173,7 @@ const UpdateIdentityProviderBaseFields = {
   ),
 } as const;
 
-export interface UpdateIdentityProviderForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface UpdateIdentityProviderBaseRequest {
   identityProviderId: string;
   /** Body param: The configuration parameters for the identity provider. To view the required parameters for a specific provider, refer to our [developer documentation](https://developers.cloudflare.com/cl */
   config: {
@@ -94854,46 +94213,14 @@ export interface UpdateIdentityProviderForAccountRequest {
   };
 }
 
-export interface UpdateIdentityProviderForZoneRequest {
+export interface UpdateIdentityProviderForAccountRequest extends UpdateIdentityProviderBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface UpdateIdentityProviderForZoneRequest extends UpdateIdentityProviderBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  identityProviderId: string;
-  /** Body param: The configuration parameters for the identity provider. To view the required parameters for a specific provider, refer to our [developer documentation](https://developers.cloudflare.com/cl */
-  config: {
-    claims?: string[];
-    clientId?: string;
-    clientSecret?: string;
-    conditionalAccessEnabled?: boolean;
-    directoryId?: string;
-    emailClaimName?: string;
-    prompt?: "login" | "select_account" | "none";
-    supportGroups?: boolean;
-  };
-  /** Body param: The name of the identity provider, shown to users on the login page. */
-  name: string;
-  /** Body param: The type of identity provider. To determine the value for a specific provider, refer to our [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integrat */
-  type:
-    | "onetimepin"
-    | "azureAD"
-    | "saml"
-    | "centrify"
-    | "facebook"
-    | "github"
-    | "google-apps"
-    | "google"
-    | "linkedin"
-    | "oidc"
-    | "okta"
-    | "onelogin"
-    | "pingone"
-    | "yandex";
-  /** Body param: The configuration settings for enabling a System for Cross-Domain Identity Management (SCIM) with the identity provider. */
-  scimConfig?: {
-    enabled?: boolean;
-    identityUpdateBehavior?: "automatic" | "reauth" | "no_action";
-    seatDeprovision?: boolean;
-    userDeprovision?: boolean;
-  };
 }
 
 export type UpdateIdentityProviderRequest =
@@ -96343,16 +95670,18 @@ const DeleteIdentityProviderBaseFields = {
   identityProviderId: Schema.String.pipe(T.HttpPath("identityProviderId")),
 } as const;
 
-export interface DeleteIdentityProviderForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface DeleteIdentityProviderBaseRequest {
   identityProviderId: string;
 }
 
-export interface DeleteIdentityProviderForZoneRequest {
+export interface DeleteIdentityProviderForAccountRequest extends DeleteIdentityProviderBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface DeleteIdentityProviderForZoneRequest extends DeleteIdentityProviderBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  identityProviderId: string;
 }
 
 export type DeleteIdentityProviderRequest =
@@ -98699,12 +98028,14 @@ export const deleteNetworkVirtualNetwork: API.OperationMethod<
 
 const ListOrganizationsBaseFields = {} as const;
 
-export interface ListOrganizationsForAccountRequest {
+interface ListOrganizationsBaseRequest {}
+
+export interface ListOrganizationsForAccountRequest extends ListOrganizationsBaseRequest {
   /** Path param: The Account ID to use for this endpoint. */
   accountId: string;
 }
 
-export interface ListOrganizationsForZoneRequest {
+export interface ListOrganizationsForZoneRequest extends ListOrganizationsBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
@@ -98917,9 +98248,7 @@ const CreateOrganizationBaseFields = {
   warpAuthSessionDuration: Schema.optional(Schema.String),
 } as const;
 
-export interface CreateOrganizationForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface CreateOrganizationBaseRequest {
   /** Body param: The unique subdomain assigned to your Zero Trust organization. */
   authDomain: string;
   /** Body param: The name of your Zero Trust organization. */
@@ -98948,35 +98277,14 @@ export interface CreateOrganizationForAccountRequest {
   warpAuthSessionDuration?: string;
 }
 
-export interface CreateOrganizationForZoneRequest {
+export interface CreateOrganizationForAccountRequest extends CreateOrganizationBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface CreateOrganizationForZoneRequest extends CreateOrganizationBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  /** Body param: The unique subdomain assigned to your Zero Trust organization. */
-  authDomain: string;
-  /** Body param: The name of your Zero Trust organization. */
-  name: string;
-  /** Body param: When set to true, users can authenticate via WARP for any application in your organization. Application settings will take precedence over this value. */
-  allowAuthenticateViaWarp?: boolean;
-  /** Body param: When set to `true`, users skip the identity provider selection step during login. */
-  autoRedirectToIdentity?: boolean;
-  /** Body param: Lock all settings as Read-Only in the Dashboard, regardless of user permission. Updates may only be made via the API or Terraform for this account when enabled. */
-  isUiReadOnly?: boolean;
-  /** Body param: */
-  loginDesign?: {
-    backgroundColor?: string;
-    footerText?: string;
-    headerText?: string;
-    logoPath?: string;
-    textColor?: string;
-  };
-  /** Body param: The amount of time that tokens issued for applications will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. */
-  sessionDuration?: string;
-  /** Body param: A description of the reason why the UI read only field is being toggled. */
-  uiReadOnlyToggleReason?: string;
-  /** Body param: The amount of time a user seat is inactive before it expires. When the user seat exceeds the set time of inactivity, the user is removed as an active seat and no longer counts against your */
-  userSeatExpirationInactiveTime?: string;
-  /** Body param: The amount of time that tokens issued for applications will be valid. Must be in the format `30m` or `2h45m`. Valid time units are: m, h. */
-  warpAuthSessionDuration?: string;
 }
 
 export type CreateOrganizationRequest =
@@ -99222,9 +98530,7 @@ const UpdateOrganizationBaseFields = {
   warpAuthSessionDuration: Schema.optional(Schema.String),
 } as const;
 
-export interface UpdateOrganizationForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface UpdateOrganizationBaseRequest {
   /** Body param: When set to true, users can authenticate via WARP for any application in your organization. Application settings will take precedence over this value. */
   allowAuthenticateViaWarp?: boolean;
   /** Body param: The unique subdomain assigned to your Zero Trust organization. */
@@ -99255,37 +98561,14 @@ export interface UpdateOrganizationForAccountRequest {
   warpAuthSessionDuration?: string;
 }
 
-export interface UpdateOrganizationForZoneRequest {
+export interface UpdateOrganizationForAccountRequest extends UpdateOrganizationBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface UpdateOrganizationForZoneRequest extends UpdateOrganizationBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  /** Body param: When set to true, users can authenticate via WARP for any application in your organization. Application settings will take precedence over this value. */
-  allowAuthenticateViaWarp?: boolean;
-  /** Body param: The unique subdomain assigned to your Zero Trust organization. */
-  authDomain?: string;
-  /** Body param: When set to `true`, users skip the identity provider selection step during login. */
-  autoRedirectToIdentity?: boolean;
-  /** Body param: */
-  customPages?: { forbidden?: string; identityDenied?: string };
-  /** Body param: Lock all settings as Read-Only in the Dashboard, regardless of user permission. Updates may only be made via the API or Terraform for this account when enabled. */
-  isUiReadOnly?: boolean;
-  /** Body param: */
-  loginDesign?: {
-    backgroundColor?: string;
-    footerText?: string;
-    headerText?: string;
-    logoPath?: string;
-    textColor?: string;
-  };
-  /** Body param: The name of your Zero Trust organization. */
-  name?: string;
-  /** Body param: The amount of time that tokens issued for applications will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. */
-  sessionDuration?: string;
-  /** Body param: A description of the reason why the UI read only field is being toggled. */
-  uiReadOnlyToggleReason?: string;
-  /** Body param: The amount of time a user seat is inactive before it expires. When the user seat exceeds the set time of inactivity, the user is removed as an active seat and no longer counts against your */
-  userSeatExpirationInactiveTime?: string;
-  /** Body param: The amount of time that tokens issued for applications will be valid. Must be in the format `30m` or `2h45m`. Valid time units are: m, h. */
-  warpAuthSessionDuration?: string;
 }
 
 export type UpdateOrganizationRequest =
@@ -101525,16 +100808,18 @@ const RevokeTokensAccessApplicationBaseFields = {
   appId: Schema.String.pipe(T.HttpPath("appId")),
 } as const;
 
-export interface RevokeTokensAccessApplicationForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface RevokeTokensAccessApplicationBaseRequest {
   appId: string;
 }
 
-export interface RevokeTokensAccessApplicationForZoneRequest {
+export interface RevokeTokensAccessApplicationForAccountRequest extends RevokeTokensAccessApplicationBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface RevokeTokensAccessApplicationForZoneRequest extends RevokeTokensAccessApplicationBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  appId: string;
 }
 
 export type RevokeTokensAccessApplicationRequest =
@@ -104952,9 +104237,7 @@ const RevokeUsersOrganizationBaseFields = {
   warpSessionReauth: Schema.optional(Schema.Boolean),
 } as const;
 
-export interface RevokeUsersOrganizationForAccountRequest {
-  /** Path param: The Account ID to use for this endpoint. */
-  accountId: string;
+interface RevokeUsersOrganizationBaseRequest {
   /** Query param: When set to `true`, all devices associated with the user will be revoked. */
   queryDevices?: boolean;
   /** Body param: The email of the user to revoke. */
@@ -104967,19 +104250,14 @@ export interface RevokeUsersOrganizationForAccountRequest {
   warpSessionReauth?: boolean;
 }
 
-export interface RevokeUsersOrganizationForZoneRequest {
+export interface RevokeUsersOrganizationForAccountRequest extends RevokeUsersOrganizationBaseRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface RevokeUsersOrganizationForZoneRequest extends RevokeUsersOrganizationBaseRequest {
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
-  /** Query param: When set to `true`, all devices associated with the user will be revoked. */
-  queryDevices?: boolean;
-  /** Body param: The email of the user to revoke. */
-  email: string;
-  /** Body param: When set to `true`, all devices associated with the user will be revoked. */
-  bodyDevices?: boolean;
-  /** Body param: The uuid of the user to revoke. */
-  userUid?: string;
-  /** Body param: When set to `true`, the user will be required to re-authenticate to WARP for all Gateway policies that enforce a WARP client session duration. When `false`, the user’s WARP session will re */
-  warpSessionReauth?: boolean;
 }
 
 export type RevokeUsersOrganizationRequest =

--- a/packages/cloudflare/src/services/zero-trust.ts
+++ b/packages/cloudflare/src/services/zero-trust.ts
@@ -5,6 +5,8 @@
  * DO NOT EDIT - regenerate with: bun scripts/generate.ts --service zero-trust
  */
 
+import * as Effect from "effect/Effect";
+import * as stream from "effect/Stream";
 import * as Schema from "effect/Schema";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
@@ -1174,15 +1176,44 @@ export const syncAccessAiControlMcpServer: API.OperationMethod<
 // AccessApplication
 // =============================================================================
 
-export interface GetAccessApplicationRequest {}
+const GetAccessApplicationBaseFields = {
+  appId: Schema.String.pipe(T.HttpPath("appId")),
+} as const;
 
-export const GetAccessApplicationRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
+export interface GetAccessApplicationForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  appId: string;
+}
+
+export interface GetAccessApplicationForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  appId: string;
+}
+
+export type GetAccessApplicationRequest =
+  | GetAccessApplicationForAccountRequest
+  | GetAccessApplicationForZoneRequest;
+
+export const GetAccessApplicationForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetAccessApplicationBaseFields,
+  }).pipe(
     T.Http({
       method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/apps/{appId}",
+      path: "/accounts/{account_id}/access/apps/{appId}",
     }),
-  ) as unknown as Schema.Schema<GetAccessApplicationRequest>;
+  ) as unknown as Schema.Schema<GetAccessApplicationForAccountRequest>;
+
+export const GetAccessApplicationForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...GetAccessApplicationBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/zones/{zone_id}/access/apps/{appId}" }),
+  ) as unknown as Schema.Schema<GetAccessApplicationForZoneRequest>;
 
 export type GetAccessApplicationResponse =
   | {
@@ -8832,26 +8863,70 @@ export const GetAccessApplicationResponse =
 
 export type GetAccessApplicationError = DefaultErrors;
 
-export const getAccessApplication: API.OperationMethod<
-  GetAccessApplicationRequest,
+export const getAccessApplicationForAccount: API.OperationMethod<
+  GetAccessApplicationForAccountRequest,
   GetAccessApplicationResponse,
   GetAccessApplicationError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: GetAccessApplicationRequest,
+  input: GetAccessApplicationForAccountRequest,
   output: GetAccessApplicationResponse,
   errors: [],
 }));
 
-export interface ListAccessApplicationsRequest {}
+export const getAccessApplicationForZone: API.OperationMethod<
+  GetAccessApplicationForZoneRequest,
+  GetAccessApplicationResponse,
+  GetAccessApplicationError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetAccessApplicationForZoneRequest,
+  output: GetAccessApplicationResponse,
+  errors: [],
+}));
 
-export const ListAccessApplicationsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
-    T.Http({
-      method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/apps",
-    }),
-  ) as unknown as Schema.Schema<ListAccessApplicationsRequest>;
+export const getAccessApplication = (
+  input: GetAccessApplicationRequest,
+): Effect.Effect<
+  GetAccessApplicationResponse,
+  GetAccessApplicationError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? getAccessApplicationForAccount(input)
+    : getAccessApplicationForZone(input);
+
+const ListAccessApplicationsBaseFields = {} as const;
+
+export interface ListAccessApplicationsForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface ListAccessApplicationsForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+}
+
+export type ListAccessApplicationsRequest =
+  | ListAccessApplicationsForAccountRequest
+  | ListAccessApplicationsForZoneRequest;
+
+export const ListAccessApplicationsForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...ListAccessApplicationsBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/accounts/{account_id}/access/apps" }),
+  ) as unknown as Schema.Schema<ListAccessApplicationsForAccountRequest>;
+
+export const ListAccessApplicationsForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...ListAccessApplicationsBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/zones/{zone_id}/access/apps" }),
+  ) as unknown as Schema.Schema<ListAccessApplicationsForZoneRequest>;
 
 export interface ListAccessApplicationsResponse {
   result: (
@@ -16855,13 +16930,13 @@ export const ListAccessApplicationsResponse =
 
 export type ListAccessApplicationsError = DefaultErrors;
 
-export const listAccessApplications: API.PaginatedOperationMethod<
-  ListAccessApplicationsRequest,
+export const listAccessApplicationsForAccount: API.PaginatedOperationMethod<
+  ListAccessApplicationsForAccountRequest,
   ListAccessApplicationsResponse,
   ListAccessApplicationsError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
-  input: ListAccessApplicationsRequest,
+  input: ListAccessApplicationsForAccountRequest,
   output: ListAccessApplicationsResponse,
   errors: [],
   pagination: {
@@ -16873,11 +16948,324 @@ export const listAccessApplications: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export interface CreateAccessApplicationRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
+export const listAccessApplicationsForZone: API.PaginatedOperationMethod<
+  ListAccessApplicationsForZoneRequest,
+  ListAccessApplicationsResponse,
+  ListAccessApplicationsError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+  input: ListAccessApplicationsForZoneRequest,
+  output: ListAccessApplicationsResponse,
+  errors: [],
+  pagination: {
+    mode: "page",
+    inputToken: "page",
+    outputToken: "resultInfo.page",
+    items: "result",
+    pageSize: "perPage",
+  } as const,
+}));
+
+export const listAccessApplications = (
+  input: ListAccessApplicationsRequest,
+): stream.Stream<
+  ListAccessApplicationsResponse,
+  ListAccessApplicationsError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? listAccessApplicationsForAccount.pages(input)
+    : listAccessApplicationsForZone.pages(input);
+
+const CreateAccessApplicationBaseFields = {
+  domain: Schema.String,
+  type: Schema.Literals([
+    "self_hosted",
+    "saas",
+    "ssh",
+    "vnc",
+    "app_launcher",
+    "warp",
+    "biso",
+    "bookmark",
+    "dash_sso",
+    "infrastructure",
+    "rdp",
+    "mcp",
+    "mcp_portal",
+    "proxy_endpoint",
+  ]),
+  allowAuthenticateViaWarp: Schema.optional(Schema.Boolean),
+  allowIframe: Schema.optional(Schema.Boolean),
+  allowedIdps: Schema.optional(Schema.Array(Schema.String)),
+  appLauncherVisible: Schema.optional(Schema.Boolean),
+  autoRedirectToIdentity: Schema.optional(Schema.Boolean),
+  corsHeaders: Schema.optional(
+    Schema.Struct({
+      allowAllHeaders: Schema.optional(Schema.Boolean),
+      allowAllMethods: Schema.optional(Schema.Boolean),
+      allowAllOrigins: Schema.optional(Schema.Boolean),
+      allowCredentials: Schema.optional(Schema.Boolean),
+      allowedHeaders: Schema.optional(Schema.Array(Schema.String)),
+      allowedMethods: Schema.optional(
+        Schema.Array(
+          Schema.Literals([
+            "GET",
+            "POST",
+            "HEAD",
+            "PUT",
+            "DELETE",
+            "CONNECT",
+            "OPTIONS",
+            "TRACE",
+            "PATCH",
+          ]),
+        ),
+      ),
+      allowedOrigins: Schema.optional(Schema.Array(Schema.String)),
+      maxAge: Schema.optional(Schema.Number),
+    }).pipe(
+      Schema.encodeKeys({
+        allowAllHeaders: "allow_all_headers",
+        allowAllMethods: "allow_all_methods",
+        allowAllOrigins: "allow_all_origins",
+        allowCredentials: "allow_credentials",
+        allowedHeaders: "allowed_headers",
+        allowedMethods: "allowed_methods",
+        allowedOrigins: "allowed_origins",
+        maxAge: "max_age",
+      }),
+    ),
+  ),
+  customDenyMessage: Schema.optional(Schema.String),
+  customDenyUrl: Schema.optional(Schema.String),
+  customNonIdentityDenyUrl: Schema.optional(Schema.String),
+  customPages: Schema.optional(Schema.Array(Schema.String)),
+  destinations: Schema.optional(
+    Schema.Array(
+      Schema.Union([
+        Schema.Struct({
+          type: Schema.optional(Schema.Literal("public")),
+          uri: Schema.optional(Schema.String),
+        }),
+        Schema.Struct({
+          cidr: Schema.optional(Schema.String),
+          hostname: Schema.optional(Schema.String),
+          l4Protocol: Schema.optional(Schema.Literals(["tcp", "udp"])),
+          portRange: Schema.optional(Schema.String),
+          type: Schema.optional(Schema.Literal("private")),
+          vnetId: Schema.optional(Schema.String),
+        }).pipe(
+          Schema.encodeKeys({
+            cidr: "cidr",
+            hostname: "hostname",
+            l4Protocol: "l4_protocol",
+            portRange: "port_range",
+            type: "type",
+            vnetId: "vnet_id",
+          }),
+        ),
+        Schema.Struct({
+          mcpServerId: Schema.optional(Schema.String),
+          type: Schema.optional(Schema.Literal("via_mcp_server_portal")),
+        }).pipe(
+          Schema.encodeKeys({ mcpServerId: "mcp_server_id", type: "type" }),
+        ),
+      ]),
+    ),
+  ),
+  enableBindingCookie: Schema.optional(Schema.Boolean),
+  httpOnlyCookieAttribute: Schema.optional(Schema.Boolean),
+  logoUrl: Schema.optional(Schema.String),
+  name: Schema.optional(Schema.String),
+  optionsPreflightBypass: Schema.optional(Schema.Boolean),
+  pathCookieAttribute: Schema.optional(Schema.Boolean),
+  policies: Schema.optional(
+    Schema.Array(
+      Schema.Union([
+        Schema.Struct({
+          id: Schema.optional(Schema.String),
+          precedence: Schema.optional(Schema.Number),
+        }),
+        Schema.String,
+        Schema.Struct({
+          id: Schema.optional(Schema.String),
+          approvalGroups: Schema.optional(
+            Schema.Array(
+              Schema.Struct({
+                approvalsNeeded: Schema.Number,
+                emailAddresses: Schema.optional(Schema.Array(Schema.String)),
+                emailListUuid: Schema.optional(Schema.String),
+              }).pipe(
+                Schema.encodeKeys({
+                  approvalsNeeded: "approvals_needed",
+                  emailAddresses: "email_addresses",
+                  emailListUuid: "email_list_uuid",
+                }),
+              ),
+            ),
+          ),
+          approvalRequired: Schema.optional(Schema.Boolean),
+          isolationRequired: Schema.optional(Schema.Boolean),
+          precedence: Schema.optional(Schema.Number),
+          purposeJustificationPrompt: Schema.optional(Schema.String),
+          purposeJustificationRequired: Schema.optional(Schema.Boolean),
+          sessionDuration: Schema.optional(Schema.String),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            approvalGroups: "approval_groups",
+            approvalRequired: "approval_required",
+            isolationRequired: "isolation_required",
+            precedence: "precedence",
+            purposeJustificationPrompt: "purpose_justification_prompt",
+            purposeJustificationRequired: "purpose_justification_required",
+            sessionDuration: "session_duration",
+          }),
+        ),
+      ]),
+    ),
+  ),
+  readServiceTokensFromHeader: Schema.optional(Schema.String),
+  sameSiteCookieAttribute: Schema.optional(Schema.String),
+  scimConfig: Schema.optional(
+    Schema.Struct({
+      idpUid: Schema.String,
+      remoteUri: Schema.String,
+      authentication: Schema.optional(
+        Schema.Union([
+          Schema.Struct({
+            authorizationUrl: Schema.String,
+            clientId: Schema.String,
+            clientSecret: SensitiveString,
+            scheme: Schema.Literal("oauth2"),
+            tokenUrl: Schema.String,
+            scopes: Schema.optional(Schema.Array(Schema.String)),
+          }).pipe(
+            Schema.encodeKeys({
+              authorizationUrl: "authorization_url",
+              clientId: "client_id",
+              clientSecret: "client_secret",
+              scheme: "scheme",
+              tokenUrl: "token_url",
+              scopes: "scopes",
+            }),
+          ),
+          Schema.Struct({
+            password: SensitiveString,
+            scheme: Schema.Literal("httpbasic"),
+            user: Schema.String,
+          }),
+          Schema.Struct({
+            clientId: Schema.String,
+            clientSecret: SensitiveString,
+            scheme: Schema.Literal("access_service_token"),
+          }).pipe(
+            Schema.encodeKeys({
+              clientId: "client_id",
+              clientSecret: "client_secret",
+              scheme: "scheme",
+            }),
+          ),
+          Schema.Struct({
+            token: Schema.String,
+            scheme: Schema.Literal("oauthbearertoken"),
+          }),
+          Schema.Array(
+            Schema.Union([
+              Schema.Struct({
+                authorizationUrl: Schema.String,
+                clientId: Schema.String,
+                clientSecret: SensitiveString,
+                scheme: Schema.Literal("oauth2"),
+                tokenUrl: Schema.String,
+                scopes: Schema.optional(Schema.Array(Schema.String)),
+              }).pipe(
+                Schema.encodeKeys({
+                  authorizationUrl: "authorization_url",
+                  clientId: "client_id",
+                  clientSecret: "client_secret",
+                  scheme: "scheme",
+                  tokenUrl: "token_url",
+                  scopes: "scopes",
+                }),
+              ),
+              Schema.Struct({
+                password: SensitiveString,
+                scheme: Schema.Literal("httpbasic"),
+                user: Schema.String,
+              }),
+              Schema.Struct({
+                clientId: Schema.String,
+                clientSecret: SensitiveString,
+                scheme: Schema.Literal("access_service_token"),
+              }).pipe(
+                Schema.encodeKeys({
+                  clientId: "client_id",
+                  clientSecret: "client_secret",
+                  scheme: "scheme",
+                }),
+              ),
+              Schema.Struct({
+                token: Schema.String,
+                scheme: Schema.Literal("oauthbearertoken"),
+              }),
+            ]),
+          ),
+        ]),
+      ),
+      deactivateOnDelete: Schema.optional(Schema.Boolean),
+      enabled: Schema.optional(Schema.Boolean),
+      mappings: Schema.optional(
+        Schema.Array(
+          Schema.Struct({
+            schema: Schema.String,
+            enabled: Schema.optional(Schema.Boolean),
+            filter: Schema.optional(Schema.String),
+            operations: Schema.optional(
+              Schema.Struct({
+                create: Schema.optional(Schema.Boolean),
+                delete: Schema.optional(Schema.Boolean),
+                update: Schema.optional(Schema.Boolean),
+              }),
+            ),
+            strictness: Schema.optional(
+              Schema.Literals(["strict", "passthrough"]),
+            ),
+            transformJsonata: Schema.optional(Schema.String),
+          }).pipe(
+            Schema.encodeKeys({
+              schema: "schema",
+              enabled: "enabled",
+              filter: "filter",
+              operations: "operations",
+              strictness: "strictness",
+              transformJsonata: "transform_jsonata",
+            }),
+          ),
+        ),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        idpUid: "idp_uid",
+        remoteUri: "remote_uri",
+        authentication: "authentication",
+        deactivateOnDelete: "deactivate_on_delete",
+        enabled: "enabled",
+        mappings: "mappings",
+      }),
+    ),
+  ),
+  selfHostedDomains: Schema.optional(Schema.Array(Schema.String)),
+  serviceAuth_401Redirect: Schema.optional(Schema.Boolean),
+  sessionDuration: Schema.optional(Schema.String),
+  skipInterstitial: Schema.optional(Schema.Boolean),
+  tags: Schema.optional(Schema.Array(Schema.String)),
+} as const;
+
+export interface CreateAccessApplicationForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   /** Body param: The primary hostname and path secured by Access. This domain will be displayed if the app is visible in the App Launcher. */
   domain: string;
   /** Body param: The application type. */
@@ -17043,293 +17431,182 @@ export interface CreateAccessApplicationRequest {
   tags?: string[];
 }
 
-export const CreateAccessApplicationRequest =
+export interface CreateAccessApplicationForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  /** Body param: The primary hostname and path secured by Access. This domain will be displayed if the app is visible in the App Launcher. */
+  domain: string;
+  /** Body param: The application type. */
+  type:
+    | "self_hosted"
+    | "saas"
+    | "ssh"
+    | "vnc"
+    | "app_launcher"
+    | "warp"
+    | "biso"
+    | "bookmark"
+    | "dash_sso"
+    | "infrastructure"
+    | "rdp"
+    | "mcp"
+    | "mcp_portal"
+    | "proxy_endpoint";
+  /** Body param: When set to true, users can authenticate to this application using their WARP session. When set to false this application will always require direct IdP authentication. This setting always */
+  allowAuthenticateViaWarp?: boolean;
+  /** Body param: Enables loading application content in an iFrame. */
+  allowIframe?: boolean;
+  /** Body param: The identity providers your users can select when connecting to this application. Defaults to all IdPs configured in your account. */
+  allowedIdps?: string[];
+  /** Body param: Displays the application in the App Launcher. */
+  appLauncherVisible?: boolean;
+  /** Body param: When set to `true`, users skip the identity provider selection step during login. You must specify only one identity provider in allowed_idps. */
+  autoRedirectToIdentity?: boolean;
+  /** Body param: */
+  corsHeaders?: {
+    allowAllHeaders?: boolean;
+    allowAllMethods?: boolean;
+    allowAllOrigins?: boolean;
+    allowCredentials?: boolean;
+    allowedHeaders?: string[];
+    allowedMethods?: (
+      | "GET"
+      | "POST"
+      | "HEAD"
+      | "PUT"
+      | "DELETE"
+      | "CONNECT"
+      | "OPTIONS"
+      | "TRACE"
+      | "PATCH"
+    )[];
+    allowedOrigins?: string[];
+    maxAge?: number;
+  };
+  /** Body param: The custom error message shown to a user when they are denied access to the application. */
+  customDenyMessage?: string;
+  /** Body param: The custom URL a user is redirected to when they are denied access to the application when failing identity-based rules. */
+  customDenyUrl?: string;
+  /** Body param: The custom URL a user is redirected to when they are denied access to the application when failing non-identity rules. */
+  customNonIdentityDenyUrl?: string;
+  /** Body param: The custom pages that will be displayed when applicable for this application */
+  customPages?: string[];
+  /** Body param: List of destinations secured by Access. This supersedes `self_hosted_domains` to allow for more flexibility in defining different types of domains. If `destinations` are provided, then `se */
+  destinations?: (
+    | { type?: "public"; uri?: string }
+    | {
+        cidr?: string;
+        hostname?: string;
+        l4Protocol?: "tcp" | "udp";
+        portRange?: string;
+        type?: "private";
+        vnetId?: string;
+      }
+    | { mcpServerId?: string; type?: "via_mcp_server_portal" }
+  )[];
+  /** Body param: Enables the binding cookie, which increases security against compromised authorization tokens and CSRF attacks. */
+  enableBindingCookie?: boolean;
+  /** Body param: Enables the HttpOnly cookie attribute, which increases security against XSS attacks. */
+  httpOnlyCookieAttribute?: boolean;
+  /** Body param: The image URL for the logo shown in the App Launcher dashboard. */
+  logoUrl?: string;
+  /** Body param: The name of the application. */
+  name?: string;
+  /** Body param: Allows options preflight requests to bypass Access authentication and go directly to the origin. Cannot turn on if cors_headers is set. */
+  optionsPreflightBypass?: boolean;
+  /** Body param: Enables cookie paths to scope an application's JWT to the application path. If disabled, the JWT will scope to the hostname by default */
+  pathCookieAttribute?: boolean;
+  /** Body param: The policies that Access applies to the application, in ascending order of precedence. Items can reference existing policies or create new policies exclusive to the application. */
+  policies?: (
+    | { id?: string; precedence?: number }
+    | string
+    | {
+        id?: string;
+        approvalGroups?: {
+          approvalsNeeded: number;
+          emailAddresses?: string[];
+          emailListUuid?: string;
+        }[];
+        approvalRequired?: boolean;
+        isolationRequired?: boolean;
+        precedence?: number;
+        purposeJustificationPrompt?: string;
+        purposeJustificationRequired?: boolean;
+        sessionDuration?: string;
+      }
+  )[];
+  /** Body param: Allows matching Access Service Tokens passed HTTP in a single header with this name. This works as an alternative to the (CF-Access-Client-Id, CF-Access-Client-Secret) pair of headers. The */
+  readServiceTokensFromHeader?: string;
+  /** Body param: Sets the SameSite cookie setting, which provides increased security against CSRF attacks. */
+  sameSiteCookieAttribute?: string;
+  /** Body param: Configuration for provisioning to this application via SCIM. This is currently in closed beta. */
+  scimConfig?: {
+    idpUid: string;
+    remoteUri: string;
+    authentication?:
+      | { password: string; scheme: "httpbasic"; user: string }
+      | { token: string; scheme: "oauthbearertoken" }
+      | {
+          authorizationUrl: string;
+          clientId: string;
+          clientSecret: string;
+          scheme: "oauth2";
+          tokenUrl: string;
+          scopes?: string[];
+        }
+      | {
+          clientId: string;
+          clientSecret: string;
+          scheme: "access_service_token";
+        }
+      | (
+          | { password: string; scheme: "httpbasic"; user: string }
+          | { token: string; scheme: "oauthbearertoken" }
+          | {
+              authorizationUrl: string;
+              clientId: string;
+              clientSecret: string;
+              scheme: "oauth2";
+              tokenUrl: string;
+              scopes?: string[];
+            }
+          | {
+              clientId: string;
+              clientSecret: string;
+              scheme: "access_service_token";
+            }
+        )[];
+    deactivateOnDelete?: boolean;
+    enabled?: boolean;
+    mappings?: {
+      schema: string;
+      enabled?: boolean;
+      filter?: string;
+      operations?: { create?: boolean; delete?: boolean; update?: boolean };
+      strictness?: "strict" | "passthrough";
+      transformJsonata?: string;
+    }[];
+  };
+  /** @deprecated Body param: List of public domains that Access will secure. This field is deprecated in favor of `destinations` and will be supported until   November 21, 2025.  If `destinations` are prov */
+  selfHostedDomains?: string[];
+  /** Body param: Returns a 401 status code when the request is blocked by a Service Auth policy. */
+  serviceAuth_401Redirect?: boolean;
+  /** Body param: The amount of time that tokens issued for this application will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. Note: unsupported for */
+  sessionDuration?: string;
+  /** Body param: Enables automatic authentication through cloudflared. */
+  skipInterstitial?: boolean;
+  /** Body param: The tags you want assigned to an application. Tags are used to filter applications in the App Launcher dashboard. */
+  tags?: string[];
+}
+
+export type CreateAccessApplicationRequest =
+  | CreateAccessApplicationForAccountRequest
+  | CreateAccessApplicationForZoneRequest;
+
+export const CreateAccessApplicationForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    domain: Schema.String,
-    type: Schema.Literals([
-      "self_hosted",
-      "saas",
-      "ssh",
-      "vnc",
-      "app_launcher",
-      "warp",
-      "biso",
-      "bookmark",
-      "dash_sso",
-      "infrastructure",
-      "rdp",
-      "mcp",
-      "mcp_portal",
-      "proxy_endpoint",
-    ]),
-    allowAuthenticateViaWarp: Schema.optional(Schema.Boolean),
-    allowIframe: Schema.optional(Schema.Boolean),
-    allowedIdps: Schema.optional(Schema.Array(Schema.String)),
-    appLauncherVisible: Schema.optional(Schema.Boolean),
-    autoRedirectToIdentity: Schema.optional(Schema.Boolean),
-    corsHeaders: Schema.optional(
-      Schema.Struct({
-        allowAllHeaders: Schema.optional(Schema.Boolean),
-        allowAllMethods: Schema.optional(Schema.Boolean),
-        allowAllOrigins: Schema.optional(Schema.Boolean),
-        allowCredentials: Schema.optional(Schema.Boolean),
-        allowedHeaders: Schema.optional(Schema.Array(Schema.String)),
-        allowedMethods: Schema.optional(
-          Schema.Array(
-            Schema.Literals([
-              "GET",
-              "POST",
-              "HEAD",
-              "PUT",
-              "DELETE",
-              "CONNECT",
-              "OPTIONS",
-              "TRACE",
-              "PATCH",
-            ]),
-          ),
-        ),
-        allowedOrigins: Schema.optional(Schema.Array(Schema.String)),
-        maxAge: Schema.optional(Schema.Number),
-      }).pipe(
-        Schema.encodeKeys({
-          allowAllHeaders: "allow_all_headers",
-          allowAllMethods: "allow_all_methods",
-          allowAllOrigins: "allow_all_origins",
-          allowCredentials: "allow_credentials",
-          allowedHeaders: "allowed_headers",
-          allowedMethods: "allowed_methods",
-          allowedOrigins: "allowed_origins",
-          maxAge: "max_age",
-        }),
-      ),
-    ),
-    customDenyMessage: Schema.optional(Schema.String),
-    customDenyUrl: Schema.optional(Schema.String),
-    customNonIdentityDenyUrl: Schema.optional(Schema.String),
-    customPages: Schema.optional(Schema.Array(Schema.String)),
-    destinations: Schema.optional(
-      Schema.Array(
-        Schema.Union([
-          Schema.Struct({
-            type: Schema.optional(Schema.Literal("public")),
-            uri: Schema.optional(Schema.String),
-          }),
-          Schema.Struct({
-            cidr: Schema.optional(Schema.String),
-            hostname: Schema.optional(Schema.String),
-            l4Protocol: Schema.optional(Schema.Literals(["tcp", "udp"])),
-            portRange: Schema.optional(Schema.String),
-            type: Schema.optional(Schema.Literal("private")),
-            vnetId: Schema.optional(Schema.String),
-          }).pipe(
-            Schema.encodeKeys({
-              cidr: "cidr",
-              hostname: "hostname",
-              l4Protocol: "l4_protocol",
-              portRange: "port_range",
-              type: "type",
-              vnetId: "vnet_id",
-            }),
-          ),
-          Schema.Struct({
-            mcpServerId: Schema.optional(Schema.String),
-            type: Schema.optional(Schema.Literal("via_mcp_server_portal")),
-          }).pipe(
-            Schema.encodeKeys({ mcpServerId: "mcp_server_id", type: "type" }),
-          ),
-        ]),
-      ),
-    ),
-    enableBindingCookie: Schema.optional(Schema.Boolean),
-    httpOnlyCookieAttribute: Schema.optional(Schema.Boolean),
-    logoUrl: Schema.optional(Schema.String),
-    name: Schema.optional(Schema.String),
-    optionsPreflightBypass: Schema.optional(Schema.Boolean),
-    pathCookieAttribute: Schema.optional(Schema.Boolean),
-    policies: Schema.optional(
-      Schema.Array(
-        Schema.Union([
-          Schema.Struct({
-            id: Schema.optional(Schema.String),
-            precedence: Schema.optional(Schema.Number),
-          }),
-          Schema.String,
-          Schema.Struct({
-            id: Schema.optional(Schema.String),
-            approvalGroups: Schema.optional(
-              Schema.Array(
-                Schema.Struct({
-                  approvalsNeeded: Schema.Number,
-                  emailAddresses: Schema.optional(Schema.Array(Schema.String)),
-                  emailListUuid: Schema.optional(Schema.String),
-                }).pipe(
-                  Schema.encodeKeys({
-                    approvalsNeeded: "approvals_needed",
-                    emailAddresses: "email_addresses",
-                    emailListUuid: "email_list_uuid",
-                  }),
-                ),
-              ),
-            ),
-            approvalRequired: Schema.optional(Schema.Boolean),
-            isolationRequired: Schema.optional(Schema.Boolean),
-            precedence: Schema.optional(Schema.Number),
-            purposeJustificationPrompt: Schema.optional(Schema.String),
-            purposeJustificationRequired: Schema.optional(Schema.Boolean),
-            sessionDuration: Schema.optional(Schema.String),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              approvalGroups: "approval_groups",
-              approvalRequired: "approval_required",
-              isolationRequired: "isolation_required",
-              precedence: "precedence",
-              purposeJustificationPrompt: "purpose_justification_prompt",
-              purposeJustificationRequired: "purpose_justification_required",
-              sessionDuration: "session_duration",
-            }),
-          ),
-        ]),
-      ),
-    ),
-    readServiceTokensFromHeader: Schema.optional(Schema.String),
-    sameSiteCookieAttribute: Schema.optional(Schema.String),
-    scimConfig: Schema.optional(
-      Schema.Struct({
-        idpUid: Schema.String,
-        remoteUri: Schema.String,
-        authentication: Schema.optional(
-          Schema.Union([
-            Schema.Struct({
-              authorizationUrl: Schema.String,
-              clientId: Schema.String,
-              clientSecret: SensitiveString,
-              scheme: Schema.Literal("oauth2"),
-              tokenUrl: Schema.String,
-              scopes: Schema.optional(Schema.Array(Schema.String)),
-            }).pipe(
-              Schema.encodeKeys({
-                authorizationUrl: "authorization_url",
-                clientId: "client_id",
-                clientSecret: "client_secret",
-                scheme: "scheme",
-                tokenUrl: "token_url",
-                scopes: "scopes",
-              }),
-            ),
-            Schema.Struct({
-              password: SensitiveString,
-              scheme: Schema.Literal("httpbasic"),
-              user: Schema.String,
-            }),
-            Schema.Struct({
-              clientId: Schema.String,
-              clientSecret: SensitiveString,
-              scheme: Schema.Literal("access_service_token"),
-            }).pipe(
-              Schema.encodeKeys({
-                clientId: "client_id",
-                clientSecret: "client_secret",
-                scheme: "scheme",
-              }),
-            ),
-            Schema.Struct({
-              token: Schema.String,
-              scheme: Schema.Literal("oauthbearertoken"),
-            }),
-            Schema.Array(
-              Schema.Union([
-                Schema.Struct({
-                  authorizationUrl: Schema.String,
-                  clientId: Schema.String,
-                  clientSecret: SensitiveString,
-                  scheme: Schema.Literal("oauth2"),
-                  tokenUrl: Schema.String,
-                  scopes: Schema.optional(Schema.Array(Schema.String)),
-                }).pipe(
-                  Schema.encodeKeys({
-                    authorizationUrl: "authorization_url",
-                    clientId: "client_id",
-                    clientSecret: "client_secret",
-                    scheme: "scheme",
-                    tokenUrl: "token_url",
-                    scopes: "scopes",
-                  }),
-                ),
-                Schema.Struct({
-                  password: SensitiveString,
-                  scheme: Schema.Literal("httpbasic"),
-                  user: Schema.String,
-                }),
-                Schema.Struct({
-                  clientId: Schema.String,
-                  clientSecret: SensitiveString,
-                  scheme: Schema.Literal("access_service_token"),
-                }).pipe(
-                  Schema.encodeKeys({
-                    clientId: "client_id",
-                    clientSecret: "client_secret",
-                    scheme: "scheme",
-                  }),
-                ),
-                Schema.Struct({
-                  token: Schema.String,
-                  scheme: Schema.Literal("oauthbearertoken"),
-                }),
-              ]),
-            ),
-          ]),
-        ),
-        deactivateOnDelete: Schema.optional(Schema.Boolean),
-        enabled: Schema.optional(Schema.Boolean),
-        mappings: Schema.optional(
-          Schema.Array(
-            Schema.Struct({
-              schema: Schema.String,
-              enabled: Schema.optional(Schema.Boolean),
-              filter: Schema.optional(Schema.String),
-              operations: Schema.optional(
-                Schema.Struct({
-                  create: Schema.optional(Schema.Boolean),
-                  delete: Schema.optional(Schema.Boolean),
-                  update: Schema.optional(Schema.Boolean),
-                }),
-              ),
-              strictness: Schema.optional(
-                Schema.Literals(["strict", "passthrough"]),
-              ),
-              transformJsonata: Schema.optional(Schema.String),
-            }).pipe(
-              Schema.encodeKeys({
-                schema: "schema",
-                enabled: "enabled",
-                filter: "filter",
-                operations: "operations",
-                strictness: "strictness",
-                transformJsonata: "transform_jsonata",
-              }),
-            ),
-          ),
-        ),
-      }).pipe(
-        Schema.encodeKeys({
-          idpUid: "idp_uid",
-          remoteUri: "remote_uri",
-          authentication: "authentication",
-          deactivateOnDelete: "deactivate_on_delete",
-          enabled: "enabled",
-          mappings: "mappings",
-        }),
-      ),
-    ),
-    selfHostedDomains: Schema.optional(Schema.Array(Schema.String)),
-    serviceAuth_401Redirect: Schema.optional(Schema.Boolean),
-    sessionDuration: Schema.optional(Schema.String),
-    skipInterstitial: Schema.optional(Schema.Boolean),
-    tags: Schema.optional(Schema.Array(Schema.String)),
+    ...CreateAccessApplicationBaseFields,
   }).pipe(
     Schema.encodeKeys({
       domain: "domain",
@@ -17361,11 +17638,46 @@ export const CreateAccessApplicationRequest =
       skipInterstitial: "skip_interstitial",
       tags: "tags",
     }),
-    T.Http({
-      method: "POST",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/apps",
+    T.Http({ method: "POST", path: "/accounts/{account_id}/access/apps" }),
+  ) as unknown as Schema.Schema<CreateAccessApplicationForAccountRequest>;
+
+export const CreateAccessApplicationForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...CreateAccessApplicationBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      domain: "domain",
+      type: "type",
+      allowAuthenticateViaWarp: "allow_authenticate_via_warp",
+      allowIframe: "allow_iframe",
+      allowedIdps: "allowed_idps",
+      appLauncherVisible: "app_launcher_visible",
+      autoRedirectToIdentity: "auto_redirect_to_identity",
+      corsHeaders: "cors_headers",
+      customDenyMessage: "custom_deny_message",
+      customDenyUrl: "custom_deny_url",
+      customNonIdentityDenyUrl: "custom_non_identity_deny_url",
+      customPages: "custom_pages",
+      destinations: "destinations",
+      enableBindingCookie: "enable_binding_cookie",
+      httpOnlyCookieAttribute: "http_only_cookie_attribute",
+      logoUrl: "logo_url",
+      name: "name",
+      optionsPreflightBypass: "options_preflight_bypass",
+      pathCookieAttribute: "path_cookie_attribute",
+      policies: "policies",
+      readServiceTokensFromHeader: "read_service_tokens_from_header",
+      sameSiteCookieAttribute: "same_site_cookie_attribute",
+      scimConfig: "scim_config",
+      selfHostedDomains: "self_hosted_domains",
+      serviceAuth_401Redirect: "service_auth_401_redirect",
+      sessionDuration: "session_duration",
+      skipInterstitial: "skip_interstitial",
+      tags: "tags",
     }),
-  ) as unknown as Schema.Schema<CreateAccessApplicationRequest>;
+    T.Http({ method: "POST", path: "/zones/{zone_id}/access/apps" }),
+  ) as unknown as Schema.Schema<CreateAccessApplicationForZoneRequest>;
 
 export type CreateAccessApplicationResponse =
   | {
@@ -25015,22 +25327,330 @@ export const CreateAccessApplicationResponse =
 
 export type CreateAccessApplicationError = DefaultErrors;
 
-export const createAccessApplication: API.OperationMethod<
-  CreateAccessApplicationRequest,
+export const createAccessApplicationForAccount: API.OperationMethod<
+  CreateAccessApplicationForAccountRequest,
   CreateAccessApplicationResponse,
   CreateAccessApplicationError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: CreateAccessApplicationRequest,
+  input: CreateAccessApplicationForAccountRequest,
   output: CreateAccessApplicationResponse,
   errors: [],
 }));
 
-export interface UpdateAccessApplicationRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
+export const createAccessApplicationForZone: API.OperationMethod<
+  CreateAccessApplicationForZoneRequest,
+  CreateAccessApplicationResponse,
+  CreateAccessApplicationError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: CreateAccessApplicationForZoneRequest,
+  output: CreateAccessApplicationResponse,
+  errors: [],
+}));
+
+export const createAccessApplication = (
+  input: CreateAccessApplicationRequest,
+): Effect.Effect<
+  CreateAccessApplicationResponse,
+  CreateAccessApplicationError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? createAccessApplicationForAccount(input)
+    : createAccessApplicationForZone(input);
+
+const UpdateAccessApplicationBaseFields = {
+  appId: Schema.String.pipe(T.HttpPath("appId")),
+  domain: Schema.String,
+  type: Schema.Literals([
+    "self_hosted",
+    "saas",
+    "ssh",
+    "vnc",
+    "app_launcher",
+    "warp",
+    "biso",
+    "bookmark",
+    "dash_sso",
+    "infrastructure",
+    "rdp",
+    "mcp",
+    "mcp_portal",
+    "proxy_endpoint",
+  ]),
+  allowAuthenticateViaWarp: Schema.optional(Schema.Boolean),
+  allowIframe: Schema.optional(Schema.Boolean),
+  allowedIdps: Schema.optional(Schema.Array(Schema.String)),
+  appLauncherVisible: Schema.optional(Schema.Boolean),
+  autoRedirectToIdentity: Schema.optional(Schema.Boolean),
+  corsHeaders: Schema.optional(
+    Schema.Struct({
+      allowAllHeaders: Schema.optional(Schema.Boolean),
+      allowAllMethods: Schema.optional(Schema.Boolean),
+      allowAllOrigins: Schema.optional(Schema.Boolean),
+      allowCredentials: Schema.optional(Schema.Boolean),
+      allowedHeaders: Schema.optional(Schema.Array(Schema.String)),
+      allowedMethods: Schema.optional(
+        Schema.Array(
+          Schema.Literals([
+            "GET",
+            "POST",
+            "HEAD",
+            "PUT",
+            "DELETE",
+            "CONNECT",
+            "OPTIONS",
+            "TRACE",
+            "PATCH",
+          ]),
+        ),
+      ),
+      allowedOrigins: Schema.optional(Schema.Array(Schema.String)),
+      maxAge: Schema.optional(Schema.Number),
+    }).pipe(
+      Schema.encodeKeys({
+        allowAllHeaders: "allow_all_headers",
+        allowAllMethods: "allow_all_methods",
+        allowAllOrigins: "allow_all_origins",
+        allowCredentials: "allow_credentials",
+        allowedHeaders: "allowed_headers",
+        allowedMethods: "allowed_methods",
+        allowedOrigins: "allowed_origins",
+        maxAge: "max_age",
+      }),
+    ),
+  ),
+  customDenyMessage: Schema.optional(Schema.String),
+  customDenyUrl: Schema.optional(Schema.String),
+  customNonIdentityDenyUrl: Schema.optional(Schema.String),
+  customPages: Schema.optional(Schema.Array(Schema.String)),
+  destinations: Schema.optional(
+    Schema.Array(
+      Schema.Union([
+        Schema.Struct({
+          type: Schema.optional(Schema.Literal("public")),
+          uri: Schema.optional(Schema.String),
+        }),
+        Schema.Struct({
+          cidr: Schema.optional(Schema.String),
+          hostname: Schema.optional(Schema.String),
+          l4Protocol: Schema.optional(Schema.Literals(["tcp", "udp"])),
+          portRange: Schema.optional(Schema.String),
+          type: Schema.optional(Schema.Literal("private")),
+          vnetId: Schema.optional(Schema.String),
+        }).pipe(
+          Schema.encodeKeys({
+            cidr: "cidr",
+            hostname: "hostname",
+            l4Protocol: "l4_protocol",
+            portRange: "port_range",
+            type: "type",
+            vnetId: "vnet_id",
+          }),
+        ),
+        Schema.Struct({
+          mcpServerId: Schema.optional(Schema.String),
+          type: Schema.optional(Schema.Literal("via_mcp_server_portal")),
+        }).pipe(
+          Schema.encodeKeys({ mcpServerId: "mcp_server_id", type: "type" }),
+        ),
+      ]),
+    ),
+  ),
+  enableBindingCookie: Schema.optional(Schema.Boolean),
+  httpOnlyCookieAttribute: Schema.optional(Schema.Boolean),
+  logoUrl: Schema.optional(Schema.String),
+  name: Schema.optional(Schema.String),
+  optionsPreflightBypass: Schema.optional(Schema.Boolean),
+  pathCookieAttribute: Schema.optional(Schema.Boolean),
+  policies: Schema.optional(
+    Schema.Array(
+      Schema.Union([
+        Schema.Struct({
+          id: Schema.optional(Schema.String),
+          precedence: Schema.optional(Schema.Number),
+        }),
+        Schema.String,
+        Schema.Struct({
+          id: Schema.optional(Schema.String),
+          approvalGroups: Schema.optional(
+            Schema.Array(
+              Schema.Struct({
+                approvalsNeeded: Schema.Number,
+                emailAddresses: Schema.optional(Schema.Array(Schema.String)),
+                emailListUuid: Schema.optional(Schema.String),
+              }).pipe(
+                Schema.encodeKeys({
+                  approvalsNeeded: "approvals_needed",
+                  emailAddresses: "email_addresses",
+                  emailListUuid: "email_list_uuid",
+                }),
+              ),
+            ),
+          ),
+          approvalRequired: Schema.optional(Schema.Boolean),
+          isolationRequired: Schema.optional(Schema.Boolean),
+          precedence: Schema.optional(Schema.Number),
+          purposeJustificationPrompt: Schema.optional(Schema.String),
+          purposeJustificationRequired: Schema.optional(Schema.Boolean),
+          sessionDuration: Schema.optional(Schema.String),
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            approvalGroups: "approval_groups",
+            approvalRequired: "approval_required",
+            isolationRequired: "isolation_required",
+            precedence: "precedence",
+            purposeJustificationPrompt: "purpose_justification_prompt",
+            purposeJustificationRequired: "purpose_justification_required",
+            sessionDuration: "session_duration",
+          }),
+        ),
+      ]),
+    ),
+  ),
+  readServiceTokensFromHeader: Schema.optional(Schema.String),
+  sameSiteCookieAttribute: Schema.optional(Schema.String),
+  scimConfig: Schema.optional(
+    Schema.Struct({
+      idpUid: Schema.String,
+      remoteUri: Schema.String,
+      authentication: Schema.optional(
+        Schema.Union([
+          Schema.Struct({
+            authorizationUrl: Schema.String,
+            clientId: Schema.String,
+            clientSecret: SensitiveString,
+            scheme: Schema.Literal("oauth2"),
+            tokenUrl: Schema.String,
+            scopes: Schema.optional(Schema.Array(Schema.String)),
+          }).pipe(
+            Schema.encodeKeys({
+              authorizationUrl: "authorization_url",
+              clientId: "client_id",
+              clientSecret: "client_secret",
+              scheme: "scheme",
+              tokenUrl: "token_url",
+              scopes: "scopes",
+            }),
+          ),
+          Schema.Struct({
+            password: SensitiveString,
+            scheme: Schema.Literal("httpbasic"),
+            user: Schema.String,
+          }),
+          Schema.Struct({
+            clientId: Schema.String,
+            clientSecret: SensitiveString,
+            scheme: Schema.Literal("access_service_token"),
+          }).pipe(
+            Schema.encodeKeys({
+              clientId: "client_id",
+              clientSecret: "client_secret",
+              scheme: "scheme",
+            }),
+          ),
+          Schema.Struct({
+            token: Schema.String,
+            scheme: Schema.Literal("oauthbearertoken"),
+          }),
+          Schema.Array(
+            Schema.Union([
+              Schema.Struct({
+                authorizationUrl: Schema.String,
+                clientId: Schema.String,
+                clientSecret: SensitiveString,
+                scheme: Schema.Literal("oauth2"),
+                tokenUrl: Schema.String,
+                scopes: Schema.optional(Schema.Array(Schema.String)),
+              }).pipe(
+                Schema.encodeKeys({
+                  authorizationUrl: "authorization_url",
+                  clientId: "client_id",
+                  clientSecret: "client_secret",
+                  scheme: "scheme",
+                  tokenUrl: "token_url",
+                  scopes: "scopes",
+                }),
+              ),
+              Schema.Struct({
+                password: SensitiveString,
+                scheme: Schema.Literal("httpbasic"),
+                user: Schema.String,
+              }),
+              Schema.Struct({
+                clientId: Schema.String,
+                clientSecret: SensitiveString,
+                scheme: Schema.Literal("access_service_token"),
+              }).pipe(
+                Schema.encodeKeys({
+                  clientId: "client_id",
+                  clientSecret: "client_secret",
+                  scheme: "scheme",
+                }),
+              ),
+              Schema.Struct({
+                token: Schema.String,
+                scheme: Schema.Literal("oauthbearertoken"),
+              }),
+            ]),
+          ),
+        ]),
+      ),
+      deactivateOnDelete: Schema.optional(Schema.Boolean),
+      enabled: Schema.optional(Schema.Boolean),
+      mappings: Schema.optional(
+        Schema.Array(
+          Schema.Struct({
+            schema: Schema.String,
+            enabled: Schema.optional(Schema.Boolean),
+            filter: Schema.optional(Schema.String),
+            operations: Schema.optional(
+              Schema.Struct({
+                create: Schema.optional(Schema.Boolean),
+                delete: Schema.optional(Schema.Boolean),
+                update: Schema.optional(Schema.Boolean),
+              }),
+            ),
+            strictness: Schema.optional(
+              Schema.Literals(["strict", "passthrough"]),
+            ),
+            transformJsonata: Schema.optional(Schema.String),
+          }).pipe(
+            Schema.encodeKeys({
+              schema: "schema",
+              enabled: "enabled",
+              filter: "filter",
+              operations: "operations",
+              strictness: "strictness",
+              transformJsonata: "transform_jsonata",
+            }),
+          ),
+        ),
+      ),
+    }).pipe(
+      Schema.encodeKeys({
+        idpUid: "idp_uid",
+        remoteUri: "remote_uri",
+        authentication: "authentication",
+        deactivateOnDelete: "deactivate_on_delete",
+        enabled: "enabled",
+        mappings: "mappings",
+      }),
+    ),
+  ),
+  selfHostedDomains: Schema.optional(Schema.Array(Schema.String)),
+  serviceAuth_401Redirect: Schema.optional(Schema.Boolean),
+  sessionDuration: Schema.optional(Schema.String),
+  skipInterstitial: Schema.optional(Schema.Boolean),
+  tags: Schema.optional(Schema.Array(Schema.String)),
+} as const;
+
+export interface UpdateAccessApplicationForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  appId: string;
   /** Body param: The primary hostname and path secured by Access. This domain will be displayed if the app is visible in the App Launcher. */
   domain: string;
   /** Body param: The application type. */
@@ -25196,293 +25816,183 @@ export interface UpdateAccessApplicationRequest {
   tags?: string[];
 }
 
-export const UpdateAccessApplicationRequest =
+export interface UpdateAccessApplicationForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  appId: string;
+  /** Body param: The primary hostname and path secured by Access. This domain will be displayed if the app is visible in the App Launcher. */
+  domain: string;
+  /** Body param: The application type. */
+  type:
+    | "self_hosted"
+    | "saas"
+    | "ssh"
+    | "vnc"
+    | "app_launcher"
+    | "warp"
+    | "biso"
+    | "bookmark"
+    | "dash_sso"
+    | "infrastructure"
+    | "rdp"
+    | "mcp"
+    | "mcp_portal"
+    | "proxy_endpoint";
+  /** Body param: When set to true, users can authenticate to this application using their WARP session. When set to false this application will always require direct IdP authentication. This setting always */
+  allowAuthenticateViaWarp?: boolean;
+  /** Body param: Enables loading application content in an iFrame. */
+  allowIframe?: boolean;
+  /** Body param: The identity providers your users can select when connecting to this application. Defaults to all IdPs configured in your account. */
+  allowedIdps?: string[];
+  /** Body param: Displays the application in the App Launcher. */
+  appLauncherVisible?: boolean;
+  /** Body param: When set to `true`, users skip the identity provider selection step during login. You must specify only one identity provider in allowed_idps. */
+  autoRedirectToIdentity?: boolean;
+  /** Body param: */
+  corsHeaders?: {
+    allowAllHeaders?: boolean;
+    allowAllMethods?: boolean;
+    allowAllOrigins?: boolean;
+    allowCredentials?: boolean;
+    allowedHeaders?: string[];
+    allowedMethods?: (
+      | "GET"
+      | "POST"
+      | "HEAD"
+      | "PUT"
+      | "DELETE"
+      | "CONNECT"
+      | "OPTIONS"
+      | "TRACE"
+      | "PATCH"
+    )[];
+    allowedOrigins?: string[];
+    maxAge?: number;
+  };
+  /** Body param: The custom error message shown to a user when they are denied access to the application. */
+  customDenyMessage?: string;
+  /** Body param: The custom URL a user is redirected to when they are denied access to the application when failing identity-based rules. */
+  customDenyUrl?: string;
+  /** Body param: The custom URL a user is redirected to when they are denied access to the application when failing non-identity rules. */
+  customNonIdentityDenyUrl?: string;
+  /** Body param: The custom pages that will be displayed when applicable for this application */
+  customPages?: string[];
+  /** Body param: List of destinations secured by Access. This supersedes `self_hosted_domains` to allow for more flexibility in defining different types of domains. If `destinations` are provided, then `se */
+  destinations?: (
+    | { type?: "public"; uri?: string }
+    | {
+        cidr?: string;
+        hostname?: string;
+        l4Protocol?: "tcp" | "udp";
+        portRange?: string;
+        type?: "private";
+        vnetId?: string;
+      }
+    | { mcpServerId?: string; type?: "via_mcp_server_portal" }
+  )[];
+  /** Body param: Enables the binding cookie, which increases security against compromised authorization tokens and CSRF attacks. */
+  enableBindingCookie?: boolean;
+  /** Body param: Enables the HttpOnly cookie attribute, which increases security against XSS attacks. */
+  httpOnlyCookieAttribute?: boolean;
+  /** Body param: The image URL for the logo shown in the App Launcher dashboard. */
+  logoUrl?: string;
+  /** Body param: The name of the application. */
+  name?: string;
+  /** Body param: Allows options preflight requests to bypass Access authentication and go directly to the origin. Cannot turn on if cors_headers is set. */
+  optionsPreflightBypass?: boolean;
+  /** Body param: Enables cookie paths to scope an application's JWT to the application path. If disabled, the JWT will scope to the hostname by default */
+  pathCookieAttribute?: boolean;
+  /** Body param: The policies that Access applies to the application, in ascending order of precedence. Items can reference existing policies or create new policies exclusive to the application. */
+  policies?: (
+    | { id?: string; precedence?: number }
+    | string
+    | {
+        id?: string;
+        approvalGroups?: {
+          approvalsNeeded: number;
+          emailAddresses?: string[];
+          emailListUuid?: string;
+        }[];
+        approvalRequired?: boolean;
+        isolationRequired?: boolean;
+        precedence?: number;
+        purposeJustificationPrompt?: string;
+        purposeJustificationRequired?: boolean;
+        sessionDuration?: string;
+      }
+  )[];
+  /** Body param: Allows matching Access Service Tokens passed HTTP in a single header with this name. This works as an alternative to the (CF-Access-Client-Id, CF-Access-Client-Secret) pair of headers. The */
+  readServiceTokensFromHeader?: string;
+  /** Body param: Sets the SameSite cookie setting, which provides increased security against CSRF attacks. */
+  sameSiteCookieAttribute?: string;
+  /** Body param: Configuration for provisioning to this application via SCIM. This is currently in closed beta. */
+  scimConfig?: {
+    idpUid: string;
+    remoteUri: string;
+    authentication?:
+      | { password: string; scheme: "httpbasic"; user: string }
+      | { token: string; scheme: "oauthbearertoken" }
+      | {
+          authorizationUrl: string;
+          clientId: string;
+          clientSecret: string;
+          scheme: "oauth2";
+          tokenUrl: string;
+          scopes?: string[];
+        }
+      | {
+          clientId: string;
+          clientSecret: string;
+          scheme: "access_service_token";
+        }
+      | (
+          | { password: string; scheme: "httpbasic"; user: string }
+          | { token: string; scheme: "oauthbearertoken" }
+          | {
+              authorizationUrl: string;
+              clientId: string;
+              clientSecret: string;
+              scheme: "oauth2";
+              tokenUrl: string;
+              scopes?: string[];
+            }
+          | {
+              clientId: string;
+              clientSecret: string;
+              scheme: "access_service_token";
+            }
+        )[];
+    deactivateOnDelete?: boolean;
+    enabled?: boolean;
+    mappings?: {
+      schema: string;
+      enabled?: boolean;
+      filter?: string;
+      operations?: { create?: boolean; delete?: boolean; update?: boolean };
+      strictness?: "strict" | "passthrough";
+      transformJsonata?: string;
+    }[];
+  };
+  /** @deprecated Body param: List of public domains that Access will secure. This field is deprecated in favor of `destinations` and will be supported until   November 21, 2025.  If `destinations` are prov */
+  selfHostedDomains?: string[];
+  /** Body param: Returns a 401 status code when the request is blocked by a Service Auth policy. */
+  serviceAuth_401Redirect?: boolean;
+  /** Body param: The amount of time that tokens issued for this application will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. Note: unsupported for */
+  sessionDuration?: string;
+  /** Body param: Enables automatic authentication through cloudflared. */
+  skipInterstitial?: boolean;
+  /** Body param: The tags you want assigned to an application. Tags are used to filter applications in the App Launcher dashboard. */
+  tags?: string[];
+}
+
+export type UpdateAccessApplicationRequest =
+  | UpdateAccessApplicationForAccountRequest
+  | UpdateAccessApplicationForZoneRequest;
+
+export const UpdateAccessApplicationForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    domain: Schema.String,
-    type: Schema.Literals([
-      "self_hosted",
-      "saas",
-      "ssh",
-      "vnc",
-      "app_launcher",
-      "warp",
-      "biso",
-      "bookmark",
-      "dash_sso",
-      "infrastructure",
-      "rdp",
-      "mcp",
-      "mcp_portal",
-      "proxy_endpoint",
-    ]),
-    allowAuthenticateViaWarp: Schema.optional(Schema.Boolean),
-    allowIframe: Schema.optional(Schema.Boolean),
-    allowedIdps: Schema.optional(Schema.Array(Schema.String)),
-    appLauncherVisible: Schema.optional(Schema.Boolean),
-    autoRedirectToIdentity: Schema.optional(Schema.Boolean),
-    corsHeaders: Schema.optional(
-      Schema.Struct({
-        allowAllHeaders: Schema.optional(Schema.Boolean),
-        allowAllMethods: Schema.optional(Schema.Boolean),
-        allowAllOrigins: Schema.optional(Schema.Boolean),
-        allowCredentials: Schema.optional(Schema.Boolean),
-        allowedHeaders: Schema.optional(Schema.Array(Schema.String)),
-        allowedMethods: Schema.optional(
-          Schema.Array(
-            Schema.Literals([
-              "GET",
-              "POST",
-              "HEAD",
-              "PUT",
-              "DELETE",
-              "CONNECT",
-              "OPTIONS",
-              "TRACE",
-              "PATCH",
-            ]),
-          ),
-        ),
-        allowedOrigins: Schema.optional(Schema.Array(Schema.String)),
-        maxAge: Schema.optional(Schema.Number),
-      }).pipe(
-        Schema.encodeKeys({
-          allowAllHeaders: "allow_all_headers",
-          allowAllMethods: "allow_all_methods",
-          allowAllOrigins: "allow_all_origins",
-          allowCredentials: "allow_credentials",
-          allowedHeaders: "allowed_headers",
-          allowedMethods: "allowed_methods",
-          allowedOrigins: "allowed_origins",
-          maxAge: "max_age",
-        }),
-      ),
-    ),
-    customDenyMessage: Schema.optional(Schema.String),
-    customDenyUrl: Schema.optional(Schema.String),
-    customNonIdentityDenyUrl: Schema.optional(Schema.String),
-    customPages: Schema.optional(Schema.Array(Schema.String)),
-    destinations: Schema.optional(
-      Schema.Array(
-        Schema.Union([
-          Schema.Struct({
-            type: Schema.optional(Schema.Literal("public")),
-            uri: Schema.optional(Schema.String),
-          }),
-          Schema.Struct({
-            cidr: Schema.optional(Schema.String),
-            hostname: Schema.optional(Schema.String),
-            l4Protocol: Schema.optional(Schema.Literals(["tcp", "udp"])),
-            portRange: Schema.optional(Schema.String),
-            type: Schema.optional(Schema.Literal("private")),
-            vnetId: Schema.optional(Schema.String),
-          }).pipe(
-            Schema.encodeKeys({
-              cidr: "cidr",
-              hostname: "hostname",
-              l4Protocol: "l4_protocol",
-              portRange: "port_range",
-              type: "type",
-              vnetId: "vnet_id",
-            }),
-          ),
-          Schema.Struct({
-            mcpServerId: Schema.optional(Schema.String),
-            type: Schema.optional(Schema.Literal("via_mcp_server_portal")),
-          }).pipe(
-            Schema.encodeKeys({ mcpServerId: "mcp_server_id", type: "type" }),
-          ),
-        ]),
-      ),
-    ),
-    enableBindingCookie: Schema.optional(Schema.Boolean),
-    httpOnlyCookieAttribute: Schema.optional(Schema.Boolean),
-    logoUrl: Schema.optional(Schema.String),
-    name: Schema.optional(Schema.String),
-    optionsPreflightBypass: Schema.optional(Schema.Boolean),
-    pathCookieAttribute: Schema.optional(Schema.Boolean),
-    policies: Schema.optional(
-      Schema.Array(
-        Schema.Union([
-          Schema.Struct({
-            id: Schema.optional(Schema.String),
-            precedence: Schema.optional(Schema.Number),
-          }),
-          Schema.String,
-          Schema.Struct({
-            id: Schema.optional(Schema.String),
-            approvalGroups: Schema.optional(
-              Schema.Array(
-                Schema.Struct({
-                  approvalsNeeded: Schema.Number,
-                  emailAddresses: Schema.optional(Schema.Array(Schema.String)),
-                  emailListUuid: Schema.optional(Schema.String),
-                }).pipe(
-                  Schema.encodeKeys({
-                    approvalsNeeded: "approvals_needed",
-                    emailAddresses: "email_addresses",
-                    emailListUuid: "email_list_uuid",
-                  }),
-                ),
-              ),
-            ),
-            approvalRequired: Schema.optional(Schema.Boolean),
-            isolationRequired: Schema.optional(Schema.Boolean),
-            precedence: Schema.optional(Schema.Number),
-            purposeJustificationPrompt: Schema.optional(Schema.String),
-            purposeJustificationRequired: Schema.optional(Schema.Boolean),
-            sessionDuration: Schema.optional(Schema.String),
-          }).pipe(
-            Schema.encodeKeys({
-              id: "id",
-              approvalGroups: "approval_groups",
-              approvalRequired: "approval_required",
-              isolationRequired: "isolation_required",
-              precedence: "precedence",
-              purposeJustificationPrompt: "purpose_justification_prompt",
-              purposeJustificationRequired: "purpose_justification_required",
-              sessionDuration: "session_duration",
-            }),
-          ),
-        ]),
-      ),
-    ),
-    readServiceTokensFromHeader: Schema.optional(Schema.String),
-    sameSiteCookieAttribute: Schema.optional(Schema.String),
-    scimConfig: Schema.optional(
-      Schema.Struct({
-        idpUid: Schema.String,
-        remoteUri: Schema.String,
-        authentication: Schema.optional(
-          Schema.Union([
-            Schema.Struct({
-              authorizationUrl: Schema.String,
-              clientId: Schema.String,
-              clientSecret: SensitiveString,
-              scheme: Schema.Literal("oauth2"),
-              tokenUrl: Schema.String,
-              scopes: Schema.optional(Schema.Array(Schema.String)),
-            }).pipe(
-              Schema.encodeKeys({
-                authorizationUrl: "authorization_url",
-                clientId: "client_id",
-                clientSecret: "client_secret",
-                scheme: "scheme",
-                tokenUrl: "token_url",
-                scopes: "scopes",
-              }),
-            ),
-            Schema.Struct({
-              password: SensitiveString,
-              scheme: Schema.Literal("httpbasic"),
-              user: Schema.String,
-            }),
-            Schema.Struct({
-              clientId: Schema.String,
-              clientSecret: SensitiveString,
-              scheme: Schema.Literal("access_service_token"),
-            }).pipe(
-              Schema.encodeKeys({
-                clientId: "client_id",
-                clientSecret: "client_secret",
-                scheme: "scheme",
-              }),
-            ),
-            Schema.Struct({
-              token: Schema.String,
-              scheme: Schema.Literal("oauthbearertoken"),
-            }),
-            Schema.Array(
-              Schema.Union([
-                Schema.Struct({
-                  authorizationUrl: Schema.String,
-                  clientId: Schema.String,
-                  clientSecret: SensitiveString,
-                  scheme: Schema.Literal("oauth2"),
-                  tokenUrl: Schema.String,
-                  scopes: Schema.optional(Schema.Array(Schema.String)),
-                }).pipe(
-                  Schema.encodeKeys({
-                    authorizationUrl: "authorization_url",
-                    clientId: "client_id",
-                    clientSecret: "client_secret",
-                    scheme: "scheme",
-                    tokenUrl: "token_url",
-                    scopes: "scopes",
-                  }),
-                ),
-                Schema.Struct({
-                  password: SensitiveString,
-                  scheme: Schema.Literal("httpbasic"),
-                  user: Schema.String,
-                }),
-                Schema.Struct({
-                  clientId: Schema.String,
-                  clientSecret: SensitiveString,
-                  scheme: Schema.Literal("access_service_token"),
-                }).pipe(
-                  Schema.encodeKeys({
-                    clientId: "client_id",
-                    clientSecret: "client_secret",
-                    scheme: "scheme",
-                  }),
-                ),
-                Schema.Struct({
-                  token: Schema.String,
-                  scheme: Schema.Literal("oauthbearertoken"),
-                }),
-              ]),
-            ),
-          ]),
-        ),
-        deactivateOnDelete: Schema.optional(Schema.Boolean),
-        enabled: Schema.optional(Schema.Boolean),
-        mappings: Schema.optional(
-          Schema.Array(
-            Schema.Struct({
-              schema: Schema.String,
-              enabled: Schema.optional(Schema.Boolean),
-              filter: Schema.optional(Schema.String),
-              operations: Schema.optional(
-                Schema.Struct({
-                  create: Schema.optional(Schema.Boolean),
-                  delete: Schema.optional(Schema.Boolean),
-                  update: Schema.optional(Schema.Boolean),
-                }),
-              ),
-              strictness: Schema.optional(
-                Schema.Literals(["strict", "passthrough"]),
-              ),
-              transformJsonata: Schema.optional(Schema.String),
-            }).pipe(
-              Schema.encodeKeys({
-                schema: "schema",
-                enabled: "enabled",
-                filter: "filter",
-                operations: "operations",
-                strictness: "strictness",
-                transformJsonata: "transform_jsonata",
-              }),
-            ),
-          ),
-        ),
-      }).pipe(
-        Schema.encodeKeys({
-          idpUid: "idp_uid",
-          remoteUri: "remote_uri",
-          authentication: "authentication",
-          deactivateOnDelete: "deactivate_on_delete",
-          enabled: "enabled",
-          mappings: "mappings",
-        }),
-      ),
-    ),
-    selfHostedDomains: Schema.optional(Schema.Array(Schema.String)),
-    serviceAuth_401Redirect: Schema.optional(Schema.Boolean),
-    sessionDuration: Schema.optional(Schema.String),
-    skipInterstitial: Schema.optional(Schema.Boolean),
-    tags: Schema.optional(Schema.Array(Schema.String)),
+    ...UpdateAccessApplicationBaseFields,
   }).pipe(
     Schema.encodeKeys({
       domain: "domain",
@@ -25516,9 +26026,47 @@ export const UpdateAccessApplicationRequest =
     }),
     T.Http({
       method: "PUT",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/apps/{appId}",
+      path: "/accounts/{account_id}/access/apps/{appId}",
     }),
-  ) as unknown as Schema.Schema<UpdateAccessApplicationRequest>;
+  ) as unknown as Schema.Schema<UpdateAccessApplicationForAccountRequest>;
+
+export const UpdateAccessApplicationForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...UpdateAccessApplicationBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      domain: "domain",
+      type: "type",
+      allowAuthenticateViaWarp: "allow_authenticate_via_warp",
+      allowIframe: "allow_iframe",
+      allowedIdps: "allowed_idps",
+      appLauncherVisible: "app_launcher_visible",
+      autoRedirectToIdentity: "auto_redirect_to_identity",
+      corsHeaders: "cors_headers",
+      customDenyMessage: "custom_deny_message",
+      customDenyUrl: "custom_deny_url",
+      customNonIdentityDenyUrl: "custom_non_identity_deny_url",
+      customPages: "custom_pages",
+      destinations: "destinations",
+      enableBindingCookie: "enable_binding_cookie",
+      httpOnlyCookieAttribute: "http_only_cookie_attribute",
+      logoUrl: "logo_url",
+      name: "name",
+      optionsPreflightBypass: "options_preflight_bypass",
+      pathCookieAttribute: "path_cookie_attribute",
+      policies: "policies",
+      readServiceTokensFromHeader: "read_service_tokens_from_header",
+      sameSiteCookieAttribute: "same_site_cookie_attribute",
+      scimConfig: "scim_config",
+      selfHostedDomains: "self_hosted_domains",
+      serviceAuth_401Redirect: "service_auth_401_redirect",
+      sessionDuration: "session_duration",
+      skipInterstitial: "skip_interstitial",
+      tags: "tags",
+    }),
+    T.Http({ method: "PUT", path: "/zones/{zone_id}/access/apps/{appId}" }),
+  ) as unknown as Schema.Schema<UpdateAccessApplicationForZoneRequest>;
 
 export type UpdateAccessApplicationResponse =
   | {
@@ -33168,26 +33716,77 @@ export const UpdateAccessApplicationResponse =
 
 export type UpdateAccessApplicationError = DefaultErrors;
 
-export const updateAccessApplication: API.OperationMethod<
-  UpdateAccessApplicationRequest,
+export const updateAccessApplicationForAccount: API.OperationMethod<
+  UpdateAccessApplicationForAccountRequest,
   UpdateAccessApplicationResponse,
   UpdateAccessApplicationError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: UpdateAccessApplicationRequest,
+  input: UpdateAccessApplicationForAccountRequest,
   output: UpdateAccessApplicationResponse,
   errors: [],
 }));
 
-export interface DeleteAccessApplicationRequest {}
+export const updateAccessApplicationForZone: API.OperationMethod<
+  UpdateAccessApplicationForZoneRequest,
+  UpdateAccessApplicationResponse,
+  UpdateAccessApplicationError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: UpdateAccessApplicationForZoneRequest,
+  output: UpdateAccessApplicationResponse,
+  errors: [],
+}));
 
-export const DeleteAccessApplicationRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
+export const updateAccessApplication = (
+  input: UpdateAccessApplicationRequest,
+): Effect.Effect<
+  UpdateAccessApplicationResponse,
+  UpdateAccessApplicationError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? updateAccessApplicationForAccount(input)
+    : updateAccessApplicationForZone(input);
+
+const DeleteAccessApplicationBaseFields = {
+  appId: Schema.String.pipe(T.HttpPath("appId")),
+} as const;
+
+export interface DeleteAccessApplicationForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  appId: string;
+}
+
+export interface DeleteAccessApplicationForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  appId: string;
+}
+
+export type DeleteAccessApplicationRequest =
+  | DeleteAccessApplicationForAccountRequest
+  | DeleteAccessApplicationForZoneRequest;
+
+export const DeleteAccessApplicationForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...DeleteAccessApplicationBaseFields,
+  }).pipe(
     T.Http({
       method: "DELETE",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/apps/{appId}",
+      path: "/accounts/{account_id}/access/apps/{appId}",
     }),
-  ) as unknown as Schema.Schema<DeleteAccessApplicationRequest>;
+  ) as unknown as Schema.Schema<DeleteAccessApplicationForAccountRequest>;
+
+export const DeleteAccessApplicationForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...DeleteAccessApplicationBaseFields,
+  }).pipe(
+    T.Http({ method: "DELETE", path: "/zones/{zone_id}/access/apps/{appId}" }),
+  ) as unknown as Schema.Schema<DeleteAccessApplicationForZoneRequest>;
 
 export interface DeleteAccessApplicationResponse {
   /** UUID. */
@@ -33203,34 +33802,81 @@ export const DeleteAccessApplicationResponse =
 
 export type DeleteAccessApplicationError = DefaultErrors;
 
-export const deleteAccessApplication: API.OperationMethod<
-  DeleteAccessApplicationRequest,
+export const deleteAccessApplicationForAccount: API.OperationMethod<
+  DeleteAccessApplicationForAccountRequest,
   DeleteAccessApplicationResponse,
   DeleteAccessApplicationError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: DeleteAccessApplicationRequest,
+  input: DeleteAccessApplicationForAccountRequest,
   output: DeleteAccessApplicationResponse,
   errors: [],
 }));
+
+export const deleteAccessApplicationForZone: API.OperationMethod<
+  DeleteAccessApplicationForZoneRequest,
+  DeleteAccessApplicationResponse,
+  DeleteAccessApplicationError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: DeleteAccessApplicationForZoneRequest,
+  output: DeleteAccessApplicationResponse,
+  errors: [],
+}));
+
+export const deleteAccessApplication = (
+  input: DeleteAccessApplicationRequest,
+): Effect.Effect<
+  DeleteAccessApplicationResponse,
+  DeleteAccessApplicationError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? deleteAccessApplicationForAccount(input)
+    : deleteAccessApplicationForZone(input);
 
 // =============================================================================
 // AccessApplicationCa
 // =============================================================================
 
-export interface GetAccessApplicationCaRequest {
+const GetAccessApplicationCaBaseFields = {
+  appId: Schema.String.pipe(T.HttpPath("appId")),
+} as const;
+
+export interface GetAccessApplicationCaForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   appId: string;
 }
 
-export const GetAccessApplicationCaRequest =
+export interface GetAccessApplicationCaForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  appId: string;
+}
+
+export type GetAccessApplicationCaRequest =
+  | GetAccessApplicationCaForAccountRequest
+  | GetAccessApplicationCaForZoneRequest;
+
+export const GetAccessApplicationCaForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    appId: Schema.String.pipe(T.HttpPath("appId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetAccessApplicationCaBaseFields,
   }).pipe(
     T.Http({
       method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/apps/{appId}/ca",
+      path: "/accounts/{account_id}/access/apps/{appId}/ca",
     }),
-  ) as unknown as Schema.Schema<GetAccessApplicationCaRequest>;
+  ) as unknown as Schema.Schema<GetAccessApplicationCaForAccountRequest>;
+
+export const GetAccessApplicationCaForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...GetAccessApplicationCaBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/zones/{zone_id}/access/apps/{appId}/ca" }),
+  ) as unknown as Schema.Schema<GetAccessApplicationCaForZoneRequest>;
 
 export interface GetAccessApplicationCaResponse {
   /** The ID of the CA. */
@@ -33254,26 +33900,70 @@ export const GetAccessApplicationCaResponse =
 
 export type GetAccessApplicationCaError = DefaultErrors;
 
-export const getAccessApplicationCa: API.OperationMethod<
-  GetAccessApplicationCaRequest,
+export const getAccessApplicationCaForAccount: API.OperationMethod<
+  GetAccessApplicationCaForAccountRequest,
   GetAccessApplicationCaResponse,
   GetAccessApplicationCaError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: GetAccessApplicationCaRequest,
+  input: GetAccessApplicationCaForAccountRequest,
   output: GetAccessApplicationCaResponse,
   errors: [],
 }));
 
-export interface ListAccessApplicationCasRequest {}
+export const getAccessApplicationCaForZone: API.OperationMethod<
+  GetAccessApplicationCaForZoneRequest,
+  GetAccessApplicationCaResponse,
+  GetAccessApplicationCaError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetAccessApplicationCaForZoneRequest,
+  output: GetAccessApplicationCaResponse,
+  errors: [],
+}));
 
-export const ListAccessApplicationCasRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
-    T.Http({
-      method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/apps/ca",
-    }),
-  ) as unknown as Schema.Schema<ListAccessApplicationCasRequest>;
+export const getAccessApplicationCa = (
+  input: GetAccessApplicationCaRequest,
+): Effect.Effect<
+  GetAccessApplicationCaResponse,
+  GetAccessApplicationCaError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? getAccessApplicationCaForAccount(input)
+    : getAccessApplicationCaForZone(input);
+
+const ListAccessApplicationCasBaseFields = {} as const;
+
+export interface ListAccessApplicationCasForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface ListAccessApplicationCasForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+}
+
+export type ListAccessApplicationCasRequest =
+  | ListAccessApplicationCasForAccountRequest
+  | ListAccessApplicationCasForZoneRequest;
+
+export const ListAccessApplicationCasForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...ListAccessApplicationCasBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/accounts/{account_id}/access/apps/ca" }),
+  ) as unknown as Schema.Schema<ListAccessApplicationCasForAccountRequest>;
+
+export const ListAccessApplicationCasForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...ListAccessApplicationCasBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/zones/{zone_id}/access/apps/ca" }),
+  ) as unknown as Schema.Schema<ListAccessApplicationCasForZoneRequest>;
 
 export interface ListAccessApplicationCasResponse {
   result: {
@@ -33326,13 +34016,13 @@ export const ListAccessApplicationCasResponse =
 
 export type ListAccessApplicationCasError = DefaultErrors;
 
-export const listAccessApplicationCas: API.PaginatedOperationMethod<
-  ListAccessApplicationCasRequest,
+export const listAccessApplicationCasForAccount: API.PaginatedOperationMethod<
+  ListAccessApplicationCasForAccountRequest,
   ListAccessApplicationCasResponse,
   ListAccessApplicationCasError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
-  input: ListAccessApplicationCasRequest,
+  input: ListAccessApplicationCasForAccountRequest,
   output: ListAccessApplicationCasResponse,
   errors: [],
   pagination: {
@@ -33344,19 +34034,73 @@ export const listAccessApplicationCas: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export interface CreateAccessApplicationCaRequest {
+export const listAccessApplicationCasForZone: API.PaginatedOperationMethod<
+  ListAccessApplicationCasForZoneRequest,
+  ListAccessApplicationCasResponse,
+  ListAccessApplicationCasError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+  input: ListAccessApplicationCasForZoneRequest,
+  output: ListAccessApplicationCasResponse,
+  errors: [],
+  pagination: {
+    mode: "page",
+    inputToken: "page",
+    outputToken: "resultInfo.page",
+    items: "result",
+    pageSize: "perPage",
+  } as const,
+}));
+
+export const listAccessApplicationCas = (
+  input: ListAccessApplicationCasRequest,
+): stream.Stream<
+  ListAccessApplicationCasResponse,
+  ListAccessApplicationCasError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? listAccessApplicationCasForAccount.pages(input)
+    : listAccessApplicationCasForZone.pages(input);
+
+const CreateAccessApplicationCaBaseFields = {
+  appId: Schema.String.pipe(T.HttpPath("appId")),
+} as const;
+
+export interface CreateAccessApplicationCaForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   appId: string;
 }
 
-export const CreateAccessApplicationCaRequest =
+export interface CreateAccessApplicationCaForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  appId: string;
+}
+
+export type CreateAccessApplicationCaRequest =
+  | CreateAccessApplicationCaForAccountRequest
+  | CreateAccessApplicationCaForZoneRequest;
+
+export const CreateAccessApplicationCaForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    appId: Schema.String.pipe(T.HttpPath("appId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...CreateAccessApplicationCaBaseFields,
   }).pipe(
     T.Http({
       method: "POST",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/apps/{appId}/ca",
+      path: "/accounts/{account_id}/access/apps/{appId}/ca",
     }),
-  ) as unknown as Schema.Schema<CreateAccessApplicationCaRequest>;
+  ) as unknown as Schema.Schema<CreateAccessApplicationCaForAccountRequest>;
+
+export const CreateAccessApplicationCaForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...CreateAccessApplicationCaBaseFields,
+  }).pipe(
+    T.Http({ method: "POST", path: "/zones/{zone_id}/access/apps/{appId}/ca" }),
+  ) as unknown as Schema.Schema<CreateAccessApplicationCaForZoneRequest>;
 
 export interface CreateAccessApplicationCaResponse {
   /** The ID of the CA. */
@@ -33380,30 +34124,80 @@ export const CreateAccessApplicationCaResponse =
 
 export type CreateAccessApplicationCaError = DefaultErrors;
 
-export const createAccessApplicationCa: API.OperationMethod<
-  CreateAccessApplicationCaRequest,
+export const createAccessApplicationCaForAccount: API.OperationMethod<
+  CreateAccessApplicationCaForAccountRequest,
   CreateAccessApplicationCaResponse,
   CreateAccessApplicationCaError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: CreateAccessApplicationCaRequest,
+  input: CreateAccessApplicationCaForAccountRequest,
   output: CreateAccessApplicationCaResponse,
   errors: [],
 }));
 
-export interface DeleteAccessApplicationCaRequest {
+export const createAccessApplicationCaForZone: API.OperationMethod<
+  CreateAccessApplicationCaForZoneRequest,
+  CreateAccessApplicationCaResponse,
+  CreateAccessApplicationCaError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: CreateAccessApplicationCaForZoneRequest,
+  output: CreateAccessApplicationCaResponse,
+  errors: [],
+}));
+
+export const createAccessApplicationCa = (
+  input: CreateAccessApplicationCaRequest,
+): Effect.Effect<
+  CreateAccessApplicationCaResponse,
+  CreateAccessApplicationCaError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? createAccessApplicationCaForAccount(input)
+    : createAccessApplicationCaForZone(input);
+
+const DeleteAccessApplicationCaBaseFields = {
+  appId: Schema.String.pipe(T.HttpPath("appId")),
+} as const;
+
+export interface DeleteAccessApplicationCaForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   appId: string;
 }
 
-export const DeleteAccessApplicationCaRequest =
+export interface DeleteAccessApplicationCaForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  appId: string;
+}
+
+export type DeleteAccessApplicationCaRequest =
+  | DeleteAccessApplicationCaForAccountRequest
+  | DeleteAccessApplicationCaForZoneRequest;
+
+export const DeleteAccessApplicationCaForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    appId: Schema.String.pipe(T.HttpPath("appId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...DeleteAccessApplicationCaBaseFields,
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/apps/{appId}/ca",
+      path: "/accounts/{account_id}/access/apps/{appId}/ca",
     }),
-  ) as unknown as Schema.Schema<DeleteAccessApplicationCaRequest>;
+  ) as unknown as Schema.Schema<DeleteAccessApplicationCaForAccountRequest>;
+
+export const DeleteAccessApplicationCaForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...DeleteAccessApplicationCaBaseFields,
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/zones/{zone_id}/access/apps/{appId}/ca",
+    }),
+  ) as unknown as Schema.Schema<DeleteAccessApplicationCaForZoneRequest>;
 
 export interface DeleteAccessApplicationCaResponse {
   /** The ID of the CA. */
@@ -33419,36 +34213,87 @@ export const DeleteAccessApplicationCaResponse =
 
 export type DeleteAccessApplicationCaError = DefaultErrors;
 
-export const deleteAccessApplicationCa: API.OperationMethod<
-  DeleteAccessApplicationCaRequest,
+export const deleteAccessApplicationCaForAccount: API.OperationMethod<
+  DeleteAccessApplicationCaForAccountRequest,
   DeleteAccessApplicationCaResponse,
   DeleteAccessApplicationCaError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: DeleteAccessApplicationCaRequest,
+  input: DeleteAccessApplicationCaForAccountRequest,
   output: DeleteAccessApplicationCaResponse,
   errors: [],
 }));
+
+export const deleteAccessApplicationCaForZone: API.OperationMethod<
+  DeleteAccessApplicationCaForZoneRequest,
+  DeleteAccessApplicationCaResponse,
+  DeleteAccessApplicationCaError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: DeleteAccessApplicationCaForZoneRequest,
+  output: DeleteAccessApplicationCaResponse,
+  errors: [],
+}));
+
+export const deleteAccessApplicationCa = (
+  input: DeleteAccessApplicationCaRequest,
+): Effect.Effect<
+  DeleteAccessApplicationCaResponse,
+  DeleteAccessApplicationCaError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? deleteAccessApplicationCaForAccount(input)
+    : deleteAccessApplicationCaForZone(input);
 
 // =============================================================================
 // AccessApplicationPolicy
 // =============================================================================
 
-export interface GetAccessApplicationPolicyRequest {
+const GetAccessApplicationPolicyBaseFields = {
+  appId: Schema.String.pipe(T.HttpPath("appId")),
+  policyId: Schema.String.pipe(T.HttpPath("policyId")),
+} as const;
+
+export interface GetAccessApplicationPolicyForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   appId: string;
   policyId: string;
 }
 
-export const GetAccessApplicationPolicyRequest =
+export interface GetAccessApplicationPolicyForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  appId: string;
+  policyId: string;
+}
+
+export type GetAccessApplicationPolicyRequest =
+  | GetAccessApplicationPolicyForAccountRequest
+  | GetAccessApplicationPolicyForZoneRequest;
+
+export const GetAccessApplicationPolicyForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    appId: Schema.String.pipe(T.HttpPath("appId")),
-    policyId: Schema.String.pipe(T.HttpPath("policyId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetAccessApplicationPolicyBaseFields,
   }).pipe(
     T.Http({
       method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/apps/{appId}/policies/{policyId}",
+      path: "/accounts/{account_id}/access/apps/{appId}/policies/{policyId}",
     }),
-  ) as unknown as Schema.Schema<GetAccessApplicationPolicyRequest>;
+  ) as unknown as Schema.Schema<GetAccessApplicationPolicyForAccountRequest>;
+
+export const GetAccessApplicationPolicyForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...GetAccessApplicationPolicyBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/access/apps/{appId}/policies/{policyId}",
+    }),
+  ) as unknown as Schema.Schema<GetAccessApplicationPolicyForZoneRequest>;
 
 export interface GetAccessApplicationPolicyResponse {
   /** The UUID of the policy */
@@ -34283,30 +35128,80 @@ export const GetAccessApplicationPolicyResponse =
 
 export type GetAccessApplicationPolicyError = DefaultErrors;
 
-export const getAccessApplicationPolicy: API.OperationMethod<
-  GetAccessApplicationPolicyRequest,
+export const getAccessApplicationPolicyForAccount: API.OperationMethod<
+  GetAccessApplicationPolicyForAccountRequest,
   GetAccessApplicationPolicyResponse,
   GetAccessApplicationPolicyError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: GetAccessApplicationPolicyRequest,
+  input: GetAccessApplicationPolicyForAccountRequest,
   output: GetAccessApplicationPolicyResponse,
   errors: [],
 }));
 
-export interface ListAccessApplicationPoliciesRequest {
+export const getAccessApplicationPolicyForZone: API.OperationMethod<
+  GetAccessApplicationPolicyForZoneRequest,
+  GetAccessApplicationPolicyResponse,
+  GetAccessApplicationPolicyError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetAccessApplicationPolicyForZoneRequest,
+  output: GetAccessApplicationPolicyResponse,
+  errors: [],
+}));
+
+export const getAccessApplicationPolicy = (
+  input: GetAccessApplicationPolicyRequest,
+): Effect.Effect<
+  GetAccessApplicationPolicyResponse,
+  GetAccessApplicationPolicyError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? getAccessApplicationPolicyForAccount(input)
+    : getAccessApplicationPolicyForZone(input);
+
+const ListAccessApplicationPoliciesBaseFields = {
+  appId: Schema.String.pipe(T.HttpPath("appId")),
+} as const;
+
+export interface ListAccessApplicationPoliciesForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   appId: string;
 }
 
-export const ListAccessApplicationPoliciesRequest =
+export interface ListAccessApplicationPoliciesForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  appId: string;
+}
+
+export type ListAccessApplicationPoliciesRequest =
+  | ListAccessApplicationPoliciesForAccountRequest
+  | ListAccessApplicationPoliciesForZoneRequest;
+
+export const ListAccessApplicationPoliciesForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    appId: Schema.String.pipe(T.HttpPath("appId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...ListAccessApplicationPoliciesBaseFields,
   }).pipe(
     T.Http({
       method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/apps/{appId}/policies",
+      path: "/accounts/{account_id}/access/apps/{appId}/policies",
     }),
-  ) as unknown as Schema.Schema<ListAccessApplicationPoliciesRequest>;
+  ) as unknown as Schema.Schema<ListAccessApplicationPoliciesForAccountRequest>;
+
+export const ListAccessApplicationPoliciesForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...ListAccessApplicationPoliciesBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/access/apps/{appId}/policies",
+    }),
+  ) as unknown as Schema.Schema<ListAccessApplicationPoliciesForZoneRequest>;
 
 export interface ListAccessApplicationPoliciesResponse {
   result: {
@@ -35182,13 +36077,13 @@ export const ListAccessApplicationPoliciesResponse =
 
 export type ListAccessApplicationPoliciesError = DefaultErrors;
 
-export const listAccessApplicationPolicies: API.PaginatedOperationMethod<
-  ListAccessApplicationPoliciesRequest,
+export const listAccessApplicationPoliciesForAccount: API.PaginatedOperationMethod<
+  ListAccessApplicationPoliciesForAccountRequest,
   ListAccessApplicationPoliciesResponse,
   ListAccessApplicationPoliciesError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
-  input: ListAccessApplicationPoliciesRequest,
+  input: ListAccessApplicationPoliciesForAccountRequest,
   output: ListAccessApplicationPoliciesResponse,
   errors: [],
   pagination: {
@@ -35200,12 +36095,64 @@ export const listAccessApplicationPolicies: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export interface CreateAccessApplicationPolicyRequest {
+export const listAccessApplicationPoliciesForZone: API.PaginatedOperationMethod<
+  ListAccessApplicationPoliciesForZoneRequest,
+  ListAccessApplicationPoliciesResponse,
+  ListAccessApplicationPoliciesError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+  input: ListAccessApplicationPoliciesForZoneRequest,
+  output: ListAccessApplicationPoliciesResponse,
+  errors: [],
+  pagination: {
+    mode: "page",
+    inputToken: "page",
+    outputToken: "resultInfo.page",
+    items: "result",
+    pageSize: "perPage",
+  } as const,
+}));
+
+export const listAccessApplicationPolicies = (
+  input: ListAccessApplicationPoliciesRequest,
+): stream.Stream<
+  ListAccessApplicationPoliciesResponse,
+  ListAccessApplicationPoliciesError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? listAccessApplicationPoliciesForAccount.pages(input)
+    : listAccessApplicationPoliciesForZone.pages(input);
+
+const CreateAccessApplicationPolicyBaseFields = {
+  appId: Schema.String.pipe(T.HttpPath("appId")),
+  approvalGroups: Schema.optional(
+    Schema.Array(
+      Schema.Struct({
+        approvalsNeeded: Schema.Number,
+        emailAddresses: Schema.optional(Schema.Array(Schema.String)),
+        emailListUuid: Schema.optional(Schema.String),
+      }).pipe(
+        Schema.encodeKeys({
+          approvalsNeeded: "approvals_needed",
+          emailAddresses: "email_addresses",
+          emailListUuid: "email_list_uuid",
+        }),
+      ),
+    ),
+  ),
+  approvalRequired: Schema.optional(Schema.Boolean),
+  isolationRequired: Schema.optional(Schema.Boolean),
+  precedence: Schema.optional(Schema.Number),
+  purposeJustificationPrompt: Schema.optional(Schema.String),
+  purposeJustificationRequired: Schema.optional(Schema.Boolean),
+  sessionDuration: Schema.optional(Schema.String),
+} as const;
+
+export interface CreateAccessApplicationPolicyForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   appId: string;
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
   /** Body param: Administrators who can approve a temporary authentication request. */
   approvalGroups?: {
     approvalsNeeded: number;
@@ -35226,32 +36173,38 @@ export interface CreateAccessApplicationPolicyRequest {
   sessionDuration?: string;
 }
 
-export const CreateAccessApplicationPolicyRequest =
+export interface CreateAccessApplicationPolicyForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  appId: string;
+  /** Body param: Administrators who can approve a temporary authentication request. */
+  approvalGroups?: {
+    approvalsNeeded: number;
+    emailAddresses?: string[];
+    emailListUuid?: string;
+  }[];
+  /** Body param: Requires the user to request access from an administrator at the start of each session. */
+  approvalRequired?: boolean;
+  /** Body param: Require this application to be served in an isolated browser for users matching this policy. 'Client Web Isolation' must be on for the account in order to use this feature. */
+  isolationRequired?: boolean;
+  /** Body param: The order of execution for this policy. Must be unique for each policy within an app. */
+  precedence?: number;
+  /** Body param: A custom message that will appear on the purpose justification screen. */
+  purposeJustificationPrompt?: string;
+  /** Body param: Require users to enter a justification when they log in to the application. */
+  purposeJustificationRequired?: boolean;
+  /** Body param: The amount of time that tokens issued for the application will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. */
+  sessionDuration?: string;
+}
+
+export type CreateAccessApplicationPolicyRequest =
+  | CreateAccessApplicationPolicyForAccountRequest
+  | CreateAccessApplicationPolicyForZoneRequest;
+
+export const CreateAccessApplicationPolicyForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    appId: Schema.String.pipe(T.HttpPath("appId")),
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    approvalGroups: Schema.optional(
-      Schema.Array(
-        Schema.Struct({
-          approvalsNeeded: Schema.Number,
-          emailAddresses: Schema.optional(Schema.Array(Schema.String)),
-          emailListUuid: Schema.optional(Schema.String),
-        }).pipe(
-          Schema.encodeKeys({
-            approvalsNeeded: "approvals_needed",
-            emailAddresses: "email_addresses",
-            emailListUuid: "email_list_uuid",
-          }),
-        ),
-      ),
-    ),
-    approvalRequired: Schema.optional(Schema.Boolean),
-    isolationRequired: Schema.optional(Schema.Boolean),
-    precedence: Schema.optional(Schema.Number),
-    purposeJustificationPrompt: Schema.optional(Schema.String),
-    purposeJustificationRequired: Schema.optional(Schema.Boolean),
-    sessionDuration: Schema.optional(Schema.String),
+    ...CreateAccessApplicationPolicyBaseFields,
   }).pipe(
     Schema.encodeKeys({
       approvalGroups: "approval_groups",
@@ -35264,9 +36217,29 @@ export const CreateAccessApplicationPolicyRequest =
     }),
     T.Http({
       method: "POST",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/apps/{appId}/policies",
+      path: "/accounts/{account_id}/access/apps/{appId}/policies",
     }),
-  ) as unknown as Schema.Schema<CreateAccessApplicationPolicyRequest>;
+  ) as unknown as Schema.Schema<CreateAccessApplicationPolicyForAccountRequest>;
+
+export const CreateAccessApplicationPolicyForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...CreateAccessApplicationPolicyBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      approvalGroups: "approval_groups",
+      approvalRequired: "approval_required",
+      isolationRequired: "isolation_required",
+      precedence: "precedence",
+      purposeJustificationPrompt: "purpose_justification_prompt",
+      purposeJustificationRequired: "purpose_justification_required",
+      sessionDuration: "session_duration",
+    }),
+    T.Http({
+      method: "POST",
+      path: "/zones/{zone_id}/access/apps/{appId}/policies",
+    }),
+  ) as unknown as Schema.Schema<CreateAccessApplicationPolicyForZoneRequest>;
 
 export interface CreateAccessApplicationPolicyResponse {
   /** The UUID of the policy */
@@ -36101,24 +37074,70 @@ export const CreateAccessApplicationPolicyResponse =
 
 export type CreateAccessApplicationPolicyError = DefaultErrors;
 
-export const createAccessApplicationPolicy: API.OperationMethod<
-  CreateAccessApplicationPolicyRequest,
+export const createAccessApplicationPolicyForAccount: API.OperationMethod<
+  CreateAccessApplicationPolicyForAccountRequest,
   CreateAccessApplicationPolicyResponse,
   CreateAccessApplicationPolicyError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: CreateAccessApplicationPolicyRequest,
+  input: CreateAccessApplicationPolicyForAccountRequest,
   output: CreateAccessApplicationPolicyResponse,
   errors: [],
 }));
 
-export interface UpdateAccessApplicationPolicyRequest {
+export const createAccessApplicationPolicyForZone: API.OperationMethod<
+  CreateAccessApplicationPolicyForZoneRequest,
+  CreateAccessApplicationPolicyResponse,
+  CreateAccessApplicationPolicyError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: CreateAccessApplicationPolicyForZoneRequest,
+  output: CreateAccessApplicationPolicyResponse,
+  errors: [],
+}));
+
+export const createAccessApplicationPolicy = (
+  input: CreateAccessApplicationPolicyRequest,
+): Effect.Effect<
+  CreateAccessApplicationPolicyResponse,
+  CreateAccessApplicationPolicyError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? createAccessApplicationPolicyForAccount(input)
+    : createAccessApplicationPolicyForZone(input);
+
+const UpdateAccessApplicationPolicyBaseFields = {
+  appId: Schema.String.pipe(T.HttpPath("appId")),
+  policyId: Schema.String.pipe(T.HttpPath("policyId")),
+  approvalGroups: Schema.optional(
+    Schema.Array(
+      Schema.Struct({
+        approvalsNeeded: Schema.Number,
+        emailAddresses: Schema.optional(Schema.Array(Schema.String)),
+        emailListUuid: Schema.optional(Schema.String),
+      }).pipe(
+        Schema.encodeKeys({
+          approvalsNeeded: "approvals_needed",
+          emailAddresses: "email_addresses",
+          emailListUuid: "email_list_uuid",
+        }),
+      ),
+    ),
+  ),
+  approvalRequired: Schema.optional(Schema.Boolean),
+  isolationRequired: Schema.optional(Schema.Boolean),
+  precedence: Schema.optional(Schema.Number),
+  purposeJustificationPrompt: Schema.optional(Schema.String),
+  purposeJustificationRequired: Schema.optional(Schema.Boolean),
+  sessionDuration: Schema.optional(Schema.String),
+} as const;
+
+export interface UpdateAccessApplicationPolicyForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   appId: string;
   policyId: string;
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
   /** Body param: Administrators who can approve a temporary authentication request. */
   approvalGroups?: {
     approvalsNeeded: number;
@@ -36139,33 +37158,39 @@ export interface UpdateAccessApplicationPolicyRequest {
   sessionDuration?: string;
 }
 
-export const UpdateAccessApplicationPolicyRequest =
+export interface UpdateAccessApplicationPolicyForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  appId: string;
+  policyId: string;
+  /** Body param: Administrators who can approve a temporary authentication request. */
+  approvalGroups?: {
+    approvalsNeeded: number;
+    emailAddresses?: string[];
+    emailListUuid?: string;
+  }[];
+  /** Body param: Requires the user to request access from an administrator at the start of each session. */
+  approvalRequired?: boolean;
+  /** Body param: Require this application to be served in an isolated browser for users matching this policy. 'Client Web Isolation' must be on for the account in order to use this feature. */
+  isolationRequired?: boolean;
+  /** Body param: The order of execution for this policy. Must be unique for each policy within an app. */
+  precedence?: number;
+  /** Body param: A custom message that will appear on the purpose justification screen. */
+  purposeJustificationPrompt?: string;
+  /** Body param: Require users to enter a justification when they log in to the application. */
+  purposeJustificationRequired?: boolean;
+  /** Body param: The amount of time that tokens issued for the application will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. */
+  sessionDuration?: string;
+}
+
+export type UpdateAccessApplicationPolicyRequest =
+  | UpdateAccessApplicationPolicyForAccountRequest
+  | UpdateAccessApplicationPolicyForZoneRequest;
+
+export const UpdateAccessApplicationPolicyForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    appId: Schema.String.pipe(T.HttpPath("appId")),
-    policyId: Schema.String.pipe(T.HttpPath("policyId")),
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    approvalGroups: Schema.optional(
-      Schema.Array(
-        Schema.Struct({
-          approvalsNeeded: Schema.Number,
-          emailAddresses: Schema.optional(Schema.Array(Schema.String)),
-          emailListUuid: Schema.optional(Schema.String),
-        }).pipe(
-          Schema.encodeKeys({
-            approvalsNeeded: "approvals_needed",
-            emailAddresses: "email_addresses",
-            emailListUuid: "email_list_uuid",
-          }),
-        ),
-      ),
-    ),
-    approvalRequired: Schema.optional(Schema.Boolean),
-    isolationRequired: Schema.optional(Schema.Boolean),
-    precedence: Schema.optional(Schema.Number),
-    purposeJustificationPrompt: Schema.optional(Schema.String),
-    purposeJustificationRequired: Schema.optional(Schema.Boolean),
-    sessionDuration: Schema.optional(Schema.String),
+    ...UpdateAccessApplicationPolicyBaseFields,
   }).pipe(
     Schema.encodeKeys({
       approvalGroups: "approval_groups",
@@ -36178,9 +37203,29 @@ export const UpdateAccessApplicationPolicyRequest =
     }),
     T.Http({
       method: "PUT",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/apps/{appId}/policies/{policyId}",
+      path: "/accounts/{account_id}/access/apps/{appId}/policies/{policyId}",
     }),
-  ) as unknown as Schema.Schema<UpdateAccessApplicationPolicyRequest>;
+  ) as unknown as Schema.Schema<UpdateAccessApplicationPolicyForAccountRequest>;
+
+export const UpdateAccessApplicationPolicyForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...UpdateAccessApplicationPolicyBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      approvalGroups: "approval_groups",
+      approvalRequired: "approval_required",
+      isolationRequired: "isolation_required",
+      precedence: "precedence",
+      purposeJustificationPrompt: "purpose_justification_prompt",
+      purposeJustificationRequired: "purpose_justification_required",
+      sessionDuration: "session_duration",
+    }),
+    T.Http({
+      method: "PUT",
+      path: "/zones/{zone_id}/access/apps/{appId}/policies/{policyId}",
+    }),
+  ) as unknown as Schema.Schema<UpdateAccessApplicationPolicyForZoneRequest>;
 
 export interface UpdateAccessApplicationPolicyResponse {
   /** The UUID of the policy */
@@ -37015,32 +38060,83 @@ export const UpdateAccessApplicationPolicyResponse =
 
 export type UpdateAccessApplicationPolicyError = DefaultErrors;
 
-export const updateAccessApplicationPolicy: API.OperationMethod<
-  UpdateAccessApplicationPolicyRequest,
+export const updateAccessApplicationPolicyForAccount: API.OperationMethod<
+  UpdateAccessApplicationPolicyForAccountRequest,
   UpdateAccessApplicationPolicyResponse,
   UpdateAccessApplicationPolicyError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: UpdateAccessApplicationPolicyRequest,
+  input: UpdateAccessApplicationPolicyForAccountRequest,
   output: UpdateAccessApplicationPolicyResponse,
   errors: [],
 }));
 
-export interface DeleteAccessApplicationPolicyRequest {
+export const updateAccessApplicationPolicyForZone: API.OperationMethod<
+  UpdateAccessApplicationPolicyForZoneRequest,
+  UpdateAccessApplicationPolicyResponse,
+  UpdateAccessApplicationPolicyError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: UpdateAccessApplicationPolicyForZoneRequest,
+  output: UpdateAccessApplicationPolicyResponse,
+  errors: [],
+}));
+
+export const updateAccessApplicationPolicy = (
+  input: UpdateAccessApplicationPolicyRequest,
+): Effect.Effect<
+  UpdateAccessApplicationPolicyResponse,
+  UpdateAccessApplicationPolicyError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? updateAccessApplicationPolicyForAccount(input)
+    : updateAccessApplicationPolicyForZone(input);
+
+const DeleteAccessApplicationPolicyBaseFields = {
+  appId: Schema.String.pipe(T.HttpPath("appId")),
+  policyId: Schema.String.pipe(T.HttpPath("policyId")),
+} as const;
+
+export interface DeleteAccessApplicationPolicyForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   appId: string;
   policyId: string;
 }
 
-export const DeleteAccessApplicationPolicyRequest =
+export interface DeleteAccessApplicationPolicyForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  appId: string;
+  policyId: string;
+}
+
+export type DeleteAccessApplicationPolicyRequest =
+  | DeleteAccessApplicationPolicyForAccountRequest
+  | DeleteAccessApplicationPolicyForZoneRequest;
+
+export const DeleteAccessApplicationPolicyForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    appId: Schema.String.pipe(T.HttpPath("appId")),
-    policyId: Schema.String.pipe(T.HttpPath("policyId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...DeleteAccessApplicationPolicyBaseFields,
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/apps/{appId}/policies/{policyId}",
+      path: "/accounts/{account_id}/access/apps/{appId}/policies/{policyId}",
     }),
-  ) as unknown as Schema.Schema<DeleteAccessApplicationPolicyRequest>;
+  ) as unknown as Schema.Schema<DeleteAccessApplicationPolicyForAccountRequest>;
+
+export const DeleteAccessApplicationPolicyForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...DeleteAccessApplicationPolicyBaseFields,
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/zones/{zone_id}/access/apps/{appId}/policies/{policyId}",
+    }),
+  ) as unknown as Schema.Schema<DeleteAccessApplicationPolicyForZoneRequest>;
 
 export interface DeleteAccessApplicationPolicyResponse {
   /** UUID. */
@@ -37056,16 +38152,38 @@ export const DeleteAccessApplicationPolicyResponse =
 
 export type DeleteAccessApplicationPolicyError = DefaultErrors;
 
-export const deleteAccessApplicationPolicy: API.OperationMethod<
-  DeleteAccessApplicationPolicyRequest,
+export const deleteAccessApplicationPolicyForAccount: API.OperationMethod<
+  DeleteAccessApplicationPolicyForAccountRequest,
   DeleteAccessApplicationPolicyResponse,
   DeleteAccessApplicationPolicyError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: DeleteAccessApplicationPolicyRequest,
+  input: DeleteAccessApplicationPolicyForAccountRequest,
   output: DeleteAccessApplicationPolicyResponse,
   errors: [],
 }));
+
+export const deleteAccessApplicationPolicyForZone: API.OperationMethod<
+  DeleteAccessApplicationPolicyForZoneRequest,
+  DeleteAccessApplicationPolicyResponse,
+  DeleteAccessApplicationPolicyError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: DeleteAccessApplicationPolicyForZoneRequest,
+  output: DeleteAccessApplicationPolicyResponse,
+  errors: [],
+}));
+
+export const deleteAccessApplicationPolicy = (
+  input: DeleteAccessApplicationPolicyRequest,
+): Effect.Effect<
+  DeleteAccessApplicationPolicyResponse,
+  DeleteAccessApplicationPolicyError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? deleteAccessApplicationPolicyForAccount(input)
+    : deleteAccessApplicationPolicyForZone(input);
 
 // =============================================================================
 // AccessApplicationPolicyTest
@@ -38113,23 +39231,40 @@ export const listAccessApplicationPolicyTestUsers: API.PaginatedOperationMethod<
 // AccessApplicationSetting
 // =============================================================================
 
-export interface PutAccessApplicationSettingRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
+const PutAccessApplicationSettingBaseFields = {
+  appId: Schema.String.pipe(T.HttpPath("appId")),
+  allowIframe: Schema.optional(Schema.Boolean),
+  skipInterstitial: Schema.optional(Schema.Boolean),
+} as const;
+
+export interface PutAccessApplicationSettingForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  appId: string;
   /** Body param: Enables loading application content in an iFrame. */
   allowIframe?: boolean;
   /** Body param: Enables automatic authentication through cloudflared. */
   skipInterstitial?: boolean;
 }
 
-export const PutAccessApplicationSettingRequest =
+export interface PutAccessApplicationSettingForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  appId: string;
+  /** Body param: Enables loading application content in an iFrame. */
+  allowIframe?: boolean;
+  /** Body param: Enables automatic authentication through cloudflared. */
+  skipInterstitial?: boolean;
+}
+
+export type PutAccessApplicationSettingRequest =
+  | PutAccessApplicationSettingForAccountRequest
+  | PutAccessApplicationSettingForZoneRequest;
+
+export const PutAccessApplicationSettingForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    allowIframe: Schema.optional(Schema.Boolean),
-    skipInterstitial: Schema.optional(Schema.Boolean),
+    ...PutAccessApplicationSettingBaseFields,
   }).pipe(
     Schema.encodeKeys({
       allowIframe: "allow_iframe",
@@ -38137,9 +39272,24 @@ export const PutAccessApplicationSettingRequest =
     }),
     T.Http({
       method: "PUT",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/apps/{appId}/settings",
+      path: "/accounts/{account_id}/access/apps/{appId}/settings",
     }),
-  ) as unknown as Schema.Schema<PutAccessApplicationSettingRequest>;
+  ) as unknown as Schema.Schema<PutAccessApplicationSettingForAccountRequest>;
+
+export const PutAccessApplicationSettingForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...PutAccessApplicationSettingBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      allowIframe: "allow_iframe",
+      skipInterstitial: "skip_interstitial",
+    }),
+    T.Http({
+      method: "PUT",
+      path: "/zones/{zone_id}/access/apps/{appId}/settings",
+    }),
+  ) as unknown as Schema.Schema<PutAccessApplicationSettingForZoneRequest>;
 
 export interface PutAccessApplicationSettingResponse {
   /** Enables loading application content in an iFrame. */
@@ -38167,34 +39317,73 @@ export const PutAccessApplicationSettingResponse =
 
 export type PutAccessApplicationSettingError = DefaultErrors;
 
-export const putAccessApplicationSetting: API.OperationMethod<
-  PutAccessApplicationSettingRequest,
+export const putAccessApplicationSettingForAccount: API.OperationMethod<
+  PutAccessApplicationSettingForAccountRequest,
   PutAccessApplicationSettingResponse,
   PutAccessApplicationSettingError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: PutAccessApplicationSettingRequest,
+  input: PutAccessApplicationSettingForAccountRequest,
   output: PutAccessApplicationSettingResponse,
   errors: [],
 }));
 
-export interface PatchAccessApplicationSettingRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
+export const putAccessApplicationSettingForZone: API.OperationMethod<
+  PutAccessApplicationSettingForZoneRequest,
+  PutAccessApplicationSettingResponse,
+  PutAccessApplicationSettingError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: PutAccessApplicationSettingForZoneRequest,
+  output: PutAccessApplicationSettingResponse,
+  errors: [],
+}));
+
+export const putAccessApplicationSetting = (
+  input: PutAccessApplicationSettingRequest,
+): Effect.Effect<
+  PutAccessApplicationSettingResponse,
+  PutAccessApplicationSettingError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? putAccessApplicationSettingForAccount(input)
+    : putAccessApplicationSettingForZone(input);
+
+const PatchAccessApplicationSettingBaseFields = {
+  appId: Schema.String.pipe(T.HttpPath("appId")),
+  allowIframe: Schema.optional(Schema.Boolean),
+  skipInterstitial: Schema.optional(Schema.Boolean),
+} as const;
+
+export interface PatchAccessApplicationSettingForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  appId: string;
   /** Body param: Enables loading application content in an iFrame. */
   allowIframe?: boolean;
   /** Body param: Enables automatic authentication through cloudflared. */
   skipInterstitial?: boolean;
 }
 
-export const PatchAccessApplicationSettingRequest =
+export interface PatchAccessApplicationSettingForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  appId: string;
+  /** Body param: Enables loading application content in an iFrame. */
+  allowIframe?: boolean;
+  /** Body param: Enables automatic authentication through cloudflared. */
+  skipInterstitial?: boolean;
+}
+
+export type PatchAccessApplicationSettingRequest =
+  | PatchAccessApplicationSettingForAccountRequest
+  | PatchAccessApplicationSettingForZoneRequest;
+
+export const PatchAccessApplicationSettingForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    allowIframe: Schema.optional(Schema.Boolean),
-    skipInterstitial: Schema.optional(Schema.Boolean),
+    ...PatchAccessApplicationSettingBaseFields,
   }).pipe(
     Schema.encodeKeys({
       allowIframe: "allow_iframe",
@@ -38202,9 +39391,24 @@ export const PatchAccessApplicationSettingRequest =
     }),
     T.Http({
       method: "PATCH",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/apps/{appId}/settings",
+      path: "/accounts/{account_id}/access/apps/{appId}/settings",
     }),
-  ) as unknown as Schema.Schema<PatchAccessApplicationSettingRequest>;
+  ) as unknown as Schema.Schema<PatchAccessApplicationSettingForAccountRequest>;
+
+export const PatchAccessApplicationSettingForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...PatchAccessApplicationSettingBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      allowIframe: "allow_iframe",
+      skipInterstitial: "skip_interstitial",
+    }),
+    T.Http({
+      method: "PATCH",
+      path: "/zones/{zone_id}/access/apps/{appId}/settings",
+    }),
+  ) as unknown as Schema.Schema<PatchAccessApplicationSettingForZoneRequest>;
 
 export interface PatchAccessApplicationSettingResponse {
   /** Enables loading application content in an iFrame. */
@@ -38232,30 +39436,84 @@ export const PatchAccessApplicationSettingResponse =
 
 export type PatchAccessApplicationSettingError = DefaultErrors;
 
-export const patchAccessApplicationSetting: API.OperationMethod<
-  PatchAccessApplicationSettingRequest,
+export const patchAccessApplicationSettingForAccount: API.OperationMethod<
+  PatchAccessApplicationSettingForAccountRequest,
   PatchAccessApplicationSettingResponse,
   PatchAccessApplicationSettingError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: PatchAccessApplicationSettingRequest,
+  input: PatchAccessApplicationSettingForAccountRequest,
   output: PatchAccessApplicationSettingResponse,
   errors: [],
 }));
+
+export const patchAccessApplicationSettingForZone: API.OperationMethod<
+  PatchAccessApplicationSettingForZoneRequest,
+  PatchAccessApplicationSettingResponse,
+  PatchAccessApplicationSettingError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: PatchAccessApplicationSettingForZoneRequest,
+  output: PatchAccessApplicationSettingResponse,
+  errors: [],
+}));
+
+export const patchAccessApplicationSetting = (
+  input: PatchAccessApplicationSettingRequest,
+): Effect.Effect<
+  PatchAccessApplicationSettingResponse,
+  PatchAccessApplicationSettingError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? patchAccessApplicationSettingForAccount(input)
+    : patchAccessApplicationSettingForZone(input);
 
 // =============================================================================
 // AccessApplicationUserPolicyCheck
 // =============================================================================
 
-export interface ListAccessApplicationUserPolicyChecksRequest {}
+const ListAccessApplicationUserPolicyChecksBaseFields = {
+  appId: Schema.String.pipe(T.HttpPath("appId")),
+} as const;
 
-export const ListAccessApplicationUserPolicyChecksRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
+export interface ListAccessApplicationUserPolicyChecksForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  appId: string;
+}
+
+export interface ListAccessApplicationUserPolicyChecksForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  appId: string;
+}
+
+export type ListAccessApplicationUserPolicyChecksRequest =
+  | ListAccessApplicationUserPolicyChecksForAccountRequest
+  | ListAccessApplicationUserPolicyChecksForZoneRequest;
+
+export const ListAccessApplicationUserPolicyChecksForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...ListAccessApplicationUserPolicyChecksBaseFields,
+  }).pipe(
     T.Http({
       method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/apps/{appId}/user_policy_checks",
+      path: "/accounts/{account_id}/access/apps/{appId}/user_policy_checks",
     }),
-  ) as unknown as Schema.Schema<ListAccessApplicationUserPolicyChecksRequest>;
+  ) as unknown as Schema.Schema<ListAccessApplicationUserPolicyChecksForAccountRequest>;
+
+export const ListAccessApplicationUserPolicyChecksForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...ListAccessApplicationUserPolicyChecksBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/access/apps/{appId}/user_policy_checks",
+    }),
+  ) as unknown as Schema.Schema<ListAccessApplicationUserPolicyChecksForZoneRequest>;
 
 export interface ListAccessApplicationUserPolicyChecksResponse {
   appState?: {
@@ -38367,16 +39625,38 @@ export const ListAccessApplicationUserPolicyChecksResponse =
 
 export type ListAccessApplicationUserPolicyChecksError = DefaultErrors;
 
-export const listAccessApplicationUserPolicyChecks: API.OperationMethod<
-  ListAccessApplicationUserPolicyChecksRequest,
+export const listAccessApplicationUserPolicyChecksForAccount: API.OperationMethod<
+  ListAccessApplicationUserPolicyChecksForAccountRequest,
   ListAccessApplicationUserPolicyChecksResponse,
   ListAccessApplicationUserPolicyChecksError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: ListAccessApplicationUserPolicyChecksRequest,
+  input: ListAccessApplicationUserPolicyChecksForAccountRequest,
   output: ListAccessApplicationUserPolicyChecksResponse,
   errors: [],
 }));
+
+export const listAccessApplicationUserPolicyChecksForZone: API.OperationMethod<
+  ListAccessApplicationUserPolicyChecksForZoneRequest,
+  ListAccessApplicationUserPolicyChecksResponse,
+  ListAccessApplicationUserPolicyChecksError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: ListAccessApplicationUserPolicyChecksForZoneRequest,
+  output: ListAccessApplicationUserPolicyChecksResponse,
+  errors: [],
+}));
+
+export const listAccessApplicationUserPolicyChecks = (
+  input: ListAccessApplicationUserPolicyChecksRequest,
+): Effect.Effect<
+  ListAccessApplicationUserPolicyChecksResponse,
+  ListAccessApplicationUserPolicyChecksError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? listAccessApplicationUserPolicyChecksForAccount(input)
+    : listAccessApplicationUserPolicyChecksForZone(input);
 
 // =============================================================================
 // AccessBookmark
@@ -38691,19 +39971,47 @@ export const deleteAccessBookmark: API.OperationMethod<
 // AccessCertificate
 // =============================================================================
 
-export interface GetAccessCertificateRequest {
+const GetAccessCertificateBaseFields = {
+  certificateId: Schema.String.pipe(T.HttpPath("certificateId")),
+} as const;
+
+export interface GetAccessCertificateForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   certificateId: string;
 }
 
-export const GetAccessCertificateRequest =
+export interface GetAccessCertificateForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  certificateId: string;
+}
+
+export type GetAccessCertificateRequest =
+  | GetAccessCertificateForAccountRequest
+  | GetAccessCertificateForZoneRequest;
+
+export const GetAccessCertificateForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    certificateId: Schema.String.pipe(T.HttpPath("certificateId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetAccessCertificateBaseFields,
   }).pipe(
     T.Http({
       method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/certificates/{certificateId}",
+      path: "/accounts/{account_id}/access/certificates/{certificateId}",
     }),
-  ) as unknown as Schema.Schema<GetAccessCertificateRequest>;
+  ) as unknown as Schema.Schema<GetAccessCertificateForAccountRequest>;
+
+export const GetAccessCertificateForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...GetAccessCertificateBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/access/certificates/{certificateId}",
+    }),
+  ) as unknown as Schema.Schema<GetAccessCertificateForZoneRequest>;
 
 export interface GetAccessCertificateResponse {
   /** The ID of the application that will use this certificate. */
@@ -38742,26 +40050,73 @@ export const GetAccessCertificateResponse =
 
 export type GetAccessCertificateError = DefaultErrors;
 
-export const getAccessCertificate: API.OperationMethod<
-  GetAccessCertificateRequest,
+export const getAccessCertificateForAccount: API.OperationMethod<
+  GetAccessCertificateForAccountRequest,
   GetAccessCertificateResponse,
   GetAccessCertificateError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: GetAccessCertificateRequest,
+  input: GetAccessCertificateForAccountRequest,
   output: GetAccessCertificateResponse,
   errors: [],
 }));
 
-export interface ListAccessCertificatesRequest {}
+export const getAccessCertificateForZone: API.OperationMethod<
+  GetAccessCertificateForZoneRequest,
+  GetAccessCertificateResponse,
+  GetAccessCertificateError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetAccessCertificateForZoneRequest,
+  output: GetAccessCertificateResponse,
+  errors: [],
+}));
 
-export const ListAccessCertificatesRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
+export const getAccessCertificate = (
+  input: GetAccessCertificateRequest,
+): Effect.Effect<
+  GetAccessCertificateResponse,
+  GetAccessCertificateError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? getAccessCertificateForAccount(input)
+    : getAccessCertificateForZone(input);
+
+const ListAccessCertificatesBaseFields = {} as const;
+
+export interface ListAccessCertificatesForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface ListAccessCertificatesForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+}
+
+export type ListAccessCertificatesRequest =
+  | ListAccessCertificatesForAccountRequest
+  | ListAccessCertificatesForZoneRequest;
+
+export const ListAccessCertificatesForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...ListAccessCertificatesBaseFields,
+  }).pipe(
     T.Http({
       method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/certificates",
+      path: "/accounts/{account_id}/access/certificates",
     }),
-  ) as unknown as Schema.Schema<ListAccessCertificatesRequest>;
+  ) as unknown as Schema.Schema<ListAccessCertificatesForAccountRequest>;
+
+export const ListAccessCertificatesForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...ListAccessCertificatesBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/zones/{zone_id}/access/certificates" }),
+  ) as unknown as Schema.Schema<ListAccessCertificatesForZoneRequest>;
 
 export interface ListAccessCertificatesResponse {
   result: {
@@ -38828,13 +40183,13 @@ export const ListAccessCertificatesResponse =
 
 export type ListAccessCertificatesError = DefaultErrors;
 
-export const listAccessCertificates: API.PaginatedOperationMethod<
-  ListAccessCertificatesRequest,
+export const listAccessCertificatesForAccount: API.PaginatedOperationMethod<
+  ListAccessCertificatesForAccountRequest,
   ListAccessCertificatesResponse,
   ListAccessCertificatesError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
-  input: ListAccessCertificatesRequest,
+  input: ListAccessCertificatesForAccountRequest,
   output: ListAccessCertificatesResponse,
   errors: [],
   pagination: {
@@ -38846,11 +40201,44 @@ export const listAccessCertificates: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export interface CreateAccessCertificateRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
+export const listAccessCertificatesForZone: API.PaginatedOperationMethod<
+  ListAccessCertificatesForZoneRequest,
+  ListAccessCertificatesResponse,
+  ListAccessCertificatesError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+  input: ListAccessCertificatesForZoneRequest,
+  output: ListAccessCertificatesResponse,
+  errors: [],
+  pagination: {
+    mode: "page",
+    inputToken: "page",
+    outputToken: "resultInfo.page",
+    items: "result",
+    pageSize: "perPage",
+  } as const,
+}));
+
+export const listAccessCertificates = (
+  input: ListAccessCertificatesRequest,
+): stream.Stream<
+  ListAccessCertificatesResponse,
+  ListAccessCertificatesError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? listAccessCertificatesForAccount.pages(input)
+    : listAccessCertificatesForZone.pages(input);
+
+const CreateAccessCertificateBaseFields = {
+  certificate: Schema.String,
+  name: Schema.String,
+  associatedHostnames: Schema.optional(Schema.Array(Schema.String)),
+} as const;
+
+export interface CreateAccessCertificateForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   /** Body param: The certificate content. */
   certificate: string;
   /** Body param: The name of the certificate. */
@@ -38859,13 +40247,25 @@ export interface CreateAccessCertificateRequest {
   associatedHostnames?: string[];
 }
 
-export const CreateAccessCertificateRequest =
+export interface CreateAccessCertificateForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  /** Body param: The certificate content. */
+  certificate: string;
+  /** Body param: The name of the certificate. */
+  name: string;
+  /** Body param: The hostnames of the applications that will use this certificate. */
+  associatedHostnames?: string[];
+}
+
+export type CreateAccessCertificateRequest =
+  | CreateAccessCertificateForAccountRequest
+  | CreateAccessCertificateForZoneRequest;
+
+export const CreateAccessCertificateForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    certificate: Schema.String,
-    name: Schema.String,
-    associatedHostnames: Schema.optional(Schema.Array(Schema.String)),
+    ...CreateAccessCertificateBaseFields,
   }).pipe(
     Schema.encodeKeys({
       certificate: "certificate",
@@ -38874,9 +40274,22 @@ export const CreateAccessCertificateRequest =
     }),
     T.Http({
       method: "POST",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/certificates",
+      path: "/accounts/{account_id}/access/certificates",
     }),
-  ) as unknown as Schema.Schema<CreateAccessCertificateRequest>;
+  ) as unknown as Schema.Schema<CreateAccessCertificateForAccountRequest>;
+
+export const CreateAccessCertificateForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...CreateAccessCertificateBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      certificate: "certificate",
+      name: "name",
+      associatedHostnames: "associated_hostnames",
+    }),
+    T.Http({ method: "POST", path: "/zones/{zone_id}/access/certificates" }),
+  ) as unknown as Schema.Schema<CreateAccessCertificateForZoneRequest>;
 
 export interface CreateAccessCertificateResponse {
   /** The ID of the application that will use this certificate. */
@@ -38915,36 +40328,73 @@ export const CreateAccessCertificateResponse =
 
 export type CreateAccessCertificateError = DefaultErrors;
 
-export const createAccessCertificate: API.OperationMethod<
-  CreateAccessCertificateRequest,
+export const createAccessCertificateForAccount: API.OperationMethod<
+  CreateAccessCertificateForAccountRequest,
   CreateAccessCertificateResponse,
   CreateAccessCertificateError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: CreateAccessCertificateRequest,
+  input: CreateAccessCertificateForAccountRequest,
   output: CreateAccessCertificateResponse,
   errors: [],
 }));
 
-export interface UpdateAccessCertificateRequest {
+export const createAccessCertificateForZone: API.OperationMethod<
+  CreateAccessCertificateForZoneRequest,
+  CreateAccessCertificateResponse,
+  CreateAccessCertificateError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: CreateAccessCertificateForZoneRequest,
+  output: CreateAccessCertificateResponse,
+  errors: [],
+}));
+
+export const createAccessCertificate = (
+  input: CreateAccessCertificateRequest,
+): Effect.Effect<
+  CreateAccessCertificateResponse,
+  CreateAccessCertificateError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? createAccessCertificateForAccount(input)
+    : createAccessCertificateForZone(input);
+
+const UpdateAccessCertificateBaseFields = {
+  certificateId: Schema.String.pipe(T.HttpPath("certificateId")),
+  associatedHostnames: Schema.Array(Schema.String),
+  name: Schema.optional(Schema.String),
+} as const;
+
+export interface UpdateAccessCertificateForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   certificateId: string;
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
   /** Body param: The hostnames of the applications that will use this certificate. */
   associatedHostnames: string[];
   /** Body param: The name of the certificate. */
   name?: string;
 }
 
-export const UpdateAccessCertificateRequest =
+export interface UpdateAccessCertificateForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  certificateId: string;
+  /** Body param: The hostnames of the applications that will use this certificate. */
+  associatedHostnames: string[];
+  /** Body param: The name of the certificate. */
+  name?: string;
+}
+
+export type UpdateAccessCertificateRequest =
+  | UpdateAccessCertificateForAccountRequest
+  | UpdateAccessCertificateForZoneRequest;
+
+export const UpdateAccessCertificateForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    certificateId: Schema.String.pipe(T.HttpPath("certificateId")),
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    associatedHostnames: Schema.Array(Schema.String),
-    name: Schema.optional(Schema.String),
+    ...UpdateAccessCertificateBaseFields,
   }).pipe(
     Schema.encodeKeys({
       associatedHostnames: "associated_hostnames",
@@ -38952,9 +40402,24 @@ export const UpdateAccessCertificateRequest =
     }),
     T.Http({
       method: "PUT",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/certificates/{certificateId}",
+      path: "/accounts/{account_id}/access/certificates/{certificateId}",
     }),
-  ) as unknown as Schema.Schema<UpdateAccessCertificateRequest>;
+  ) as unknown as Schema.Schema<UpdateAccessCertificateForAccountRequest>;
+
+export const UpdateAccessCertificateForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...UpdateAccessCertificateBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      associatedHostnames: "associated_hostnames",
+      name: "name",
+    }),
+    T.Http({
+      method: "PUT",
+      path: "/zones/{zone_id}/access/certificates/{certificateId}",
+    }),
+  ) as unknown as Schema.Schema<UpdateAccessCertificateForZoneRequest>;
 
 export interface UpdateAccessCertificateResponse {
   /** The ID of the application that will use this certificate. */
@@ -38993,30 +40458,80 @@ export const UpdateAccessCertificateResponse =
 
 export type UpdateAccessCertificateError = DefaultErrors;
 
-export const updateAccessCertificate: API.OperationMethod<
-  UpdateAccessCertificateRequest,
+export const updateAccessCertificateForAccount: API.OperationMethod<
+  UpdateAccessCertificateForAccountRequest,
   UpdateAccessCertificateResponse,
   UpdateAccessCertificateError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: UpdateAccessCertificateRequest,
+  input: UpdateAccessCertificateForAccountRequest,
   output: UpdateAccessCertificateResponse,
   errors: [],
 }));
 
-export interface DeleteAccessCertificateRequest {
+export const updateAccessCertificateForZone: API.OperationMethod<
+  UpdateAccessCertificateForZoneRequest,
+  UpdateAccessCertificateResponse,
+  UpdateAccessCertificateError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: UpdateAccessCertificateForZoneRequest,
+  output: UpdateAccessCertificateResponse,
+  errors: [],
+}));
+
+export const updateAccessCertificate = (
+  input: UpdateAccessCertificateRequest,
+): Effect.Effect<
+  UpdateAccessCertificateResponse,
+  UpdateAccessCertificateError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? updateAccessCertificateForAccount(input)
+    : updateAccessCertificateForZone(input);
+
+const DeleteAccessCertificateBaseFields = {
+  certificateId: Schema.String.pipe(T.HttpPath("certificateId")),
+} as const;
+
+export interface DeleteAccessCertificateForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   certificateId: string;
 }
 
-export const DeleteAccessCertificateRequest =
+export interface DeleteAccessCertificateForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  certificateId: string;
+}
+
+export type DeleteAccessCertificateRequest =
+  | DeleteAccessCertificateForAccountRequest
+  | DeleteAccessCertificateForZoneRequest;
+
+export const DeleteAccessCertificateForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    certificateId: Schema.String.pipe(T.HttpPath("certificateId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...DeleteAccessCertificateBaseFields,
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/certificates/{certificateId}",
+      path: "/accounts/{account_id}/access/certificates/{certificateId}",
     }),
-  ) as unknown as Schema.Schema<DeleteAccessCertificateRequest>;
+  ) as unknown as Schema.Schema<DeleteAccessCertificateForAccountRequest>;
+
+export const DeleteAccessCertificateForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...DeleteAccessCertificateBaseFields,
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/zones/{zone_id}/access/certificates/{certificateId}",
+    }),
+  ) as unknown as Schema.Schema<DeleteAccessCertificateForZoneRequest>;
 
 export interface DeleteAccessCertificateResponse {
   /** UUID. */
@@ -39032,30 +40547,80 @@ export const DeleteAccessCertificateResponse =
 
 export type DeleteAccessCertificateError = DefaultErrors;
 
-export const deleteAccessCertificate: API.OperationMethod<
-  DeleteAccessCertificateRequest,
+export const deleteAccessCertificateForAccount: API.OperationMethod<
+  DeleteAccessCertificateForAccountRequest,
   DeleteAccessCertificateResponse,
   DeleteAccessCertificateError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: DeleteAccessCertificateRequest,
+  input: DeleteAccessCertificateForAccountRequest,
   output: DeleteAccessCertificateResponse,
   errors: [],
 }));
+
+export const deleteAccessCertificateForZone: API.OperationMethod<
+  DeleteAccessCertificateForZoneRequest,
+  DeleteAccessCertificateResponse,
+  DeleteAccessCertificateError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: DeleteAccessCertificateForZoneRequest,
+  output: DeleteAccessCertificateResponse,
+  errors: [],
+}));
+
+export const deleteAccessCertificate = (
+  input: DeleteAccessCertificateRequest,
+): Effect.Effect<
+  DeleteAccessCertificateResponse,
+  DeleteAccessCertificateError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? deleteAccessCertificateForAccount(input)
+    : deleteAccessCertificateForZone(input);
 
 // =============================================================================
 // AccessCertificateSetting
 // =============================================================================
 
-export interface GetAccessCertificateSettingRequest {}
+const GetAccessCertificateSettingBaseFields = {} as const;
 
-export const GetAccessCertificateSettingRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
+export interface GetAccessCertificateSettingForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface GetAccessCertificateSettingForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+}
+
+export type GetAccessCertificateSettingRequest =
+  | GetAccessCertificateSettingForAccountRequest
+  | GetAccessCertificateSettingForZoneRequest;
+
+export const GetAccessCertificateSettingForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetAccessCertificateSettingBaseFields,
+  }).pipe(
     T.Http({
       method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/certificates/settings",
+      path: "/accounts/{account_id}/access/certificates/settings",
     }),
-  ) as unknown as Schema.Schema<GetAccessCertificateSettingRequest>;
+  ) as unknown as Schema.Schema<GetAccessCertificateSettingForAccountRequest>;
+
+export const GetAccessCertificateSettingForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...GetAccessCertificateSettingBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/access/certificates/settings",
+    }),
+  ) as unknown as Schema.Schema<GetAccessCertificateSettingForZoneRequest>;
 
 export interface GetAccessCertificateSettingResponse {
   result: {
@@ -39084,13 +40649,13 @@ export const GetAccessCertificateSettingResponse =
 
 export type GetAccessCertificateSettingError = DefaultErrors;
 
-export const getAccessCertificateSetting: API.PaginatedOperationMethod<
-  GetAccessCertificateSettingRequest,
+export const getAccessCertificateSettingForAccount: API.PaginatedOperationMethod<
+  GetAccessCertificateSettingForAccountRequest,
   GetAccessCertificateSettingResponse,
   GetAccessCertificateSettingError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
-  input: GetAccessCertificateSettingRequest,
+  input: GetAccessCertificateSettingForAccountRequest,
   output: GetAccessCertificateSettingResponse,
   errors: [],
   pagination: {
@@ -39099,11 +40664,51 @@ export const getAccessCertificateSetting: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export interface PutAccessCertificateSettingRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
+export const getAccessCertificateSettingForZone: API.PaginatedOperationMethod<
+  GetAccessCertificateSettingForZoneRequest,
+  GetAccessCertificateSettingResponse,
+  GetAccessCertificateSettingError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+  input: GetAccessCertificateSettingForZoneRequest,
+  output: GetAccessCertificateSettingResponse,
+  errors: [],
+  pagination: {
+    mode: "single",
+    items: "result",
+  } as const,
+}));
+
+export const getAccessCertificateSetting = (
+  input: GetAccessCertificateSettingRequest,
+): stream.Stream<
+  GetAccessCertificateSettingResponse,
+  GetAccessCertificateSettingError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? getAccessCertificateSettingForAccount.pages(input)
+    : getAccessCertificateSettingForZone.pages(input);
+
+const PutAccessCertificateSettingBaseFields = {
+  settings: Schema.Array(
+    Schema.Struct({
+      chinaNetwork: Schema.Boolean,
+      clientCertificateForwarding: Schema.Boolean,
+      hostname: Schema.String,
+    }).pipe(
+      Schema.encodeKeys({
+        chinaNetwork: "china_network",
+        clientCertificateForwarding: "client_certificate_forwarding",
+        hostname: "hostname",
+      }),
+    ),
+  ),
+} as const;
+
+export interface PutAccessCertificateSettingForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   /** Body param: */
   settings: {
     chinaNetwork: boolean;
@@ -39112,29 +40717,42 @@ export interface PutAccessCertificateSettingRequest {
   }[];
 }
 
-export const PutAccessCertificateSettingRequest =
+export interface PutAccessCertificateSettingForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  /** Body param: */
+  settings: {
+    chinaNetwork: boolean;
+    clientCertificateForwarding: boolean;
+    hostname: string;
+  }[];
+}
+
+export type PutAccessCertificateSettingRequest =
+  | PutAccessCertificateSettingForAccountRequest
+  | PutAccessCertificateSettingForZoneRequest;
+
+export const PutAccessCertificateSettingForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    settings: Schema.Array(
-      Schema.Struct({
-        chinaNetwork: Schema.Boolean,
-        clientCertificateForwarding: Schema.Boolean,
-        hostname: Schema.String,
-      }).pipe(
-        Schema.encodeKeys({
-          chinaNetwork: "china_network",
-          clientCertificateForwarding: "client_certificate_forwarding",
-          hostname: "hostname",
-        }),
-      ),
-    ),
+    ...PutAccessCertificateSettingBaseFields,
   }).pipe(
     T.Http({
       method: "PUT",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/certificates/settings",
+      path: "/accounts/{account_id}/access/certificates/settings",
     }),
-  ) as unknown as Schema.Schema<PutAccessCertificateSettingRequest>;
+  ) as unknown as Schema.Schema<PutAccessCertificateSettingForAccountRequest>;
+
+export const PutAccessCertificateSettingForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...PutAccessCertificateSettingBaseFields,
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/zones/{zone_id}/access/certificates/settings",
+    }),
+  ) as unknown as Schema.Schema<PutAccessCertificateSettingForZoneRequest>;
 
 export interface PutAccessCertificateSettingResponse {
   result: {
@@ -39163,13 +40781,13 @@ export const PutAccessCertificateSettingResponse =
 
 export type PutAccessCertificateSettingError = DefaultErrors;
 
-export const putAccessCertificateSetting: API.PaginatedOperationMethod<
-  PutAccessCertificateSettingRequest,
+export const putAccessCertificateSettingForAccount: API.PaginatedOperationMethod<
+  PutAccessCertificateSettingForAccountRequest,
   PutAccessCertificateSettingResponse,
   PutAccessCertificateSettingError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
-  input: PutAccessCertificateSettingRequest,
+  input: PutAccessCertificateSettingForAccountRequest,
   output: PutAccessCertificateSettingResponse,
   errors: [],
   pagination: {
@@ -39177,6 +40795,32 @@ export const putAccessCertificateSetting: API.PaginatedOperationMethod<
     items: "result",
   } as const,
 }));
+
+export const putAccessCertificateSettingForZone: API.PaginatedOperationMethod<
+  PutAccessCertificateSettingForZoneRequest,
+  PutAccessCertificateSettingResponse,
+  PutAccessCertificateSettingError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+  input: PutAccessCertificateSettingForZoneRequest,
+  output: PutAccessCertificateSettingResponse,
+  errors: [],
+  pagination: {
+    mode: "single",
+    items: "result",
+  } as const,
+}));
+
+export const putAccessCertificateSetting = (
+  input: PutAccessCertificateSettingRequest,
+): stream.Stream<
+  PutAccessCertificateSettingResponse,
+  PutAccessCertificateSettingError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? putAccessCertificateSettingForAccount.pages(input)
+    : putAccessCertificateSettingForZone.pages(input);
 
 // =============================================================================
 // AccessCustomPage
@@ -39630,18 +41274,44 @@ export const deleteAccessGatewayCa: API.OperationMethod<
 // AccessGroup
 // =============================================================================
 
-export interface GetAccessGroupRequest {
+const GetAccessGroupBaseFields = {
+  groupId: Schema.String.pipe(T.HttpPath("groupId")),
+} as const;
+
+export interface GetAccessGroupForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   groupId: string;
 }
 
-export const GetAccessGroupRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-  groupId: Schema.String.pipe(T.HttpPath("groupId")),
-}).pipe(
-  T.Http({
-    method: "GET",
-    path: "/{accountOrZone}/{accountOrZoneId}/access/groups/{groupId}",
-  }),
-) as unknown as Schema.Schema<GetAccessGroupRequest>;
+export interface GetAccessGroupForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  groupId: string;
+}
+
+export type GetAccessGroupRequest =
+  | GetAccessGroupForAccountRequest
+  | GetAccessGroupForZoneRequest;
+
+export const GetAccessGroupForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetAccessGroupBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/accounts/{account_id}/access/groups/{groupId}",
+    }),
+  ) as unknown as Schema.Schema<GetAccessGroupForAccountRequest>;
+
+export const GetAccessGroupForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...GetAccessGroupBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/zones/{zone_id}/access/groups/{groupId}" }),
+  ) as unknown as Schema.Schema<GetAccessGroupForZoneRequest>;
 
 export interface GetAccessGroupResponse {
   /** UUID. */
@@ -40640,26 +42310,70 @@ export const GetAccessGroupResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
 
 export type GetAccessGroupError = DefaultErrors;
 
-export const getAccessGroup: API.OperationMethod<
-  GetAccessGroupRequest,
+export const getAccessGroupForAccount: API.OperationMethod<
+  GetAccessGroupForAccountRequest,
   GetAccessGroupResponse,
   GetAccessGroupError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: GetAccessGroupRequest,
+  input: GetAccessGroupForAccountRequest,
   output: GetAccessGroupResponse,
   errors: [],
 }));
 
-export interface ListAccessGroupsRequest {}
+export const getAccessGroupForZone: API.OperationMethod<
+  GetAccessGroupForZoneRequest,
+  GetAccessGroupResponse,
+  GetAccessGroupError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetAccessGroupForZoneRequest,
+  output: GetAccessGroupResponse,
+  errors: [],
+}));
 
-export const ListAccessGroupsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
-    T.Http({
-      method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/groups",
-    }),
-  ) as unknown as Schema.Schema<ListAccessGroupsRequest>;
+export const getAccessGroup = (
+  input: GetAccessGroupRequest,
+): Effect.Effect<
+  GetAccessGroupResponse,
+  GetAccessGroupError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? getAccessGroupForAccount(input)
+    : getAccessGroupForZone(input);
+
+const ListAccessGroupsBaseFields = {} as const;
+
+export interface ListAccessGroupsForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface ListAccessGroupsForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+}
+
+export type ListAccessGroupsRequest =
+  | ListAccessGroupsForAccountRequest
+  | ListAccessGroupsForZoneRequest;
+
+export const ListAccessGroupsForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...ListAccessGroupsBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/accounts/{account_id}/access/groups" }),
+  ) as unknown as Schema.Schema<ListAccessGroupsForAccountRequest>;
+
+export const ListAccessGroupsForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...ListAccessGroupsBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/zones/{zone_id}/access/groups" }),
+  ) as unknown as Schema.Schema<ListAccessGroupsForZoneRequest>;
 
 export interface ListAccessGroupsResponse {
   result: {
@@ -41713,13 +43427,13 @@ export const ListAccessGroupsResponse =
 
 export type ListAccessGroupsError = DefaultErrors;
 
-export const listAccessGroups: API.PaginatedOperationMethod<
-  ListAccessGroupsRequest,
+export const listAccessGroupsForAccount: API.PaginatedOperationMethod<
+  ListAccessGroupsForAccountRequest,
   ListAccessGroupsResponse,
   ListAccessGroupsError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
-  input: ListAccessGroupsRequest,
+  input: ListAccessGroupsForAccountRequest,
   output: ListAccessGroupsResponse,
   errors: [],
   pagination: {
@@ -41731,157 +43445,215 @@ export const listAccessGroups: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export interface CreateAccessGroupRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
-  /** Body param: Rules evaluated with an OR logical operator. A user needs to meet only one of the Include rules. */
-  include: (
-    | { group: { id: string } }
-    | { anyValidServiceToken: unknown }
-    | { authContext: { id: string; acId: string; identityProviderId: string } }
-    | { authMethod: { authMethod: string } }
-    | { azureAD: { id: string; identityProviderId: string } }
-    | { certificate: unknown }
-    | { commonName: { commonName: string } }
-    | { geo: { countryCode: string } }
-    | { devicePosture: { integrationUid: string } }
-    | { emailDomain: { domain: string } }
-    | { emailList: { id: string } }
-    | { email: { email: string } }
-    | { everyone: unknown }
-    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
-    | {
-        githubOrganization: {
-          identityProviderId: string;
-          name: string;
-          team?: string;
-        };
-      }
-    | { gsuite: { email: string; identityProviderId: string } }
-    | { loginMethod: { id: string } }
-    | { ipList: { id: string } }
-    | { ip: { ip: string } }
-    | { okta: { identityProviderId: string; name: string } }
-    | {
-        saml: {
-          attributeName: string;
-          attributeValue: string;
-          identityProviderId: string;
-        };
-      }
-    | {
-        oidc: {
-          claimName: string;
-          claimValue: string;
-          identityProviderId: string;
-        };
-      }
-    | { serviceToken: { tokenId: string } }
-    | { linkedAppToken: { appUid: string } }
-  )[];
-  /** Body param: The name of the Access group. */
-  name: string;
-  /** Body param: Rules evaluated with a NOT logical operator. To match a policy, a user cannot meet any of the Exclude rules. */
-  exclude?: (
-    | { group: { id: string } }
-    | { anyValidServiceToken: unknown }
-    | { authContext: { id: string; acId: string; identityProviderId: string } }
-    | { authMethod: { authMethod: string } }
-    | { azureAD: { id: string; identityProviderId: string } }
-    | { certificate: unknown }
-    | { commonName: { commonName: string } }
-    | { geo: { countryCode: string } }
-    | { devicePosture: { integrationUid: string } }
-    | { emailDomain: { domain: string } }
-    | { emailList: { id: string } }
-    | { email: { email: string } }
-    | { everyone: unknown }
-    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
-    | {
-        githubOrganization: {
-          identityProviderId: string;
-          name: string;
-          team?: string;
-        };
-      }
-    | { gsuite: { email: string; identityProviderId: string } }
-    | { loginMethod: { id: string } }
-    | { ipList: { id: string } }
-    | { ip: { ip: string } }
-    | { okta: { identityProviderId: string; name: string } }
-    | {
-        saml: {
-          attributeName: string;
-          attributeValue: string;
-          identityProviderId: string;
-        };
-      }
-    | {
-        oidc: {
-          claimName: string;
-          claimValue: string;
-          identityProviderId: string;
-        };
-      }
-    | { serviceToken: { tokenId: string } }
-    | { linkedAppToken: { appUid: string } }
-  )[];
-  /** Body param: Whether this is the default group */
-  isDefault?: boolean;
-  /** Body param: Rules evaluated with an AND logical operator. To match a policy, a user must meet all of the Require rules. */
-  require?: (
-    | { group: { id: string } }
-    | { anyValidServiceToken: unknown }
-    | { authContext: { id: string; acId: string; identityProviderId: string } }
-    | { authMethod: { authMethod: string } }
-    | { azureAD: { id: string; identityProviderId: string } }
-    | { certificate: unknown }
-    | { commonName: { commonName: string } }
-    | { geo: { countryCode: string } }
-    | { devicePosture: { integrationUid: string } }
-    | { emailDomain: { domain: string } }
-    | { emailList: { id: string } }
-    | { email: { email: string } }
-    | { everyone: unknown }
-    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
-    | {
-        githubOrganization: {
-          identityProviderId: string;
-          name: string;
-          team?: string;
-        };
-      }
-    | { gsuite: { email: string; identityProviderId: string } }
-    | { loginMethod: { id: string } }
-    | { ipList: { id: string } }
-    | { ip: { ip: string } }
-    | { okta: { identityProviderId: string; name: string } }
-    | {
-        saml: {
-          attributeName: string;
-          attributeValue: string;
-          identityProviderId: string;
-        };
-      }
-    | {
-        oidc: {
-          claimName: string;
-          claimValue: string;
-          identityProviderId: string;
-        };
-      }
-    | { serviceToken: { tokenId: string } }
-    | { linkedAppToken: { appUid: string } }
-  )[];
-}
+export const listAccessGroupsForZone: API.PaginatedOperationMethod<
+  ListAccessGroupsForZoneRequest,
+  ListAccessGroupsResponse,
+  ListAccessGroupsError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+  input: ListAccessGroupsForZoneRequest,
+  output: ListAccessGroupsResponse,
+  errors: [],
+  pagination: {
+    mode: "page",
+    inputToken: "page",
+    outputToken: "resultInfo.page",
+    items: "result",
+    pageSize: "perPage",
+  } as const,
+}));
 
-export const CreateAccessGroupRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    include: Schema.Array(
+export const listAccessGroups = (
+  input: ListAccessGroupsRequest,
+): stream.Stream<
+  ListAccessGroupsResponse,
+  ListAccessGroupsError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? listAccessGroupsForAccount.pages(input)
+    : listAccessGroupsForZone.pages(input);
+
+const CreateAccessGroupBaseFields = {
+  include: Schema.Array(
+    Schema.Union([
+      Schema.Struct({
+        group: Schema.Struct({
+          id: Schema.String,
+        }),
+      }),
+      Schema.Struct({
+        anyValidServiceToken: Schema.Unknown,
+      }).pipe(
+        Schema.encodeKeys({ anyValidServiceToken: "any_valid_service_token" }),
+      ),
+      Schema.Struct({
+        authContext: Schema.Struct({
+          id: Schema.String,
+          acId: Schema.String,
+          identityProviderId: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            acId: "ac_id",
+            identityProviderId: "identity_provider_id",
+          }),
+        ),
+      }).pipe(Schema.encodeKeys({ authContext: "auth_context" })),
+      Schema.Struct({
+        authMethod: Schema.Struct({
+          authMethod: Schema.String,
+        }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
+      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
+      Schema.Struct({
+        azureAD: Schema.Struct({
+          id: Schema.String,
+          identityProviderId: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            identityProviderId: "identity_provider_id",
+          }),
+        ),
+      }),
+      Schema.Struct({
+        certificate: Schema.Unknown,
+      }),
+      Schema.Struct({
+        commonName: Schema.Struct({
+          commonName: Schema.String,
+        }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
+      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
+      Schema.Struct({
+        geo: Schema.Struct({
+          countryCode: Schema.String,
+        }).pipe(Schema.encodeKeys({ countryCode: "country_code" })),
+      }),
+      Schema.Struct({
+        devicePosture: Schema.Struct({
+          integrationUid: Schema.String,
+        }).pipe(Schema.encodeKeys({ integrationUid: "integration_uid" })),
+      }).pipe(Schema.encodeKeys({ devicePosture: "device_posture" })),
+      Schema.Struct({
+        emailDomain: Schema.Struct({
+          domain: Schema.String,
+        }),
+      }).pipe(Schema.encodeKeys({ emailDomain: "email_domain" })),
+      Schema.Struct({
+        emailList: Schema.Struct({
+          id: Schema.String,
+        }),
+      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
+      Schema.Struct({
+        email: Schema.Struct({
+          email: Schema.String,
+        }),
+      }),
+      Schema.Struct({
+        everyone: Schema.Unknown,
+      }),
+      Schema.Struct({
+        externalEvaluation: Schema.Struct({
+          evaluateUrl: Schema.String,
+          keysUrl: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            evaluateUrl: "evaluate_url",
+            keysUrl: "keys_url",
+          }),
+        ),
+      }).pipe(Schema.encodeKeys({ externalEvaluation: "external_evaluation" })),
+      Schema.Struct({
+        githubOrganization: Schema.Struct({
+          identityProviderId: Schema.String,
+          name: Schema.String,
+          team: Schema.optional(Schema.String),
+        }).pipe(
+          Schema.encodeKeys({
+            identityProviderId: "identity_provider_id",
+            name: "name",
+            team: "team",
+          }),
+        ),
+      }).pipe(Schema.encodeKeys({ githubOrganization: "github-organization" })),
+      Schema.Struct({
+        gsuite: Schema.Struct({
+          email: Schema.String,
+          identityProviderId: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            email: "email",
+            identityProviderId: "identity_provider_id",
+          }),
+        ),
+      }),
+      Schema.Struct({
+        loginMethod: Schema.Struct({
+          id: Schema.String,
+        }),
+      }).pipe(Schema.encodeKeys({ loginMethod: "login_method" })),
+      Schema.Struct({
+        ipList: Schema.Struct({
+          id: Schema.String,
+        }),
+      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
+      Schema.Struct({
+        ip: Schema.Struct({
+          ip: Schema.String,
+        }),
+      }),
+      Schema.Struct({
+        okta: Schema.Struct({
+          identityProviderId: Schema.String,
+          name: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            identityProviderId: "identity_provider_id",
+            name: "name",
+          }),
+        ),
+      }),
+      Schema.Struct({
+        saml: Schema.Struct({
+          attributeName: Schema.String,
+          attributeValue: Schema.String,
+          identityProviderId: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            attributeName: "attribute_name",
+            attributeValue: "attribute_value",
+            identityProviderId: "identity_provider_id",
+          }),
+        ),
+      }),
+      Schema.Struct({
+        oidc: Schema.Struct({
+          claimName: Schema.String,
+          claimValue: Schema.String,
+          identityProviderId: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            claimName: "claim_name",
+            claimValue: "claim_value",
+            identityProviderId: "identity_provider_id",
+          }),
+        ),
+      }),
+      Schema.Struct({
+        serviceToken: Schema.Struct({
+          tokenId: Schema.String,
+        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
+      }).pipe(Schema.encodeKeys({ serviceToken: "service_token" })),
+      Schema.Struct({
+        linkedAppToken: Schema.Struct({
+          appUid: Schema.String,
+        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
+      }).pipe(Schema.encodeKeys({ linkedAppToken: "linked_app_token" })),
+    ]),
+  ),
+  name: Schema.String,
+  exclude: Schema.optional(
+    Schema.Array(
       Schema.Union([
         Schema.Struct({
           group: Schema.Struct({
@@ -42063,376 +43835,490 @@ export const CreateAccessGroupRequest =
         }).pipe(Schema.encodeKeys({ linkedAppToken: "linked_app_token" })),
       ]),
     ),
-    name: Schema.String,
-    exclude: Schema.optional(
-      Schema.Array(
-        Schema.Union([
-          Schema.Struct({
-            group: Schema.Struct({
-              id: Schema.String,
-            }),
+  ),
+  isDefault: Schema.optional(Schema.Boolean),
+  require: Schema.optional(
+    Schema.Array(
+      Schema.Union([
+        Schema.Struct({
+          group: Schema.Struct({
+            id: Schema.String,
           }),
-          Schema.Struct({
-            anyValidServiceToken: Schema.Unknown,
+        }),
+        Schema.Struct({
+          anyValidServiceToken: Schema.Unknown,
+        }).pipe(
+          Schema.encodeKeys({
+            anyValidServiceToken: "any_valid_service_token",
+          }),
+        ),
+        Schema.Struct({
+          authContext: Schema.Struct({
+            id: Schema.String,
+            acId: Schema.String,
+            identityProviderId: Schema.String,
           }).pipe(
             Schema.encodeKeys({
-              anyValidServiceToken: "any_valid_service_token",
+              id: "id",
+              acId: "ac_id",
+              identityProviderId: "identity_provider_id",
             }),
           ),
-          Schema.Struct({
-            authContext: Schema.Struct({
-              id: Schema.String,
-              acId: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                id: "id",
-                acId: "ac_id",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }).pipe(Schema.encodeKeys({ authContext: "auth_context" })),
-          Schema.Struct({
-            authMethod: Schema.Struct({
-              authMethod: Schema.String,
-            }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
+        }).pipe(Schema.encodeKeys({ authContext: "auth_context" })),
+        Schema.Struct({
+          authMethod: Schema.Struct({
+            authMethod: Schema.String,
           }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
-          Schema.Struct({
-            azureAD: Schema.Struct({
-              id: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                id: "id",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            certificate: Schema.Unknown,
-          }),
-          Schema.Struct({
-            commonName: Schema.Struct({
-              commonName: Schema.String,
-            }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
-          }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
-          Schema.Struct({
-            geo: Schema.Struct({
-              countryCode: Schema.String,
-            }).pipe(Schema.encodeKeys({ countryCode: "country_code" })),
-          }),
-          Schema.Struct({
-            devicePosture: Schema.Struct({
-              integrationUid: Schema.String,
-            }).pipe(Schema.encodeKeys({ integrationUid: "integration_uid" })),
-          }).pipe(Schema.encodeKeys({ devicePosture: "device_posture" })),
-          Schema.Struct({
-            emailDomain: Schema.Struct({
-              domain: Schema.String,
-            }),
-          }).pipe(Schema.encodeKeys({ emailDomain: "email_domain" })),
-          Schema.Struct({
-            emailList: Schema.Struct({
-              id: Schema.String,
-            }),
-          }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
-          Schema.Struct({
-            email: Schema.Struct({
-              email: Schema.String,
-            }),
-          }),
-          Schema.Struct({
-            everyone: Schema.Unknown,
-          }),
-          Schema.Struct({
-            externalEvaluation: Schema.Struct({
-              evaluateUrl: Schema.String,
-              keysUrl: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                evaluateUrl: "evaluate_url",
-                keysUrl: "keys_url",
-              }),
-            ),
-          }).pipe(
-            Schema.encodeKeys({ externalEvaluation: "external_evaluation" }),
-          ),
-          Schema.Struct({
-            githubOrganization: Schema.Struct({
-              identityProviderId: Schema.String,
-              name: Schema.String,
-              team: Schema.optional(Schema.String),
-            }).pipe(
-              Schema.encodeKeys({
-                identityProviderId: "identity_provider_id",
-                name: "name",
-                team: "team",
-              }),
-            ),
-          }).pipe(
-            Schema.encodeKeys({ githubOrganization: "github-organization" }),
-          ),
-          Schema.Struct({
-            gsuite: Schema.Struct({
-              email: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                email: "email",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            loginMethod: Schema.Struct({
-              id: Schema.String,
-            }),
-          }).pipe(Schema.encodeKeys({ loginMethod: "login_method" })),
-          Schema.Struct({
-            ipList: Schema.Struct({
-              id: Schema.String,
-            }),
-          }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
-          Schema.Struct({
-            ip: Schema.Struct({
-              ip: Schema.String,
-            }),
-          }),
-          Schema.Struct({
-            okta: Schema.Struct({
-              identityProviderId: Schema.String,
-              name: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                identityProviderId: "identity_provider_id",
-                name: "name",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            saml: Schema.Struct({
-              attributeName: Schema.String,
-              attributeValue: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                attributeName: "attribute_name",
-                attributeValue: "attribute_value",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            oidc: Schema.Struct({
-              claimName: Schema.String,
-              claimValue: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                claimName: "claim_name",
-                claimValue: "claim_value",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            serviceToken: Schema.Struct({
-              tokenId: Schema.String,
-            }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
-          }).pipe(Schema.encodeKeys({ serviceToken: "service_token" })),
-          Schema.Struct({
-            linkedAppToken: Schema.Struct({
-              appUid: Schema.String,
-            }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
-          }).pipe(Schema.encodeKeys({ linkedAppToken: "linked_app_token" })),
-        ]),
-      ),
-    ),
-    isDefault: Schema.optional(Schema.Boolean),
-    require: Schema.optional(
-      Schema.Array(
-        Schema.Union([
-          Schema.Struct({
-            group: Schema.Struct({
-              id: Schema.String,
-            }),
-          }),
-          Schema.Struct({
-            anyValidServiceToken: Schema.Unknown,
+        }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
+        Schema.Struct({
+          azureAD: Schema.Struct({
+            id: Schema.String,
+            identityProviderId: Schema.String,
           }).pipe(
             Schema.encodeKeys({
-              anyValidServiceToken: "any_valid_service_token",
+              id: "id",
+              identityProviderId: "identity_provider_id",
             }),
           ),
-          Schema.Struct({
-            authContext: Schema.Struct({
-              id: Schema.String,
-              acId: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                id: "id",
-                acId: "ac_id",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }).pipe(Schema.encodeKeys({ authContext: "auth_context" })),
-          Schema.Struct({
-            authMethod: Schema.Struct({
-              authMethod: Schema.String,
-            }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
-          }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
-          Schema.Struct({
-            azureAD: Schema.Struct({
-              id: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                id: "id",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            certificate: Schema.Unknown,
-          }),
-          Schema.Struct({
-            commonName: Schema.Struct({
-              commonName: Schema.String,
-            }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
+        }),
+        Schema.Struct({
+          certificate: Schema.Unknown,
+        }),
+        Schema.Struct({
+          commonName: Schema.Struct({
+            commonName: Schema.String,
           }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
-          Schema.Struct({
-            geo: Schema.Struct({
-              countryCode: Schema.String,
-            }).pipe(Schema.encodeKeys({ countryCode: "country_code" })),
+        }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
+        Schema.Struct({
+          geo: Schema.Struct({
+            countryCode: Schema.String,
+          }).pipe(Schema.encodeKeys({ countryCode: "country_code" })),
+        }),
+        Schema.Struct({
+          devicePosture: Schema.Struct({
+            integrationUid: Schema.String,
+          }).pipe(Schema.encodeKeys({ integrationUid: "integration_uid" })),
+        }).pipe(Schema.encodeKeys({ devicePosture: "device_posture" })),
+        Schema.Struct({
+          emailDomain: Schema.Struct({
+            domain: Schema.String,
           }),
-          Schema.Struct({
-            devicePosture: Schema.Struct({
-              integrationUid: Schema.String,
-            }).pipe(Schema.encodeKeys({ integrationUid: "integration_uid" })),
-          }).pipe(Schema.encodeKeys({ devicePosture: "device_posture" })),
-          Schema.Struct({
-            emailDomain: Schema.Struct({
-              domain: Schema.String,
-            }),
-          }).pipe(Schema.encodeKeys({ emailDomain: "email_domain" })),
-          Schema.Struct({
-            emailList: Schema.Struct({
-              id: Schema.String,
-            }),
-          }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
-          Schema.Struct({
-            email: Schema.Struct({
-              email: Schema.String,
-            }),
+        }).pipe(Schema.encodeKeys({ emailDomain: "email_domain" })),
+        Schema.Struct({
+          emailList: Schema.Struct({
+            id: Schema.String,
           }),
-          Schema.Struct({
-            everyone: Schema.Unknown,
+        }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
+        Schema.Struct({
+          email: Schema.Struct({
+            email: Schema.String,
           }),
-          Schema.Struct({
-            externalEvaluation: Schema.Struct({
-              evaluateUrl: Schema.String,
-              keysUrl: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                evaluateUrl: "evaluate_url",
-                keysUrl: "keys_url",
-              }),
-            ),
+        }),
+        Schema.Struct({
+          everyone: Schema.Unknown,
+        }),
+        Schema.Struct({
+          externalEvaluation: Schema.Struct({
+            evaluateUrl: Schema.String,
+            keysUrl: Schema.String,
           }).pipe(
-            Schema.encodeKeys({ externalEvaluation: "external_evaluation" }),
+            Schema.encodeKeys({
+              evaluateUrl: "evaluate_url",
+              keysUrl: "keys_url",
+            }),
           ),
-          Schema.Struct({
-            githubOrganization: Schema.Struct({
-              identityProviderId: Schema.String,
-              name: Schema.String,
-              team: Schema.optional(Schema.String),
-            }).pipe(
-              Schema.encodeKeys({
-                identityProviderId: "identity_provider_id",
-                name: "name",
-                team: "team",
-              }),
-            ),
+        }).pipe(
+          Schema.encodeKeys({ externalEvaluation: "external_evaluation" }),
+        ),
+        Schema.Struct({
+          githubOrganization: Schema.Struct({
+            identityProviderId: Schema.String,
+            name: Schema.String,
+            team: Schema.optional(Schema.String),
           }).pipe(
-            Schema.encodeKeys({ githubOrganization: "github-organization" }),
+            Schema.encodeKeys({
+              identityProviderId: "identity_provider_id",
+              name: "name",
+              team: "team",
+            }),
           ),
-          Schema.Struct({
-            gsuite: Schema.Struct({
-              email: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                email: "email",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            loginMethod: Schema.Struct({
-              id: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({ githubOrganization: "github-organization" }),
+        ),
+        Schema.Struct({
+          gsuite: Schema.Struct({
+            email: Schema.String,
+            identityProviderId: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              email: "email",
+              identityProviderId: "identity_provider_id",
             }),
-          }).pipe(Schema.encodeKeys({ loginMethod: "login_method" })),
-          Schema.Struct({
-            ipList: Schema.Struct({
-              id: Schema.String,
+          ),
+        }),
+        Schema.Struct({
+          loginMethod: Schema.Struct({
+            id: Schema.String,
+          }),
+        }).pipe(Schema.encodeKeys({ loginMethod: "login_method" })),
+        Schema.Struct({
+          ipList: Schema.Struct({
+            id: Schema.String,
+          }),
+        }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
+        Schema.Struct({
+          ip: Schema.Struct({
+            ip: Schema.String,
+          }),
+        }),
+        Schema.Struct({
+          okta: Schema.Struct({
+            identityProviderId: Schema.String,
+            name: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              identityProviderId: "identity_provider_id",
+              name: "name",
             }),
-          }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
-          Schema.Struct({
-            ip: Schema.Struct({
-              ip: Schema.String,
+          ),
+        }),
+        Schema.Struct({
+          saml: Schema.Struct({
+            attributeName: Schema.String,
+            attributeValue: Schema.String,
+            identityProviderId: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              attributeName: "attribute_name",
+              attributeValue: "attribute_value",
+              identityProviderId: "identity_provider_id",
             }),
-          }),
-          Schema.Struct({
-            okta: Schema.Struct({
-              identityProviderId: Schema.String,
-              name: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                identityProviderId: "identity_provider_id",
-                name: "name",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            saml: Schema.Struct({
-              attributeName: Schema.String,
-              attributeValue: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                attributeName: "attribute_name",
-                attributeValue: "attribute_value",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            oidc: Schema.Struct({
-              claimName: Schema.String,
-              claimValue: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                claimName: "claim_name",
-                claimValue: "claim_value",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            serviceToken: Schema.Struct({
-              tokenId: Schema.String,
-            }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
-          }).pipe(Schema.encodeKeys({ serviceToken: "service_token" })),
-          Schema.Struct({
-            linkedAppToken: Schema.Struct({
-              appUid: Schema.String,
-            }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
-          }).pipe(Schema.encodeKeys({ linkedAppToken: "linked_app_token" })),
-        ]),
-      ),
+          ),
+        }),
+        Schema.Struct({
+          oidc: Schema.Struct({
+            claimName: Schema.String,
+            claimValue: Schema.String,
+            identityProviderId: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              claimName: "claim_name",
+              claimValue: "claim_value",
+              identityProviderId: "identity_provider_id",
+            }),
+          ),
+        }),
+        Schema.Struct({
+          serviceToken: Schema.Struct({
+            tokenId: Schema.String,
+          }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
+        }).pipe(Schema.encodeKeys({ serviceToken: "service_token" })),
+        Schema.Struct({
+          linkedAppToken: Schema.Struct({
+            appUid: Schema.String,
+          }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
+        }).pipe(Schema.encodeKeys({ linkedAppToken: "linked_app_token" })),
+      ]),
     ),
+  ),
+} as const;
+
+export interface CreateAccessGroupForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  /** Body param: Rules evaluated with an OR logical operator. A user needs to meet only one of the Include rules. */
+  include: (
+    | { group: { id: string } }
+    | { anyValidServiceToken: unknown }
+    | { authContext: { id: string; acId: string; identityProviderId: string } }
+    | { authMethod: { authMethod: string } }
+    | { azureAD: { id: string; identityProviderId: string } }
+    | { certificate: unknown }
+    | { commonName: { commonName: string } }
+    | { geo: { countryCode: string } }
+    | { devicePosture: { integrationUid: string } }
+    | { emailDomain: { domain: string } }
+    | { emailList: { id: string } }
+    | { email: { email: string } }
+    | { everyone: unknown }
+    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
+    | {
+        githubOrganization: {
+          identityProviderId: string;
+          name: string;
+          team?: string;
+        };
+      }
+    | { gsuite: { email: string; identityProviderId: string } }
+    | { loginMethod: { id: string } }
+    | { ipList: { id: string } }
+    | { ip: { ip: string } }
+    | { okta: { identityProviderId: string; name: string } }
+    | {
+        saml: {
+          attributeName: string;
+          attributeValue: string;
+          identityProviderId: string;
+        };
+      }
+    | {
+        oidc: {
+          claimName: string;
+          claimValue: string;
+          identityProviderId: string;
+        };
+      }
+    | { serviceToken: { tokenId: string } }
+    | { linkedAppToken: { appUid: string } }
+  )[];
+  /** Body param: The name of the Access group. */
+  name: string;
+  /** Body param: Rules evaluated with a NOT logical operator. To match a policy, a user cannot meet any of the Exclude rules. */
+  exclude?: (
+    | { group: { id: string } }
+    | { anyValidServiceToken: unknown }
+    | { authContext: { id: string; acId: string; identityProviderId: string } }
+    | { authMethod: { authMethod: string } }
+    | { azureAD: { id: string; identityProviderId: string } }
+    | { certificate: unknown }
+    | { commonName: { commonName: string } }
+    | { geo: { countryCode: string } }
+    | { devicePosture: { integrationUid: string } }
+    | { emailDomain: { domain: string } }
+    | { emailList: { id: string } }
+    | { email: { email: string } }
+    | { everyone: unknown }
+    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
+    | {
+        githubOrganization: {
+          identityProviderId: string;
+          name: string;
+          team?: string;
+        };
+      }
+    | { gsuite: { email: string; identityProviderId: string } }
+    | { loginMethod: { id: string } }
+    | { ipList: { id: string } }
+    | { ip: { ip: string } }
+    | { okta: { identityProviderId: string; name: string } }
+    | {
+        saml: {
+          attributeName: string;
+          attributeValue: string;
+          identityProviderId: string;
+        };
+      }
+    | {
+        oidc: {
+          claimName: string;
+          claimValue: string;
+          identityProviderId: string;
+        };
+      }
+    | { serviceToken: { tokenId: string } }
+    | { linkedAppToken: { appUid: string } }
+  )[];
+  /** Body param: Whether this is the default group */
+  isDefault?: boolean;
+  /** Body param: Rules evaluated with an AND logical operator. To match a policy, a user must meet all of the Require rules. */
+  require?: (
+    | { group: { id: string } }
+    | { anyValidServiceToken: unknown }
+    | { authContext: { id: string; acId: string; identityProviderId: string } }
+    | { authMethod: { authMethod: string } }
+    | { azureAD: { id: string; identityProviderId: string } }
+    | { certificate: unknown }
+    | { commonName: { commonName: string } }
+    | { geo: { countryCode: string } }
+    | { devicePosture: { integrationUid: string } }
+    | { emailDomain: { domain: string } }
+    | { emailList: { id: string } }
+    | { email: { email: string } }
+    | { everyone: unknown }
+    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
+    | {
+        githubOrganization: {
+          identityProviderId: string;
+          name: string;
+          team?: string;
+        };
+      }
+    | { gsuite: { email: string; identityProviderId: string } }
+    | { loginMethod: { id: string } }
+    | { ipList: { id: string } }
+    | { ip: { ip: string } }
+    | { okta: { identityProviderId: string; name: string } }
+    | {
+        saml: {
+          attributeName: string;
+          attributeValue: string;
+          identityProviderId: string;
+        };
+      }
+    | {
+        oidc: {
+          claimName: string;
+          claimValue: string;
+          identityProviderId: string;
+        };
+      }
+    | { serviceToken: { tokenId: string } }
+    | { linkedAppToken: { appUid: string } }
+  )[];
+}
+
+export interface CreateAccessGroupForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  /** Body param: Rules evaluated with an OR logical operator. A user needs to meet only one of the Include rules. */
+  include: (
+    | { group: { id: string } }
+    | { anyValidServiceToken: unknown }
+    | { authContext: { id: string; acId: string; identityProviderId: string } }
+    | { authMethod: { authMethod: string } }
+    | { azureAD: { id: string; identityProviderId: string } }
+    | { certificate: unknown }
+    | { commonName: { commonName: string } }
+    | { geo: { countryCode: string } }
+    | { devicePosture: { integrationUid: string } }
+    | { emailDomain: { domain: string } }
+    | { emailList: { id: string } }
+    | { email: { email: string } }
+    | { everyone: unknown }
+    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
+    | {
+        githubOrganization: {
+          identityProviderId: string;
+          name: string;
+          team?: string;
+        };
+      }
+    | { gsuite: { email: string; identityProviderId: string } }
+    | { loginMethod: { id: string } }
+    | { ipList: { id: string } }
+    | { ip: { ip: string } }
+    | { okta: { identityProviderId: string; name: string } }
+    | {
+        saml: {
+          attributeName: string;
+          attributeValue: string;
+          identityProviderId: string;
+        };
+      }
+    | {
+        oidc: {
+          claimName: string;
+          claimValue: string;
+          identityProviderId: string;
+        };
+      }
+    | { serviceToken: { tokenId: string } }
+    | { linkedAppToken: { appUid: string } }
+  )[];
+  /** Body param: The name of the Access group. */
+  name: string;
+  /** Body param: Rules evaluated with a NOT logical operator. To match a policy, a user cannot meet any of the Exclude rules. */
+  exclude?: (
+    | { group: { id: string } }
+    | { anyValidServiceToken: unknown }
+    | { authContext: { id: string; acId: string; identityProviderId: string } }
+    | { authMethod: { authMethod: string } }
+    | { azureAD: { id: string; identityProviderId: string } }
+    | { certificate: unknown }
+    | { commonName: { commonName: string } }
+    | { geo: { countryCode: string } }
+    | { devicePosture: { integrationUid: string } }
+    | { emailDomain: { domain: string } }
+    | { emailList: { id: string } }
+    | { email: { email: string } }
+    | { everyone: unknown }
+    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
+    | {
+        githubOrganization: {
+          identityProviderId: string;
+          name: string;
+          team?: string;
+        };
+      }
+    | { gsuite: { email: string; identityProviderId: string } }
+    | { loginMethod: { id: string } }
+    | { ipList: { id: string } }
+    | { ip: { ip: string } }
+    | { okta: { identityProviderId: string; name: string } }
+    | {
+        saml: {
+          attributeName: string;
+          attributeValue: string;
+          identityProviderId: string;
+        };
+      }
+    | {
+        oidc: {
+          claimName: string;
+          claimValue: string;
+          identityProviderId: string;
+        };
+      }
+    | { serviceToken: { tokenId: string } }
+    | { linkedAppToken: { appUid: string } }
+  )[];
+  /** Body param: Whether this is the default group */
+  isDefault?: boolean;
+  /** Body param: Rules evaluated with an AND logical operator. To match a policy, a user must meet all of the Require rules. */
+  require?: (
+    | { group: { id: string } }
+    | { anyValidServiceToken: unknown }
+    | { authContext: { id: string; acId: string; identityProviderId: string } }
+    | { authMethod: { authMethod: string } }
+    | { azureAD: { id: string; identityProviderId: string } }
+    | { certificate: unknown }
+    | { commonName: { commonName: string } }
+    | { geo: { countryCode: string } }
+    | { devicePosture: { integrationUid: string } }
+    | { emailDomain: { domain: string } }
+    | { emailList: { id: string } }
+    | { email: { email: string } }
+    | { everyone: unknown }
+    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
+    | {
+        githubOrganization: {
+          identityProviderId: string;
+          name: string;
+          team?: string;
+        };
+      }
+    | { gsuite: { email: string; identityProviderId: string } }
+    | { loginMethod: { id: string } }
+    | { ipList: { id: string } }
+    | { ip: { ip: string } }
+    | { okta: { identityProviderId: string; name: string } }
+    | {
+        saml: {
+          attributeName: string;
+          attributeValue: string;
+          identityProviderId: string;
+        };
+      }
+    | {
+        oidc: {
+          claimName: string;
+          claimValue: string;
+          identityProviderId: string;
+        };
+      }
+    | { serviceToken: { tokenId: string } }
+    | { linkedAppToken: { appUid: string } }
+  )[];
+}
+
+export type CreateAccessGroupRequest =
+  | CreateAccessGroupForAccountRequest
+  | CreateAccessGroupForZoneRequest;
+
+export const CreateAccessGroupForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...CreateAccessGroupBaseFields,
   }).pipe(
     Schema.encodeKeys({
       include: "include",
@@ -42441,11 +44327,23 @@ export const CreateAccessGroupRequest =
       isDefault: "is_default",
       require: "require",
     }),
-    T.Http({
-      method: "POST",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/groups",
+    T.Http({ method: "POST", path: "/accounts/{account_id}/access/groups" }),
+  ) as unknown as Schema.Schema<CreateAccessGroupForAccountRequest>;
+
+export const CreateAccessGroupForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...CreateAccessGroupBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      include: "include",
+      name: "name",
+      exclude: "exclude",
+      isDefault: "is_default",
+      require: "require",
     }),
-  ) as unknown as Schema.Schema<CreateAccessGroupRequest>;
+    T.Http({ method: "POST", path: "/zones/{zone_id}/access/groups" }),
+  ) as unknown as Schema.Schema<CreateAccessGroupForZoneRequest>;
 
 export interface CreateAccessGroupResponse {
   /** UUID. */
@@ -43443,170 +45341,220 @@ export const CreateAccessGroupResponse =
 
 export type CreateAccessGroupError = DefaultErrors;
 
-export const createAccessGroup: API.OperationMethod<
-  CreateAccessGroupRequest,
+export const createAccessGroupForAccount: API.OperationMethod<
+  CreateAccessGroupForAccountRequest,
   CreateAccessGroupResponse,
   CreateAccessGroupError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: CreateAccessGroupRequest,
+  input: CreateAccessGroupForAccountRequest,
   output: CreateAccessGroupResponse,
   errors: [],
 }));
 
-export interface UpdateAccessGroupRequest {
-  groupId: string;
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
-  /** Body param: Rules evaluated with an OR logical operator. A user needs to meet only one of the Include rules. */
-  include: (
-    | { group: { id: string } }
-    | { anyValidServiceToken: unknown }
-    | { authContext: { id: string; acId: string; identityProviderId: string } }
-    | { authMethod: { authMethod: string } }
-    | { azureAD: { id: string; identityProviderId: string } }
-    | { certificate: unknown }
-    | { commonName: { commonName: string } }
-    | { geo: { countryCode: string } }
-    | { devicePosture: { integrationUid: string } }
-    | { emailDomain: { domain: string } }
-    | { emailList: { id: string } }
-    | { email: { email: string } }
-    | { everyone: unknown }
-    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
-    | {
-        githubOrganization: {
-          identityProviderId: string;
-          name: string;
-          team?: string;
-        };
-      }
-    | { gsuite: { email: string; identityProviderId: string } }
-    | { loginMethod: { id: string } }
-    | { ipList: { id: string } }
-    | { ip: { ip: string } }
-    | { okta: { identityProviderId: string; name: string } }
-    | {
-        saml: {
-          attributeName: string;
-          attributeValue: string;
-          identityProviderId: string;
-        };
-      }
-    | {
-        oidc: {
-          claimName: string;
-          claimValue: string;
-          identityProviderId: string;
-        };
-      }
-    | { serviceToken: { tokenId: string } }
-    | { linkedAppToken: { appUid: string } }
-  )[];
-  /** Body param: The name of the Access group. */
-  name: string;
-  /** Body param: Rules evaluated with a NOT logical operator. To match a policy, a user cannot meet any of the Exclude rules. */
-  exclude?: (
-    | { group: { id: string } }
-    | { anyValidServiceToken: unknown }
-    | { authContext: { id: string; acId: string; identityProviderId: string } }
-    | { authMethod: { authMethod: string } }
-    | { azureAD: { id: string; identityProviderId: string } }
-    | { certificate: unknown }
-    | { commonName: { commonName: string } }
-    | { geo: { countryCode: string } }
-    | { devicePosture: { integrationUid: string } }
-    | { emailDomain: { domain: string } }
-    | { emailList: { id: string } }
-    | { email: { email: string } }
-    | { everyone: unknown }
-    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
-    | {
-        githubOrganization: {
-          identityProviderId: string;
-          name: string;
-          team?: string;
-        };
-      }
-    | { gsuite: { email: string; identityProviderId: string } }
-    | { loginMethod: { id: string } }
-    | { ipList: { id: string } }
-    | { ip: { ip: string } }
-    | { okta: { identityProviderId: string; name: string } }
-    | {
-        saml: {
-          attributeName: string;
-          attributeValue: string;
-          identityProviderId: string;
-        };
-      }
-    | {
-        oidc: {
-          claimName: string;
-          claimValue: string;
-          identityProviderId: string;
-        };
-      }
-    | { serviceToken: { tokenId: string } }
-    | { linkedAppToken: { appUid: string } }
-  )[];
-  /** Body param: Whether this is the default group */
-  isDefault?: boolean;
-  /** Body param: Rules evaluated with an AND logical operator. To match a policy, a user must meet all of the Require rules. */
-  require?: (
-    | { group: { id: string } }
-    | { anyValidServiceToken: unknown }
-    | { authContext: { id: string; acId: string; identityProviderId: string } }
-    | { authMethod: { authMethod: string } }
-    | { azureAD: { id: string; identityProviderId: string } }
-    | { certificate: unknown }
-    | { commonName: { commonName: string } }
-    | { geo: { countryCode: string } }
-    | { devicePosture: { integrationUid: string } }
-    | { emailDomain: { domain: string } }
-    | { emailList: { id: string } }
-    | { email: { email: string } }
-    | { everyone: unknown }
-    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
-    | {
-        githubOrganization: {
-          identityProviderId: string;
-          name: string;
-          team?: string;
-        };
-      }
-    | { gsuite: { email: string; identityProviderId: string } }
-    | { loginMethod: { id: string } }
-    | { ipList: { id: string } }
-    | { ip: { ip: string } }
-    | { okta: { identityProviderId: string; name: string } }
-    | {
-        saml: {
-          attributeName: string;
-          attributeValue: string;
-          identityProviderId: string;
-        };
-      }
-    | {
-        oidc: {
-          claimName: string;
-          claimValue: string;
-          identityProviderId: string;
-        };
-      }
-    | { serviceToken: { tokenId: string } }
-    | { linkedAppToken: { appUid: string } }
-  )[];
-}
+export const createAccessGroupForZone: API.OperationMethod<
+  CreateAccessGroupForZoneRequest,
+  CreateAccessGroupResponse,
+  CreateAccessGroupError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: CreateAccessGroupForZoneRequest,
+  output: CreateAccessGroupResponse,
+  errors: [],
+}));
 
-export const UpdateAccessGroupRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    groupId: Schema.String.pipe(T.HttpPath("groupId")),
-    accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    include: Schema.Array(
+export const createAccessGroup = (
+  input: CreateAccessGroupRequest,
+): Effect.Effect<
+  CreateAccessGroupResponse,
+  CreateAccessGroupError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? createAccessGroupForAccount(input)
+    : createAccessGroupForZone(input);
+
+const UpdateAccessGroupBaseFields = {
+  groupId: Schema.String.pipe(T.HttpPath("groupId")),
+  include: Schema.Array(
+    Schema.Union([
+      Schema.Struct({
+        group: Schema.Struct({
+          id: Schema.String,
+        }),
+      }),
+      Schema.Struct({
+        anyValidServiceToken: Schema.Unknown,
+      }).pipe(
+        Schema.encodeKeys({ anyValidServiceToken: "any_valid_service_token" }),
+      ),
+      Schema.Struct({
+        authContext: Schema.Struct({
+          id: Schema.String,
+          acId: Schema.String,
+          identityProviderId: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            acId: "ac_id",
+            identityProviderId: "identity_provider_id",
+          }),
+        ),
+      }).pipe(Schema.encodeKeys({ authContext: "auth_context" })),
+      Schema.Struct({
+        authMethod: Schema.Struct({
+          authMethod: Schema.String,
+        }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
+      }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
+      Schema.Struct({
+        azureAD: Schema.Struct({
+          id: Schema.String,
+          identityProviderId: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            id: "id",
+            identityProviderId: "identity_provider_id",
+          }),
+        ),
+      }),
+      Schema.Struct({
+        certificate: Schema.Unknown,
+      }),
+      Schema.Struct({
+        commonName: Schema.Struct({
+          commonName: Schema.String,
+        }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
+      }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
+      Schema.Struct({
+        geo: Schema.Struct({
+          countryCode: Schema.String,
+        }).pipe(Schema.encodeKeys({ countryCode: "country_code" })),
+      }),
+      Schema.Struct({
+        devicePosture: Schema.Struct({
+          integrationUid: Schema.String,
+        }).pipe(Schema.encodeKeys({ integrationUid: "integration_uid" })),
+      }).pipe(Schema.encodeKeys({ devicePosture: "device_posture" })),
+      Schema.Struct({
+        emailDomain: Schema.Struct({
+          domain: Schema.String,
+        }),
+      }).pipe(Schema.encodeKeys({ emailDomain: "email_domain" })),
+      Schema.Struct({
+        emailList: Schema.Struct({
+          id: Schema.String,
+        }),
+      }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
+      Schema.Struct({
+        email: Schema.Struct({
+          email: Schema.String,
+        }),
+      }),
+      Schema.Struct({
+        everyone: Schema.Unknown,
+      }),
+      Schema.Struct({
+        externalEvaluation: Schema.Struct({
+          evaluateUrl: Schema.String,
+          keysUrl: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            evaluateUrl: "evaluate_url",
+            keysUrl: "keys_url",
+          }),
+        ),
+      }).pipe(Schema.encodeKeys({ externalEvaluation: "external_evaluation" })),
+      Schema.Struct({
+        githubOrganization: Schema.Struct({
+          identityProviderId: Schema.String,
+          name: Schema.String,
+          team: Schema.optional(Schema.String),
+        }).pipe(
+          Schema.encodeKeys({
+            identityProviderId: "identity_provider_id",
+            name: "name",
+            team: "team",
+          }),
+        ),
+      }).pipe(Schema.encodeKeys({ githubOrganization: "github-organization" })),
+      Schema.Struct({
+        gsuite: Schema.Struct({
+          email: Schema.String,
+          identityProviderId: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            email: "email",
+            identityProviderId: "identity_provider_id",
+          }),
+        ),
+      }),
+      Schema.Struct({
+        loginMethod: Schema.Struct({
+          id: Schema.String,
+        }),
+      }).pipe(Schema.encodeKeys({ loginMethod: "login_method" })),
+      Schema.Struct({
+        ipList: Schema.Struct({
+          id: Schema.String,
+        }),
+      }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
+      Schema.Struct({
+        ip: Schema.Struct({
+          ip: Schema.String,
+        }),
+      }),
+      Schema.Struct({
+        okta: Schema.Struct({
+          identityProviderId: Schema.String,
+          name: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            identityProviderId: "identity_provider_id",
+            name: "name",
+          }),
+        ),
+      }),
+      Schema.Struct({
+        saml: Schema.Struct({
+          attributeName: Schema.String,
+          attributeValue: Schema.String,
+          identityProviderId: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            attributeName: "attribute_name",
+            attributeValue: "attribute_value",
+            identityProviderId: "identity_provider_id",
+          }),
+        ),
+      }),
+      Schema.Struct({
+        oidc: Schema.Struct({
+          claimName: Schema.String,
+          claimValue: Schema.String,
+          identityProviderId: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({
+            claimName: "claim_name",
+            claimValue: "claim_value",
+            identityProviderId: "identity_provider_id",
+          }),
+        ),
+      }),
+      Schema.Struct({
+        serviceToken: Schema.Struct({
+          tokenId: Schema.String,
+        }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
+      }).pipe(Schema.encodeKeys({ serviceToken: "service_token" })),
+      Schema.Struct({
+        linkedAppToken: Schema.Struct({
+          appUid: Schema.String,
+        }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
+      }).pipe(Schema.encodeKeys({ linkedAppToken: "linked_app_token" })),
+    ]),
+  ),
+  name: Schema.String,
+  exclude: Schema.optional(
+    Schema.Array(
       Schema.Union([
         Schema.Struct({
           group: Schema.Struct({
@@ -43788,376 +45736,492 @@ export const UpdateAccessGroupRequest =
         }).pipe(Schema.encodeKeys({ linkedAppToken: "linked_app_token" })),
       ]),
     ),
-    name: Schema.String,
-    exclude: Schema.optional(
-      Schema.Array(
-        Schema.Union([
-          Schema.Struct({
-            group: Schema.Struct({
-              id: Schema.String,
-            }),
+  ),
+  isDefault: Schema.optional(Schema.Boolean),
+  require: Schema.optional(
+    Schema.Array(
+      Schema.Union([
+        Schema.Struct({
+          group: Schema.Struct({
+            id: Schema.String,
           }),
-          Schema.Struct({
-            anyValidServiceToken: Schema.Unknown,
+        }),
+        Schema.Struct({
+          anyValidServiceToken: Schema.Unknown,
+        }).pipe(
+          Schema.encodeKeys({
+            anyValidServiceToken: "any_valid_service_token",
+          }),
+        ),
+        Schema.Struct({
+          authContext: Schema.Struct({
+            id: Schema.String,
+            acId: Schema.String,
+            identityProviderId: Schema.String,
           }).pipe(
             Schema.encodeKeys({
-              anyValidServiceToken: "any_valid_service_token",
+              id: "id",
+              acId: "ac_id",
+              identityProviderId: "identity_provider_id",
             }),
           ),
-          Schema.Struct({
-            authContext: Schema.Struct({
-              id: Schema.String,
-              acId: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                id: "id",
-                acId: "ac_id",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }).pipe(Schema.encodeKeys({ authContext: "auth_context" })),
-          Schema.Struct({
-            authMethod: Schema.Struct({
-              authMethod: Schema.String,
-            }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
+        }).pipe(Schema.encodeKeys({ authContext: "auth_context" })),
+        Schema.Struct({
+          authMethod: Schema.Struct({
+            authMethod: Schema.String,
           }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
-          Schema.Struct({
-            azureAD: Schema.Struct({
-              id: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                id: "id",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            certificate: Schema.Unknown,
-          }),
-          Schema.Struct({
-            commonName: Schema.Struct({
-              commonName: Schema.String,
-            }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
-          }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
-          Schema.Struct({
-            geo: Schema.Struct({
-              countryCode: Schema.String,
-            }).pipe(Schema.encodeKeys({ countryCode: "country_code" })),
-          }),
-          Schema.Struct({
-            devicePosture: Schema.Struct({
-              integrationUid: Schema.String,
-            }).pipe(Schema.encodeKeys({ integrationUid: "integration_uid" })),
-          }).pipe(Schema.encodeKeys({ devicePosture: "device_posture" })),
-          Schema.Struct({
-            emailDomain: Schema.Struct({
-              domain: Schema.String,
-            }),
-          }).pipe(Schema.encodeKeys({ emailDomain: "email_domain" })),
-          Schema.Struct({
-            emailList: Schema.Struct({
-              id: Schema.String,
-            }),
-          }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
-          Schema.Struct({
-            email: Schema.Struct({
-              email: Schema.String,
-            }),
-          }),
-          Schema.Struct({
-            everyone: Schema.Unknown,
-          }),
-          Schema.Struct({
-            externalEvaluation: Schema.Struct({
-              evaluateUrl: Schema.String,
-              keysUrl: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                evaluateUrl: "evaluate_url",
-                keysUrl: "keys_url",
-              }),
-            ),
-          }).pipe(
-            Schema.encodeKeys({ externalEvaluation: "external_evaluation" }),
-          ),
-          Schema.Struct({
-            githubOrganization: Schema.Struct({
-              identityProviderId: Schema.String,
-              name: Schema.String,
-              team: Schema.optional(Schema.String),
-            }).pipe(
-              Schema.encodeKeys({
-                identityProviderId: "identity_provider_id",
-                name: "name",
-                team: "team",
-              }),
-            ),
-          }).pipe(
-            Schema.encodeKeys({ githubOrganization: "github-organization" }),
-          ),
-          Schema.Struct({
-            gsuite: Schema.Struct({
-              email: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                email: "email",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            loginMethod: Schema.Struct({
-              id: Schema.String,
-            }),
-          }).pipe(Schema.encodeKeys({ loginMethod: "login_method" })),
-          Schema.Struct({
-            ipList: Schema.Struct({
-              id: Schema.String,
-            }),
-          }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
-          Schema.Struct({
-            ip: Schema.Struct({
-              ip: Schema.String,
-            }),
-          }),
-          Schema.Struct({
-            okta: Schema.Struct({
-              identityProviderId: Schema.String,
-              name: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                identityProviderId: "identity_provider_id",
-                name: "name",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            saml: Schema.Struct({
-              attributeName: Schema.String,
-              attributeValue: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                attributeName: "attribute_name",
-                attributeValue: "attribute_value",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            oidc: Schema.Struct({
-              claimName: Schema.String,
-              claimValue: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                claimName: "claim_name",
-                claimValue: "claim_value",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            serviceToken: Schema.Struct({
-              tokenId: Schema.String,
-            }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
-          }).pipe(Schema.encodeKeys({ serviceToken: "service_token" })),
-          Schema.Struct({
-            linkedAppToken: Schema.Struct({
-              appUid: Schema.String,
-            }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
-          }).pipe(Schema.encodeKeys({ linkedAppToken: "linked_app_token" })),
-        ]),
-      ),
-    ),
-    isDefault: Schema.optional(Schema.Boolean),
-    require: Schema.optional(
-      Schema.Array(
-        Schema.Union([
-          Schema.Struct({
-            group: Schema.Struct({
-              id: Schema.String,
-            }),
-          }),
-          Schema.Struct({
-            anyValidServiceToken: Schema.Unknown,
+        }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
+        Schema.Struct({
+          azureAD: Schema.Struct({
+            id: Schema.String,
+            identityProviderId: Schema.String,
           }).pipe(
             Schema.encodeKeys({
-              anyValidServiceToken: "any_valid_service_token",
+              id: "id",
+              identityProviderId: "identity_provider_id",
             }),
           ),
-          Schema.Struct({
-            authContext: Schema.Struct({
-              id: Schema.String,
-              acId: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                id: "id",
-                acId: "ac_id",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }).pipe(Schema.encodeKeys({ authContext: "auth_context" })),
-          Schema.Struct({
-            authMethod: Schema.Struct({
-              authMethod: Schema.String,
-            }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
-          }).pipe(Schema.encodeKeys({ authMethod: "auth_method" })),
-          Schema.Struct({
-            azureAD: Schema.Struct({
-              id: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                id: "id",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            certificate: Schema.Unknown,
-          }),
-          Schema.Struct({
-            commonName: Schema.Struct({
-              commonName: Schema.String,
-            }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
+        }),
+        Schema.Struct({
+          certificate: Schema.Unknown,
+        }),
+        Schema.Struct({
+          commonName: Schema.Struct({
+            commonName: Schema.String,
           }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
-          Schema.Struct({
-            geo: Schema.Struct({
-              countryCode: Schema.String,
-            }).pipe(Schema.encodeKeys({ countryCode: "country_code" })),
+        }).pipe(Schema.encodeKeys({ commonName: "common_name" })),
+        Schema.Struct({
+          geo: Schema.Struct({
+            countryCode: Schema.String,
+          }).pipe(Schema.encodeKeys({ countryCode: "country_code" })),
+        }),
+        Schema.Struct({
+          devicePosture: Schema.Struct({
+            integrationUid: Schema.String,
+          }).pipe(Schema.encodeKeys({ integrationUid: "integration_uid" })),
+        }).pipe(Schema.encodeKeys({ devicePosture: "device_posture" })),
+        Schema.Struct({
+          emailDomain: Schema.Struct({
+            domain: Schema.String,
           }),
-          Schema.Struct({
-            devicePosture: Schema.Struct({
-              integrationUid: Schema.String,
-            }).pipe(Schema.encodeKeys({ integrationUid: "integration_uid" })),
-          }).pipe(Schema.encodeKeys({ devicePosture: "device_posture" })),
-          Schema.Struct({
-            emailDomain: Schema.Struct({
-              domain: Schema.String,
-            }),
-          }).pipe(Schema.encodeKeys({ emailDomain: "email_domain" })),
-          Schema.Struct({
-            emailList: Schema.Struct({
-              id: Schema.String,
-            }),
-          }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
-          Schema.Struct({
-            email: Schema.Struct({
-              email: Schema.String,
-            }),
+        }).pipe(Schema.encodeKeys({ emailDomain: "email_domain" })),
+        Schema.Struct({
+          emailList: Schema.Struct({
+            id: Schema.String,
           }),
-          Schema.Struct({
-            everyone: Schema.Unknown,
+        }).pipe(Schema.encodeKeys({ emailList: "email_list" })),
+        Schema.Struct({
+          email: Schema.Struct({
+            email: Schema.String,
           }),
-          Schema.Struct({
-            externalEvaluation: Schema.Struct({
-              evaluateUrl: Schema.String,
-              keysUrl: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                evaluateUrl: "evaluate_url",
-                keysUrl: "keys_url",
-              }),
-            ),
+        }),
+        Schema.Struct({
+          everyone: Schema.Unknown,
+        }),
+        Schema.Struct({
+          externalEvaluation: Schema.Struct({
+            evaluateUrl: Schema.String,
+            keysUrl: Schema.String,
           }).pipe(
-            Schema.encodeKeys({ externalEvaluation: "external_evaluation" }),
+            Schema.encodeKeys({
+              evaluateUrl: "evaluate_url",
+              keysUrl: "keys_url",
+            }),
           ),
-          Schema.Struct({
-            githubOrganization: Schema.Struct({
-              identityProviderId: Schema.String,
-              name: Schema.String,
-              team: Schema.optional(Schema.String),
-            }).pipe(
-              Schema.encodeKeys({
-                identityProviderId: "identity_provider_id",
-                name: "name",
-                team: "team",
-              }),
-            ),
+        }).pipe(
+          Schema.encodeKeys({ externalEvaluation: "external_evaluation" }),
+        ),
+        Schema.Struct({
+          githubOrganization: Schema.Struct({
+            identityProviderId: Schema.String,
+            name: Schema.String,
+            team: Schema.optional(Schema.String),
           }).pipe(
-            Schema.encodeKeys({ githubOrganization: "github-organization" }),
+            Schema.encodeKeys({
+              identityProviderId: "identity_provider_id",
+              name: "name",
+              team: "team",
+            }),
           ),
-          Schema.Struct({
-            gsuite: Schema.Struct({
-              email: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                email: "email",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            loginMethod: Schema.Struct({
-              id: Schema.String,
+        }).pipe(
+          Schema.encodeKeys({ githubOrganization: "github-organization" }),
+        ),
+        Schema.Struct({
+          gsuite: Schema.Struct({
+            email: Schema.String,
+            identityProviderId: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              email: "email",
+              identityProviderId: "identity_provider_id",
             }),
-          }).pipe(Schema.encodeKeys({ loginMethod: "login_method" })),
-          Schema.Struct({
-            ipList: Schema.Struct({
-              id: Schema.String,
+          ),
+        }),
+        Schema.Struct({
+          loginMethod: Schema.Struct({
+            id: Schema.String,
+          }),
+        }).pipe(Schema.encodeKeys({ loginMethod: "login_method" })),
+        Schema.Struct({
+          ipList: Schema.Struct({
+            id: Schema.String,
+          }),
+        }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
+        Schema.Struct({
+          ip: Schema.Struct({
+            ip: Schema.String,
+          }),
+        }),
+        Schema.Struct({
+          okta: Schema.Struct({
+            identityProviderId: Schema.String,
+            name: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              identityProviderId: "identity_provider_id",
+              name: "name",
             }),
-          }).pipe(Schema.encodeKeys({ ipList: "ip_list" })),
-          Schema.Struct({
-            ip: Schema.Struct({
-              ip: Schema.String,
+          ),
+        }),
+        Schema.Struct({
+          saml: Schema.Struct({
+            attributeName: Schema.String,
+            attributeValue: Schema.String,
+            identityProviderId: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              attributeName: "attribute_name",
+              attributeValue: "attribute_value",
+              identityProviderId: "identity_provider_id",
             }),
-          }),
-          Schema.Struct({
-            okta: Schema.Struct({
-              identityProviderId: Schema.String,
-              name: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                identityProviderId: "identity_provider_id",
-                name: "name",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            saml: Schema.Struct({
-              attributeName: Schema.String,
-              attributeValue: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                attributeName: "attribute_name",
-                attributeValue: "attribute_value",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            oidc: Schema.Struct({
-              claimName: Schema.String,
-              claimValue: Schema.String,
-              identityProviderId: Schema.String,
-            }).pipe(
-              Schema.encodeKeys({
-                claimName: "claim_name",
-                claimValue: "claim_value",
-                identityProviderId: "identity_provider_id",
-              }),
-            ),
-          }),
-          Schema.Struct({
-            serviceToken: Schema.Struct({
-              tokenId: Schema.String,
-            }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
-          }).pipe(Schema.encodeKeys({ serviceToken: "service_token" })),
-          Schema.Struct({
-            linkedAppToken: Schema.Struct({
-              appUid: Schema.String,
-            }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
-          }).pipe(Schema.encodeKeys({ linkedAppToken: "linked_app_token" })),
-        ]),
-      ),
+          ),
+        }),
+        Schema.Struct({
+          oidc: Schema.Struct({
+            claimName: Schema.String,
+            claimValue: Schema.String,
+            identityProviderId: Schema.String,
+          }).pipe(
+            Schema.encodeKeys({
+              claimName: "claim_name",
+              claimValue: "claim_value",
+              identityProviderId: "identity_provider_id",
+            }),
+          ),
+        }),
+        Schema.Struct({
+          serviceToken: Schema.Struct({
+            tokenId: Schema.String,
+          }).pipe(Schema.encodeKeys({ tokenId: "token_id" })),
+        }).pipe(Schema.encodeKeys({ serviceToken: "service_token" })),
+        Schema.Struct({
+          linkedAppToken: Schema.Struct({
+            appUid: Schema.String,
+          }).pipe(Schema.encodeKeys({ appUid: "app_uid" })),
+        }).pipe(Schema.encodeKeys({ linkedAppToken: "linked_app_token" })),
+      ]),
     ),
+  ),
+} as const;
+
+export interface UpdateAccessGroupForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  groupId: string;
+  /** Body param: Rules evaluated with an OR logical operator. A user needs to meet only one of the Include rules. */
+  include: (
+    | { group: { id: string } }
+    | { anyValidServiceToken: unknown }
+    | { authContext: { id: string; acId: string; identityProviderId: string } }
+    | { authMethod: { authMethod: string } }
+    | { azureAD: { id: string; identityProviderId: string } }
+    | { certificate: unknown }
+    | { commonName: { commonName: string } }
+    | { geo: { countryCode: string } }
+    | { devicePosture: { integrationUid: string } }
+    | { emailDomain: { domain: string } }
+    | { emailList: { id: string } }
+    | { email: { email: string } }
+    | { everyone: unknown }
+    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
+    | {
+        githubOrganization: {
+          identityProviderId: string;
+          name: string;
+          team?: string;
+        };
+      }
+    | { gsuite: { email: string; identityProviderId: string } }
+    | { loginMethod: { id: string } }
+    | { ipList: { id: string } }
+    | { ip: { ip: string } }
+    | { okta: { identityProviderId: string; name: string } }
+    | {
+        saml: {
+          attributeName: string;
+          attributeValue: string;
+          identityProviderId: string;
+        };
+      }
+    | {
+        oidc: {
+          claimName: string;
+          claimValue: string;
+          identityProviderId: string;
+        };
+      }
+    | { serviceToken: { tokenId: string } }
+    | { linkedAppToken: { appUid: string } }
+  )[];
+  /** Body param: The name of the Access group. */
+  name: string;
+  /** Body param: Rules evaluated with a NOT logical operator. To match a policy, a user cannot meet any of the Exclude rules. */
+  exclude?: (
+    | { group: { id: string } }
+    | { anyValidServiceToken: unknown }
+    | { authContext: { id: string; acId: string; identityProviderId: string } }
+    | { authMethod: { authMethod: string } }
+    | { azureAD: { id: string; identityProviderId: string } }
+    | { certificate: unknown }
+    | { commonName: { commonName: string } }
+    | { geo: { countryCode: string } }
+    | { devicePosture: { integrationUid: string } }
+    | { emailDomain: { domain: string } }
+    | { emailList: { id: string } }
+    | { email: { email: string } }
+    | { everyone: unknown }
+    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
+    | {
+        githubOrganization: {
+          identityProviderId: string;
+          name: string;
+          team?: string;
+        };
+      }
+    | { gsuite: { email: string; identityProviderId: string } }
+    | { loginMethod: { id: string } }
+    | { ipList: { id: string } }
+    | { ip: { ip: string } }
+    | { okta: { identityProviderId: string; name: string } }
+    | {
+        saml: {
+          attributeName: string;
+          attributeValue: string;
+          identityProviderId: string;
+        };
+      }
+    | {
+        oidc: {
+          claimName: string;
+          claimValue: string;
+          identityProviderId: string;
+        };
+      }
+    | { serviceToken: { tokenId: string } }
+    | { linkedAppToken: { appUid: string } }
+  )[];
+  /** Body param: Whether this is the default group */
+  isDefault?: boolean;
+  /** Body param: Rules evaluated with an AND logical operator. To match a policy, a user must meet all of the Require rules. */
+  require?: (
+    | { group: { id: string } }
+    | { anyValidServiceToken: unknown }
+    | { authContext: { id: string; acId: string; identityProviderId: string } }
+    | { authMethod: { authMethod: string } }
+    | { azureAD: { id: string; identityProviderId: string } }
+    | { certificate: unknown }
+    | { commonName: { commonName: string } }
+    | { geo: { countryCode: string } }
+    | { devicePosture: { integrationUid: string } }
+    | { emailDomain: { domain: string } }
+    | { emailList: { id: string } }
+    | { email: { email: string } }
+    | { everyone: unknown }
+    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
+    | {
+        githubOrganization: {
+          identityProviderId: string;
+          name: string;
+          team?: string;
+        };
+      }
+    | { gsuite: { email: string; identityProviderId: string } }
+    | { loginMethod: { id: string } }
+    | { ipList: { id: string } }
+    | { ip: { ip: string } }
+    | { okta: { identityProviderId: string; name: string } }
+    | {
+        saml: {
+          attributeName: string;
+          attributeValue: string;
+          identityProviderId: string;
+        };
+      }
+    | {
+        oidc: {
+          claimName: string;
+          claimValue: string;
+          identityProviderId: string;
+        };
+      }
+    | { serviceToken: { tokenId: string } }
+    | { linkedAppToken: { appUid: string } }
+  )[];
+}
+
+export interface UpdateAccessGroupForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  groupId: string;
+  /** Body param: Rules evaluated with an OR logical operator. A user needs to meet only one of the Include rules. */
+  include: (
+    | { group: { id: string } }
+    | { anyValidServiceToken: unknown }
+    | { authContext: { id: string; acId: string; identityProviderId: string } }
+    | { authMethod: { authMethod: string } }
+    | { azureAD: { id: string; identityProviderId: string } }
+    | { certificate: unknown }
+    | { commonName: { commonName: string } }
+    | { geo: { countryCode: string } }
+    | { devicePosture: { integrationUid: string } }
+    | { emailDomain: { domain: string } }
+    | { emailList: { id: string } }
+    | { email: { email: string } }
+    | { everyone: unknown }
+    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
+    | {
+        githubOrganization: {
+          identityProviderId: string;
+          name: string;
+          team?: string;
+        };
+      }
+    | { gsuite: { email: string; identityProviderId: string } }
+    | { loginMethod: { id: string } }
+    | { ipList: { id: string } }
+    | { ip: { ip: string } }
+    | { okta: { identityProviderId: string; name: string } }
+    | {
+        saml: {
+          attributeName: string;
+          attributeValue: string;
+          identityProviderId: string;
+        };
+      }
+    | {
+        oidc: {
+          claimName: string;
+          claimValue: string;
+          identityProviderId: string;
+        };
+      }
+    | { serviceToken: { tokenId: string } }
+    | { linkedAppToken: { appUid: string } }
+  )[];
+  /** Body param: The name of the Access group. */
+  name: string;
+  /** Body param: Rules evaluated with a NOT logical operator. To match a policy, a user cannot meet any of the Exclude rules. */
+  exclude?: (
+    | { group: { id: string } }
+    | { anyValidServiceToken: unknown }
+    | { authContext: { id: string; acId: string; identityProviderId: string } }
+    | { authMethod: { authMethod: string } }
+    | { azureAD: { id: string; identityProviderId: string } }
+    | { certificate: unknown }
+    | { commonName: { commonName: string } }
+    | { geo: { countryCode: string } }
+    | { devicePosture: { integrationUid: string } }
+    | { emailDomain: { domain: string } }
+    | { emailList: { id: string } }
+    | { email: { email: string } }
+    | { everyone: unknown }
+    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
+    | {
+        githubOrganization: {
+          identityProviderId: string;
+          name: string;
+          team?: string;
+        };
+      }
+    | { gsuite: { email: string; identityProviderId: string } }
+    | { loginMethod: { id: string } }
+    | { ipList: { id: string } }
+    | { ip: { ip: string } }
+    | { okta: { identityProviderId: string; name: string } }
+    | {
+        saml: {
+          attributeName: string;
+          attributeValue: string;
+          identityProviderId: string;
+        };
+      }
+    | {
+        oidc: {
+          claimName: string;
+          claimValue: string;
+          identityProviderId: string;
+        };
+      }
+    | { serviceToken: { tokenId: string } }
+    | { linkedAppToken: { appUid: string } }
+  )[];
+  /** Body param: Whether this is the default group */
+  isDefault?: boolean;
+  /** Body param: Rules evaluated with an AND logical operator. To match a policy, a user must meet all of the Require rules. */
+  require?: (
+    | { group: { id: string } }
+    | { anyValidServiceToken: unknown }
+    | { authContext: { id: string; acId: string; identityProviderId: string } }
+    | { authMethod: { authMethod: string } }
+    | { azureAD: { id: string; identityProviderId: string } }
+    | { certificate: unknown }
+    | { commonName: { commonName: string } }
+    | { geo: { countryCode: string } }
+    | { devicePosture: { integrationUid: string } }
+    | { emailDomain: { domain: string } }
+    | { emailList: { id: string } }
+    | { email: { email: string } }
+    | { everyone: unknown }
+    | { externalEvaluation: { evaluateUrl: string; keysUrl: string } }
+    | {
+        githubOrganization: {
+          identityProviderId: string;
+          name: string;
+          team?: string;
+        };
+      }
+    | { gsuite: { email: string; identityProviderId: string } }
+    | { loginMethod: { id: string } }
+    | { ipList: { id: string } }
+    | { ip: { ip: string } }
+    | { okta: { identityProviderId: string; name: string } }
+    | {
+        saml: {
+          attributeName: string;
+          attributeValue: string;
+          identityProviderId: string;
+        };
+      }
+    | {
+        oidc: {
+          claimName: string;
+          claimValue: string;
+          identityProviderId: string;
+        };
+      }
+    | { serviceToken: { tokenId: string } }
+    | { linkedAppToken: { appUid: string } }
+  )[];
+}
+
+export type UpdateAccessGroupRequest =
+  | UpdateAccessGroupForAccountRequest
+  | UpdateAccessGroupForZoneRequest;
+
+export const UpdateAccessGroupForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...UpdateAccessGroupBaseFields,
   }).pipe(
     Schema.encodeKeys({
       include: "include",
@@ -44168,9 +46232,24 @@ export const UpdateAccessGroupRequest =
     }),
     T.Http({
       method: "PUT",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/groups/{groupId}",
+      path: "/accounts/{account_id}/access/groups/{groupId}",
     }),
-  ) as unknown as Schema.Schema<UpdateAccessGroupRequest>;
+  ) as unknown as Schema.Schema<UpdateAccessGroupForAccountRequest>;
+
+export const UpdateAccessGroupForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...UpdateAccessGroupBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      include: "include",
+      name: "name",
+      exclude: "exclude",
+      isDefault: "is_default",
+      require: "require",
+    }),
+    T.Http({ method: "PUT", path: "/zones/{zone_id}/access/groups/{groupId}" }),
+  ) as unknown as Schema.Schema<UpdateAccessGroupForZoneRequest>;
 
 export interface UpdateAccessGroupResponse {
   /** UUID. */
@@ -45168,30 +47247,80 @@ export const UpdateAccessGroupResponse =
 
 export type UpdateAccessGroupError = DefaultErrors;
 
-export const updateAccessGroup: API.OperationMethod<
-  UpdateAccessGroupRequest,
+export const updateAccessGroupForAccount: API.OperationMethod<
+  UpdateAccessGroupForAccountRequest,
   UpdateAccessGroupResponse,
   UpdateAccessGroupError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: UpdateAccessGroupRequest,
+  input: UpdateAccessGroupForAccountRequest,
   output: UpdateAccessGroupResponse,
   errors: [],
 }));
 
-export interface DeleteAccessGroupRequest {
+export const updateAccessGroupForZone: API.OperationMethod<
+  UpdateAccessGroupForZoneRequest,
+  UpdateAccessGroupResponse,
+  UpdateAccessGroupError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: UpdateAccessGroupForZoneRequest,
+  output: UpdateAccessGroupResponse,
+  errors: [],
+}));
+
+export const updateAccessGroup = (
+  input: UpdateAccessGroupRequest,
+): Effect.Effect<
+  UpdateAccessGroupResponse,
+  UpdateAccessGroupError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? updateAccessGroupForAccount(input)
+    : updateAccessGroupForZone(input);
+
+const DeleteAccessGroupBaseFields = {
+  groupId: Schema.String.pipe(T.HttpPath("groupId")),
+} as const;
+
+export interface DeleteAccessGroupForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   groupId: string;
 }
 
-export const DeleteAccessGroupRequest =
+export interface DeleteAccessGroupForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  groupId: string;
+}
+
+export type DeleteAccessGroupRequest =
+  | DeleteAccessGroupForAccountRequest
+  | DeleteAccessGroupForZoneRequest;
+
+export const DeleteAccessGroupForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    groupId: Schema.String.pipe(T.HttpPath("groupId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...DeleteAccessGroupBaseFields,
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/groups/{groupId}",
+      path: "/accounts/{account_id}/access/groups/{groupId}",
     }),
-  ) as unknown as Schema.Schema<DeleteAccessGroupRequest>;
+  ) as unknown as Schema.Schema<DeleteAccessGroupForAccountRequest>;
+
+export const DeleteAccessGroupForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...DeleteAccessGroupBaseFields,
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/zones/{zone_id}/access/groups/{groupId}",
+    }),
+  ) as unknown as Schema.Schema<DeleteAccessGroupForZoneRequest>;
 
 export interface DeleteAccessGroupResponse {
   /** UUID. */
@@ -45207,16 +47336,38 @@ export const DeleteAccessGroupResponse =
 
 export type DeleteAccessGroupError = DefaultErrors;
 
-export const deleteAccessGroup: API.OperationMethod<
-  DeleteAccessGroupRequest,
+export const deleteAccessGroupForAccount: API.OperationMethod<
+  DeleteAccessGroupForAccountRequest,
   DeleteAccessGroupResponse,
   DeleteAccessGroupError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: DeleteAccessGroupRequest,
+  input: DeleteAccessGroupForAccountRequest,
   output: DeleteAccessGroupResponse,
   errors: [],
 }));
+
+export const deleteAccessGroupForZone: API.OperationMethod<
+  DeleteAccessGroupForZoneRequest,
+  DeleteAccessGroupResponse,
+  DeleteAccessGroupError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: DeleteAccessGroupForZoneRequest,
+  output: DeleteAccessGroupResponse,
+  errors: [],
+}));
+
+export const deleteAccessGroup = (
+  input: DeleteAccessGroupRequest,
+): Effect.Effect<
+  DeleteAccessGroupResponse,
+  DeleteAccessGroupError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? deleteAccessGroupForAccount(input)
+    : deleteAccessGroupForZone(input);
 
 // =============================================================================
 // AccessInfrastructureTarget
@@ -51389,19 +53540,47 @@ export const deleteAccessPolicy: API.OperationMethod<
 // AccessServiceToken
 // =============================================================================
 
-export interface GetAccessServiceTokenRequest {
+const GetAccessServiceTokenBaseFields = {
+  serviceTokenId: Schema.String.pipe(T.HttpPath("serviceTokenId")),
+} as const;
+
+export interface GetAccessServiceTokenForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   serviceTokenId: string;
 }
 
-export const GetAccessServiceTokenRequest =
+export interface GetAccessServiceTokenForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  serviceTokenId: string;
+}
+
+export type GetAccessServiceTokenRequest =
+  | GetAccessServiceTokenForAccountRequest
+  | GetAccessServiceTokenForZoneRequest;
+
+export const GetAccessServiceTokenForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    serviceTokenId: Schema.String.pipe(T.HttpPath("serviceTokenId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetAccessServiceTokenBaseFields,
   }).pipe(
     T.Http({
       method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/service_tokens/{serviceTokenId}",
+      path: "/accounts/{account_id}/access/service_tokens/{serviceTokenId}",
     }),
-  ) as unknown as Schema.Schema<GetAccessServiceTokenRequest>;
+  ) as unknown as Schema.Schema<GetAccessServiceTokenForAccountRequest>;
+
+export const GetAccessServiceTokenForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...GetAccessServiceTokenBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/access/service_tokens/{serviceTokenId}",
+    }),
+  ) as unknown as Schema.Schema<GetAccessServiceTokenForZoneRequest>;
 
 export interface GetAccessServiceTokenResponse {
   /** The ID of the service token. */
@@ -51438,26 +53617,73 @@ export const GetAccessServiceTokenResponse =
 
 export type GetAccessServiceTokenError = DefaultErrors;
 
-export const getAccessServiceToken: API.OperationMethod<
-  GetAccessServiceTokenRequest,
+export const getAccessServiceTokenForAccount: API.OperationMethod<
+  GetAccessServiceTokenForAccountRequest,
   GetAccessServiceTokenResponse,
   GetAccessServiceTokenError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: GetAccessServiceTokenRequest,
+  input: GetAccessServiceTokenForAccountRequest,
   output: GetAccessServiceTokenResponse,
   errors: [],
 }));
 
-export interface ListAccessServiceTokensRequest {}
+export const getAccessServiceTokenForZone: API.OperationMethod<
+  GetAccessServiceTokenForZoneRequest,
+  GetAccessServiceTokenResponse,
+  GetAccessServiceTokenError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetAccessServiceTokenForZoneRequest,
+  output: GetAccessServiceTokenResponse,
+  errors: [],
+}));
 
-export const ListAccessServiceTokensRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
+export const getAccessServiceToken = (
+  input: GetAccessServiceTokenRequest,
+): Effect.Effect<
+  GetAccessServiceTokenResponse,
+  GetAccessServiceTokenError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? getAccessServiceTokenForAccount(input)
+    : getAccessServiceTokenForZone(input);
+
+const ListAccessServiceTokensBaseFields = {} as const;
+
+export interface ListAccessServiceTokensForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface ListAccessServiceTokensForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+}
+
+export type ListAccessServiceTokensRequest =
+  | ListAccessServiceTokensForAccountRequest
+  | ListAccessServiceTokensForZoneRequest;
+
+export const ListAccessServiceTokensForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...ListAccessServiceTokensBaseFields,
+  }).pipe(
     T.Http({
       method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/service_tokens",
+      path: "/accounts/{account_id}/access/service_tokens",
     }),
-  ) as unknown as Schema.Schema<ListAccessServiceTokensRequest>;
+  ) as unknown as Schema.Schema<ListAccessServiceTokensForAccountRequest>;
+
+export const ListAccessServiceTokensForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...ListAccessServiceTokensBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/zones/{zone_id}/access/service_tokens" }),
+  ) as unknown as Schema.Schema<ListAccessServiceTokensForZoneRequest>;
 
 export interface ListAccessServiceTokensResponse {
   result: {
@@ -51520,13 +53746,13 @@ export const ListAccessServiceTokensResponse =
 
 export type ListAccessServiceTokensError = DefaultErrors;
 
-export const listAccessServiceTokens: API.PaginatedOperationMethod<
-  ListAccessServiceTokensRequest,
+export const listAccessServiceTokensForAccount: API.PaginatedOperationMethod<
+  ListAccessServiceTokensForAccountRequest,
   ListAccessServiceTokensResponse,
   ListAccessServiceTokensError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
-  input: ListAccessServiceTokensRequest,
+  input: ListAccessServiceTokensForAccountRequest,
   output: ListAccessServiceTokensResponse,
   errors: [],
   pagination: {
@@ -51538,11 +53764,45 @@ export const listAccessServiceTokens: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export interface CreateAccessServiceTokenRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
+export const listAccessServiceTokensForZone: API.PaginatedOperationMethod<
+  ListAccessServiceTokensForZoneRequest,
+  ListAccessServiceTokensResponse,
+  ListAccessServiceTokensError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+  input: ListAccessServiceTokensForZoneRequest,
+  output: ListAccessServiceTokensResponse,
+  errors: [],
+  pagination: {
+    mode: "page",
+    inputToken: "page",
+    outputToken: "resultInfo.page",
+    items: "result",
+    pageSize: "perPage",
+  } as const,
+}));
+
+export const listAccessServiceTokens = (
+  input: ListAccessServiceTokensRequest,
+): stream.Stream<
+  ListAccessServiceTokensResponse,
+  ListAccessServiceTokensError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? listAccessServiceTokensForAccount.pages(input)
+    : listAccessServiceTokensForZone.pages(input);
+
+const CreateAccessServiceTokenBaseFields = {
+  name: Schema.String,
+  clientSecretVersion: Schema.optional(Schema.Number),
+  duration: Schema.optional(Schema.String),
+  previousClientSecretExpiresAt: Schema.optional(Schema.String),
+} as const;
+
+export interface CreateAccessServiceTokenForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   /** Body param: The name of the service token. */
   name: string;
   /** Body param: A version number identifying the current `client_secret` associated with the service token. Incrementing it triggers a rotation; the previous secret will still be accepted until the time i */
@@ -51553,14 +53813,27 @@ export interface CreateAccessServiceTokenRequest {
   previousClientSecretExpiresAt?: string;
 }
 
-export const CreateAccessServiceTokenRequest =
+export interface CreateAccessServiceTokenForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  /** Body param: The name of the service token. */
+  name: string;
+  /** Body param: A version number identifying the current `client_secret` associated with the service token. Incrementing it triggers a rotation; the previous secret will still be accepted until the time i */
+  clientSecretVersion?: number;
+  /** Body param: The duration for how long the service token will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. The default is 1 year in hours (8760 */
+  duration?: string;
+  /** Body param: The expiration of the previous `client_secret`. This can be modified at any point after a rotation. For example, you may extend it further into the future if you need more time to update s */
+  previousClientSecretExpiresAt?: string;
+}
+
+export type CreateAccessServiceTokenRequest =
+  | CreateAccessServiceTokenForAccountRequest
+  | CreateAccessServiceTokenForZoneRequest;
+
+export const CreateAccessServiceTokenForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    name: Schema.String,
-    clientSecretVersion: Schema.optional(Schema.Number),
-    duration: Schema.optional(Schema.String),
-    previousClientSecretExpiresAt: Schema.optional(Schema.String),
+    ...CreateAccessServiceTokenBaseFields,
   }).pipe(
     Schema.encodeKeys({
       name: "name",
@@ -51570,9 +53843,23 @@ export const CreateAccessServiceTokenRequest =
     }),
     T.Http({
       method: "POST",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/service_tokens",
+      path: "/accounts/{account_id}/access/service_tokens",
     }),
-  ) as unknown as Schema.Schema<CreateAccessServiceTokenRequest>;
+  ) as unknown as Schema.Schema<CreateAccessServiceTokenForAccountRequest>;
+
+export const CreateAccessServiceTokenForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...CreateAccessServiceTokenBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      name: "name",
+      clientSecretVersion: "client_secret_version",
+      duration: "duration",
+      previousClientSecretExpiresAt: "previous_client_secret_expires_at",
+    }),
+    T.Http({ method: "POST", path: "/zones/{zone_id}/access/service_tokens" }),
+  ) as unknown as Schema.Schema<CreateAccessServiceTokenForZoneRequest>;
 
 export interface CreateAccessServiceTokenResponse {
   /** The ID of the service token. */
@@ -51610,23 +53897,51 @@ export const CreateAccessServiceTokenResponse =
 
 export type CreateAccessServiceTokenError = DefaultErrors;
 
-export const createAccessServiceToken: API.OperationMethod<
-  CreateAccessServiceTokenRequest,
+export const createAccessServiceTokenForAccount: API.OperationMethod<
+  CreateAccessServiceTokenForAccountRequest,
   CreateAccessServiceTokenResponse,
   CreateAccessServiceTokenError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: CreateAccessServiceTokenRequest,
+  input: CreateAccessServiceTokenForAccountRequest,
   output: CreateAccessServiceTokenResponse,
   errors: [],
 }));
 
-export interface UpdateAccessServiceTokenRequest {
+export const createAccessServiceTokenForZone: API.OperationMethod<
+  CreateAccessServiceTokenForZoneRequest,
+  CreateAccessServiceTokenResponse,
+  CreateAccessServiceTokenError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: CreateAccessServiceTokenForZoneRequest,
+  output: CreateAccessServiceTokenResponse,
+  errors: [],
+}));
+
+export const createAccessServiceToken = (
+  input: CreateAccessServiceTokenRequest,
+): Effect.Effect<
+  CreateAccessServiceTokenResponse,
+  CreateAccessServiceTokenError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? createAccessServiceTokenForAccount(input)
+    : createAccessServiceTokenForZone(input);
+
+const UpdateAccessServiceTokenBaseFields = {
+  serviceTokenId: Schema.String.pipe(T.HttpPath("serviceTokenId")),
+  clientSecretVersion: Schema.optional(Schema.Number),
+  duration: Schema.optional(Schema.String),
+  name: Schema.optional(Schema.String),
+  previousClientSecretExpiresAt: Schema.optional(Schema.String),
+} as const;
+
+export interface UpdateAccessServiceTokenForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   serviceTokenId: string;
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
   /** Body param: A version number identifying the current `client_secret` associated with the service token. Incrementing it triggers a rotation; the previous secret will still be accepted until the time i */
   clientSecretVersion?: number;
   /** Body param: The duration for how long the service token will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. The default is 1 year in hours (8760 */
@@ -51637,15 +53952,28 @@ export interface UpdateAccessServiceTokenRequest {
   previousClientSecretExpiresAt?: string;
 }
 
-export const UpdateAccessServiceTokenRequest =
+export interface UpdateAccessServiceTokenForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  serviceTokenId: string;
+  /** Body param: A version number identifying the current `client_secret` associated with the service token. Incrementing it triggers a rotation; the previous secret will still be accepted until the time i */
+  clientSecretVersion?: number;
+  /** Body param: The duration for how long the service token will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. The default is 1 year in hours (8760 */
+  duration?: string;
+  /** Body param: The name of the service token. */
+  name?: string;
+  /** Body param: The expiration of the previous `client_secret`. This can be modified at any point after a rotation. For example, you may extend it further into the future if you need more time to update s */
+  previousClientSecretExpiresAt?: string;
+}
+
+export type UpdateAccessServiceTokenRequest =
+  | UpdateAccessServiceTokenForAccountRequest
+  | UpdateAccessServiceTokenForZoneRequest;
+
+export const UpdateAccessServiceTokenForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    serviceTokenId: Schema.String.pipe(T.HttpPath("serviceTokenId")),
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    clientSecretVersion: Schema.optional(Schema.Number),
-    duration: Schema.optional(Schema.String),
-    name: Schema.optional(Schema.String),
-    previousClientSecretExpiresAt: Schema.optional(Schema.String),
+    ...UpdateAccessServiceTokenBaseFields,
   }).pipe(
     Schema.encodeKeys({
       clientSecretVersion: "client_secret_version",
@@ -51655,9 +53983,26 @@ export const UpdateAccessServiceTokenRequest =
     }),
     T.Http({
       method: "PUT",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/service_tokens/{serviceTokenId}",
+      path: "/accounts/{account_id}/access/service_tokens/{serviceTokenId}",
     }),
-  ) as unknown as Schema.Schema<UpdateAccessServiceTokenRequest>;
+  ) as unknown as Schema.Schema<UpdateAccessServiceTokenForAccountRequest>;
+
+export const UpdateAccessServiceTokenForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...UpdateAccessServiceTokenBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      clientSecretVersion: "client_secret_version",
+      duration: "duration",
+      name: "name",
+      previousClientSecretExpiresAt: "previous_client_secret_expires_at",
+    }),
+    T.Http({
+      method: "PUT",
+      path: "/zones/{zone_id}/access/service_tokens/{serviceTokenId}",
+    }),
+  ) as unknown as Schema.Schema<UpdateAccessServiceTokenForZoneRequest>;
 
 export interface UpdateAccessServiceTokenResponse {
   /** The ID of the service token. */
@@ -51694,30 +54039,80 @@ export const UpdateAccessServiceTokenResponse =
 
 export type UpdateAccessServiceTokenError = DefaultErrors;
 
-export const updateAccessServiceToken: API.OperationMethod<
-  UpdateAccessServiceTokenRequest,
+export const updateAccessServiceTokenForAccount: API.OperationMethod<
+  UpdateAccessServiceTokenForAccountRequest,
   UpdateAccessServiceTokenResponse,
   UpdateAccessServiceTokenError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: UpdateAccessServiceTokenRequest,
+  input: UpdateAccessServiceTokenForAccountRequest,
   output: UpdateAccessServiceTokenResponse,
   errors: [],
 }));
 
-export interface DeleteAccessServiceTokenRequest {
+export const updateAccessServiceTokenForZone: API.OperationMethod<
+  UpdateAccessServiceTokenForZoneRequest,
+  UpdateAccessServiceTokenResponse,
+  UpdateAccessServiceTokenError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: UpdateAccessServiceTokenForZoneRequest,
+  output: UpdateAccessServiceTokenResponse,
+  errors: [],
+}));
+
+export const updateAccessServiceToken = (
+  input: UpdateAccessServiceTokenRequest,
+): Effect.Effect<
+  UpdateAccessServiceTokenResponse,
+  UpdateAccessServiceTokenError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? updateAccessServiceTokenForAccount(input)
+    : updateAccessServiceTokenForZone(input);
+
+const DeleteAccessServiceTokenBaseFields = {
+  serviceTokenId: Schema.String.pipe(T.HttpPath("serviceTokenId")),
+} as const;
+
+export interface DeleteAccessServiceTokenForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   serviceTokenId: string;
 }
 
-export const DeleteAccessServiceTokenRequest =
+export interface DeleteAccessServiceTokenForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  serviceTokenId: string;
+}
+
+export type DeleteAccessServiceTokenRequest =
+  | DeleteAccessServiceTokenForAccountRequest
+  | DeleteAccessServiceTokenForZoneRequest;
+
+export const DeleteAccessServiceTokenForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    serviceTokenId: Schema.String.pipe(T.HttpPath("serviceTokenId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...DeleteAccessServiceTokenBaseFields,
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/service_tokens/{serviceTokenId}",
+      path: "/accounts/{account_id}/access/service_tokens/{serviceTokenId}",
     }),
-  ) as unknown as Schema.Schema<DeleteAccessServiceTokenRequest>;
+  ) as unknown as Schema.Schema<DeleteAccessServiceTokenForAccountRequest>;
+
+export const DeleteAccessServiceTokenForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...DeleteAccessServiceTokenBaseFields,
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/zones/{zone_id}/access/service_tokens/{serviceTokenId}",
+    }),
+  ) as unknown as Schema.Schema<DeleteAccessServiceTokenForZoneRequest>;
 
 export interface DeleteAccessServiceTokenResponse {
   /** The ID of the service token. */
@@ -51754,16 +54149,38 @@ export const DeleteAccessServiceTokenResponse =
 
 export type DeleteAccessServiceTokenError = DefaultErrors;
 
-export const deleteAccessServiceToken: API.OperationMethod<
-  DeleteAccessServiceTokenRequest,
+export const deleteAccessServiceTokenForAccount: API.OperationMethod<
+  DeleteAccessServiceTokenForAccountRequest,
   DeleteAccessServiceTokenResponse,
   DeleteAccessServiceTokenError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: DeleteAccessServiceTokenRequest,
+  input: DeleteAccessServiceTokenForAccountRequest,
   output: DeleteAccessServiceTokenResponse,
   errors: [],
 }));
+
+export const deleteAccessServiceTokenForZone: API.OperationMethod<
+  DeleteAccessServiceTokenForZoneRequest,
+  DeleteAccessServiceTokenResponse,
+  DeleteAccessServiceTokenError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: DeleteAccessServiceTokenForZoneRequest,
+  output: DeleteAccessServiceTokenResponse,
+  errors: [],
+}));
+
+export const deleteAccessServiceToken = (
+  input: DeleteAccessServiceTokenRequest,
+): Effect.Effect<
+  DeleteAccessServiceTokenResponse,
+  DeleteAccessServiceTokenError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? deleteAccessServiceTokenForAccount(input)
+    : deleteAccessServiceTokenForZone(input);
 
 export interface RefreshAccessServiceTokenRequest {
   serviceTokenId: string;
@@ -87880,19 +90297,47 @@ export const deleteGatewayRule: API.OperationMethod<
 // IdentityProvider
 // =============================================================================
 
-export interface GetIdentityProviderRequest {
+const GetIdentityProviderBaseFields = {
+  identityProviderId: Schema.String.pipe(T.HttpPath("identityProviderId")),
+} as const;
+
+export interface GetIdentityProviderForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   identityProviderId: string;
 }
 
-export const GetIdentityProviderRequest =
+export interface GetIdentityProviderForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  identityProviderId: string;
+}
+
+export type GetIdentityProviderRequest =
+  | GetIdentityProviderForAccountRequest
+  | GetIdentityProviderForZoneRequest;
+
+export const GetIdentityProviderForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    identityProviderId: Schema.String.pipe(T.HttpPath("identityProviderId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...GetIdentityProviderBaseFields,
   }).pipe(
     T.Http({
       method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/identity_providers/{identityProviderId}",
+      path: "/accounts/{account_id}/access/identity_providers/{identityProviderId}",
     }),
-  ) as unknown as Schema.Schema<GetIdentityProviderRequest>;
+  ) as unknown as Schema.Schema<GetIdentityProviderForAccountRequest>;
+
+export const GetIdentityProviderForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...GetIdentityProviderBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/access/identity_providers/{identityProviderId}",
+    }),
+  ) as unknown as Schema.Schema<GetIdentityProviderForZoneRequest>;
 
 export type GetIdentityProviderResponse =
   | {
@@ -89266,26 +91711,76 @@ export const GetIdentityProviderResponse =
 
 export type GetIdentityProviderError = DefaultErrors;
 
-export const getIdentityProvider: API.OperationMethod<
-  GetIdentityProviderRequest,
+export const getIdentityProviderForAccount: API.OperationMethod<
+  GetIdentityProviderForAccountRequest,
   GetIdentityProviderResponse,
   GetIdentityProviderError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: GetIdentityProviderRequest,
+  input: GetIdentityProviderForAccountRequest,
   output: GetIdentityProviderResponse,
   errors: [],
 }));
 
-export interface ListIdentityProvidersRequest {}
+export const getIdentityProviderForZone: API.OperationMethod<
+  GetIdentityProviderForZoneRequest,
+  GetIdentityProviderResponse,
+  GetIdentityProviderError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: GetIdentityProviderForZoneRequest,
+  output: GetIdentityProviderResponse,
+  errors: [],
+}));
 
-export const ListIdentityProvidersRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
+export const getIdentityProvider = (
+  input: GetIdentityProviderRequest,
+): Effect.Effect<
+  GetIdentityProviderResponse,
+  GetIdentityProviderError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? getIdentityProviderForAccount(input)
+    : getIdentityProviderForZone(input);
+
+const ListIdentityProvidersBaseFields = {} as const;
+
+export interface ListIdentityProvidersForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface ListIdentityProvidersForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+}
+
+export type ListIdentityProvidersRequest =
+  | ListIdentityProvidersForAccountRequest
+  | ListIdentityProvidersForZoneRequest;
+
+export const ListIdentityProvidersForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...ListIdentityProvidersBaseFields,
+  }).pipe(
     T.Http({
       method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/identity_providers",
+      path: "/accounts/{account_id}/access/identity_providers",
     }),
-  ) as unknown as Schema.Schema<ListIdentityProvidersRequest>;
+  ) as unknown as Schema.Schema<ListIdentityProvidersForAccountRequest>;
+
+export const ListIdentityProvidersForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...ListIdentityProvidersBaseFields,
+  }).pipe(
+    T.Http({
+      method: "GET",
+      path: "/zones/{zone_id}/access/identity_providers",
+    }),
+  ) as unknown as Schema.Schema<ListIdentityProvidersForZoneRequest>;
 
 export interface ListIdentityProvidersResponse {
   result: (
@@ -90624,13 +93119,13 @@ export const ListIdentityProvidersResponse =
 
 export type ListIdentityProvidersError = DefaultErrors;
 
-export const listIdentityProviders: API.PaginatedOperationMethod<
-  ListIdentityProvidersRequest,
+export const listIdentityProvidersForAccount: API.PaginatedOperationMethod<
+  ListIdentityProvidersForAccountRequest,
   ListIdentityProvidersResponse,
   ListIdentityProvidersError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
-  input: ListIdentityProvidersRequest,
+  input: ListIdentityProvidersForAccountRequest,
   output: ListIdentityProvidersResponse,
   errors: [],
   pagination: {
@@ -90642,11 +93137,98 @@ export const listIdentityProviders: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export interface CreateIdentityProviderRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
+export const listIdentityProvidersForZone: API.PaginatedOperationMethod<
+  ListIdentityProvidersForZoneRequest,
+  ListIdentityProvidersResponse,
+  ListIdentityProvidersError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+  input: ListIdentityProvidersForZoneRequest,
+  output: ListIdentityProvidersResponse,
+  errors: [],
+  pagination: {
+    mode: "page",
+    inputToken: "page",
+    outputToken: "resultInfo.page",
+    items: "result",
+    pageSize: "perPage",
+  } as const,
+}));
+
+export const listIdentityProviders = (
+  input: ListIdentityProvidersRequest,
+): stream.Stream<
+  ListIdentityProvidersResponse,
+  ListIdentityProvidersError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? listIdentityProvidersForAccount.pages(input)
+    : listIdentityProvidersForZone.pages(input);
+
+const CreateIdentityProviderBaseFields = {
+  config: Schema.Struct({
+    claims: Schema.optional(Schema.Array(Schema.String)),
+    clientId: Schema.optional(Schema.String),
+    clientSecret: Schema.optional(SensitiveString),
+    conditionalAccessEnabled: Schema.optional(Schema.Boolean),
+    directoryId: Schema.optional(Schema.String),
+    emailClaimName: Schema.optional(Schema.String),
+    prompt: Schema.optional(
+      Schema.Literals(["login", "select_account", "none"]),
+    ),
+    supportGroups: Schema.optional(Schema.Boolean),
+  }).pipe(
+    Schema.encodeKeys({
+      claims: "claims",
+      clientId: "client_id",
+      clientSecret: "client_secret",
+      conditionalAccessEnabled: "conditional_access_enabled",
+      directoryId: "directory_id",
+      emailClaimName: "email_claim_name",
+      prompt: "prompt",
+      supportGroups: "support_groups",
+    }),
+  ),
+  name: Schema.String,
+  type: Schema.Literals([
+    "onetimepin",
+    "azureAD",
+    "saml",
+    "centrify",
+    "facebook",
+    "github",
+    "google-apps",
+    "google",
+    "linkedin",
+    "oidc",
+    "okta",
+    "onelogin",
+    "pingone",
+    "yandex",
+  ]),
+  scimConfig: Schema.optional(
+    Schema.Struct({
+      enabled: Schema.optional(Schema.Boolean),
+      identityUpdateBehavior: Schema.optional(
+        Schema.Literals(["automatic", "reauth", "no_action"]),
+      ),
+      seatDeprovision: Schema.optional(Schema.Boolean),
+      userDeprovision: Schema.optional(Schema.Boolean),
+    }).pipe(
+      Schema.encodeKeys({
+        enabled: "enabled",
+        identityUpdateBehavior: "identity_update_behavior",
+        seatDeprovision: "seat_deprovision",
+        userDeprovision: "user_deprovision",
+      }),
+    ),
+  ),
+} as const;
+
+export interface CreateIdentityProviderForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   /** Body param: The configuration parameters for the identity provider. To view the required parameters for a specific provider, refer to our [developer documentation](https://developers.cloudflare.com/cl */
   config: {
     claims?: string[];
@@ -90685,67 +93267,55 @@ export interface CreateIdentityProviderRequest {
   };
 }
 
-export const CreateIdentityProviderRequest =
+export interface CreateIdentityProviderForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  /** Body param: The configuration parameters for the identity provider. To view the required parameters for a specific provider, refer to our [developer documentation](https://developers.cloudflare.com/cl */
+  config: {
+    claims?: string[];
+    clientId?: string;
+    clientSecret?: string;
+    conditionalAccessEnabled?: boolean;
+    directoryId?: string;
+    emailClaimName?: string;
+    prompt?: "login" | "select_account" | "none";
+    supportGroups?: boolean;
+  };
+  /** Body param: The name of the identity provider, shown to users on the login page. */
+  name: string;
+  /** Body param: The type of identity provider. To determine the value for a specific provider, refer to our [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integrat */
+  type:
+    | "onetimepin"
+    | "azureAD"
+    | "saml"
+    | "centrify"
+    | "facebook"
+    | "github"
+    | "google-apps"
+    | "google"
+    | "linkedin"
+    | "oidc"
+    | "okta"
+    | "onelogin"
+    | "pingone"
+    | "yandex";
+  /** Body param: The configuration settings for enabling a System for Cross-Domain Identity Management (SCIM) with the identity provider. */
+  scimConfig?: {
+    enabled?: boolean;
+    identityUpdateBehavior?: "automatic" | "reauth" | "no_action";
+    seatDeprovision?: boolean;
+    userDeprovision?: boolean;
+  };
+}
+
+export type CreateIdentityProviderRequest =
+  | CreateIdentityProviderForAccountRequest
+  | CreateIdentityProviderForZoneRequest;
+
+export const CreateIdentityProviderForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    config: Schema.Struct({
-      claims: Schema.optional(Schema.Array(Schema.String)),
-      clientId: Schema.optional(Schema.String),
-      clientSecret: Schema.optional(SensitiveString),
-      conditionalAccessEnabled: Schema.optional(Schema.Boolean),
-      directoryId: Schema.optional(Schema.String),
-      emailClaimName: Schema.optional(Schema.String),
-      prompt: Schema.optional(
-        Schema.Literals(["login", "select_account", "none"]),
-      ),
-      supportGroups: Schema.optional(Schema.Boolean),
-    }).pipe(
-      Schema.encodeKeys({
-        claims: "claims",
-        clientId: "client_id",
-        clientSecret: "client_secret",
-        conditionalAccessEnabled: "conditional_access_enabled",
-        directoryId: "directory_id",
-        emailClaimName: "email_claim_name",
-        prompt: "prompt",
-        supportGroups: "support_groups",
-      }),
-    ),
-    name: Schema.String,
-    type: Schema.Literals([
-      "onetimepin",
-      "azureAD",
-      "saml",
-      "centrify",
-      "facebook",
-      "github",
-      "google-apps",
-      "google",
-      "linkedin",
-      "oidc",
-      "okta",
-      "onelogin",
-      "pingone",
-      "yandex",
-    ]),
-    scimConfig: Schema.optional(
-      Schema.Struct({
-        enabled: Schema.optional(Schema.Boolean),
-        identityUpdateBehavior: Schema.optional(
-          Schema.Literals(["automatic", "reauth", "no_action"]),
-        ),
-        seatDeprovision: Schema.optional(Schema.Boolean),
-        userDeprovision: Schema.optional(Schema.Boolean),
-      }).pipe(
-        Schema.encodeKeys({
-          enabled: "enabled",
-          identityUpdateBehavior: "identity_update_behavior",
-          seatDeprovision: "seat_deprovision",
-          userDeprovision: "user_deprovision",
-        }),
-      ),
-    ),
+    ...CreateIdentityProviderBaseFields,
   }).pipe(
     Schema.encodeKeys({
       config: "config",
@@ -90755,9 +93325,26 @@ export const CreateIdentityProviderRequest =
     }),
     T.Http({
       method: "POST",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/identity_providers",
+      path: "/accounts/{account_id}/access/identity_providers",
     }),
-  ) as unknown as Schema.Schema<CreateIdentityProviderRequest>;
+  ) as unknown as Schema.Schema<CreateIdentityProviderForAccountRequest>;
+
+export const CreateIdentityProviderForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...CreateIdentityProviderBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      config: "config",
+      name: "name",
+      type: "type",
+      scimConfig: "scim_config",
+    }),
+    T.Http({
+      method: "POST",
+      path: "/zones/{zone_id}/access/identity_providers",
+    }),
+  ) as unknown as Schema.Schema<CreateIdentityProviderForZoneRequest>;
 
 export type CreateIdentityProviderResponse =
   | {
@@ -92131,23 +94718,104 @@ export const CreateIdentityProviderResponse =
 
 export type CreateIdentityProviderError = DefaultErrors;
 
-export const createIdentityProvider: API.OperationMethod<
-  CreateIdentityProviderRequest,
+export const createIdentityProviderForAccount: API.OperationMethod<
+  CreateIdentityProviderForAccountRequest,
   CreateIdentityProviderResponse,
   CreateIdentityProviderError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: CreateIdentityProviderRequest,
+  input: CreateIdentityProviderForAccountRequest,
   output: CreateIdentityProviderResponse,
   errors: [],
 }));
 
-export interface UpdateIdentityProviderRequest {
+export const createIdentityProviderForZone: API.OperationMethod<
+  CreateIdentityProviderForZoneRequest,
+  CreateIdentityProviderResponse,
+  CreateIdentityProviderError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: CreateIdentityProviderForZoneRequest,
+  output: CreateIdentityProviderResponse,
+  errors: [],
+}));
+
+export const createIdentityProvider = (
+  input: CreateIdentityProviderRequest,
+): Effect.Effect<
+  CreateIdentityProviderResponse,
+  CreateIdentityProviderError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? createIdentityProviderForAccount(input)
+    : createIdentityProviderForZone(input);
+
+const UpdateIdentityProviderBaseFields = {
+  identityProviderId: Schema.String.pipe(T.HttpPath("identityProviderId")),
+  config: Schema.Struct({
+    claims: Schema.optional(Schema.Array(Schema.String)),
+    clientId: Schema.optional(Schema.String),
+    clientSecret: Schema.optional(SensitiveString),
+    conditionalAccessEnabled: Schema.optional(Schema.Boolean),
+    directoryId: Schema.optional(Schema.String),
+    emailClaimName: Schema.optional(Schema.String),
+    prompt: Schema.optional(
+      Schema.Literals(["login", "select_account", "none"]),
+    ),
+    supportGroups: Schema.optional(Schema.Boolean),
+  }).pipe(
+    Schema.encodeKeys({
+      claims: "claims",
+      clientId: "client_id",
+      clientSecret: "client_secret",
+      conditionalAccessEnabled: "conditional_access_enabled",
+      directoryId: "directory_id",
+      emailClaimName: "email_claim_name",
+      prompt: "prompt",
+      supportGroups: "support_groups",
+    }),
+  ),
+  name: Schema.String,
+  type: Schema.Literals([
+    "onetimepin",
+    "azureAD",
+    "saml",
+    "centrify",
+    "facebook",
+    "github",
+    "google-apps",
+    "google",
+    "linkedin",
+    "oidc",
+    "okta",
+    "onelogin",
+    "pingone",
+    "yandex",
+  ]),
+  scimConfig: Schema.optional(
+    Schema.Struct({
+      enabled: Schema.optional(Schema.Boolean),
+      identityUpdateBehavior: Schema.optional(
+        Schema.Literals(["automatic", "reauth", "no_action"]),
+      ),
+      seatDeprovision: Schema.optional(Schema.Boolean),
+      userDeprovision: Schema.optional(Schema.Boolean),
+    }).pipe(
+      Schema.encodeKeys({
+        enabled: "enabled",
+        identityUpdateBehavior: "identity_update_behavior",
+        seatDeprovision: "seat_deprovision",
+        userDeprovision: "user_deprovision",
+      }),
+    ),
+  ),
+} as const;
+
+export interface UpdateIdentityProviderForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   identityProviderId: string;
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
   /** Body param: The configuration parameters for the identity provider. To view the required parameters for a specific provider, refer to our [developer documentation](https://developers.cloudflare.com/cl */
   config: {
     claims?: string[];
@@ -92186,68 +94854,56 @@ export interface UpdateIdentityProviderRequest {
   };
 }
 
-export const UpdateIdentityProviderRequest =
+export interface UpdateIdentityProviderForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  identityProviderId: string;
+  /** Body param: The configuration parameters for the identity provider. To view the required parameters for a specific provider, refer to our [developer documentation](https://developers.cloudflare.com/cl */
+  config: {
+    claims?: string[];
+    clientId?: string;
+    clientSecret?: string;
+    conditionalAccessEnabled?: boolean;
+    directoryId?: string;
+    emailClaimName?: string;
+    prompt?: "login" | "select_account" | "none";
+    supportGroups?: boolean;
+  };
+  /** Body param: The name of the identity provider, shown to users on the login page. */
+  name: string;
+  /** Body param: The type of identity provider. To determine the value for a specific provider, refer to our [developer documentation](https://developers.cloudflare.com/cloudflare-one/identity/idp-integrat */
+  type:
+    | "onetimepin"
+    | "azureAD"
+    | "saml"
+    | "centrify"
+    | "facebook"
+    | "github"
+    | "google-apps"
+    | "google"
+    | "linkedin"
+    | "oidc"
+    | "okta"
+    | "onelogin"
+    | "pingone"
+    | "yandex";
+  /** Body param: The configuration settings for enabling a System for Cross-Domain Identity Management (SCIM) with the identity provider. */
+  scimConfig?: {
+    enabled?: boolean;
+    identityUpdateBehavior?: "automatic" | "reauth" | "no_action";
+    seatDeprovision?: boolean;
+    userDeprovision?: boolean;
+  };
+}
+
+export type UpdateIdentityProviderRequest =
+  | UpdateIdentityProviderForAccountRequest
+  | UpdateIdentityProviderForZoneRequest;
+
+export const UpdateIdentityProviderForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    identityProviderId: Schema.String.pipe(T.HttpPath("identityProviderId")),
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    config: Schema.Struct({
-      claims: Schema.optional(Schema.Array(Schema.String)),
-      clientId: Schema.optional(Schema.String),
-      clientSecret: Schema.optional(SensitiveString),
-      conditionalAccessEnabled: Schema.optional(Schema.Boolean),
-      directoryId: Schema.optional(Schema.String),
-      emailClaimName: Schema.optional(Schema.String),
-      prompt: Schema.optional(
-        Schema.Literals(["login", "select_account", "none"]),
-      ),
-      supportGroups: Schema.optional(Schema.Boolean),
-    }).pipe(
-      Schema.encodeKeys({
-        claims: "claims",
-        clientId: "client_id",
-        clientSecret: "client_secret",
-        conditionalAccessEnabled: "conditional_access_enabled",
-        directoryId: "directory_id",
-        emailClaimName: "email_claim_name",
-        prompt: "prompt",
-        supportGroups: "support_groups",
-      }),
-    ),
-    name: Schema.String,
-    type: Schema.Literals([
-      "onetimepin",
-      "azureAD",
-      "saml",
-      "centrify",
-      "facebook",
-      "github",
-      "google-apps",
-      "google",
-      "linkedin",
-      "oidc",
-      "okta",
-      "onelogin",
-      "pingone",
-      "yandex",
-    ]),
-    scimConfig: Schema.optional(
-      Schema.Struct({
-        enabled: Schema.optional(Schema.Boolean),
-        identityUpdateBehavior: Schema.optional(
-          Schema.Literals(["automatic", "reauth", "no_action"]),
-        ),
-        seatDeprovision: Schema.optional(Schema.Boolean),
-        userDeprovision: Schema.optional(Schema.Boolean),
-      }).pipe(
-        Schema.encodeKeys({
-          enabled: "enabled",
-          identityUpdateBehavior: "identity_update_behavior",
-          seatDeprovision: "seat_deprovision",
-          userDeprovision: "user_deprovision",
-        }),
-      ),
-    ),
+    ...UpdateIdentityProviderBaseFields,
   }).pipe(
     Schema.encodeKeys({
       config: "config",
@@ -92257,9 +94913,26 @@ export const UpdateIdentityProviderRequest =
     }),
     T.Http({
       method: "PUT",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/identity_providers/{identityProviderId}",
+      path: "/accounts/{account_id}/access/identity_providers/{identityProviderId}",
     }),
-  ) as unknown as Schema.Schema<UpdateIdentityProviderRequest>;
+  ) as unknown as Schema.Schema<UpdateIdentityProviderForAccountRequest>;
+
+export const UpdateIdentityProviderForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...UpdateIdentityProviderBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      config: "config",
+      name: "name",
+      type: "type",
+      scimConfig: "scim_config",
+    }),
+    T.Http({
+      method: "PUT",
+      path: "/zones/{zone_id}/access/identity_providers/{identityProviderId}",
+    }),
+  ) as unknown as Schema.Schema<UpdateIdentityProviderForZoneRequest>;
 
 export type UpdateIdentityProviderResponse =
   | {
@@ -93633,30 +96306,80 @@ export const UpdateIdentityProviderResponse =
 
 export type UpdateIdentityProviderError = DefaultErrors;
 
-export const updateIdentityProvider: API.OperationMethod<
-  UpdateIdentityProviderRequest,
+export const updateIdentityProviderForAccount: API.OperationMethod<
+  UpdateIdentityProviderForAccountRequest,
   UpdateIdentityProviderResponse,
   UpdateIdentityProviderError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: UpdateIdentityProviderRequest,
+  input: UpdateIdentityProviderForAccountRequest,
   output: UpdateIdentityProviderResponse,
   errors: [],
 }));
 
-export interface DeleteIdentityProviderRequest {
+export const updateIdentityProviderForZone: API.OperationMethod<
+  UpdateIdentityProviderForZoneRequest,
+  UpdateIdentityProviderResponse,
+  UpdateIdentityProviderError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: UpdateIdentityProviderForZoneRequest,
+  output: UpdateIdentityProviderResponse,
+  errors: [],
+}));
+
+export const updateIdentityProvider = (
+  input: UpdateIdentityProviderRequest,
+): Effect.Effect<
+  UpdateIdentityProviderResponse,
+  UpdateIdentityProviderError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? updateIdentityProviderForAccount(input)
+    : updateIdentityProviderForZone(input);
+
+const DeleteIdentityProviderBaseFields = {
+  identityProviderId: Schema.String.pipe(T.HttpPath("identityProviderId")),
+} as const;
+
+export interface DeleteIdentityProviderForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   identityProviderId: string;
 }
 
-export const DeleteIdentityProviderRequest =
+export interface DeleteIdentityProviderForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  identityProviderId: string;
+}
+
+export type DeleteIdentityProviderRequest =
+  | DeleteIdentityProviderForAccountRequest
+  | DeleteIdentityProviderForZoneRequest;
+
+export const DeleteIdentityProviderForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
-    identityProviderId: Schema.String.pipe(T.HttpPath("identityProviderId")),
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...DeleteIdentityProviderBaseFields,
   }).pipe(
     T.Http({
       method: "DELETE",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/identity_providers/{identityProviderId}",
+      path: "/accounts/{account_id}/access/identity_providers/{identityProviderId}",
     }),
-  ) as unknown as Schema.Schema<DeleteIdentityProviderRequest>;
+  ) as unknown as Schema.Schema<DeleteIdentityProviderForAccountRequest>;
+
+export const DeleteIdentityProviderForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...DeleteIdentityProviderBaseFields,
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/zones/{zone_id}/access/identity_providers/{identityProviderId}",
+    }),
+  ) as unknown as Schema.Schema<DeleteIdentityProviderForZoneRequest>;
 
 export interface DeleteIdentityProviderResponse {
   /** UUID. */
@@ -93672,16 +96395,38 @@ export const DeleteIdentityProviderResponse =
 
 export type DeleteIdentityProviderError = DefaultErrors;
 
-export const deleteIdentityProvider: API.OperationMethod<
-  DeleteIdentityProviderRequest,
+export const deleteIdentityProviderForAccount: API.OperationMethod<
+  DeleteIdentityProviderForAccountRequest,
   DeleteIdentityProviderResponse,
   DeleteIdentityProviderError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: DeleteIdentityProviderRequest,
+  input: DeleteIdentityProviderForAccountRequest,
   output: DeleteIdentityProviderResponse,
   errors: [],
 }));
+
+export const deleteIdentityProviderForZone: API.OperationMethod<
+  DeleteIdentityProviderForZoneRequest,
+  DeleteIdentityProviderResponse,
+  DeleteIdentityProviderError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: DeleteIdentityProviderForZoneRequest,
+  output: DeleteIdentityProviderResponse,
+  errors: [],
+}));
+
+export const deleteIdentityProvider = (
+  input: DeleteIdentityProviderRequest,
+): Effect.Effect<
+  DeleteIdentityProviderResponse,
+  DeleteIdentityProviderError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? deleteIdentityProviderForAccount(input)
+    : deleteIdentityProviderForZone(input);
 
 // =============================================================================
 // IdentityProviderScimGroup
@@ -95952,15 +98697,40 @@ export const deleteNetworkVirtualNetwork: API.OperationMethod<
 // Organization
 // =============================================================================
 
-export interface ListOrganizationsRequest {}
+const ListOrganizationsBaseFields = {} as const;
 
-export const ListOrganizationsRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
+export interface ListOrganizationsForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+}
+
+export interface ListOrganizationsForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+}
+
+export type ListOrganizationsRequest =
+  | ListOrganizationsForAccountRequest
+  | ListOrganizationsForZoneRequest;
+
+export const ListOrganizationsForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...ListOrganizationsBaseFields,
+  }).pipe(
     T.Http({
       method: "GET",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/organizations",
+      path: "/accounts/{account_id}/access/organizations",
     }),
-  ) as unknown as Schema.Schema<ListOrganizationsRequest>;
+  ) as unknown as Schema.Schema<ListOrganizationsForAccountRequest>;
+
+export const ListOrganizationsForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...ListOrganizationsBaseFields,
+  }).pipe(
+    T.Http({ method: "GET", path: "/zones/{zone_id}/access/organizations" }),
+  ) as unknown as Schema.Schema<ListOrganizationsForZoneRequest>;
 
 export interface ListOrganizationsResponse {
   /** When set to true, users can authenticate via WARP for any application in your organization. Application settings will take precedence over this value. */
@@ -96085,22 +98855,71 @@ export const ListOrganizationsResponse =
 
 export type ListOrganizationsError = DefaultErrors;
 
-export const listOrganizations: API.OperationMethod<
-  ListOrganizationsRequest,
+export const listOrganizationsForAccount: API.OperationMethod<
+  ListOrganizationsForAccountRequest,
   ListOrganizationsResponse,
   ListOrganizationsError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: ListOrganizationsRequest,
+  input: ListOrganizationsForAccountRequest,
   output: ListOrganizationsResponse,
   errors: [],
 }));
 
-export interface CreateOrganizationRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
+export const listOrganizationsForZone: API.OperationMethod<
+  ListOrganizationsForZoneRequest,
+  ListOrganizationsResponse,
+  ListOrganizationsError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: ListOrganizationsForZoneRequest,
+  output: ListOrganizationsResponse,
+  errors: [],
+}));
+
+export const listOrganizations = (
+  input: ListOrganizationsRequest,
+): Effect.Effect<
+  ListOrganizationsResponse,
+  ListOrganizationsError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? listOrganizationsForAccount(input)
+    : listOrganizationsForZone(input);
+
+const CreateOrganizationBaseFields = {
+  authDomain: Schema.String,
+  name: Schema.String,
+  allowAuthenticateViaWarp: Schema.optional(Schema.Boolean),
+  autoRedirectToIdentity: Schema.optional(Schema.Boolean),
+  isUiReadOnly: Schema.optional(Schema.Boolean),
+  loginDesign: Schema.optional(
+    Schema.Struct({
+      backgroundColor: Schema.optional(Schema.String),
+      footerText: Schema.optional(Schema.String),
+      headerText: Schema.optional(Schema.String),
+      logoPath: Schema.optional(Schema.String),
+      textColor: Schema.optional(Schema.String),
+    }).pipe(
+      Schema.encodeKeys({
+        backgroundColor: "background_color",
+        footerText: "footer_text",
+        headerText: "header_text",
+        logoPath: "logo_path",
+        textColor: "text_color",
+      }),
+    ),
+  ),
+  sessionDuration: Schema.optional(Schema.String),
+  uiReadOnlyToggleReason: Schema.optional(Schema.String),
+  userSeatExpirationInactiveTime: Schema.optional(Schema.String),
+  warpAuthSessionDuration: Schema.optional(Schema.String),
+} as const;
+
+export interface CreateOrganizationForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   /** Body param: The unique subdomain assigned to your Zero Trust organization. */
   authDomain: string;
   /** Body param: The name of your Zero Trust organization. */
@@ -96129,36 +98948,45 @@ export interface CreateOrganizationRequest {
   warpAuthSessionDuration?: string;
 }
 
-export const CreateOrganizationRequest =
+export interface CreateOrganizationForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  /** Body param: The unique subdomain assigned to your Zero Trust organization. */
+  authDomain: string;
+  /** Body param: The name of your Zero Trust organization. */
+  name: string;
+  /** Body param: When set to true, users can authenticate via WARP for any application in your organization. Application settings will take precedence over this value. */
+  allowAuthenticateViaWarp?: boolean;
+  /** Body param: When set to `true`, users skip the identity provider selection step during login. */
+  autoRedirectToIdentity?: boolean;
+  /** Body param: Lock all settings as Read-Only in the Dashboard, regardless of user permission. Updates may only be made via the API or Terraform for this account when enabled. */
+  isUiReadOnly?: boolean;
+  /** Body param: */
+  loginDesign?: {
+    backgroundColor?: string;
+    footerText?: string;
+    headerText?: string;
+    logoPath?: string;
+    textColor?: string;
+  };
+  /** Body param: The amount of time that tokens issued for applications will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. */
+  sessionDuration?: string;
+  /** Body param: A description of the reason why the UI read only field is being toggled. */
+  uiReadOnlyToggleReason?: string;
+  /** Body param: The amount of time a user seat is inactive before it expires. When the user seat exceeds the set time of inactivity, the user is removed as an active seat and no longer counts against your */
+  userSeatExpirationInactiveTime?: string;
+  /** Body param: The amount of time that tokens issued for applications will be valid. Must be in the format `30m` or `2h45m`. Valid time units are: m, h. */
+  warpAuthSessionDuration?: string;
+}
+
+export type CreateOrganizationRequest =
+  | CreateOrganizationForAccountRequest
+  | CreateOrganizationForZoneRequest;
+
+export const CreateOrganizationForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    authDomain: Schema.String,
-    name: Schema.String,
-    allowAuthenticateViaWarp: Schema.optional(Schema.Boolean),
-    autoRedirectToIdentity: Schema.optional(Schema.Boolean),
-    isUiReadOnly: Schema.optional(Schema.Boolean),
-    loginDesign: Schema.optional(
-      Schema.Struct({
-        backgroundColor: Schema.optional(Schema.String),
-        footerText: Schema.optional(Schema.String),
-        headerText: Schema.optional(Schema.String),
-        logoPath: Schema.optional(Schema.String),
-        textColor: Schema.optional(Schema.String),
-      }).pipe(
-        Schema.encodeKeys({
-          backgroundColor: "background_color",
-          footerText: "footer_text",
-          headerText: "header_text",
-          logoPath: "logo_path",
-          textColor: "text_color",
-        }),
-      ),
-    ),
-    sessionDuration: Schema.optional(Schema.String),
-    uiReadOnlyToggleReason: Schema.optional(Schema.String),
-    userSeatExpirationInactiveTime: Schema.optional(Schema.String),
-    warpAuthSessionDuration: Schema.optional(Schema.String),
+    ...CreateOrganizationBaseFields,
   }).pipe(
     Schema.encodeKeys({
       authDomain: "auth_domain",
@@ -96174,9 +99002,29 @@ export const CreateOrganizationRequest =
     }),
     T.Http({
       method: "POST",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/organizations",
+      path: "/accounts/{account_id}/access/organizations",
     }),
-  ) as unknown as Schema.Schema<CreateOrganizationRequest>;
+  ) as unknown as Schema.Schema<CreateOrganizationForAccountRequest>;
+
+export const CreateOrganizationForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...CreateOrganizationBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      authDomain: "auth_domain",
+      name: "name",
+      allowAuthenticateViaWarp: "allow_authenticate_via_warp",
+      autoRedirectToIdentity: "auto_redirect_to_identity",
+      isUiReadOnly: "is_ui_read_only",
+      loginDesign: "login_design",
+      sessionDuration: "session_duration",
+      uiReadOnlyToggleReason: "ui_read_only_toggle_reason",
+      userSeatExpirationInactiveTime: "user_seat_expiration_inactive_time",
+      warpAuthSessionDuration: "warp_auth_session_duration",
+    }),
+    T.Http({ method: "POST", path: "/zones/{zone_id}/access/organizations" }),
+  ) as unknown as Schema.Schema<CreateOrganizationForZoneRequest>;
 
 export interface CreateOrganizationResponse {
   /** When set to true, users can authenticate via WARP for any application in your organization. Application settings will take precedence over this value. */
@@ -96301,22 +99149,82 @@ export const CreateOrganizationResponse =
 
 export type CreateOrganizationError = DefaultErrors;
 
-export const createOrganization: API.OperationMethod<
-  CreateOrganizationRequest,
+export const createOrganizationForAccount: API.OperationMethod<
+  CreateOrganizationForAccountRequest,
   CreateOrganizationResponse,
   CreateOrganizationError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: CreateOrganizationRequest,
+  input: CreateOrganizationForAccountRequest,
   output: CreateOrganizationResponse,
   errors: [],
 }));
 
-export interface UpdateOrganizationRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
+export const createOrganizationForZone: API.OperationMethod<
+  CreateOrganizationForZoneRequest,
+  CreateOrganizationResponse,
+  CreateOrganizationError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: CreateOrganizationForZoneRequest,
+  output: CreateOrganizationResponse,
+  errors: [],
+}));
+
+export const createOrganization = (
+  input: CreateOrganizationRequest,
+): Effect.Effect<
+  CreateOrganizationResponse,
+  CreateOrganizationError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? createOrganizationForAccount(input)
+    : createOrganizationForZone(input);
+
+const UpdateOrganizationBaseFields = {
+  allowAuthenticateViaWarp: Schema.optional(Schema.Boolean),
+  authDomain: Schema.optional(Schema.String),
+  autoRedirectToIdentity: Schema.optional(Schema.Boolean),
+  customPages: Schema.optional(
+    Schema.Struct({
+      forbidden: Schema.optional(Schema.String),
+      identityDenied: Schema.optional(Schema.String),
+    }).pipe(
+      Schema.encodeKeys({
+        forbidden: "forbidden",
+        identityDenied: "identity_denied",
+      }),
+    ),
+  ),
+  isUiReadOnly: Schema.optional(Schema.Boolean),
+  loginDesign: Schema.optional(
+    Schema.Struct({
+      backgroundColor: Schema.optional(Schema.String),
+      footerText: Schema.optional(Schema.String),
+      headerText: Schema.optional(Schema.String),
+      logoPath: Schema.optional(Schema.String),
+      textColor: Schema.optional(Schema.String),
+    }).pipe(
+      Schema.encodeKeys({
+        backgroundColor: "background_color",
+        footerText: "footer_text",
+        headerText: "header_text",
+        logoPath: "logo_path",
+        textColor: "text_color",
+      }),
+    ),
+  ),
+  name: Schema.optional(Schema.String),
+  sessionDuration: Schema.optional(Schema.String),
+  uiReadOnlyToggleReason: Schema.optional(Schema.String),
+  userSeatExpirationInactiveTime: Schema.optional(Schema.String),
+  warpAuthSessionDuration: Schema.optional(Schema.String),
+} as const;
+
+export interface UpdateOrganizationForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   /** Body param: When set to true, users can authenticate via WARP for any application in your organization. Application settings will take precedence over this value. */
   allowAuthenticateViaWarp?: boolean;
   /** Body param: The unique subdomain assigned to your Zero Trust organization. */
@@ -96347,47 +99255,47 @@ export interface UpdateOrganizationRequest {
   warpAuthSessionDuration?: string;
 }
 
-export const UpdateOrganizationRequest =
+export interface UpdateOrganizationForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  /** Body param: When set to true, users can authenticate via WARP for any application in your organization. Application settings will take precedence over this value. */
+  allowAuthenticateViaWarp?: boolean;
+  /** Body param: The unique subdomain assigned to your Zero Trust organization. */
+  authDomain?: string;
+  /** Body param: When set to `true`, users skip the identity provider selection step during login. */
+  autoRedirectToIdentity?: boolean;
+  /** Body param: */
+  customPages?: { forbidden?: string; identityDenied?: string };
+  /** Body param: Lock all settings as Read-Only in the Dashboard, regardless of user permission. Updates may only be made via the API or Terraform for this account when enabled. */
+  isUiReadOnly?: boolean;
+  /** Body param: */
+  loginDesign?: {
+    backgroundColor?: string;
+    footerText?: string;
+    headerText?: string;
+    logoPath?: string;
+    textColor?: string;
+  };
+  /** Body param: The name of your Zero Trust organization. */
+  name?: string;
+  /** Body param: The amount of time that tokens issued for applications will be valid. Must be in the format `300ms` or `2h45m`. Valid time units are: ns, us (or µs), ms, s, m, h. */
+  sessionDuration?: string;
+  /** Body param: A description of the reason why the UI read only field is being toggled. */
+  uiReadOnlyToggleReason?: string;
+  /** Body param: The amount of time a user seat is inactive before it expires. When the user seat exceeds the set time of inactivity, the user is removed as an active seat and no longer counts against your */
+  userSeatExpirationInactiveTime?: string;
+  /** Body param: The amount of time that tokens issued for applications will be valid. Must be in the format `30m` or `2h45m`. Valid time units are: m, h. */
+  warpAuthSessionDuration?: string;
+}
+
+export type UpdateOrganizationRequest =
+  | UpdateOrganizationForAccountRequest
+  | UpdateOrganizationForZoneRequest;
+
+export const UpdateOrganizationForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    allowAuthenticateViaWarp: Schema.optional(Schema.Boolean),
-    authDomain: Schema.optional(Schema.String),
-    autoRedirectToIdentity: Schema.optional(Schema.Boolean),
-    customPages: Schema.optional(
-      Schema.Struct({
-        forbidden: Schema.optional(Schema.String),
-        identityDenied: Schema.optional(Schema.String),
-      }).pipe(
-        Schema.encodeKeys({
-          forbidden: "forbidden",
-          identityDenied: "identity_denied",
-        }),
-      ),
-    ),
-    isUiReadOnly: Schema.optional(Schema.Boolean),
-    loginDesign: Schema.optional(
-      Schema.Struct({
-        backgroundColor: Schema.optional(Schema.String),
-        footerText: Schema.optional(Schema.String),
-        headerText: Schema.optional(Schema.String),
-        logoPath: Schema.optional(Schema.String),
-        textColor: Schema.optional(Schema.String),
-      }).pipe(
-        Schema.encodeKeys({
-          backgroundColor: "background_color",
-          footerText: "footer_text",
-          headerText: "header_text",
-          logoPath: "logo_path",
-          textColor: "text_color",
-        }),
-      ),
-    ),
-    name: Schema.optional(Schema.String),
-    sessionDuration: Schema.optional(Schema.String),
-    uiReadOnlyToggleReason: Schema.optional(Schema.String),
-    userSeatExpirationInactiveTime: Schema.optional(Schema.String),
-    warpAuthSessionDuration: Schema.optional(Schema.String),
+    ...UpdateOrganizationBaseFields,
   }).pipe(
     Schema.encodeKeys({
       allowAuthenticateViaWarp: "allow_authenticate_via_warp",
@@ -96404,9 +99312,30 @@ export const UpdateOrganizationRequest =
     }),
     T.Http({
       method: "PUT",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/organizations",
+      path: "/accounts/{account_id}/access/organizations",
     }),
-  ) as unknown as Schema.Schema<UpdateOrganizationRequest>;
+  ) as unknown as Schema.Schema<UpdateOrganizationForAccountRequest>;
+
+export const UpdateOrganizationForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...UpdateOrganizationBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      allowAuthenticateViaWarp: "allow_authenticate_via_warp",
+      authDomain: "auth_domain",
+      autoRedirectToIdentity: "auto_redirect_to_identity",
+      customPages: "custom_pages",
+      isUiReadOnly: "is_ui_read_only",
+      loginDesign: "login_design",
+      name: "name",
+      sessionDuration: "session_duration",
+      uiReadOnlyToggleReason: "ui_read_only_toggle_reason",
+      userSeatExpirationInactiveTime: "user_seat_expiration_inactive_time",
+      warpAuthSessionDuration: "warp_auth_session_duration",
+    }),
+    T.Http({ method: "PUT", path: "/zones/{zone_id}/access/organizations" }),
+  ) as unknown as Schema.Schema<UpdateOrganizationForZoneRequest>;
 
 export interface UpdateOrganizationResponse {
   /** When set to true, users can authenticate via WARP for any application in your organization. Application settings will take precedence over this value. */
@@ -96531,16 +99460,38 @@ export const UpdateOrganizationResponse =
 
 export type UpdateOrganizationError = DefaultErrors;
 
-export const updateOrganization: API.OperationMethod<
-  UpdateOrganizationRequest,
+export const updateOrganizationForAccount: API.OperationMethod<
+  UpdateOrganizationForAccountRequest,
   UpdateOrganizationResponse,
   UpdateOrganizationError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: UpdateOrganizationRequest,
+  input: UpdateOrganizationForAccountRequest,
   output: UpdateOrganizationResponse,
   errors: [],
 }));
+
+export const updateOrganizationForZone: API.OperationMethod<
+  UpdateOrganizationForZoneRequest,
+  UpdateOrganizationResponse,
+  UpdateOrganizationError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: UpdateOrganizationForZoneRequest,
+  output: UpdateOrganizationResponse,
+  errors: [],
+}));
+
+export const updateOrganization = (
+  input: UpdateOrganizationRequest,
+): Effect.Effect<
+  UpdateOrganizationResponse,
+  UpdateOrganizationError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? updateOrganizationForAccount(input)
+    : updateOrganizationForZone(input);
 
 // =============================================================================
 // OrganizationDoh
@@ -98570,15 +101521,47 @@ export const overTimeDexFleetStatus: API.OperationMethod<
 // TokensAccessApplication
 // =============================================================================
 
-export interface RevokeTokensAccessApplicationRequest {}
+const RevokeTokensAccessApplicationBaseFields = {
+  appId: Schema.String.pipe(T.HttpPath("appId")),
+} as const;
 
-export const RevokeTokensAccessApplicationRequest =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({}).pipe(
+export interface RevokeTokensAccessApplicationForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
+  appId: string;
+}
+
+export interface RevokeTokensAccessApplicationForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  appId: string;
+}
+
+export type RevokeTokensAccessApplicationRequest =
+  | RevokeTokensAccessApplicationForAccountRequest
+  | RevokeTokensAccessApplicationForZoneRequest;
+
+export const RevokeTokensAccessApplicationForAccountRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    ...RevokeTokensAccessApplicationBaseFields,
+  }).pipe(
     T.Http({
       method: "POST",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/apps/{appId}/revoke_tokens",
+      path: "/accounts/{account_id}/access/apps/{appId}/revoke_tokens",
     }),
-  ) as unknown as Schema.Schema<RevokeTokensAccessApplicationRequest>;
+  ) as unknown as Schema.Schema<RevokeTokensAccessApplicationForAccountRequest>;
+
+export const RevokeTokensAccessApplicationForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...RevokeTokensAccessApplicationBaseFields,
+  }).pipe(
+    T.Http({
+      method: "POST",
+      path: "/zones/{zone_id}/access/apps/{appId}/revoke_tokens",
+    }),
+  ) as unknown as Schema.Schema<RevokeTokensAccessApplicationForZoneRequest>;
 
 export type RevokeTokensAccessApplicationResponse = unknown;
 
@@ -98589,16 +101572,38 @@ export const RevokeTokensAccessApplicationResponse =
 
 export type RevokeTokensAccessApplicationError = DefaultErrors;
 
-export const revokeTokensAccessApplication: API.OperationMethod<
-  RevokeTokensAccessApplicationRequest,
+export const revokeTokensAccessApplicationForAccount: API.OperationMethod<
+  RevokeTokensAccessApplicationForAccountRequest,
   RevokeTokensAccessApplicationResponse,
   RevokeTokensAccessApplicationError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: RevokeTokensAccessApplicationRequest,
+  input: RevokeTokensAccessApplicationForAccountRequest,
   output: RevokeTokensAccessApplicationResponse,
   errors: [],
 }));
+
+export const revokeTokensAccessApplicationForZone: API.OperationMethod<
+  RevokeTokensAccessApplicationForZoneRequest,
+  RevokeTokensAccessApplicationResponse,
+  RevokeTokensAccessApplicationError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: RevokeTokensAccessApplicationForZoneRequest,
+  output: RevokeTokensAccessApplicationResponse,
+  errors: [],
+}));
+
+export const revokeTokensAccessApplication = (
+  input: RevokeTokensAccessApplicationRequest,
+): Effect.Effect<
+  RevokeTokensAccessApplicationResponse,
+  RevokeTokensAccessApplicationError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? revokeTokensAccessApplicationForAccount(input)
+    : revokeTokensAccessApplicationForZone(input);
 
 // =============================================================================
 // Tunnel
@@ -101937,11 +104942,19 @@ export const getTunnelWarpConnectorToken: API.OperationMethod<
 // UsersOrganization
 // =============================================================================
 
-export interface RevokeUsersOrganizationRequest {
-  /** Path param: The Account ID to use for this endpoint. Mutually exclusive with the Zone ID. */
-  accountId?: string;
-  /** Path param: The Zone ID to use for this endpoint. Mutually exclusive with the Account ID. */
-  zoneId?: string;
+const RevokeUsersOrganizationBaseFields = {
+  queryDevices: Schema.optional(Schema.Boolean).pipe(
+    T.HttpQuery("query_devices"),
+  ),
+  email: Schema.String,
+  bodyDevices: Schema.optional(Schema.Boolean),
+  userUid: Schema.optional(Schema.String),
+  warpSessionReauth: Schema.optional(Schema.Boolean),
+} as const;
+
+export interface RevokeUsersOrganizationForAccountRequest {
+  /** Path param: The Account ID to use for this endpoint. */
+  accountId: string;
   /** Query param: When set to `true`, all devices associated with the user will be revoked. */
   queryDevices?: boolean;
   /** Body param: The email of the user to revoke. */
@@ -101954,17 +104967,29 @@ export interface RevokeUsersOrganizationRequest {
   warpSessionReauth?: boolean;
 }
 
-export const RevokeUsersOrganizationRequest =
+export interface RevokeUsersOrganizationForZoneRequest {
+  /** Path param: The Zone ID to use for this endpoint. */
+  zoneId: string;
+  /** Query param: When set to `true`, all devices associated with the user will be revoked. */
+  queryDevices?: boolean;
+  /** Body param: The email of the user to revoke. */
+  email: string;
+  /** Body param: When set to `true`, all devices associated with the user will be revoked. */
+  bodyDevices?: boolean;
+  /** Body param: The uuid of the user to revoke. */
+  userUid?: string;
+  /** Body param: When set to `true`, the user will be required to re-authenticate to WARP for all Gateway policies that enforce a WARP client session duration. When `false`, the user’s WARP session will re */
+  warpSessionReauth?: boolean;
+}
+
+export type RevokeUsersOrganizationRequest =
+  | RevokeUsersOrganizationForAccountRequest
+  | RevokeUsersOrganizationForZoneRequest;
+
+export const RevokeUsersOrganizationForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
-    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
-    queryDevices: Schema.optional(Schema.Boolean).pipe(
-      T.HttpQuery("query_devices"),
-    ),
-    email: Schema.String,
-    bodyDevices: Schema.optional(Schema.Boolean),
-    userUid: Schema.optional(Schema.String),
-    warpSessionReauth: Schema.optional(Schema.Boolean),
+    ...RevokeUsersOrganizationBaseFields,
   }).pipe(
     Schema.encodeKeys({
       email: "email",
@@ -101974,9 +104999,26 @@ export const RevokeUsersOrganizationRequest =
     }),
     T.Http({
       method: "POST",
-      path: "/{accountOrZone}/{accountOrZoneId}/access/organizations/revoke_user",
+      path: "/accounts/{account_id}/access/organizations/revoke_user",
     }),
-  ) as unknown as Schema.Schema<RevokeUsersOrganizationRequest>;
+  ) as unknown as Schema.Schema<RevokeUsersOrganizationForAccountRequest>;
+
+export const RevokeUsersOrganizationForZoneRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    ...RevokeUsersOrganizationBaseFields,
+  }).pipe(
+    Schema.encodeKeys({
+      email: "email",
+      bodyDevices: "body_devices",
+      userUid: "user_uid",
+      warpSessionReauth: "warp_session_reauth",
+    }),
+    T.Http({
+      method: "POST",
+      path: "/zones/{zone_id}/access/organizations/revoke_user",
+    }),
+  ) as unknown as Schema.Schema<RevokeUsersOrganizationForZoneRequest>;
 
 export type RevokeUsersOrganizationResponse = true | false;
 
@@ -101987,16 +105029,38 @@ export const RevokeUsersOrganizationResponse =
 
 export type RevokeUsersOrganizationError = DefaultErrors;
 
-export const revokeUsersOrganization: API.OperationMethod<
-  RevokeUsersOrganizationRequest,
+export const revokeUsersOrganizationForAccount: API.OperationMethod<
+  RevokeUsersOrganizationForAccountRequest,
   RevokeUsersOrganizationResponse,
   RevokeUsersOrganizationError,
   Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  input: RevokeUsersOrganizationRequest,
+  input: RevokeUsersOrganizationForAccountRequest,
   output: RevokeUsersOrganizationResponse,
   errors: [],
 }));
+
+export const revokeUsersOrganizationForZone: API.OperationMethod<
+  RevokeUsersOrganizationForZoneRequest,
+  RevokeUsersOrganizationResponse,
+  RevokeUsersOrganizationError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: RevokeUsersOrganizationForZoneRequest,
+  output: RevokeUsersOrganizationResponse,
+  errors: [],
+}));
+
+export const revokeUsersOrganization = (
+  input: RevokeUsersOrganizationRequest,
+): Effect.Effect<
+  RevokeUsersOrganizationResponse,
+  RevokeUsersOrganizationError,
+  Credentials | HttpClient.HttpClient
+> =>
+  "accountId" in input
+    ? revokeUsersOrganizationForAccount(input)
+    : revokeUsersOrganizationForZone(input);
 
 // =============================================================================
 // V2AccessInfrastructureTarget

--- a/packages/cloudflare/src/services/zero-trust.ts
+++ b/packages/cloudflare/src/services/zero-trust.ts
@@ -5,8 +5,6 @@
  * DO NOT EDIT - regenerate with: bun scripts/generate.ts --service zero-trust
  */
 
-import * as Effect from "effect/Effect";
-import * as stream from "effect/Stream";
 import * as Schema from "effect/Schema";
 import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
@@ -1193,10 +1191,6 @@ export interface GetAccessApplicationForZoneRequest extends GetAccessApplication
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type GetAccessApplicationRequest =
-  | GetAccessApplicationForAccountRequest
-  | GetAccessApplicationForZoneRequest;
 
 export const GetAccessApplicationForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -8887,17 +8881,6 @@ export const getAccessApplicationForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const getAccessApplication = (
-  input: GetAccessApplicationRequest,
-): Effect.Effect<
-  GetAccessApplicationResponse,
-  GetAccessApplicationError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? getAccessApplicationForAccount(input)
-    : getAccessApplicationForZone(input);
-
 const ListAccessApplicationsBaseFields = {} as const;
 
 interface ListAccessApplicationsBaseRequest {}
@@ -8911,10 +8894,6 @@ export interface ListAccessApplicationsForZoneRequest extends ListAccessApplicat
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type ListAccessApplicationsRequest =
-  | ListAccessApplicationsForAccountRequest
-  | ListAccessApplicationsForZoneRequest;
 
 export const ListAccessApplicationsForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -16970,17 +16949,6 @@ export const listAccessApplicationsForZone: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export const listAccessApplications = (
-  input: ListAccessApplicationsRequest,
-): stream.Stream<
-  ListAccessApplicationsResponse,
-  ListAccessApplicationsError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? listAccessApplicationsForAccount.pages(input)
-    : listAccessApplicationsForZone.pages(input);
-
 const CreateAccessApplicationBaseFields = {
   domain: Schema.String,
   type: Schema.Literals([
@@ -17442,10 +17410,6 @@ export interface CreateAccessApplicationForZoneRequest extends CreateAccessAppli
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type CreateAccessApplicationRequest =
-  | CreateAccessApplicationForAccountRequest
-  | CreateAccessApplicationForZoneRequest;
 
 export const CreateAccessApplicationForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -25193,17 +25157,6 @@ export const createAccessApplicationForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const createAccessApplication = (
-  input: CreateAccessApplicationRequest,
-): Effect.Effect<
-  CreateAccessApplicationResponse,
-  CreateAccessApplicationError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? createAccessApplicationForAccount(input)
-    : createAccessApplicationForZone(input);
-
 const UpdateAccessApplicationBaseFields = {
   appId: Schema.String.pipe(T.HttpPath("appId")),
   domain: Schema.String,
@@ -25667,10 +25620,6 @@ export interface UpdateAccessApplicationForZoneRequest extends UpdateAccessAppli
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type UpdateAccessApplicationRequest =
-  | UpdateAccessApplicationForAccountRequest
-  | UpdateAccessApplicationForZoneRequest;
 
 export const UpdateAccessApplicationForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -33421,17 +33370,6 @@ export const updateAccessApplicationForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const updateAccessApplication = (
-  input: UpdateAccessApplicationRequest,
-): Effect.Effect<
-  UpdateAccessApplicationResponse,
-  UpdateAccessApplicationError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? updateAccessApplicationForAccount(input)
-    : updateAccessApplicationForZone(input);
-
 const DeleteAccessApplicationBaseFields = {
   appId: Schema.String.pipe(T.HttpPath("appId")),
 } as const;
@@ -33449,10 +33387,6 @@ export interface DeleteAccessApplicationForZoneRequest extends DeleteAccessAppli
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type DeleteAccessApplicationRequest =
-  | DeleteAccessApplicationForAccountRequest
-  | DeleteAccessApplicationForZoneRequest;
 
 export const DeleteAccessApplicationForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -33509,17 +33443,6 @@ export const deleteAccessApplicationForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const deleteAccessApplication = (
-  input: DeleteAccessApplicationRequest,
-): Effect.Effect<
-  DeleteAccessApplicationResponse,
-  DeleteAccessApplicationError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? deleteAccessApplicationForAccount(input)
-    : deleteAccessApplicationForZone(input);
-
 // =============================================================================
 // AccessApplicationCa
 // =============================================================================
@@ -33541,10 +33464,6 @@ export interface GetAccessApplicationCaForZoneRequest extends GetAccessApplicati
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type GetAccessApplicationCaRequest =
-  | GetAccessApplicationCaForAccountRequest
-  | GetAccessApplicationCaForZoneRequest;
 
 export const GetAccessApplicationCaForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -33609,17 +33528,6 @@ export const getAccessApplicationCaForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const getAccessApplicationCa = (
-  input: GetAccessApplicationCaRequest,
-): Effect.Effect<
-  GetAccessApplicationCaResponse,
-  GetAccessApplicationCaError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? getAccessApplicationCaForAccount(input)
-    : getAccessApplicationCaForZone(input);
-
 const ListAccessApplicationCasBaseFields = {} as const;
 
 interface ListAccessApplicationCasBaseRequest {}
@@ -33633,10 +33541,6 @@ export interface ListAccessApplicationCasForZoneRequest extends ListAccessApplic
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type ListAccessApplicationCasRequest =
-  | ListAccessApplicationCasForAccountRequest
-  | ListAccessApplicationCasForZoneRequest;
 
 export const ListAccessApplicationCasForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -33741,17 +33645,6 @@ export const listAccessApplicationCasForZone: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export const listAccessApplicationCas = (
-  input: ListAccessApplicationCasRequest,
-): stream.Stream<
-  ListAccessApplicationCasResponse,
-  ListAccessApplicationCasError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? listAccessApplicationCasForAccount.pages(input)
-    : listAccessApplicationCasForZone.pages(input);
-
 const CreateAccessApplicationCaBaseFields = {
   appId: Schema.String.pipe(T.HttpPath("appId")),
 } as const;
@@ -33769,10 +33662,6 @@ export interface CreateAccessApplicationCaForZoneRequest extends CreateAccessApp
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type CreateAccessApplicationCaRequest =
-  | CreateAccessApplicationCaForAccountRequest
-  | CreateAccessApplicationCaForZoneRequest;
 
 export const CreateAccessApplicationCaForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -33837,17 +33726,6 @@ export const createAccessApplicationCaForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const createAccessApplicationCa = (
-  input: CreateAccessApplicationCaRequest,
-): Effect.Effect<
-  CreateAccessApplicationCaResponse,
-  CreateAccessApplicationCaError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? createAccessApplicationCaForAccount(input)
-    : createAccessApplicationCaForZone(input);
-
 const DeleteAccessApplicationCaBaseFields = {
   appId: Schema.String.pipe(T.HttpPath("appId")),
 } as const;
@@ -33865,10 +33743,6 @@ export interface DeleteAccessApplicationCaForZoneRequest extends DeleteAccessApp
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type DeleteAccessApplicationCaRequest =
-  | DeleteAccessApplicationCaForAccountRequest
-  | DeleteAccessApplicationCaForZoneRequest;
 
 export const DeleteAccessApplicationCaForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -33928,17 +33802,6 @@ export const deleteAccessApplicationCaForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const deleteAccessApplicationCa = (
-  input: DeleteAccessApplicationCaRequest,
-): Effect.Effect<
-  DeleteAccessApplicationCaResponse,
-  DeleteAccessApplicationCaError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? deleteAccessApplicationCaForAccount(input)
-    : deleteAccessApplicationCaForZone(input);
-
 // =============================================================================
 // AccessApplicationPolicy
 // =============================================================================
@@ -33962,10 +33825,6 @@ export interface GetAccessApplicationPolicyForZoneRequest extends GetAccessAppli
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type GetAccessApplicationPolicyRequest =
-  | GetAccessApplicationPolicyForAccountRequest
-  | GetAccessApplicationPolicyForZoneRequest;
 
 export const GetAccessApplicationPolicyForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -34844,17 +34703,6 @@ export const getAccessApplicationPolicyForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const getAccessApplicationPolicy = (
-  input: GetAccessApplicationPolicyRequest,
-): Effect.Effect<
-  GetAccessApplicationPolicyResponse,
-  GetAccessApplicationPolicyError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? getAccessApplicationPolicyForAccount(input)
-    : getAccessApplicationPolicyForZone(input);
-
 const ListAccessApplicationPoliciesBaseFields = {
   appId: Schema.String.pipe(T.HttpPath("appId")),
 } as const;
@@ -34872,10 +34720,6 @@ export interface ListAccessApplicationPoliciesForZoneRequest extends ListAccessA
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type ListAccessApplicationPoliciesRequest =
-  | ListAccessApplicationPoliciesForAccountRequest
-  | ListAccessApplicationPoliciesForZoneRequest;
 
 export const ListAccessApplicationPoliciesForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -35809,17 +35653,6 @@ export const listAccessApplicationPoliciesForZone: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export const listAccessApplicationPolicies = (
-  input: ListAccessApplicationPoliciesRequest,
-): stream.Stream<
-  ListAccessApplicationPoliciesResponse,
-  ListAccessApplicationPoliciesError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? listAccessApplicationPoliciesForAccount.pages(input)
-    : listAccessApplicationPoliciesForZone.pages(input);
-
 const CreateAccessApplicationPolicyBaseFields = {
   appId: Schema.String.pipe(T.HttpPath("appId")),
   approvalGroups: Schema.optional(
@@ -35876,10 +35709,6 @@ export interface CreateAccessApplicationPolicyForZoneRequest extends CreateAcces
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type CreateAccessApplicationPolicyRequest =
-  | CreateAccessApplicationPolicyForAccountRequest
-  | CreateAccessApplicationPolicyForZoneRequest;
 
 export const CreateAccessApplicationPolicyForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -36776,17 +36605,6 @@ export const createAccessApplicationPolicyForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const createAccessApplicationPolicy = (
-  input: CreateAccessApplicationPolicyRequest,
-): Effect.Effect<
-  CreateAccessApplicationPolicyResponse,
-  CreateAccessApplicationPolicyError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? createAccessApplicationPolicyForAccount(input)
-    : createAccessApplicationPolicyForZone(input);
-
 const UpdateAccessApplicationPolicyBaseFields = {
   appId: Schema.String.pipe(T.HttpPath("appId")),
   policyId: Schema.String.pipe(T.HttpPath("policyId")),
@@ -36845,10 +36663,6 @@ export interface UpdateAccessApplicationPolicyForZoneRequest extends UpdateAcces
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type UpdateAccessApplicationPolicyRequest =
-  | UpdateAccessApplicationPolicyForAccountRequest
-  | UpdateAccessApplicationPolicyForZoneRequest;
 
 export const UpdateAccessApplicationPolicyForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -37745,17 +37559,6 @@ export const updateAccessApplicationPolicyForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const updateAccessApplicationPolicy = (
-  input: UpdateAccessApplicationPolicyRequest,
-): Effect.Effect<
-  UpdateAccessApplicationPolicyResponse,
-  UpdateAccessApplicationPolicyError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? updateAccessApplicationPolicyForAccount(input)
-    : updateAccessApplicationPolicyForZone(input);
-
 const DeleteAccessApplicationPolicyBaseFields = {
   appId: Schema.String.pipe(T.HttpPath("appId")),
   policyId: Schema.String.pipe(T.HttpPath("policyId")),
@@ -37775,10 +37578,6 @@ export interface DeleteAccessApplicationPolicyForZoneRequest extends DeleteAcces
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type DeleteAccessApplicationPolicyRequest =
-  | DeleteAccessApplicationPolicyForAccountRequest
-  | DeleteAccessApplicationPolicyForZoneRequest;
 
 export const DeleteAccessApplicationPolicyForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -37837,17 +37636,6 @@ export const deleteAccessApplicationPolicyForZone: API.OperationMethod<
   output: DeleteAccessApplicationPolicyResponse,
   errors: [],
 }));
-
-export const deleteAccessApplicationPolicy = (
-  input: DeleteAccessApplicationPolicyRequest,
-): Effect.Effect<
-  DeleteAccessApplicationPolicyResponse,
-  DeleteAccessApplicationPolicyError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? deleteAccessApplicationPolicyForAccount(input)
-    : deleteAccessApplicationPolicyForZone(input);
 
 // =============================================================================
 // AccessApplicationPolicyTest
@@ -38919,10 +38707,6 @@ export interface PutAccessApplicationSettingForZoneRequest extends PutAccessAppl
   zoneId: string;
 }
 
-export type PutAccessApplicationSettingRequest =
-  | PutAccessApplicationSettingForAccountRequest
-  | PutAccessApplicationSettingForZoneRequest;
-
 export const PutAccessApplicationSettingForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
@@ -39001,17 +38785,6 @@ export const putAccessApplicationSettingForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const putAccessApplicationSetting = (
-  input: PutAccessApplicationSettingRequest,
-): Effect.Effect<
-  PutAccessApplicationSettingResponse,
-  PutAccessApplicationSettingError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? putAccessApplicationSettingForAccount(input)
-    : putAccessApplicationSettingForZone(input);
-
 const PatchAccessApplicationSettingBaseFields = {
   appId: Schema.String.pipe(T.HttpPath("appId")),
   allowIframe: Schema.optional(Schema.Boolean),
@@ -39035,10 +38808,6 @@ export interface PatchAccessApplicationSettingForZoneRequest extends PatchAccess
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type PatchAccessApplicationSettingRequest =
-  | PatchAccessApplicationSettingForAccountRequest
-  | PatchAccessApplicationSettingForZoneRequest;
 
 export const PatchAccessApplicationSettingForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -39118,17 +38887,6 @@ export const patchAccessApplicationSettingForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const patchAccessApplicationSetting = (
-  input: PatchAccessApplicationSettingRequest,
-): Effect.Effect<
-  PatchAccessApplicationSettingResponse,
-  PatchAccessApplicationSettingError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? patchAccessApplicationSettingForAccount(input)
-    : patchAccessApplicationSettingForZone(input);
-
 // =============================================================================
 // AccessApplicationUserPolicyCheck
 // =============================================================================
@@ -39150,10 +38908,6 @@ export interface ListAccessApplicationUserPolicyChecksForZoneRequest extends Lis
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type ListAccessApplicationUserPolicyChecksRequest =
-  | ListAccessApplicationUserPolicyChecksForAccountRequest
-  | ListAccessApplicationUserPolicyChecksForZoneRequest;
 
 export const ListAccessApplicationUserPolicyChecksForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -39308,17 +39062,6 @@ export const listAccessApplicationUserPolicyChecksForZone: API.OperationMethod<
   output: ListAccessApplicationUserPolicyChecksResponse,
   errors: [],
 }));
-
-export const listAccessApplicationUserPolicyChecks = (
-  input: ListAccessApplicationUserPolicyChecksRequest,
-): Effect.Effect<
-  ListAccessApplicationUserPolicyChecksResponse,
-  ListAccessApplicationUserPolicyChecksError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? listAccessApplicationUserPolicyChecksForAccount(input)
-    : listAccessApplicationUserPolicyChecksForZone(input);
 
 // =============================================================================
 // AccessBookmark
@@ -39651,10 +39394,6 @@ export interface GetAccessCertificateForZoneRequest extends GetAccessCertificate
   zoneId: string;
 }
 
-export type GetAccessCertificateRequest =
-  | GetAccessCertificateForAccountRequest
-  | GetAccessCertificateForZoneRequest;
-
 export const GetAccessCertificateForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
@@ -39736,17 +39475,6 @@ export const getAccessCertificateForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const getAccessCertificate = (
-  input: GetAccessCertificateRequest,
-): Effect.Effect<
-  GetAccessCertificateResponse,
-  GetAccessCertificateError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? getAccessCertificateForAccount(input)
-    : getAccessCertificateForZone(input);
-
 const ListAccessCertificatesBaseFields = {} as const;
 
 interface ListAccessCertificatesBaseRequest {}
@@ -39760,10 +39488,6 @@ export interface ListAccessCertificatesForZoneRequest extends ListAccessCertific
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type ListAccessCertificatesRequest =
-  | ListAccessCertificatesForAccountRequest
-  | ListAccessCertificatesForZoneRequest;
 
 export const ListAccessCertificatesForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -39885,17 +39609,6 @@ export const listAccessCertificatesForZone: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export const listAccessCertificates = (
-  input: ListAccessCertificatesRequest,
-): stream.Stream<
-  ListAccessCertificatesResponse,
-  ListAccessCertificatesError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? listAccessCertificatesForAccount.pages(input)
-    : listAccessCertificatesForZone.pages(input);
-
 const CreateAccessCertificateBaseFields = {
   certificate: Schema.String,
   name: Schema.String,
@@ -39920,10 +39633,6 @@ export interface CreateAccessCertificateForZoneRequest extends CreateAccessCerti
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type CreateAccessCertificateRequest =
-  | CreateAccessCertificateForAccountRequest
-  | CreateAccessCertificateForZoneRequest;
 
 export const CreateAccessCertificateForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -40013,17 +39722,6 @@ export const createAccessCertificateForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const createAccessCertificate = (
-  input: CreateAccessCertificateRequest,
-): Effect.Effect<
-  CreateAccessCertificateResponse,
-  CreateAccessCertificateError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? createAccessCertificateForAccount(input)
-    : createAccessCertificateForZone(input);
-
 const UpdateAccessCertificateBaseFields = {
   certificateId: Schema.String.pipe(T.HttpPath("certificateId")),
   associatedHostnames: Schema.Array(Schema.String),
@@ -40047,10 +39745,6 @@ export interface UpdateAccessCertificateForZoneRequest extends UpdateAccessCerti
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type UpdateAccessCertificateRequest =
-  | UpdateAccessCertificateForAccountRequest
-  | UpdateAccessCertificateForZoneRequest;
 
 export const UpdateAccessCertificateForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -40141,17 +39835,6 @@ export const updateAccessCertificateForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const updateAccessCertificate = (
-  input: UpdateAccessCertificateRequest,
-): Effect.Effect<
-  UpdateAccessCertificateResponse,
-  UpdateAccessCertificateError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? updateAccessCertificateForAccount(input)
-    : updateAccessCertificateForZone(input);
-
 const DeleteAccessCertificateBaseFields = {
   certificateId: Schema.String.pipe(T.HttpPath("certificateId")),
 } as const;
@@ -40169,10 +39852,6 @@ export interface DeleteAccessCertificateForZoneRequest extends DeleteAccessCerti
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type DeleteAccessCertificateRequest =
-  | DeleteAccessCertificateForAccountRequest
-  | DeleteAccessCertificateForZoneRequest;
 
 export const DeleteAccessCertificateForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -40232,17 +39911,6 @@ export const deleteAccessCertificateForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const deleteAccessCertificate = (
-  input: DeleteAccessCertificateRequest,
-): Effect.Effect<
-  DeleteAccessCertificateResponse,
-  DeleteAccessCertificateError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? deleteAccessCertificateForAccount(input)
-    : deleteAccessCertificateForZone(input);
-
 // =============================================================================
 // AccessCertificateSetting
 // =============================================================================
@@ -40260,10 +39928,6 @@ export interface GetAccessCertificateSettingForZoneRequest extends GetAccessCert
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type GetAccessCertificateSettingRequest =
-  | GetAccessCertificateSettingForAccountRequest
-  | GetAccessCertificateSettingForZoneRequest;
 
 export const GetAccessCertificateSettingForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -40344,17 +40008,6 @@ export const getAccessCertificateSettingForZone: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export const getAccessCertificateSetting = (
-  input: GetAccessCertificateSettingRequest,
-): stream.Stream<
-  GetAccessCertificateSettingResponse,
-  GetAccessCertificateSettingError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? getAccessCertificateSettingForAccount.pages(input)
-    : getAccessCertificateSettingForZone.pages(input);
-
 const PutAccessCertificateSettingBaseFields = {
   settings: Schema.Array(
     Schema.Struct({
@@ -40389,10 +40042,6 @@ export interface PutAccessCertificateSettingForZoneRequest extends PutAccessCert
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type PutAccessCertificateSettingRequest =
-  | PutAccessCertificateSettingForAccountRequest
-  | PutAccessCertificateSettingForZoneRequest;
 
 export const PutAccessCertificateSettingForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -40472,17 +40121,6 @@ export const putAccessCertificateSettingForZone: API.PaginatedOperationMethod<
     items: "result",
   } as const,
 }));
-
-export const putAccessCertificateSetting = (
-  input: PutAccessCertificateSettingRequest,
-): stream.Stream<
-  PutAccessCertificateSettingResponse,
-  PutAccessCertificateSettingError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? putAccessCertificateSettingForAccount.pages(input)
-    : putAccessCertificateSettingForZone.pages(input);
 
 // =============================================================================
 // AccessCustomPage
@@ -40953,10 +40591,6 @@ export interface GetAccessGroupForZoneRequest extends GetAccessGroupBaseRequest 
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type GetAccessGroupRequest =
-  | GetAccessGroupForAccountRequest
-  | GetAccessGroupForZoneRequest;
 
 export const GetAccessGroupForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -41996,17 +41630,6 @@ export const getAccessGroupForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const getAccessGroup = (
-  input: GetAccessGroupRequest,
-): Effect.Effect<
-  GetAccessGroupResponse,
-  GetAccessGroupError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? getAccessGroupForAccount(input)
-    : getAccessGroupForZone(input);
-
 const ListAccessGroupsBaseFields = {} as const;
 
 interface ListAccessGroupsBaseRequest {}
@@ -42020,10 +41643,6 @@ export interface ListAccessGroupsForZoneRequest extends ListAccessGroupsBaseRequ
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type ListAccessGroupsRequest =
-  | ListAccessGroupsForAccountRequest
-  | ListAccessGroupsForZoneRequest;
 
 export const ListAccessGroupsForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -43129,17 +42748,6 @@ export const listAccessGroupsForZone: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export const listAccessGroups = (
-  input: ListAccessGroupsRequest,
-): stream.Stream<
-  ListAccessGroupsResponse,
-  ListAccessGroupsError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? listAccessGroupsForAccount.pages(input)
-    : listAccessGroupsForZone.pages(input);
-
 const CreateAccessGroupBaseFields = {
   include: Schema.Array(
     Schema.Union([
@@ -43840,10 +43448,6 @@ export interface CreateAccessGroupForZoneRequest extends CreateAccessGroupBaseRe
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type CreateAccessGroupRequest =
-  | CreateAccessGroupForAccountRequest
-  | CreateAccessGroupForZoneRequest;
 
 export const CreateAccessGroupForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -44893,17 +44497,6 @@ export const createAccessGroupForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const createAccessGroup = (
-  input: CreateAccessGroupRequest,
-): Effect.Effect<
-  CreateAccessGroupResponse,
-  CreateAccessGroupError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? createAccessGroupForAccount(input)
-    : createAccessGroupForZone(input);
-
 const UpdateAccessGroupBaseFields = {
   groupId: Schema.String.pipe(T.HttpPath("groupId")),
   include: Schema.Array(
@@ -45606,10 +45199,6 @@ export interface UpdateAccessGroupForZoneRequest extends UpdateAccessGroupBaseRe
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type UpdateAccessGroupRequest =
-  | UpdateAccessGroupForAccountRequest
-  | UpdateAccessGroupForZoneRequest;
 
 export const UpdateAccessGroupForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -46662,17 +46251,6 @@ export const updateAccessGroupForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const updateAccessGroup = (
-  input: UpdateAccessGroupRequest,
-): Effect.Effect<
-  UpdateAccessGroupResponse,
-  UpdateAccessGroupError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? updateAccessGroupForAccount(input)
-    : updateAccessGroupForZone(input);
-
 const DeleteAccessGroupBaseFields = {
   groupId: Schema.String.pipe(T.HttpPath("groupId")),
 } as const;
@@ -46690,10 +46268,6 @@ export interface DeleteAccessGroupForZoneRequest extends DeleteAccessGroupBaseRe
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type DeleteAccessGroupRequest =
-  | DeleteAccessGroupForAccountRequest
-  | DeleteAccessGroupForZoneRequest;
 
 export const DeleteAccessGroupForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -46752,17 +46326,6 @@ export const deleteAccessGroupForZone: API.OperationMethod<
   output: DeleteAccessGroupResponse,
   errors: [],
 }));
-
-export const deleteAccessGroup = (
-  input: DeleteAccessGroupRequest,
-): Effect.Effect<
-  DeleteAccessGroupResponse,
-  DeleteAccessGroupError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? deleteAccessGroupForAccount(input)
-    : deleteAccessGroupForZone(input);
 
 // =============================================================================
 // AccessInfrastructureTarget
@@ -52953,10 +52516,6 @@ export interface GetAccessServiceTokenForZoneRequest extends GetAccessServiceTok
   zoneId: string;
 }
 
-export type GetAccessServiceTokenRequest =
-  | GetAccessServiceTokenForAccountRequest
-  | GetAccessServiceTokenForZoneRequest;
-
 export const GetAccessServiceTokenForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
@@ -53036,17 +52595,6 @@ export const getAccessServiceTokenForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const getAccessServiceToken = (
-  input: GetAccessServiceTokenRequest,
-): Effect.Effect<
-  GetAccessServiceTokenResponse,
-  GetAccessServiceTokenError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? getAccessServiceTokenForAccount(input)
-    : getAccessServiceTokenForZone(input);
-
 const ListAccessServiceTokensBaseFields = {} as const;
 
 interface ListAccessServiceTokensBaseRequest {}
@@ -53060,10 +52608,6 @@ export interface ListAccessServiceTokensForZoneRequest extends ListAccessService
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type ListAccessServiceTokensRequest =
-  | ListAccessServiceTokensForAccountRequest
-  | ListAccessServiceTokensForZoneRequest;
 
 export const ListAccessServiceTokensForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -53181,17 +52725,6 @@ export const listAccessServiceTokensForZone: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export const listAccessServiceTokens = (
-  input: ListAccessServiceTokensRequest,
-): stream.Stream<
-  ListAccessServiceTokensResponse,
-  ListAccessServiceTokensError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? listAccessServiceTokensForAccount.pages(input)
-    : listAccessServiceTokensForZone.pages(input);
-
 const CreateAccessServiceTokenBaseFields = {
   name: Schema.String,
   clientSecretVersion: Schema.optional(Schema.Number),
@@ -53219,10 +52752,6 @@ export interface CreateAccessServiceTokenForZoneRequest extends CreateAccessServ
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type CreateAccessServiceTokenRequest =
-  | CreateAccessServiceTokenForAccountRequest
-  | CreateAccessServiceTokenForZoneRequest;
 
 export const CreateAccessServiceTokenForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -53313,17 +52842,6 @@ export const createAccessServiceTokenForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const createAccessServiceToken = (
-  input: CreateAccessServiceTokenRequest,
-): Effect.Effect<
-  CreateAccessServiceTokenResponse,
-  CreateAccessServiceTokenError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? createAccessServiceTokenForAccount(input)
-    : createAccessServiceTokenForZone(input);
-
 const UpdateAccessServiceTokenBaseFields = {
   serviceTokenId: Schema.String.pipe(T.HttpPath("serviceTokenId")),
   clientSecretVersion: Schema.optional(Schema.Number),
@@ -53353,10 +52871,6 @@ export interface UpdateAccessServiceTokenForZoneRequest extends UpdateAccessServ
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type UpdateAccessServiceTokenRequest =
-  | UpdateAccessServiceTokenForAccountRequest
-  | UpdateAccessServiceTokenForZoneRequest;
 
 export const UpdateAccessServiceTokenForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -53449,17 +52963,6 @@ export const updateAccessServiceTokenForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const updateAccessServiceToken = (
-  input: UpdateAccessServiceTokenRequest,
-): Effect.Effect<
-  UpdateAccessServiceTokenResponse,
-  UpdateAccessServiceTokenError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? updateAccessServiceTokenForAccount(input)
-    : updateAccessServiceTokenForZone(input);
-
 const DeleteAccessServiceTokenBaseFields = {
   serviceTokenId: Schema.String.pipe(T.HttpPath("serviceTokenId")),
 } as const;
@@ -53477,10 +52980,6 @@ export interface DeleteAccessServiceTokenForZoneRequest extends DeleteAccessServ
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type DeleteAccessServiceTokenRequest =
-  | DeleteAccessServiceTokenForAccountRequest
-  | DeleteAccessServiceTokenForZoneRequest;
 
 export const DeleteAccessServiceTokenForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -53560,17 +53059,6 @@ export const deleteAccessServiceTokenForZone: API.OperationMethod<
   output: DeleteAccessServiceTokenResponse,
   errors: [],
 }));
-
-export const deleteAccessServiceToken = (
-  input: DeleteAccessServiceTokenRequest,
-): Effect.Effect<
-  DeleteAccessServiceTokenResponse,
-  DeleteAccessServiceTokenError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? deleteAccessServiceTokenForAccount(input)
-    : deleteAccessServiceTokenForZone(input);
 
 export interface RefreshAccessServiceTokenRequest {
   serviceTokenId: string;
@@ -89705,10 +89193,6 @@ export interface GetIdentityProviderForZoneRequest extends GetIdentityProviderBa
   zoneId: string;
 }
 
-export type GetIdentityProviderRequest =
-  | GetIdentityProviderForAccountRequest
-  | GetIdentityProviderForZoneRequest;
-
 export const GetIdentityProviderForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
@@ -91125,17 +90609,6 @@ export const getIdentityProviderForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const getIdentityProvider = (
-  input: GetIdentityProviderRequest,
-): Effect.Effect<
-  GetIdentityProviderResponse,
-  GetIdentityProviderError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? getIdentityProviderForAccount(input)
-    : getIdentityProviderForZone(input);
-
 const ListIdentityProvidersBaseFields = {} as const;
 
 interface ListIdentityProvidersBaseRequest {}
@@ -91149,10 +90622,6 @@ export interface ListIdentityProvidersForZoneRequest extends ListIdentityProvide
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type ListIdentityProvidersRequest =
-  | ListIdentityProvidersForAccountRequest
-  | ListIdentityProvidersForZoneRequest;
 
 export const ListIdentityProvidersForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -92549,17 +92018,6 @@ export const listIdentityProvidersForZone: API.PaginatedOperationMethod<
   } as const,
 }));
 
-export const listIdentityProviders = (
-  input: ListIdentityProvidersRequest,
-): stream.Stream<
-  ListIdentityProvidersResponse,
-  ListIdentityProvidersError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? listIdentityProvidersForAccount.pages(input)
-    : listIdentityProvidersForZone.pages(input);
-
 const CreateIdentityProviderBaseFields = {
   config: Schema.Struct({
     claims: Schema.optional(Schema.Array(Schema.String)),
@@ -92668,10 +92126,6 @@ export interface CreateIdentityProviderForZoneRequest extends CreateIdentityProv
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type CreateIdentityProviderRequest =
-  | CreateIdentityProviderForAccountRequest
-  | CreateIdentityProviderForZoneRequest;
 
 export const CreateIdentityProviderForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -94101,17 +93555,6 @@ export const createIdentityProviderForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const createIdentityProvider = (
-  input: CreateIdentityProviderRequest,
-): Effect.Effect<
-  CreateIdentityProviderResponse,
-  CreateIdentityProviderError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? createIdentityProviderForAccount(input)
-    : createIdentityProviderForZone(input);
-
 const UpdateIdentityProviderBaseFields = {
   identityProviderId: Schema.String.pipe(T.HttpPath("identityProviderId")),
   config: Schema.Struct({
@@ -94222,10 +93665,6 @@ export interface UpdateIdentityProviderForZoneRequest extends UpdateIdentityProv
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type UpdateIdentityProviderRequest =
-  | UpdateIdentityProviderForAccountRequest
-  | UpdateIdentityProviderForZoneRequest;
 
 export const UpdateIdentityProviderForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -95655,17 +95094,6 @@ export const updateIdentityProviderForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const updateIdentityProvider = (
-  input: UpdateIdentityProviderRequest,
-): Effect.Effect<
-  UpdateIdentityProviderResponse,
-  UpdateIdentityProviderError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? updateIdentityProviderForAccount(input)
-    : updateIdentityProviderForZone(input);
-
 const DeleteIdentityProviderBaseFields = {
   identityProviderId: Schema.String.pipe(T.HttpPath("identityProviderId")),
 } as const;
@@ -95683,10 +95111,6 @@ export interface DeleteIdentityProviderForZoneRequest extends DeleteIdentityProv
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type DeleteIdentityProviderRequest =
-  | DeleteIdentityProviderForAccountRequest
-  | DeleteIdentityProviderForZoneRequest;
 
 export const DeleteIdentityProviderForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -95745,17 +95169,6 @@ export const deleteIdentityProviderForZone: API.OperationMethod<
   output: DeleteIdentityProviderResponse,
   errors: [],
 }));
-
-export const deleteIdentityProvider = (
-  input: DeleteIdentityProviderRequest,
-): Effect.Effect<
-  DeleteIdentityProviderResponse,
-  DeleteIdentityProviderError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? deleteIdentityProviderForAccount(input)
-    : deleteIdentityProviderForZone(input);
 
 // =============================================================================
 // IdentityProviderScimGroup
@@ -98040,10 +97453,6 @@ export interface ListOrganizationsForZoneRequest extends ListOrganizationsBaseRe
   zoneId: string;
 }
 
-export type ListOrganizationsRequest =
-  | ListOrganizationsForAccountRequest
-  | ListOrganizationsForZoneRequest;
-
 export const ListOrganizationsForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
@@ -98208,17 +97617,6 @@ export const listOrganizationsForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const listOrganizations = (
-  input: ListOrganizationsRequest,
-): Effect.Effect<
-  ListOrganizationsResponse,
-  ListOrganizationsError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? listOrganizationsForAccount(input)
-    : listOrganizationsForZone(input);
-
 const CreateOrganizationBaseFields = {
   authDomain: Schema.String,
   name: Schema.String,
@@ -98286,10 +97684,6 @@ export interface CreateOrganizationForZoneRequest extends CreateOrganizationBase
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type CreateOrganizationRequest =
-  | CreateOrganizationForAccountRequest
-  | CreateOrganizationForZoneRequest;
 
 export const CreateOrganizationForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -98479,17 +97873,6 @@ export const createOrganizationForZone: API.OperationMethod<
   errors: [],
 }));
 
-export const createOrganization = (
-  input: CreateOrganizationRequest,
-): Effect.Effect<
-  CreateOrganizationResponse,
-  CreateOrganizationError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? createOrganizationForAccount(input)
-    : createOrganizationForZone(input);
-
 const UpdateOrganizationBaseFields = {
   allowAuthenticateViaWarp: Schema.optional(Schema.Boolean),
   authDomain: Schema.optional(Schema.String),
@@ -98570,10 +97953,6 @@ export interface UpdateOrganizationForZoneRequest extends UpdateOrganizationBase
   /** Path param: The Zone ID to use for this endpoint. */
   zoneId: string;
 }
-
-export type UpdateOrganizationRequest =
-  | UpdateOrganizationForAccountRequest
-  | UpdateOrganizationForZoneRequest;
 
 export const UpdateOrganizationForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -98764,17 +98143,6 @@ export const updateOrganizationForZone: API.OperationMethod<
   output: UpdateOrganizationResponse,
   errors: [],
 }));
-
-export const updateOrganization = (
-  input: UpdateOrganizationRequest,
-): Effect.Effect<
-  UpdateOrganizationResponse,
-  UpdateOrganizationError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? updateOrganizationForAccount(input)
-    : updateOrganizationForZone(input);
 
 // =============================================================================
 // OrganizationDoh
@@ -100822,10 +100190,6 @@ export interface RevokeTokensAccessApplicationForZoneRequest extends RevokeToken
   zoneId: string;
 }
 
-export type RevokeTokensAccessApplicationRequest =
-  | RevokeTokensAccessApplicationForAccountRequest
-  | RevokeTokensAccessApplicationForZoneRequest;
-
 export const RevokeTokensAccessApplicationForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
@@ -100878,17 +100242,6 @@ export const revokeTokensAccessApplicationForZone: API.OperationMethod<
   output: RevokeTokensAccessApplicationResponse,
   errors: [],
 }));
-
-export const revokeTokensAccessApplication = (
-  input: RevokeTokensAccessApplicationRequest,
-): Effect.Effect<
-  RevokeTokensAccessApplicationResponse,
-  RevokeTokensAccessApplicationError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? revokeTokensAccessApplicationForAccount(input)
-    : revokeTokensAccessApplicationForZone(input);
 
 // =============================================================================
 // Tunnel
@@ -104260,10 +103613,6 @@ export interface RevokeUsersOrganizationForZoneRequest extends RevokeUsersOrgani
   zoneId: string;
 }
 
-export type RevokeUsersOrganizationRequest =
-  | RevokeUsersOrganizationForAccountRequest
-  | RevokeUsersOrganizationForZoneRequest;
-
 export const RevokeUsersOrganizationForAccountRequest =
   /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     accountId: Schema.String.pipe(T.HttpPath("account_id")),
@@ -104328,17 +103677,6 @@ export const revokeUsersOrganizationForZone: API.OperationMethod<
   output: RevokeUsersOrganizationResponse,
   errors: [],
 }));
-
-export const revokeUsersOrganization = (
-  input: RevokeUsersOrganizationRequest,
-): Effect.Effect<
-  RevokeUsersOrganizationResponse,
-  RevokeUsersOrganizationError,
-  Credentials | HttpClient.HttpClient
-> =>
-  "accountId" in input
-    ? revokeUsersOrganizationForAccount(input)
-    : revokeUsersOrganizationForZone(input);
 
 // =============================================================================
 // V2AccessInfrastructureTarget

--- a/packages/cloudflare/test/client-api.test.ts
+++ b/packages/cloudflare/test/client-api.test.ts
@@ -3,9 +3,6 @@ import { buildRequestParts, getHttpTrait } from "@distilled.cloud/core/traits";
 import { transformCloudflareRequestParts } from "~/client/api";
 import { CreateAssetUploadRequest, PutScriptRequest } from "~/services/workers";
 import {
-  putPhas,
-  putPhasForAccount,
-  putPhasForZone,
   PutPhasForAccountRequest,
   PutPhasForZoneRequest,
 } from "~/services/rulesets";
@@ -158,38 +155,5 @@ describe("client api", () => {
       );
     });
 
-    it("putPhas wrapper dispatches to the account variant when accountId is present", () => {
-      const accountInput = {
-        accountId: "account-123",
-        rulesetPhase: "http_request_firewall_custom",
-        description: "test",
-      };
-      const wrapped = putPhas(accountInput);
-      const direct = putPhasForAccount(accountInput);
-      // Both Effects encode the same input via the same variant schema, so
-      // their internal AST references must match.
-      expect((wrapped as { _tag?: string })._tag).toBe(
-        (direct as { _tag?: string })._tag,
-      );
-      // Source-level smoke check: the wrapper picks the variant by the
-      // presence of `accountId`.
-      const src = putPhas.toString();
-      expect(src).toContain('"accountId" in input');
-      expect(src).toContain("putPhasForAccount");
-      expect(src).toContain("putPhasForZone");
-    });
-
-    it("putPhas wrapper dispatches to the zone variant when zoneId is present", () => {
-      const zoneInput = {
-        zoneId: "zone-123",
-        rulesetPhase: "http_request_firewall_custom",
-        description: "test",
-      };
-      const wrapped = putPhas(zoneInput);
-      const direct = putPhasForZone(zoneInput);
-      expect((wrapped as { _tag?: string })._tag).toBe(
-        (direct as { _tag?: string })._tag,
-      );
-    });
   });
 });

--- a/packages/cloudflare/test/client-api.test.ts
+++ b/packages/cloudflare/test/client-api.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from "vitest";
 import { buildRequestParts, getHttpTrait } from "@distilled.cloud/core/traits";
 import { transformCloudflareRequestParts } from "~/client/api";
 import { CreateAssetUploadRequest, PutScriptRequest } from "~/services/workers";
+import {
+  putPhas,
+  putPhasForAccount,
+  putPhasForZone,
+  PutPhasForAccountRequest,
+  PutPhasForZoneRequest,
+} from "~/services/rulesets";
 
 describe("client api", () => {
   it("maps createAssetUpload jwtToken to a bearer authorization header", () => {
@@ -103,6 +110,86 @@ describe("client api", () => {
           },
         ],
       },
+    });
+  });
+
+  describe("accountOrZone-scoped operations (putPhas)", () => {
+    it("putPhasForAccount binds account scope into the URL", () => {
+      const httpTrait = getHttpTrait(PutPhasForAccountRequest.ast);
+      expect(httpTrait?.path).toBe(
+        "/accounts/{account_id}/rulesets/phases/{rulesetPhase}/entrypoint",
+      );
+
+      const parts = buildRequestParts(
+        PutPhasForAccountRequest.ast,
+        httpTrait!,
+        {
+          accountId: "account-123",
+          rulesetPhase: "http_request_firewall_custom",
+          description: "test",
+        },
+        PutPhasForAccountRequest,
+      );
+
+      expect(parts.path).toBe(
+        "/accounts/account-123/rulesets/phases/http_request_firewall_custom/entrypoint",
+      );
+    });
+
+    it("putPhasForZone binds zone scope into the URL", () => {
+      const httpTrait = getHttpTrait(PutPhasForZoneRequest.ast);
+      expect(httpTrait?.path).toBe(
+        "/zones/{zone_id}/rulesets/phases/{rulesetPhase}/entrypoint",
+      );
+
+      const parts = buildRequestParts(
+        PutPhasForZoneRequest.ast,
+        httpTrait!,
+        {
+          zoneId: "zone-123",
+          rulesetPhase: "http_request_firewall_custom",
+          description: "test",
+        },
+        PutPhasForZoneRequest,
+      );
+
+      expect(parts.path).toBe(
+        "/zones/zone-123/rulesets/phases/http_request_firewall_custom/entrypoint",
+      );
+    });
+
+    it("putPhas wrapper dispatches to the account variant when accountId is present", () => {
+      const accountInput = {
+        accountId: "account-123",
+        rulesetPhase: "http_request_firewall_custom",
+        description: "test",
+      };
+      const wrapped = putPhas(accountInput);
+      const direct = putPhasForAccount(accountInput);
+      // Both Effects encode the same input via the same variant schema, so
+      // their internal AST references must match.
+      expect((wrapped as { _tag?: string })._tag).toBe(
+        (direct as { _tag?: string })._tag,
+      );
+      // Source-level smoke check: the wrapper picks the variant by the
+      // presence of `accountId`.
+      const src = putPhas.toString();
+      expect(src).toContain('"accountId" in input');
+      expect(src).toContain("putPhasForAccount");
+      expect(src).toContain("putPhasForZone");
+    });
+
+    it("putPhas wrapper dispatches to the zone variant when zoneId is present", () => {
+      const zoneInput = {
+        zoneId: "zone-123",
+        rulesetPhase: "http_request_firewall_custom",
+        description: "test",
+      };
+      const wrapped = putPhas(zoneInput);
+      const direct = putPhasForZone(zoneInput);
+      expect((wrapped as { _tag?: string })._tag).toBe(
+        (direct as { _tag?: string })._tag,
+      );
     });
   });
 });


### PR DESCRIPTION
Cloudflare's API has a path pattern `/{accountOrZone}/{accountOrZoneId}/...` where the literal first segment is `accounts` or `zones` depending on which scope ID the caller provides. The OpenAPI spec collapses both into one entry that declares `account_id` and `zone_id` as both required path params (mutually exclusive in reality). Distilled's generator was faithfully turning this into broken code: both fields typed as required, and `{accountOrZone}` / `{accountOrZoneId}` placeholders never bound to anything, so ~85 endpoints across 7 services were uncallable.

This PR fixes those endpoints by splitting each at codegen time into two concrete operations plus a thin convenience wrapper. Supersedes #257, which used a runtime trait + `throw new Error` for the same problem.

### Generator changes

Three independent fixes in `packages/cloudflare/scripts/generate.ts`:

1. **Auto-detect `accountOrZone`-scoped operations** by URL template and split each into:
   - `<op>ForAccount` — concrete URL `/accounts/{account_id}/...`, request schema with `accountId`
   - `<op>ForZone` — concrete URL `/zones/{zone_id}/...`, request schema with `zoneId`
   - `<op>` — wrapper function dispatching on `"accountId" in input`. Returns `Effect.Effect<...>` (or `stream.Stream<...>` for paginated). Input is the discriminated union, so invalid states are unrepresentable at the type level.
   - Body fields are extracted into a non-exported `<Op>BaseFields` const and spread into both variants — no source-level duplication.
   - Response and error types remain singular and shared between variants.

2. **Synthesize missing URL path params**. Some operations reference placeholders like `{rulesetPhase}` in the URL but don't declare them as parameters — these are now auto-synthesized as required string path params.

3. **Optional path params** now correctly emit as `Schema.optional(...)` instead of being typed as required.

### User-visible API

Before (broken — no way to substitute `accountOrZone`/`accountOrZoneId`, both ids typed required):

```ts
yield* cf.rulesets.putPhas({ accountId, zoneId, rulesetPhase: "...", rules: [...] });
// → PUT /{accountOrZone}/{accountOrZoneId}/rulesets/phases/.../entrypoint  (404)
```

After:

```ts
// Single function, exactly-one-of input enforced by the type system
yield* cf.rulesets.putPhas({ accountId: "...", rulesetPhase: "...", rules: [...] });
yield* cf.rulesets.putPhas({ zoneId:    "...", rulesetPhase: "...", rules: [...] });

// Or import the concrete variant directly for tighter tree-shaking
yield* cf.rulesets.putPhasForAccount({ accountId: "...", rulesetPhase: "...", rules: [...] });
```

### Why split at codegen instead of runtime

Considered a runtime approach (PR #257): mark the schema with a trait, rewrite the path in `transformRequestParts`, throw on invalid input. Rejected because (a) the throw bypasses Effect's typed error channel — it becomes an unchecked defect rather than a typed operation error, (b) "exactly one of" is encodable in the type system and shouldn't be a runtime check, and (c) it imports Cloudflare-specific path-rewriting logic into the core client. Splitting at codegen keeps core untouched, errors flow through Effect normally, and the type system enforces the invariant.

### Test coverage

Added in `packages/cloudflare/test/client-api.test.ts`:
- `putPhasForAccount` builds `/accounts/{id}/...` correctly
- `putPhasForZone` builds `/zones/{id}/...` correctly
- Wrapper dispatches to account variant when `accountId` is present
- Wrapper dispatches to zone variant when `zoneId` is present
- Source-level smoke check that the wrapper uses `"accountId" in input`

All 7 client-api tests pass; `typecheck` and `check` are clean for both the cloudflare package and core.

### Out of scope (separate issues to file)

- Truncated upstream operationIds (`getPhas`, `putPhas`, `listPhasVersions`, etc.) — these come from Cloudflare's own published OpenAPI spec and need a spec patch, not a generator fix.
- Refactoring core's `buildRequestParts` to handle `Schema.Union` natively (would let SDKs express discriminated request unions generically without codegen-time splitting).
