### PR TITLE
fix(cloudflare): send application/octet-stream bodies raw, not multipart

### DIFF
--- a/packages/cloudflare/scripts/generate.ts
+++ b/packages/cloudflare/scripts/generate.ts
@@ -491,9 +491,7 @@ function applyPatchToTypeInfo(typeInfo: TypeInfo, patch: PropertyPatch): void {
     typeInfo.values
   ) {
     for (const variant of patch.appendUnion) {
-      typeInfo.values.push(
-        JSON.parse(JSON.stringify(variant)) as TypeInfo,
-      );
+      typeInfo.values.push(JSON.parse(JSON.stringify(variant)) as TypeInfo);
     }
   }
 
@@ -1105,6 +1103,10 @@ function typeInfoToSchema(
       // File upload schema with trait annotation
       return "UploadableSchema.pipe(T.HttpFormDataFile())";
 
+    case "binary":
+      // Raw binary body — no multipart wrapping, sent as application/octet-stream
+      return "BinaryBodySchema";
+
     case "unknown":
     default:
       return "Schema.Unknown";
@@ -1209,6 +1211,9 @@ function typeInfoToTsType(
 
     case "file":
       return "File | Blob";
+
+    case "binary":
+      return "Blob | Uint8Array | ArrayBuffer | ReadableStream<Uint8Array>";
 
     case "unknown":
     default:
@@ -1432,9 +1437,12 @@ function generateOperationSchemaAst(
   // Add contentType: "multipart" when operation has file uploads or uses multipartFormRequestOptions
   const hasFiles = operationHasFiles(op);
   const isMultipart = hasFiles || op.isMultipart;
-  const httpTrait = isMultipart
-    ? `T.Http({ method: "${op.httpMethod}", path: "${openApiPath}", contentType: "multipart" })`
-    : `T.Http({ method: "${op.httpMethod}", path: "${openApiPath}" })`;
+  const isBinaryBody = operationHasBinaryBody(op);
+  const httpTrait = isBinaryBody
+    ? `T.Http({ method: "${op.httpMethod}", path: "${openApiPath}", contentType: "octet-stream" })`
+    : isMultipart
+      ? `T.Http({ method: "${op.httpMethod}", path: "${openApiPath}", contentType: "multipart" })`
+      : `T.Http({ method: "${op.httpMethod}", path: "${openApiPath}" })`;
   pipes.push(httpTrait);
 
   lines.push(
@@ -1767,9 +1775,12 @@ function generateOperationSchema(
   }
   const hasFiles = operationHasFiles(op);
   const isMultipart = hasFiles || op.isMultipart;
-  const httpTrait = isMultipart
-    ? `T.Http({ method: "${op.httpMethod}", path: "${openApiPath}", contentType: "multipart" })`
-    : `T.Http({ method: "${op.httpMethod}", path: "${openApiPath}" })`;
+  const isBinaryBody = operationHasBinaryBody(op);
+  const httpTrait = isBinaryBody
+    ? `T.Http({ method: "${op.httpMethod}", path: "${openApiPath}", contentType: "octet-stream" })`
+    : isMultipart
+      ? `T.Http({ method: "${op.httpMethod}", path: "${openApiPath}", contentType: "multipart" })`
+      : `T.Http({ method: "${op.httpMethod}", path: "${openApiPath}" })`;
   pipes.push(httpTrait);
 
   lines.push(
@@ -2141,6 +2152,7 @@ function typeInfoToOpenApiSchema(type: TypeInfo): Record<string, unknown> {
       return objectSchema;
     }
     case "file":
+    case "binary":
       return { type: "string", format: "binary" };
     case "unknown":
     default:
@@ -2208,8 +2220,9 @@ function operationToOpenApi(
     })),
   ];
   const bodySchema = bodyParamsToOpenApiSchema(resolved.bodyParams);
-  const contentType =
-    op.isMultipart || operationHasFiles(op)
+  const contentType = operationHasBinaryBody(op)
+    ? "application/octet-stream"
+    : op.isMultipart || operationHasFiles(op)
       ? "multipart/form-data"
       : "application/json";
   const errors =
@@ -2303,6 +2316,30 @@ function hasFileType(type: TypeInfo): boolean {
 }
 
 /**
+ * Check if a TypeInfo contains a binary body type
+ */
+function hasBinaryType(type: TypeInfo): boolean {
+  if (type.kind === "binary") return true;
+  if (type.kind === "array" && type.elementType) {
+    return hasBinaryType(type.elementType);
+  }
+  if (type.kind === "union" && type.values) {
+    return type.values.some(hasBinaryType);
+  }
+  if (type.kind === "object" && type.properties) {
+    return type.properties.some((p) => hasBinaryType(p.type));
+  }
+  return false;
+}
+
+/**
+ * Check if an operation sends a raw binary request body (application/octet-stream)
+ */
+function operationHasBinaryBody(op: ParsedOperation): boolean {
+  return !!op.isBinaryBody || op.bodyParams.some((p) => hasBinaryType(p.type));
+}
+
+/**
  * Check if an operation has file parameters
  */
 function operationHasFiles(op: ParsedOperation): boolean {
@@ -2315,8 +2352,11 @@ function generateServiceFile(
 ): string {
   const lines: string[] = [];
 
-  // Check if any operation has file uploads
-  const hasFileUploads = service.operations.some(operationHasFiles);
+  // Check if any operation has file uploads (request body or response)
+  const hasFileUploads = service.operations.some(
+    (op) => operationHasFiles(op) || hasFileType(op.responseType),
+  );
+  const hasBinaryBodies = service.operations.some(operationHasBinaryBody);
 
   // Header
   lines.push(`/**`);
@@ -2345,9 +2385,12 @@ function generateServiceFile(
   lines.push(`  type DefaultErrors,`);
   lines.push(`} from "${withTsExtension("../errors")}";`);
   // Conditionally import UploadableSchema for file uploads
-  if (hasFileUploads) {
+  if (hasFileUploads || hasBinaryBodies) {
+    const imports: string[] = [];
+    if (hasFileUploads) imports.push("UploadableSchema");
+    if (hasBinaryBodies) imports.push("BinaryBodySchema");
     lines.push(
-      `import { UploadableSchema } from "${withTsExtension("../schemas")}";`,
+      `import { ${imports.join(", ")} } from "${withTsExtension("../schemas")}";`,
     );
   }
   lines.push(`__SENSITIVE_IMPORT__`);

--- a/packages/cloudflare/scripts/model.ts
+++ b/packages/cloudflare/scripts/model.ts
@@ -361,7 +361,8 @@ export interface TypeInfo {
     | "object"
     | "null"
     | "unknown"
-    | "file";
+    | "file"
+    | "binary";
   value?: string; // For primitives and literals
   values?: TypeInfo[]; // For unions
   elementType?: TypeInfo; // For arrays
@@ -430,6 +431,8 @@ export interface ParsedOperation {
   urlPathParams: string[]; // Path parameters from URL, e.g., ["account_id", "bucketName"]
   /** True when the SDK method uses Core.multipartFormRequestOptions */
   isMultipart?: boolean;
+  /** True when the request body is a raw binary stream (application/octet-stream) */
+  isBinaryBody?: boolean;
   /** Pagination wrapper type: "items" when V4PagePagination (result.items), "array" when V4PagePaginationArray/SinglePage (result directly) */
   paginationType?: "items" | "array";
   /** Upstream Cloudflare page class name, e.g. V4PagePaginationArray */

--- a/packages/cloudflare/scripts/parse.ts
+++ b/packages/cloudflare/scripts/parse.ts
@@ -182,7 +182,10 @@ interface OpenApiSchema {
 const getGitHash = (repoPath: string) =>
   Effect.sync(() => {
     try {
-      return execSync("git rev-parse HEAD", { cwd: repoPath, encoding: "utf-8" }).trim();
+      return execSync("git rev-parse HEAD", {
+        cwd: repoPath,
+        encoding: "utf-8",
+      }).trim();
     } catch {
       return "";
     }
@@ -231,10 +234,8 @@ const getOpenApiContentHash = (openapiBasePath?: string) =>
     if (!openapiBasePath) return "";
 
     const fs = yield* FileSystem.FileSystem;
-    const files = yield* collectFilesMatching(
-      fs,
-      openapiBasePath,
-      (file) => OPENAPI_SPEC_REGEX.test(file),
+    const files = yield* collectFilesMatching(fs, openapiBasePath, (file) =>
+      OPENAPI_SPEC_REGEX.test(file),
     );
 
     if (files.length === 0) {
@@ -279,7 +280,9 @@ const getCacheKey = (repoPath: string, openapiBasePath?: string) =>
     if (!gitHash && !openapiHash && !parserHash) {
       return "";
     }
-    return hashString(`${CACHE_VERSION}:${gitHash}:${openapiHash}:${parserHash}`);
+    return hashString(
+      `${CACHE_VERSION}:${gitHash}:${openapiHash}:${parserHash}`,
+    );
   });
 
 /**
@@ -531,7 +534,9 @@ function tsTypeToTypeInfo(
     const candidates = knownValues.length > 0 ? knownValues : values;
     const deduped = candidates.filter((value, index) => {
       const key = JSON.stringify(value);
-      return index === candidates.findIndex((other) => JSON.stringify(other) === key);
+      return (
+        index === candidates.findIndex((other) => JSON.stringify(other) === key)
+      );
     });
 
     if (deduped.length === 0) {
@@ -585,11 +590,14 @@ function tsTypeToTypeInfo(
       kind: "object",
       name: checker.typeToString(type),
       properties: properties.map((property) => {
-        const declaration = property.valueDeclaration ?? property.declarations?.[0];
+        const declaration =
+          property.valueDeclaration ?? property.declarations?.[0];
         const propertyType = declaration
           ? checker.getTypeOfSymbolAtLocation(property, declaration)
           : checker.getTypeOfSymbol(property);
-        const description = declaration ? getJsDocComment(declaration) : undefined;
+        const description = declaration
+          ? getJsDocComment(declaration)
+          : undefined;
 
         return {
           name: property.getName(),
@@ -783,7 +791,10 @@ function typeNodeToTypeInfo(
       const resolvedFromChecker = tsTypeToTypeInfo(type, checker);
       if (
         resolvedFromChecker.kind !== "unknown" &&
-        !(resolvedFromChecker.kind === "object" && resolvedFromChecker.name === "Record")
+        !(
+          resolvedFromChecker.kind === "object" &&
+          resolvedFromChecker.name === "Record"
+        )
       ) {
         return resolvedFromChecker;
       }
@@ -801,7 +812,12 @@ function typeNodeToTypeInfo(
       if (ts.isPropertySignature(member) && member.name) {
         const rawName = member.name.getText();
         const name = rawName.replace(/^["']|["']$/g, "");
-        const type = typeNodeToTypeInfo(member.type, checker, registry, seenTypeRefs);
+        const type = typeNodeToTypeInfo(
+          member.type,
+          checker,
+          registry,
+          seenTypeRefs,
+        );
         const required = !member.questionToken;
         const comment = getJsDocComment(member);
 
@@ -851,7 +867,9 @@ function extractHttpMethod(
                 ts.isStringLiteral(prop.initializer)
               ) {
                 const override = prop.initializer.text.toUpperCase();
-                if (["GET", "POST", "PUT", "PATCH", "DELETE"].includes(override)) {
+                if (
+                  ["GET", "POST", "PUT", "PATCH", "DELETE"].includes(override)
+                ) {
                   httpMethod = override as typeof httpMethod;
                 }
               }
@@ -903,7 +921,9 @@ function detectMultipart(methodBody: ts.Block): boolean {
  * Detect pagination type from the page class used in getAPIList/postAPIList calls.
  * Returns "items" for V4PagePagination (result.items wrapper), "array" for V4PagePaginationArray/SinglePage (bare array).
  */
-function detectPaginationType(methodBody: ts.Block): "items" | "array" | undefined {
+function detectPaginationType(
+  methodBody: ts.Block,
+): "items" | "array" | undefined {
   let paginationType: "items" | "array" | undefined;
 
   function visit(node: ts.Node) {
@@ -921,7 +941,10 @@ function detectPaginationType(methodBody: ts.Block): "items" | "array" | undefin
             const pageClassName = pageClassArg.getText();
             // V4PagePagination uses result.items wrapper
             // V4PagePaginationArray and SinglePage use result directly as array
-            if (pageClassName.includes("V4PagePagination") && !pageClassName.includes("V4PagePaginationArray")) {
+            if (
+              pageClassName.includes("V4PagePagination") &&
+              !pageClassName.includes("V4PagePaginationArray")
+            ) {
               paginationType = "items";
             } else {
               paginationType = "array";
@@ -995,7 +1018,8 @@ function detectPaginationClassName(methodBody: ts.Block): string | undefined {
           const pageClassArg = node.arguments[1];
           if (
             pageClassArg &&
-            (ts.isIdentifier(pageClassArg) || ts.isPropertyAccessExpression(pageClassArg))
+            (ts.isIdentifier(pageClassArg) ||
+              ts.isPropertyAccessExpression(pageClassArg))
           ) {
             className = pageClassArg.getText().split(".").pop();
           }
@@ -1171,7 +1195,12 @@ function parseInterface(
       // e.g., '"CF-WORKER-BODY-PART"' — strip them to get the raw name
       const rawText = member.name.getText();
       const propName = rawText.replace(/^["']|["']$/g, "");
-      const type = typeNodeToTypeInfo(member.type, checker, registry, seenTypeRefs);
+      const type = typeNodeToTypeInfo(
+        member.type,
+        checker,
+        registry,
+        seenTypeRefs,
+      );
       const required = !member.questionToken;
       const comment = getJsDocComment(member);
       const location = parseParamLocation(comment);
@@ -1194,7 +1223,6 @@ function parseInterface(
 
   return { name, properties };
 }
-
 
 /**
  * Find and parse a params interface by name in a source file
@@ -1686,7 +1714,10 @@ function makeNullable(type: TypeInfo): TypeInfo {
   if (type.kind === "null") {
     return type;
   }
-  if (type.kind === "union" && type.values?.some((value) => value.kind === "null")) {
+  if (
+    type.kind === "union" &&
+    type.values?.some((value) => value.kind === "null")
+  ) {
     return type;
   }
   return {
@@ -1712,7 +1743,11 @@ function schemaObjectToTypeInfo(
     if (!resolved) {
       return { kind: "unknown" };
     }
-    return schemaObjectToTypeInfo(resolved, spec, new Set([...seenRefs, schema.$ref]));
+    return schemaObjectToTypeInfo(
+      resolved,
+      spec,
+      new Set([...seenRefs, schema.$ref]),
+    );
   }
 
   if (schema.enum && schema.enum.length > 0) {
@@ -1734,8 +1769,12 @@ function schemaObjectToTypeInfo(
       schemaObjectToTypeInfo(part, spec, seenRefs),
     );
     const objectParts = resolvedParts.filter(
-      (part): part is TypeInfo & { kind: "object"; properties: NonNullable<TypeInfo["properties"]> } =>
-        part.kind === "object" && !!part.properties,
+      (
+        part,
+      ): part is TypeInfo & {
+        kind: "object";
+        properties: NonNullable<TypeInfo["properties"]>;
+      } => part.kind === "object" && !!part.properties,
     );
     if (objectParts.length > 0) {
       const merged: TypeInfo = {
@@ -1756,9 +1795,10 @@ function schemaObjectToTypeInfo(
   let typeInfo: TypeInfo;
   switch (rawType) {
     case "string":
-      typeInfo = "format" in schema && schema.format === "binary"
-        ? { kind: "file" }
-        : { kind: "primitive", value: "string" };
+      typeInfo =
+        "format" in schema && schema.format === "binary"
+          ? { kind: "file" }
+          : { kind: "primitive", value: "string" };
       break;
     case "integer":
     case "number":
@@ -1778,12 +1818,14 @@ function schemaObjectToTypeInfo(
         const required = new Set(schema.required ?? []);
         typeInfo = {
           kind: "object",
-          properties: Object.entries(schema.properties).map(([name, propertySchema]) => ({
-            name,
-            type: schemaObjectToTypeInfo(propertySchema, spec, seenRefs),
-            required: required.has(name),
-            description: propertySchema.description,
-          })),
+          properties: Object.entries(schema.properties).map(
+            ([name, propertySchema]) => ({
+              name,
+              type: schemaObjectToTypeInfo(propertySchema, spec, seenRefs),
+              required: required.has(name),
+              description: propertySchema.description,
+            }),
+          ),
         };
       } else if (schema.additionalProperties) {
         typeInfo = { kind: "unknown" };
@@ -1796,12 +1838,14 @@ function schemaObjectToTypeInfo(
         const required = new Set(schema.required ?? []);
         typeInfo = {
           kind: "object",
-          properties: Object.entries(schema.properties).map(([name, propertySchema]) => ({
-            name,
-            type: schemaObjectToTypeInfo(propertySchema, spec, seenRefs),
-            required: required.has(name),
-            description: propertySchema.description,
-          })),
+          properties: Object.entries(schema.properties).map(
+            ([name, propertySchema]) => ({
+              name,
+              type: schemaObjectToTypeInfo(propertySchema, spec, seenRefs),
+              required: required.has(name),
+              description: propertySchema.description,
+            }),
+          ),
         };
       } else {
         typeInfo = { kind: "unknown" };
@@ -1820,15 +1864,24 @@ function requestBodyToParams(
     return [];
   }
 
+  const isOctetStream =
+    !requestBody.content["application/json"] &&
+    !!requestBody.content["application/octet-stream"];
   const mediaType =
     requestBody.content["application/json"] ??
+    requestBody.content["application/octet-stream"] ??
     Object.values(requestBody.content)[0];
   const schema = mediaType?.schema;
   if (!schema) {
     return [];
   }
 
-  const type = schemaObjectToTypeInfo(schema, spec);
+  let type = schemaObjectToTypeInfo(schema, spec);
+  // For application/octet-stream bodies, distinguish "binary" from multipart
+  // "file" — the wire format is a raw byte stream, not a multipart part.
+  if (isOctetStream && type.kind === "file") {
+    type = { kind: "binary" };
+  }
   if (type.kind === "object" && type.properties && type.properties.length > 0) {
     return type.properties.map((property) => ({
       name: property.name,
@@ -1854,7 +1907,10 @@ function getOperationMethodName(operationName: string): string {
   return match?.[0] ?? operationName;
 }
 
-function getOperationResourceName(operationName: string, methodName: string): string {
+function getOperationResourceName(
+  operationName: string,
+  methodName: string,
+): string {
   const resource = operationName.slice(methodName.length);
   return resource || "Operation";
 }
@@ -1873,7 +1929,10 @@ function buildOpenApiOperation(
   }
 
   const urlPathParams = extractPathParamsFromUrl(pathTemplate);
-  const combinedParameters = [...(pathItem.parameters ?? []), ...(operation.parameters ?? [])];
+  const combinedParameters = [
+    ...(pathItem.parameters ?? []),
+    ...(operation.parameters ?? []),
+  ];
   const deduped = new Map<string, OpenApiParameter>();
   for (const parameter of combinedParameters) {
     const resolved = resolveOpenApiParameter(parameter, spec);
@@ -1921,14 +1980,22 @@ function buildOpenApiOperation(
     : undefined;
   const mediaType =
     successResponse?.content?.["application/json"] ??
-    (successResponse?.content ? Object.values(successResponse.content)[0] : undefined);
+    (successResponse?.content
+      ? Object.values(successResponse.content)[0]
+      : undefined);
   const requestContentTypes = Object.keys(operation.requestBody?.content ?? {});
   const isMultipart = requestContentTypes.some((type) =>
     type.includes("multipart/form-data"),
   );
+  const isBinaryBody =
+    !requestContentTypes.includes("application/json") &&
+    requestContentTypes.includes("application/octet-stream");
   const responseType = schemaObjectToTypeInfo(mediaType?.schema, spec);
   const methodName = getOperationMethodName(operation.operationId);
-  const resourceName = getOperationResourceName(operation.operationId, methodName);
+  const resourceName = getOperationResourceName(
+    operation.operationId,
+    methodName,
+  );
   const errors: OperationErrorInfo[] = Object.entries(
     operation["x-distilled-errors"] ?? {},
   ).map(([tag, matchers]) => ({ tag, matchers }));
@@ -1951,6 +2018,7 @@ function buildOpenApiOperation(
     responseType,
     responsePath: operation["x-distilled-response-path"],
     isMultipart: isMultipart || undefined,
+    isBinaryBody: isBinaryBody || undefined,
     paginationClassName: operation["x-distilled-pagination-class"],
     summary: operation.summary,
     description: operation.description,
@@ -1971,10 +2039,8 @@ const parseOpenApiFiles = (
     }
 
     const fs = yield* FileSystem.FileSystem;
-    const files = yield* collectFilesMatching(
-      fs,
-      openapiBasePath,
-      (file) => OPENAPI_SPEC_REGEX.test(file),
+    const files = yield* collectFilesMatching(fs, openapiBasePath, (file) =>
+      OPENAPI_SPEC_REGEX.test(file),
     );
 
     const services: ServiceInfo[] = [];
@@ -1992,8 +2058,16 @@ const parseOpenApiFiles = (
       }
 
       const operations: ParsedOperation[] = [];
-      for (const [pathTemplate, pathItem] of Object.entries(parsed.paths ?? {})) {
-        for (const method of ["get", "post", "put", "patch", "delete"] as const) {
+      for (const [pathTemplate, pathItem] of Object.entries(
+        parsed.paths ?? {},
+      )) {
+        for (const method of [
+          "get",
+          "post",
+          "put",
+          "patch",
+          "delete",
+        ] as const) {
           const operation = pathItem[method];
           if (!operation) continue;
 
@@ -2053,8 +2127,7 @@ function mergeServices(...serviceGroups: ServiceInfo[][]): ServiceInfo[] {
     }
   }
 
-  return [...merged.values()]
-    .sort((a, b) => a.name.localeCompare(b.name));
+  return [...merged.values()].sort((a, b) => a.name.localeCompare(b.name));
 }
 
 const parseServiceFiles = (
@@ -2079,7 +2152,10 @@ const parseServiceFiles = (
     }
 
     const astServices = yield* parseServiceFilesCore(basePath, serviceFilter);
-    const openapiServices = yield* parseOpenApiFiles(openapiBasePath, serviceFilter);
+    const openapiServices = yield* parseOpenApiFiles(
+      openapiBasePath,
+      serviceFilter,
+    );
     const services = mergeServices(astServices, openapiServices);
 
     // Save to cache (only if not filtering by service)

--- a/packages/cloudflare/specs/cloudflare/r2.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/r2.openapi.yml
@@ -2669,7 +2669,7 @@ paths:
       requestBody:
         required: true
         content:
-          multipart/form-data:
+          application/octet-stream:
             schema:
               type: string
               format: binary

--- a/packages/cloudflare/src/schemas.ts
+++ b/packages/cloudflare/src/schemas.ts
@@ -49,3 +49,32 @@ export const UploadableSchema = Schema.Union([FileSchema, BlobSchema]);
  * TypeScript type for uploadable content.
  */
 export type Uploadable = File | Blob;
+
+/**
+ * Schema for raw binary request bodies (e.g. R2 putObject).
+ *
+ * Accepts any byte-bearing value that fetch() understands as a body.
+ */
+export const BinaryBodySchema = Schema.declare(
+  (
+    input,
+  ): input is Blob | Uint8Array | ArrayBuffer | ReadableStream<Uint8Array> =>
+    (typeof Blob !== "undefined" && input instanceof Blob) ||
+    input instanceof Uint8Array ||
+    input instanceof ArrayBuffer ||
+    (typeof ReadableStream !== "undefined" && input instanceof ReadableStream),
+  {
+    identifier: "BinaryBody",
+    description:
+      "Raw binary body (Blob, Uint8Array, ArrayBuffer, or ReadableStream)",
+  },
+);
+
+/**
+ * TypeScript type for raw binary request bodies.
+ */
+export type BinaryBody =
+  | Blob
+  | Uint8Array
+  | ArrayBuffer
+  | ReadableStream<Uint8Array>;

--- a/packages/cloudflare/src/services/r2.ts
+++ b/packages/cloudflare/src/services/r2.ts
@@ -11,7 +11,7 @@ import * as API from "../client/api.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import { type DefaultErrors } from "../errors.ts";
-import { UploadableSchema } from "../schemas.ts";
+import { UploadableSchema, BinaryBodySchema } from "../schemas.ts";
 import { SensitiveString } from "../sensitive.ts";
 
 // =============================================================================
@@ -2819,7 +2819,7 @@ export interface PutObjectRequest {
   expires?: string;
   /** Storage class for the object. */
   cfR2StorageClass?: "Standard" | "InfrequentAccess";
-  body: File | Blob;
+  body: Blob | Uint8Array | ArrayBuffer | ReadableStream<Uint8Array>;
 }
 
 export const PutObjectRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -2851,12 +2851,12 @@ export const PutObjectRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   cfR2StorageClass: Schema.optional(
     Schema.Literals(["Standard", "InfrequentAccess"]),
   ).pipe(T.HttpHeader("cf-r2-storage-class")),
-  body: UploadableSchema.pipe(T.HttpFormDataFile()).pipe(T.HttpBody()),
+  body: BinaryBodySchema.pipe(T.HttpBody()),
 }).pipe(
   T.Http({
     method: "PUT",
     path: "/accounts/{account_id}/r2/buckets/{bucketName}/objects/{objectName}",
-    contentType: "multipart",
+    contentType: "octet-stream",
   }),
 ) as unknown as Schema.Schema<PutObjectRequest>;
 

--- a/packages/cloudflare/test/r2.test.ts
+++ b/packages/cloudflare/test/r2.test.ts
@@ -1187,6 +1187,36 @@ describe("R2", () => {
   });
 
   // --------------------------------------------------------------------------
+  // putObject / getObject / deleteObject (raw application/octet-stream body)
+  // --------------------------------------------------------------------------
+  describe("putObject", () => {
+    test(
+      "happy path - uploads a Blob via application/octet-stream",
+      { timeout: 180_000 },
+      () =>
+        withBucket(bucketName("put-obj"), (name) =>
+          Effect.gen(function* () {
+            const objectName = `test-${testRunId}.txt`;
+            const payload = "hello from distilled";
+
+            yield* R2.putObject({
+              accountId: accountId(),
+              bucketName: name,
+              objectName,
+              body: new Blob([payload], { type: "text/plain" }),
+            });
+
+            yield* R2.deleteObject({
+              accountId: accountId(),
+              bucketName: name,
+              objectName,
+            }).pipe(Effect.catch(() => Effect.void));
+          }),
+        ),
+    );
+  });
+
+  // --------------------------------------------------------------------------
   // listBucketDomainCustoms
   // --------------------------------------------------------------------------
   describe("listBucketDomainCustoms", () => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -495,8 +495,14 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
           // Set Content-Type based on body type
           // - Skip for FormData (multipart) — browser sets boundary
           // - Use form-urlencoded for Stripe-style APIs
+          // - Use octet-stream for raw binary uploads (e.g. R2 putObject).
+          //   The user can override via a `content-type` header param.
           // - Default to JSON
           const isFormUrlEncoded = httpTrait.contentType === "form-urlencoded";
+          const isOctetStream = httpTrait.contentType === "octet-stream";
+          const userSetContentType = Object.keys(parts.headers).some(
+            (h) => h.toLowerCase() === "content-type",
+          );
           if (parts.isMultipart) {
             // browser/runtime sets Content-Type with boundary
           } else if (isFormUrlEncoded) {
@@ -504,6 +510,13 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
               "Content-Type",
               "application/x-www-form-urlencoded",
             )(request);
+          } else if (isOctetStream) {
+            if (!userSetContentType) {
+              request = HttpClientRequest.setHeader(
+                "Content-Type",
+                "application/octet-stream",
+              )(request);
+            }
           } else {
             request = HttpClientRequest.setHeader(
               "Content-Type",
@@ -530,6 +543,14 @@ export const makeAPI = <Creds>(config: ClientConfig<Creds>) => {
               );
               request = HttpClientRequest.setBody(
                 HttpBody.text(encoded, "application/x-www-form-urlencoded"),
+              )(request);
+            } else if (isOctetStream) {
+              // Raw binary body — pass through to fetch. Accepts Blob,
+              // Uint8Array, ArrayBuffer, or ReadableStream<Uint8Array>.
+              request = HttpClientRequest.setBody(
+                HttpBody.raw(parts.body, {
+                  contentType: "application/octet-stream",
+                }),
               )(request);
             } else {
               request = yield* HttpClientRequest.bodyJson(parts.body)(request);


### PR DESCRIPTION
Cloudflare R2 `putObject` (and any other endpoint that takes a raw `application/octet-stream` body) was being sent as `multipart/form-data`, which R2 rejects with code 10028 "multipart/form-data enhancement not implemented". The codegen treated every `string` + `format: binary` request body as a multipart file upload regardless of its declared content-type.

Adds a new `binary` body kind that flows through codegen end-to-end:

- `parse.ts` detects when the request body is `application/octet-stream` (and no `application/json`) and emits `{ kind: "binary" }` instead of `{ kind: "file" }`.
- `generate.ts` emits `BinaryBodySchema.pipe(T.HttpBody())` and tags the `Http` trait with `contentType: "octet-stream"` (instead of `"multipart"`).
- `core/client.ts` detects `contentType: "octet-stream"` and sends the body via `HttpBody.raw` with `Content-Type: application/octet-stream`, letting any user-supplied `content-type` header param win.

```diff
- body: UploadableSchema.pipe(T.HttpFormDataFile()).pipe(T.HttpBody()),
+ body: BinaryBodySchema.pipe(T.HttpBody()),
}).pipe(
-  T.Http({ method: "PUT", path: "...", contentType: "multipart" }),
+  T.Http({ method: "PUT", path: "...", contentType: "octet-stream" }),
);
```

Now works:

```ts
yield* R2.putObject({
  accountId,
  bucketName: "my-bucket",
  objectName: "hello.txt",
  body: new Blob(["hi"], { type: "text/plain" }),
});
```

Closes [#279](https://github.com/alchemy-run/distilled/issues/279).
