### PR TITLE
fix(cloudflare/workers): type code 10002 'unknown error' on putScript

### DIFF
--- a/packages/cloudflare/patches/workers/putScript.json
+++ b/packages/cloudflare/patches/workers/putScript.json
@@ -2,6 +2,12 @@
   "errors": {
     "InvalidRoute": [{ "code": 7003 }],
     "InvalidWorkerScript": [{ "code": 10068 }],
+    "InternalServerError": [
+      {
+        "code": 10002,
+        "message": { "includes": "An unknown error has occurred" }
+      }
+    ],
     "DurableObjectMustBeSqlite": [
       {
         "code": 10074,

--- a/packages/cloudflare/scripts/generate.ts
+++ b/packages/cloudflare/scripts/generate.ts
@@ -2964,8 +2964,21 @@ function generateServiceFile(
   lines.push(
     `import type { Credentials } from "${withTsExtension("../credentials")}";`,
   );
+  // Collect error tags that are shared classes re-exported from
+  // `../errors.ts` (and ultimately from `@distilled.cloud/core/errors`).
+  // These are imported rather than redeclared per service, so an
+  // operation that surfaces e.g. `InternalServerError` always refers to
+  // the same class everywhere.
+  const sharedErrorTags = ["InternalServerError"] as const;
+  const mergedErrorsPreview = mergeServiceErrors(service, patches);
+  const importedSharedErrors = sharedErrorTags.filter((tag) =>
+    mergedErrorsPreview.some((e) => e.tag === tag),
+  );
   lines.push(`import {`);
   lines.push(`  type DefaultErrors,`);
+  for (const tag of importedSharedErrors) {
+    lines.push(`  ${tag},`);
+  }
   lines.push(`} from "${withTsExtension("../errors")}";`);
   // Conditionally import UploadableSchema for file uploads
   if (hasFileUploads) {
@@ -2993,19 +3006,27 @@ function generateServiceFile(
   lines.push(`__SENSITIVE_IMPORT__`);
   lines.push("");
 
-  // Merge all error definitions across patches and emit each class once
-  const mergedErrors = mergeServiceErrors(service, patches);
+  // Merge all error definitions across patches and emit each class once.
+  // Tags listed in `sharedErrorTags` are not redeclared — we just attach
+  // their service-specific matchers to the imported class.
+  const mergedErrors = mergedErrorsPreview;
   if (mergedErrors.length > 0) {
     lines.push(`// ${"=".repeat(77)}`);
     lines.push(`// Errors`);
     lines.push(`// ${"=".repeat(77)}`);
     lines.push("");
     for (const { tag, matchers } of mergedErrors) {
-      lines.push(`export class ${tag} extends Schema.TaggedErrorClass<${tag}>()(
+      if ((sharedErrorTags as readonly string[]).includes(tag)) {
+        lines.push(
+          `T.applyErrorMatchers(${tag}, ${JSON.stringify(matchers)});`,
+        );
+      } else {
+        lines.push(`export class ${tag} extends Schema.TaggedErrorClass<${tag}>()(
   "${tag}",
   { code: Schema.Number, message: Schema.String },
 ) {}
 T.applyErrorMatchers(${tag}, ${JSON.stringify(matchers)});`);
+      }
       lines.push("");
     }
   }

--- a/packages/cloudflare/specs/cloudflare/workers.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers.openapi.yml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  title: Cloudflare Workers API
+  title: Cloudflare WORKERS API
   version: 0.0.0
 servers:
   - url: https://api.cloudflare.com/client/v4
@@ -7325,6 +7325,10 @@ paths:
           - code: 7003
         InvalidWorkerScript:
           - code: 10068
+        InternalServerError:
+          - code: 10002
+            message:
+              includes: An unknown error has occurred
         DurableObjectMustBeSqlite:
           - code: 10074
             message:

--- a/packages/cloudflare/src/services/alerting.ts
+++ b/packages/cloudflare/src/services/alerting.ts
@@ -10,7 +10,7 @@ import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
-import { type DefaultErrors } from "../errors.ts";
+import { type DefaultErrors, InternalServerError } from "../errors.ts";
 
 // =============================================================================
 // Errors
@@ -22,10 +22,6 @@ export class FiltersRequired extends Schema.TaggedErrorClass<FiltersRequired>()(
 ) {}
 T.applyErrorMatchers(FiltersRequired, [{ code: 17103 }]);
 
-export class InternalServerError extends Schema.TaggedErrorClass<InternalServerError>()(
-  "InternalServerError",
-  { code: Schema.Number, message: Schema.String },
-) {}
 T.applyErrorMatchers(InternalServerError, [{ code: 15000 }]);
 
 export class InvalidAlertType extends Schema.TaggedErrorClass<InvalidAlertType>()(

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -10,7 +10,7 @@ import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as API from "../client/api.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
-import { type DefaultErrors } from "../errors.ts";
+import { type DefaultErrors, InternalServerError } from "../errors.ts";
 import { UploadableSchema } from "../schemas.ts";
 
 // =============================================================================
@@ -59,6 +59,10 @@ export class HostnameAlreadyInUse extends Schema.TaggedErrorClass<HostnameAlread
   { code: Schema.Number, message: Schema.String },
 ) {}
 T.applyErrorMatchers(HostnameAlreadyInUse, [{ code: 100116 }]);
+
+T.applyErrorMatchers(InternalServerError, [
+  { code: 10002, message: { includes: "An unknown error has occurred" } },
+]);
 
 export class InvalidRoute extends Schema.TaggedErrorClass<InvalidRoute>()(
   "InvalidRoute",
@@ -7640,6 +7644,7 @@ export type PutScriptError =
   | DefaultErrors
   | InvalidRoute
   | InvalidWorkerScript
+  | InternalServerError
   | DurableObjectMustBeSqlite
   | DuplicateMigrationTarget
   | ScriptStartupError
@@ -7656,6 +7661,7 @@ export const putScript: API.OperationMethod<
   errors: [
     InvalidRoute,
     InvalidWorkerScript,
+    InternalServerError,
     DurableObjectMustBeSqlite,
     DuplicateMigrationTarget,
     ScriptStartupError,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -99,12 +99,18 @@ export class Locked extends Schema.TaggedErrorClass<Locked>()("Locked", {
 }).pipe(Category.withLockedError, Category.withRetryable()) {}
 
 /**
- * InternalServerError - Server error (500).
+ * InternalServerError - Server error.
+ *
+ * Mapped from HTTP 500 by default. Per-service patches may also pin it to a
+ * specific in-band error code/message combination (e.g. Cloudflare returns a
+ * 200 envelope carrying `{ code: 10002, message: "An unknown error has
+ * occurred" }` for transient backend failures on some endpoints).
  */
 export class InternalServerError extends Schema.TaggedErrorClass<InternalServerError>()(
   "InternalServerError",
   {
     message: Schema.String,
+    code: Schema.optional(Schema.Number),
     retryAfter: Schema.optional(DurationSchema),
   },
 ).pipe(Category.withServerError, Category.withRetryable()) {}


### PR DESCRIPTION
Cloudflare's `PUT /accounts/{account_id}/workers/scripts/{scriptName}` intermittently fails with code 10002 / message `"An unknown error has occurred. If this error persists, please file a report in the workers-sdk GitHub repository..."` — Cloudflare's generic backend-failure envelope.

It currently surfaces as the catch-all `UnknownCloudflareError`, which is awkward to match on. Reuse the existing core `InternalServerError` for it instead of introducing yet another shadow class.

```diff
// patches/workers/putScript.json
+ "InternalServerError": [
+   {
+     "code": 10002,
+     "message": { "includes": "An unknown error has occurred" }
+   }
+ ]
```

### Generator change

Previously every patch tag produced its own `export class ${tag}` in the service file — even when the tag matched an existing core export. Now tags listed in `sharedErrorTags` (currently just `InternalServerError`) are imported from `../errors.ts` and the matchers attached to the imported class.

```diff
- import { type DefaultErrors } from "../errors.ts";
+ import { type DefaultErrors, InternalServerError } from "../errors.ts";

- export class InternalServerError extends Schema.TaggedErrorClass<…>(…) {}
  T.applyErrorMatchers(InternalServerError, [{ code: 10002, … }]);
```

### Core change

`InternalServerError` now accepts an optional `code` field so it can carry the body code when matched against a 2xx error envelope (HTTP 500 status-map matching still works — `code` is optional, `message` stays required).

### Side effect

`alerting.ts`'s pre-existing shadow `InternalServerError` (code 15000) collapses into the shared one as well.
