### PR TITLE
feat(core/openapi): emit makePaginated for cursor/page/token list ops

### DIFF
--- a/packages/core/scripts/generate-openapi.ts
+++ b/packages/core/scripts/generate-openapi.ts
@@ -1232,6 +1232,12 @@ export function generateFromOpenAPI(config: GeneratorConfig): void {
             }
           }
 
+          const pagination = detectPagination(
+            parameters as ParameterObject3[],
+            responseSchema,
+            spec,
+          );
+
           const code = buildOperationFile(
             functionName,
             inputSchemaCode,
@@ -1241,6 +1247,7 @@ export function generateFromOpenAPI(config: GeneratorConfig): void {
             jsDoc,
             operationErrors,
             sensitiveImports,
+            pagination,
             config,
           );
 
@@ -1350,6 +1357,12 @@ export function generateFromOpenAPI(config: GeneratorConfig): void {
             }
           }
 
+          const pagination = detectPagination(
+            parameters as ParameterObject3[],
+            responseSchema,
+            spec,
+          );
+
           const code = buildOperationFile(
             functionName,
             inputSchemaCode,
@@ -1359,6 +1372,7 @@ export function generateFromOpenAPI(config: GeneratorConfig): void {
             jsDoc,
             operationErrors,
             sensitiveImports,
+            pagination,
             config,
           );
 
@@ -1394,6 +1408,117 @@ export function generateFromOpenAPI(config: GeneratorConfig): void {
 // Helpers
 // ============================================================================
 
+/**
+ * Detect cursor / page / token pagination on an operation by looking at the
+ * input parameters and the (resolved) response schema.
+ *
+ * Returns the `pagination` trait to feed into `API.makePaginated`, or
+ * `undefined` if the operation isn't paginated.
+ */
+function detectPagination(
+  parameters: ParameterObject3[] | undefined,
+  responseSchema: SchemaObject | null,
+  spec: any,
+): { mode: "cursor" | "page" | "token"; inputToken: string; outputToken: string; items: string } | undefined {
+  if (!responseSchema) return undefined;
+
+  // Resolve the response schema if it's still a $ref (callers usually
+  // pre-resolve, but be defensive).
+  let resolved = responseSchema;
+  if (resolved.$ref) {
+    resolved = resolveRef(spec, resolved.$ref);
+  }
+  // Flatten allOf into a single property bag for inspection.
+  let outputProps: Record<string, SchemaObject> = resolved.properties ?? {};
+  if (resolved.allOf) {
+    outputProps = { ...outputProps };
+    for (const sub of resolved.allOf) {
+      const r = sub.$ref ? (resolveRef(spec, sub.$ref) as SchemaObject) : sub;
+      if (r.properties) Object.assign(outputProps, r.properties);
+    }
+  }
+
+  // Find the next-page indicator on the output. Patterns we recognise:
+  //   pagination.cursor  / pagination.next  -> cursor mode
+  //   pagination.next_page                  -> page mode
+  //   next_token / NextToken                -> token mode (top-level)
+  //   next_page                             -> page mode (top-level)
+  let outputToken: string | undefined;
+  let mode: "cursor" | "page" | "token" | undefined;
+
+  const paginationProp = outputProps.pagination;
+  if (paginationProp) {
+    let p = paginationProp;
+    if (p.$ref) p = resolveRef(spec, p.$ref);
+    const subProps = p.properties ?? {};
+    if (subProps.cursor) {
+      outputToken = "pagination.cursor";
+      mode = "cursor";
+    } else if (subProps.next) {
+      outputToken = "pagination.next";
+      mode = "cursor";
+    } else if (subProps.next_page) {
+      outputToken = "pagination.next_page";
+      mode = "page";
+    }
+  }
+  if (!outputToken) {
+    for (const candidate of ["next_token", "NextToken", "nextToken"]) {
+      if (outputProps[candidate]) {
+        outputToken = candidate;
+        mode = "token";
+        break;
+      }
+    }
+  }
+  if (!outputToken) {
+    if (outputProps.next_page) {
+      outputToken = "next_page";
+      mode = "page";
+    }
+  }
+  if (!outputToken || !mode) return undefined;
+
+  // Find the matching input token. The query/path/etc. parameter that
+  // carries the cursor / page / next-token between requests.
+  const cursorAliases = ["cursor", "page_token", "pageToken"];
+  const tokenAliases = ["next_token", "NextToken", "nextToken"];
+  const pageAliases = ["page"];
+  const wanted =
+    mode === "cursor"
+      ? cursorAliases
+      : mode === "token"
+        ? tokenAliases
+        : pageAliases;
+  let inputToken: string | undefined;
+  for (const param of parameters ?? []) {
+    if (wanted.includes(param.name)) {
+      inputToken = param.name;
+      break;
+    }
+  }
+  if (!inputToken) return undefined;
+
+  // Items path: the first non-pagination array property at the top level.
+  // For nested envelopes (e.g. `{ result: { items: [...] } }`) callers can
+  // still hand-roll, but flat array fields like `projects`/`branches` work
+  // automatically.
+  let items: string | undefined;
+  for (const [key, value] of Object.entries(outputProps)) {
+    if (key === "pagination" || key === "next_token" || key === "NextToken")
+      continue;
+    let v = value;
+    if (v.$ref) v = resolveRef(spec, v.$ref);
+    if (v.type === "array") {
+      items = key;
+      break;
+    }
+  }
+  if (!items) return undefined;
+
+  return { mode, inputToken, outputToken, items };
+}
+
 function buildOperationFile(
   functionName: string,
   inputSchemaCode: string,
@@ -1406,6 +1531,7 @@ function buildOperationFile(
     usesSensitiveString: boolean;
     usesSensitiveNullableString: boolean;
   },
+  pagination: { mode: "cursor" | "page" | "token"; inputToken: string; outputToken: string; items: string } | undefined,
   config: GeneratorConfig,
 ): string {
   const clientImport = config.clientImport ?? `${config.importPrefix}/client`;
@@ -1420,15 +1546,20 @@ function buildOperationFile(
     ? `\n  errors: [${operationErrors.join(", ")}] as const,`
     : "";
 
+  const factory = pagination ? "makePaginated" : "make";
+  const paginationLine = pagination
+    ? `\n  pagination: { mode: "${pagination.mode}", inputToken: "${pagination.inputToken}", outputToken: "${pagination.outputToken}", items: "${pagination.items}" },`
+    : "";
+
   const operationCode = jsDoc
     ? `${jsDoc}
-export const ${functionName} = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const ${functionName} = /*@__PURE__*/ /*#__PURE__*/ API.${factory}(() => ({
   inputSchema: ${inputSchemaName},
-  outputSchema: ${outputSchemaName},${errorsLine}
+  outputSchema: ${outputSchemaName},${errorsLine}${paginationLine}
 }));`
-    : `export const ${functionName} = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+    : `export const ${functionName} = /*@__PURE__*/ /*#__PURE__*/ API.${factory}(() => ({
   inputSchema: ${inputSchemaName},
-  outputSchema: ${outputSchemaName},${errorsLine}
+  outputSchema: ${outputSchemaName},${errorsLine}${paginationLine}
 }));`;
 
   let imports = `import * as Schema from "effect/Schema";

--- a/packages/neon/src/operations/getConsumptionHistoryPerProject.ts
+++ b/packages/neon/src/operations/getConsumptionHistoryPerProject.ts
@@ -122,8 +122,14 @@ A list of metrics can be specified as an array of parameter values or as a comma
 
  */
 export const getConsumptionHistoryPerProject =
-  /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: GetConsumptionHistoryPerProjectInput,
     outputSchema: GetConsumptionHistoryPerProjectOutput,
     errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "cursor",
+      inputToken: "cursor",
+      outputToken: "pagination.cursor",
+      items: "projects",
+    },
   }));

