### PR TITLE
chore: add husky pre-commit hook running bun fmt

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+bun fmt
+git update-index --again

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@typescript/native-preview": "catalog:",
         "aws4fetch": "^1.0.20",
         "changelogithub": "^14.0.0",
+        "husky": "^9.1.7",
         "oxfmt": "catalog:",
         "oxlint": "catalog:",
         "yaml": "catalog:",
@@ -1092,6 +1093,8 @@
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "nuke": "bun --filter '@distilled.cloud/*' --filter '!@distilled.cloud/website' nuke",
     "generate-nuke": "bun ./scripts/generate-nuke.ts",
     "generate-tests": "bun ./scripts/generate-tests.ts",
-    "error-discovery": "bun ./scripts/error-discovery.ts"
+    "error-discovery": "bun ./scripts/error-discovery.ts",
+    "prepare": "husky"
   },
   "workspaces": {
     "packages": [
@@ -71,6 +72,7 @@
     "@typescript/native-preview": "catalog:",
     "aws4fetch": "^1.0.20",
     "changelogithub": "^14.0.0",
+    "husky": "^9.1.7",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
     "yaml": "catalog:"


### PR DESCRIPTION
Add a husky pre-commit hook that runs `bun fmt` so commits are always formatted.

```sh
# .husky/pre-commit
bun fmt
git update-index --again
```

`git update-index --again` re-stages formatting fixes for files that were already staged; unstaged files stay unstaged.