--- a/packages/neon/src/operations/getConsumptionHistoryPerProjectV2.ts
+++ b/packages/neon/src/operations/getConsumptionHistoryPerProjectV2.ts
@@ -116,8 +116,14 @@ A list of metrics can be specified as an array of parameter values or as a comma
 
  */
 export const getConsumptionHistoryPerProjectV2 =
-  /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: GetConsumptionHistoryPerProjectV2Input,
     outputSchema: GetConsumptionHistoryPerProjectV2Output,
     errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "cursor",
+      inputToken: "cursor",
+      outputToken: "pagination.cursor",
+      items: "projects",
+    },
   }));

--- a/packages/neon/src/operations/getOrganizationMembers.ts
+++ b/packages/neon/src/operations/getOrganizationMembers.ts
@@ -56,9 +56,14 @@ export type GetOrganizationMembersOutput =
  * @param sort_order - Defines the sorting order of entities.
  * @param limit - The maximum number of members to return in the response
  */
-export const getOrganizationMembers = /*@__PURE__*/ /*#__PURE__*/ API.make(
-  () => ({
+export const getOrganizationMembers =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: GetOrganizationMembersInput,
     outputSchema: GetOrganizationMembersOutput,
-  }),
-);
+    pagination: {
+      mode: "cursor",
+      inputToken: "cursor",
+      outputToken: "pagination.next",
+      items: "members",
+    },
+  }));

--- a/packages/neon/src/operations/listProjectBranches.ts
+++ b/packages/neon/src/operations/listProjectBranches.ts
@@ -120,8 +120,15 @@ If false or not provided, return only active (non-deleted) branches.
 This parameter is part of the Branch Recovery feature, which is in preview and not available to all users.
 
  */
-export const listProjectBranches = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListProjectBranchesInput,
-  outputSchema: ListProjectBranchesOutput,
-  errors: [NotFound] as const,
-}));
+export const listProjectBranches =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+    inputSchema: ListProjectBranchesInput,
+    outputSchema: ListProjectBranchesOutput,
+    errors: [NotFound] as const,
+    pagination: {
+      mode: "cursor",
+      inputToken: "cursor",
+      outputToken: "pagination.next",
+      items: "branches",
+    },
+  }));

--- a/packages/neon/src/operations/listProjectOperations.ts
+++ b/packages/neon/src/operations/listProjectOperations.ts
@@ -98,10 +98,15 @@ export type ListProjectOperationsOutput =
  * @param limit - Specify a value from 1 to 1000 to limit number of operations in the response
  * @param project_id - The Neon project ID
  */
-export const listProjectOperations = /*@__PURE__*/ /*#__PURE__*/ API.make(
-  () => ({
+export const listProjectOperations =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: ListProjectOperationsInput,
     outputSchema: ListProjectOperationsOutput,
     errors: [NotFound] as const,
-  }),
-);
+    pagination: {
+      mode: "cursor",
+      inputToken: "cursor",
+      outputToken: "pagination.cursor",
+      items: "operations",
+    },
+  }));

--- a/packages/neon/src/operations/listProjects.ts
+++ b/packages/neon/src/operations/listProjects.ts
@@ -138,7 +138,15 @@ If not specified, an implicit implementation defined timeout is chosen with the 
  * @param recoverable - Show only deleted projects within the recovery window.
 
  */
-export const listProjects = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListProjectsInput,
-  outputSchema: ListProjectsOutput,
-}));
+export const listProjects = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: ListProjectsInput,
+    outputSchema: ListProjectsOutput,
+    pagination: {
+      mode: "cursor",
+      inputToken: "cursor",
+      outputToken: "pagination.cursor",
+      items: "projects",
+    },
+  }),
+);

--- a/packages/neon/src/operations/listSharedProjects.ts
+++ b/packages/neon/src/operations/listSharedProjects.ts
@@ -122,7 +122,15 @@ Projects still being fetched when the timeout occurred are listed in the "unavai
 If not specified, an implicit implementation defined timeout is chosen with the same behaviour as above
 
  */
-export const listSharedProjects = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListSharedProjectsInput,
-  outputSchema: ListSharedProjectsOutput,
-}));
+export const listSharedProjects = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: ListSharedProjectsInput,
+    outputSchema: ListSharedProjectsOutput,
+    pagination: {
+      mode: "cursor",
+      inputToken: "cursor",
+      outputToken: "pagination.cursor",
+      items: "projects",
+    },
+  }),
+);

--- a/packages/planetscale/src/operations/getDeployQueue.ts
+++ b/packages/planetscale/src/operations/getDeployQueue.ts
@@ -189,8 +189,16 @@ export type GetDeployQueueOutput = typeof GetDeployQueueOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const getDeployQueue = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: GetDeployQueueInput,
-  outputSchema: GetDeployQueueOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const getDeployQueue = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: GetDeployQueueInput,
+    outputSchema: GetDeployQueueOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/planetscale/src/operations/getInvoiceLineItems.ts
+++ b/packages/planetscale/src/operations/getInvoiceLineItems.ts
@@ -57,8 +57,15 @@ export type GetInvoiceLineItemsOutput = typeof GetInvoiceLineItemsOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const getInvoiceLineItems = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: GetInvoiceLineItemsInput,
-  outputSchema: GetInvoiceLineItemsOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const getInvoiceLineItems =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+    inputSchema: GetInvoiceLineItemsInput,
+    outputSchema: GetInvoiceLineItemsOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));

--- a/packages/planetscale/src/operations/lintBranchSchema.ts
+++ b/packages/planetscale/src/operations/lintBranchSchema.ts
@@ -61,8 +61,16 @@ export type LintBranchSchemaOutput = typeof LintBranchSchemaOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const lintBranchSchema = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: LintBranchSchemaInput,
-  outputSchema: LintBranchSchemaOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const lintBranchSchema = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: LintBranchSchemaInput,
+    outputSchema: LintBranchSchemaOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/planetscale/src/operations/listBackupPolicies.ts
+++ b/packages/planetscale/src/operations/listBackupPolicies.ts
@@ -58,8 +58,16 @@ export type ListBackupPoliciesOutput = typeof ListBackupPoliciesOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listBackupPolicies = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListBackupPoliciesInput,
-  outputSchema: ListBackupPoliciesOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const listBackupPolicies = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: ListBackupPoliciesInput,
+    outputSchema: ListBackupPoliciesOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/planetscale/src/operations/listBackups.ts
+++ b/packages/planetscale/src/operations/listBackups.ts
@@ -135,8 +135,16 @@ export type ListBackupsOutput = typeof ListBackupsOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listBackups = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListBackupsInput,
-  outputSchema: ListBackupsOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const listBackups = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: ListBackupsInput,
+    outputSchema: ListBackupsOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/planetscale/src/operations/listBouncerResizeRequests.ts
+++ b/packages/planetscale/src/operations/listBouncerResizeRequests.ts
@@ -89,10 +89,15 @@ export type ListBouncerResizeRequestsOutput =
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listBouncerResizeRequests = /*@__PURE__*/ /*#__PURE__*/ API.make(
-  () => ({
+export const listBouncerResizeRequests =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: ListBouncerResizeRequestsInput,
     outputSchema: ListBouncerResizeRequestsOutput,
     errors: [Forbidden, NotFound] as const,
-  }),
-);
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));

--- a/packages/planetscale/src/operations/listBouncers.ts
+++ b/packages/planetscale/src/operations/listBouncers.ts
@@ -102,8 +102,16 @@ export type ListBouncersOutput = typeof ListBouncersOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listBouncers = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListBouncersInput,
-  outputSchema: ListBouncersOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const listBouncers = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: ListBouncersInput,
+    outputSchema: ListBouncersOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/planetscale/src/operations/listBranchBouncerResizeRequests.ts
+++ b/packages/planetscale/src/operations/listBranchBouncerResizeRequests.ts
@@ -88,8 +88,14 @@ export type ListBranchBouncerResizeRequestsOutput =
  * @param per_page - If provided, specifies the number of returned results
  */
 export const listBranchBouncerResizeRequests =
-  /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: ListBranchBouncerResizeRequestsInput,
     outputSchema: ListBranchBouncerResizeRequestsOutput,
     errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
   }));

--- a/packages/planetscale/src/operations/listBranchChangeRequests.ts
+++ b/packages/planetscale/src/operations/listBranchChangeRequests.ts
@@ -88,10 +88,15 @@ export type ListBranchChangeRequestsOutput =
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listBranchChangeRequests = /*@__PURE__*/ /*#__PURE__*/ API.make(
-  () => ({
+export const listBranchChangeRequests =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: ListBranchChangeRequestsInput,
     outputSchema: ListBranchChangeRequestsOutput,
     errors: [Forbidden, NotFound] as const,
-  }),
-);
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));

--- a/packages/planetscale/src/operations/listBranches.ts
+++ b/packages/planetscale/src/operations/listBranches.ts
@@ -111,8 +111,16 @@ export type ListBranchesOutput = typeof ListBranchesOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listBranches = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListBranchesInput,
-  outputSchema: ListBranchesOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const listBranches = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: ListBranchesInput,
+    outputSchema: ListBranchesOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/planetscale/src/operations/listDatabasePostgresCidrs.ts
+++ b/packages/planetscale/src/operations/listDatabasePostgresCidrs.ts
@@ -56,10 +56,15 @@ export type ListDatabasePostgresCidrsOutput =
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listDatabasePostgresCidrs = /*@__PURE__*/ /*#__PURE__*/ API.make(
-  () => ({
+export const listDatabasePostgresCidrs =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: ListDatabasePostgresCidrsInput,
     outputSchema: ListDatabasePostgresCidrsOutput,
     errors: [Forbidden, NotFound, UnprocessableEntity] as const,
-  }),
-);
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));

--- a/packages/planetscale/src/operations/listDatabaseRegions.ts
+++ b/packages/planetscale/src/operations/listDatabaseRegions.ts
@@ -50,8 +50,15 @@ export type ListDatabaseRegionsOutput = typeof ListDatabaseRegionsOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listDatabaseRegions = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListDatabaseRegionsInput,
-  outputSchema: ListDatabaseRegionsOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const listDatabaseRegions =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+    inputSchema: ListDatabaseRegionsInput,
+    outputSchema: ListDatabaseRegionsOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));

--- a/packages/planetscale/src/operations/listDatabases.ts
+++ b/packages/planetscale/src/operations/listDatabases.ts
@@ -109,8 +109,16 @@ export type ListDatabasesOutput = typeof ListDatabasesOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listDatabases = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListDatabasesInput,
-  outputSchema: ListDatabasesOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const listDatabases = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: ListDatabasesInput,
+    outputSchema: ListDatabasesOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/planetscale/src/operations/listDeployOperations.ts
+++ b/packages/planetscale/src/operations/listDeployOperations.ts
@@ -72,10 +72,15 @@ export type ListDeployOperationsOutput = typeof ListDeployOperationsOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listDeployOperations = /*@__PURE__*/ /*#__PURE__*/ API.make(
-  () => ({
+export const listDeployOperations =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: ListDeployOperationsInput,
     outputSchema: ListDeployOperationsOutput,
     errors: [Forbidden, NotFound] as const,
-  }),
-);
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));

--- a/packages/planetscale/src/operations/listDeployRequestReviews.ts
+++ b/packages/planetscale/src/operations/listDeployRequestReviews.ts
@@ -57,10 +57,15 @@ export type ListDeployRequestReviewsOutput =
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listDeployRequestReviews = /*@__PURE__*/ /*#__PURE__*/ API.make(
-  () => ({
+export const listDeployRequestReviews =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: ListDeployRequestReviewsInput,
     outputSchema: ListDeployRequestReviewsOutput,
     errors: [Forbidden, NotFound] as const,
-  }),
-);
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));

--- a/packages/planetscale/src/operations/listDeployRequests.ts
+++ b/packages/planetscale/src/operations/listDeployRequests.ts
@@ -264,8 +264,16 @@ export type ListDeployRequestsOutput = typeof ListDeployRequestsOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listDeployRequests = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListDeployRequestsInput,
-  outputSchema: ListDeployRequestsOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const listDeployRequests = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: ListDeployRequestsInput,
+    outputSchema: ListDeployRequestsOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/planetscale/src/operations/listInvoices.ts
+++ b/packages/planetscale/src/operations/listInvoices.ts
@@ -43,8 +43,16 @@ export type ListInvoicesOutput = typeof ListInvoicesOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listInvoices = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListInvoicesInput,
-  outputSchema: ListInvoicesOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const listInvoices = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: ListInvoicesInput,
+    outputSchema: ListInvoicesOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/planetscale/src/operations/listKeyspaces.ts
+++ b/packages/planetscale/src/operations/listKeyspaces.ts
@@ -77,8 +77,16 @@ export type ListKeyspacesOutput = typeof ListKeyspacesOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listKeyspaces = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListKeyspacesInput,
-  outputSchema: ListKeyspacesOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const listKeyspaces = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: ListKeyspacesInput,
+    outputSchema: ListKeyspacesOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/planetscale/src/operations/listMaintenanceSchedules.ts
+++ b/packages/planetscale/src/operations/listMaintenanceSchedules.ts
@@ -62,10 +62,15 @@ export type ListMaintenanceSchedulesOutput =
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listMaintenanceSchedules = /*@__PURE__*/ /*#__PURE__*/ API.make(
-  () => ({
+export const listMaintenanceSchedules =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: ListMaintenanceSchedulesInput,
     outputSchema: ListMaintenanceSchedulesOutput,
     errors: [Forbidden, NotFound] as const,
-  }),
-);
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));

--- a/packages/planetscale/src/operations/listMaintenanceWindows.ts
+++ b/packages/planetscale/src/operations/listMaintenanceWindows.ts
@@ -51,10 +51,15 @@ export type ListMaintenanceWindowsOutput =
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listMaintenanceWindows = /*@__PURE__*/ /*#__PURE__*/ API.make(
-  () => ({
+export const listMaintenanceWindows =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: ListMaintenanceWindowsInput,
     outputSchema: ListMaintenanceWindowsOutput,
     errors: [Forbidden, NotFound] as const,
-  }),
-);
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));

--- a/packages/planetscale/src/operations/listOauthApplications.ts
+++ b/packages/planetscale/src/operations/listOauthApplications.ts
@@ -55,10 +55,15 @@ export type ListOauthApplicationsOutput =
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listOauthApplications = /*@__PURE__*/ /*#__PURE__*/ API.make(
-  () => ({
+export const listOauthApplications =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: ListOauthApplicationsInput,
     outputSchema: ListOauthApplicationsOutput,
     errors: [Forbidden, NotFound] as const,
-  }),
-);
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));

--- a/packages/planetscale/src/operations/listOauthTokens.ts
+++ b/packages/planetscale/src/operations/listOauthTokens.ts
@@ -141,8 +141,16 @@ export type ListOauthTokensOutput = typeof ListOauthTokensOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listOauthTokens = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListOauthTokensInput,
-  outputSchema: ListOauthTokensOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const listOauthTokens = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: ListOauthTokensInput,
+    outputSchema: ListOauthTokensOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/planetscale/src/operations/listOrganizationMembers.ts
+++ b/packages/planetscale/src/operations/listOrganizationMembers.ts
@@ -68,10 +68,15 @@ export type ListOrganizationMembersOutput =
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listOrganizationMembers = /*@__PURE__*/ /*#__PURE__*/ API.make(
-  () => ({
+export const listOrganizationMembers =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: ListOrganizationMembersInput,
     outputSchema: ListOrganizationMembersOutput,
     errors: [Forbidden, NotFound] as const,
-  }),
-);
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));

--- a/packages/planetscale/src/operations/listOrganizationTeamMembers.ts
+++ b/packages/planetscale/src/operations/listOrganizationTeamMembers.ts
@@ -124,10 +124,15 @@ export type ListOrganizationTeamMembersOutput =
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listOrganizationTeamMembers = /*@__PURE__*/ /*#__PURE__*/ API.make(
-  () => ({
+export const listOrganizationTeamMembers =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: ListOrganizationTeamMembersInput,
     outputSchema: ListOrganizationTeamMembersOutput,
     errors: [BadRequest, Forbidden, NotFound, UnprocessableEntity] as const,
-  }),
-);
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));

--- a/packages/planetscale/src/operations/listOrganizationTeams.ts
+++ b/packages/planetscale/src/operations/listOrganizationTeams.ts
@@ -89,10 +89,15 @@ export type ListOrganizationTeamsOutput =
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listOrganizationTeams = /*@__PURE__*/ /*#__PURE__*/ API.make(
-  () => ({
+export const listOrganizationTeams =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: ListOrganizationTeamsInput,
     outputSchema: ListOrganizationTeamsOutput,
     errors: [BadRequest, Forbidden, NotFound, UnprocessableEntity] as const,
-  }),
-);
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));

--- a/packages/planetscale/src/operations/listOrganizations.ts
+++ b/packages/planetscale/src/operations/listOrganizations.ts
@@ -56,8 +56,16 @@ export type ListOrganizationsOutput = typeof ListOrganizationsOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listOrganizations = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListOrganizationsInput,
-  outputSchema: ListOrganizationsOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const listOrganizations = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: ListOrganizationsInput,
+    outputSchema: ListOrganizationsOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/planetscale/src/operations/listPasswords.ts
+++ b/packages/planetscale/src/operations/listPasswords.ts
@@ -86,8 +86,16 @@ export type ListPasswordsOutput = typeof ListPasswordsOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listPasswords = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListPasswordsInput,
-  outputSchema: ListPasswordsOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const listPasswords = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: ListPasswordsInput,
+    outputSchema: ListPasswordsOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/planetscale/src/operations/listPublicRegions.ts
+++ b/packages/planetscale/src/operations/listPublicRegions.ts
@@ -43,8 +43,16 @@ export type ListPublicRegionsOutput = typeof ListPublicRegionsOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listPublicRegions = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListPublicRegionsInput,
-  outputSchema: ListPublicRegionsOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const listPublicRegions = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: ListPublicRegionsInput,
+    outputSchema: ListPublicRegionsOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/planetscale/src/operations/listReadOnlyRegions.ts
+++ b/packages/planetscale/src/operations/listReadOnlyRegions.ts
@@ -65,8 +65,15 @@ export type ListReadOnlyRegionsOutput = typeof ListReadOnlyRegionsOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listReadOnlyRegions = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListReadOnlyRegionsInput,
-  outputSchema: ListReadOnlyRegionsOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const listReadOnlyRegions =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
+    inputSchema: ListReadOnlyRegionsInput,
+    outputSchema: ListReadOnlyRegionsOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));

--- a/packages/planetscale/src/operations/listRegionsForOrganization.ts
+++ b/packages/planetscale/src/operations/listRegionsForOrganization.ts
@@ -47,10 +47,15 @@ export type ListRegionsForOrganizationOutput =
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listRegionsForOrganization = /*@__PURE__*/ /*#__PURE__*/ API.make(
-  () => ({
+export const listRegionsForOrganization =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: ListRegionsForOrganizationInput,
     outputSchema: ListRegionsForOrganizationOutput,
     errors: [Forbidden, NotFound] as const,
-  }),
-);
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));

--- a/packages/planetscale/src/operations/listRoles.ts
+++ b/packages/planetscale/src/operations/listRoles.ts
@@ -94,8 +94,14 @@ export type ListRolesOutput = typeof ListRolesOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listRoles = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+export const listRoles = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
   inputSchema: ListRolesInput,
   outputSchema: ListRolesOutput,
   errors: [Forbidden, NotFound] as const,
+  pagination: {
+    mode: "page",
+    inputToken: "page",
+    outputToken: "next_page",
+    items: "data",
+  },
 }));

--- a/packages/planetscale/src/operations/listSchemaRecommendations.ts
+++ b/packages/planetscale/src/operations/listSchemaRecommendations.ts
@@ -79,10 +79,15 @@ export type ListSchemaRecommendationsOutput =
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listSchemaRecommendations = /*@__PURE__*/ /*#__PURE__*/ API.make(
-  () => ({
+export const listSchemaRecommendations =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: ListSchemaRecommendationsInput,
     outputSchema: ListSchemaRecommendationsOutput,
     errors: [Forbidden, NotFound] as const,
-  }),
-);
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));

--- a/packages/planetscale/src/operations/listServiceTokens.ts
+++ b/packages/planetscale/src/operations/listServiceTokens.ts
@@ -142,8 +142,16 @@ export type ListServiceTokensOutput = typeof ListServiceTokensOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listServiceTokens = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListServiceTokensInput,
-  outputSchema: ListServiceTokensOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const listServiceTokens = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: ListServiceTokensInput,
+    outputSchema: ListServiceTokensOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/planetscale/src/operations/listTrafficBudgets.ts
+++ b/packages/planetscale/src/operations/listTrafficBudgets.ts
@@ -89,8 +89,16 @@ export type ListTrafficBudgetsOutput = typeof ListTrafficBudgetsOutput.Type;
  * @param created_at - Filter by creation date range (format: 'start..end')
  * @param fingerprint - Filter budgets by query fingerprint
  */
-export const listTrafficBudgets = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListTrafficBudgetsInput,
-  outputSchema: ListTrafficBudgetsOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const listTrafficBudgets = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: ListTrafficBudgetsInput,
+    outputSchema: ListTrafficBudgetsOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/planetscale/src/operations/listWebhooks.ts
+++ b/packages/planetscale/src/operations/listWebhooks.ts
@@ -75,8 +75,16 @@ export type ListWebhooksOutput = typeof ListWebhooksOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listWebhooks = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListWebhooksInput,
-  outputSchema: ListWebhooksOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const listWebhooks = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: ListWebhooksInput,
+    outputSchema: ListWebhooksOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/planetscale/src/operations/listWorkflows.ts
+++ b/packages/planetscale/src/operations/listWorkflows.ts
@@ -167,8 +167,16 @@ export type ListWorkflowsOutput = typeof ListWorkflowsOutput.Type;
  * @param page - If provided, specifies the page offset of returned results
  * @param per_page - If provided, specifies the number of returned results
  */
-export const listWorkflows = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: ListWorkflowsInput,
-  outputSchema: ListWorkflowsOutput,
-  errors: [Forbidden, NotFound] as const,
-}));
+export const listWorkflows = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: ListWorkflowsInput,
+    outputSchema: ListWorkflowsOutput,
+    errors: [Forbidden, NotFound] as const,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/stripe/src/operations/GetChargesSearch.ts
+++ b/packages/stripe/src/operations/GetChargesSearch.ts
@@ -315,7 +315,15 @@ export type GetChargesSearchOutput = typeof GetChargesSearchOutput.Type;
  * @param page - A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
  * @param query - The search query string. See [search query language](https://docs.stripe.com/search#search-query-language) and the list of supported [query fields for charges](https://docs.stripe.com/search#query-fields-for-charges).
  */
-export const GetChargesSearch = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: GetChargesSearchInput,
-  outputSchema: GetChargesSearchOutput,
-}));
+export const GetChargesSearch = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: GetChargesSearchInput,
+    outputSchema: GetChargesSearchOutput,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/stripe/src/operations/GetCustomersSearch.ts
+++ b/packages/stripe/src/operations/GetCustomersSearch.ts
@@ -580,7 +580,15 @@ export type GetCustomersSearchOutput = typeof GetCustomersSearchOutput.Type;
  * @param page - A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
  * @param query - The search query string. See [search query language](https://docs.stripe.com/search#search-query-language) and the list of supported [query fields for customers](https://docs.stripe.com/search#query-fields-for-customers).
  */
-export const GetCustomersSearch = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: GetCustomersSearchInput,
-  outputSchema: GetCustomersSearchOutput,
-}));
+export const GetCustomersSearch = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: GetCustomersSearchInput,
+    outputSchema: GetCustomersSearchOutput,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/stripe/src/operations/GetInvoicesSearch.ts
+++ b/packages/stripe/src/operations/GetInvoicesSearch.ts
@@ -564,7 +564,15 @@ export type GetInvoicesSearchOutput = typeof GetInvoicesSearchOutput.Type;
  * @param page - A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
  * @param query - The search query string. See [search query language](https://docs.stripe.com/search#search-query-language) and the list of supported [query fields for invoices](https://docs.stripe.com/search#query-fields-for-invoices).
  */
-export const GetInvoicesSearch = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: GetInvoicesSearchInput,
-  outputSchema: GetInvoicesSearchOutput,
-}));
+export const GetInvoicesSearch = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: GetInvoicesSearchInput,
+    outputSchema: GetInvoicesSearchOutput,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/stripe/src/operations/GetPaymentIntentsSearch.ts
+++ b/packages/stripe/src/operations/GetPaymentIntentsSearch.ts
@@ -251,9 +251,14 @@ export type GetPaymentIntentsSearchOutput =
  * @param page - A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
  * @param query - The search query string. See [search query language](https://docs.stripe.com/search#search-query-language) and the list of supported [query fields for payment intents](https://docs.stripe.com/search#query-fields-for-payment-intents).
  */
-export const GetPaymentIntentsSearch = /*@__PURE__*/ /*#__PURE__*/ API.make(
-  () => ({
+export const GetPaymentIntentsSearch =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: GetPaymentIntentsSearchInput,
     outputSchema: GetPaymentIntentsSearchOutput,
-  }),
-);
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));

--- a/packages/stripe/src/operations/GetPricesSearch.ts
+++ b/packages/stripe/src/operations/GetPricesSearch.ts
@@ -101,7 +101,15 @@ export type GetPricesSearchOutput = typeof GetPricesSearchOutput.Type;
  * @param page - A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
  * @param query - The search query string. See [search query language](https://docs.stripe.com/search#search-query-language) and the list of supported [query fields for prices](https://docs.stripe.com/search#query-fields-for-prices).
  */
-export const GetPricesSearch = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: GetPricesSearchInput,
-  outputSchema: GetPricesSearchOutput,
-}));
+export const GetPricesSearch = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: GetPricesSearchInput,
+    outputSchema: GetPricesSearchOutput,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/stripe/src/operations/GetProductsSearch.ts
+++ b/packages/stripe/src/operations/GetProductsSearch.ts
@@ -71,7 +71,15 @@ export type GetProductsSearchOutput = typeof GetProductsSearchOutput.Type;
  * @param page - A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
  * @param query - The search query string. See [search query language](https://docs.stripe.com/search#search-query-language) and the list of supported [query fields for products](https://docs.stripe.com/search#query-fields-for-products).
  */
-export const GetProductsSearch = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
-  inputSchema: GetProductsSearchInput,
-  outputSchema: GetProductsSearchOutput,
-}));
+export const GetProductsSearch = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(
+  () => ({
+    inputSchema: GetProductsSearchInput,
+    outputSchema: GetProductsSearchOutput,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }),
+);

--- a/packages/stripe/src/operations/GetSubscriptionsSearch.ts
+++ b/packages/stripe/src/operations/GetSubscriptionsSearch.ts
@@ -354,9 +354,14 @@ export type GetSubscriptionsSearchOutput =
  * @param page - A cursor for pagination across multiple pages of results. Don't include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
  * @param query - The search query string. See [search query language](https://docs.stripe.com/search#search-query-language) and the list of supported [query fields for subscriptions](https://docs.stripe.com/search#query-fields-for-subscriptions).
  */
-export const GetSubscriptionsSearch = /*@__PURE__*/ /*#__PURE__*/ API.make(
-  () => ({
+export const GetSubscriptionsSearch =
+  /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
     inputSchema: GetSubscriptionsSearchInput,
     outputSchema: GetSubscriptionsSearchOutput,
-  }),
-);
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "next_page",
+      items: "data",
+    },
+  }));


### PR DESCRIPTION
Today every generated list op is `API.make(...)` and callers have to roll their own `do { … } while (cursor)` loop. After this change the generator detects pagination and emits `API.makePaginated(...)` so every list op gets `.pages()` / `.items()` Stream methods for free:

```ts
// before — manual cursor loop
let cursor: string | undefined;
do {
  const page = yield* listProjectBranches({ project_id, search: name, ...(cursor ? { cursor } : {}) });
  for (const b of page.branches) if (b.name === name) matches.push(b);
  cursor = page.pagination?.next;
} while (cursor);

// after — yield* the items stream
yield* listProjectBranches.items({ project_id, search: name }).pipe(
  Stream.filter((b) => b.name === name),
  Stream.runCollect,
);
```

### Detection rules

Inspecting the resolved input parameters and response schema:

| output marker | mode |
|---|---|
| `pagination.cursor` / `pagination.next` | `cursor` |
| `pagination.next_page` / top-level `next_page` | `page` |
| top-level `next_token` / `NextToken` | `token` |

When a marker is found, the generator looks for a matching input parameter (`cursor` / `page_token` / `next_token` / `page`) and the first non-`pagination` top-level array property as the items path. If all three line up, emit `makePaginated`; otherwise fall back to `make`.

### Impact

50 ops across `@distilled.cloud/{neon,planetscale,stripe}` flip from `make` to `makePaginated`. Type-check is clean across the workspace.
