### PR TITLE
fix(core): retry HttpClientError TransportError and 5xx in isTransientError

### DIFF
--- a/packages/core/src/category.ts
+++ b/packages/core/src/category.ts
@@ -20,6 +20,7 @@
  */
 import * as Effect from "effect/Effect";
 import * as Predicate from "effect/Predicate";
+import * as HttpClientError from "effect/unstable/http/HttpClientError";
 
 // ============================================================================
 // Error Category Constants
@@ -261,49 +262,17 @@ export const isThrottling = (error: unknown): boolean => {
 };
 
 /**
- * Effect's `FetchHttpClient` brands `HttpClientError` instances with this
- * TypeId. We duck-type against it so `isTransientError` can recognise wire-
- * level failures (undici `ConnectTimeoutError`, socket reset, DNS failure,
- * premature stream close, …) and 5xx responses without adding a hard
- * dependency on `effect/unstable/http/HttpClientError` in `@distilled.cloud/core`.
+ * Check if an error is an Effect `HttpClientError` caused by a wire-level
+ * transport failure (undici `ConnectTimeoutError`, socket reset, DNS
+ * failure, premature stream close, …). The request never reached the
+ * server (or the response never finished) so retrying is safe.
+ *
+ * Status-code retries are intentionally left to the per-SDK API client,
+ * which knows whether a given response is genuinely retryable.
  */
-const httpClientErrorTypeId = "~effect/http/HttpClientError";
-
-/**
- * Check if an error is an Effect `HttpClientError` whose underlying reason
- * is inherently retryable: a transport failure (no response was received)
- * or a 5xx response from the server.
- */
-const isRetryableHttpClientError = (error: unknown): boolean => {
-  if (
-    !Predicate.isObject(error) ||
-    !Predicate.hasProperty(httpClientErrorTypeId)(error) ||
-    !Predicate.hasProperty("reason")(error)
-  ) {
-    return false;
-  }
-  const reason = (error as { reason: unknown }).reason;
-  if (!Predicate.isObject(reason) || !Predicate.hasProperty("_tag")(reason)) {
-    return false;
-  }
-  const tag = (reason as { _tag: unknown })._tag;
-  // Wire-level failures: connect/read timeout, socket reset, DNS failure,
-  // premature stream close. The request never reached the server (or the
-  // response never finished) so retrying is safe and almost always wins.
-  if (tag === "TransportError") return true;
-  // 5xx server responses are by convention retryable.
-  if (
-    tag === "StatusCodeError" &&
-    Predicate.hasProperty("response")(reason) &&
-    Predicate.isObject((reason as { response: unknown }).response) &&
-    Predicate.hasProperty("status")((reason as { response: object }).response)
-  ) {
-    const status = (reason as { response: { status: unknown } }).response
-      .status;
-    if (typeof status === "number" && status >= 500) return true;
-  }
-  return false;
-};
+const isHttpTransportError = (error: unknown): boolean =>
+  HttpClientError.isHttpClientError(error) &&
+  error.reason._tag === "TransportError";
 
 /**
  * Check if an error is a transient error that should be automatically retried.
@@ -315,10 +284,9 @@ const isRetryableHttpClientError = (error: unknown): boolean => {
  * - NetworkError (connection issues)
  * - TimeoutError (request timed out)
  * - LockedError (423 - resource temporarily locked)
- * - Effect `HttpClientError` whose `reason` is `TransportError` (undici
- *   connect/read timeout, socket reset, DNS failure, premature stream close)
- *   or a 5xx `StatusCodeError`. This catches wire-level failures from
- *   `FetchHttpClient` that don't carry distilled category metadata.
+ * - Effect `HttpClientError` with `reason._tag === "TransportError"`
+ *   (undici connect/read timeout, socket reset, DNS failure, premature
+ *   stream close)
  */
 export const isTransientError = (error: unknown): boolean => {
   // Check for retryable trait first
@@ -333,7 +301,7 @@ export const isTransientError = (error: unknown): boolean => {
     hasCategory(error, NetworkError) ||
     hasCategory(error, TimeoutError) ||
     hasCategory(error, LockedError) ||
-    isRetryableHttpClientError(error)
+    isHttpTransportError(error)
   );
 };
 

--- a/packages/core/src/category.ts
+++ b/packages/core/src/category.ts
@@ -261,6 +261,51 @@ export const isThrottling = (error: unknown): boolean => {
 };
 
 /**
+ * Effect's `FetchHttpClient` brands `HttpClientError` instances with this
+ * TypeId. We duck-type against it so `isTransientError` can recognise wire-
+ * level failures (undici `ConnectTimeoutError`, socket reset, DNS failure,
+ * premature stream close, …) and 5xx responses without adding a hard
+ * dependency on `effect/unstable/http/HttpClientError` in `@distilled.cloud/core`.
+ */
+const httpClientErrorTypeId = "~effect/http/HttpClientError";
+
+/**
+ * Check if an error is an Effect `HttpClientError` whose underlying reason
+ * is inherently retryable: a transport failure (no response was received)
+ * or a 5xx response from the server.
+ */
+const isRetryableHttpClientError = (error: unknown): boolean => {
+  if (
+    !Predicate.isObject(error) ||
+    !Predicate.hasProperty(httpClientErrorTypeId)(error) ||
+    !Predicate.hasProperty("reason")(error)
+  ) {
+    return false;
+  }
+  const reason = (error as { reason: unknown }).reason;
+  if (!Predicate.isObject(reason) || !Predicate.hasProperty("_tag")(reason)) {
+    return false;
+  }
+  const tag = (reason as { _tag: unknown })._tag;
+  // Wire-level failures: connect/read timeout, socket reset, DNS failure,
+  // premature stream close. The request never reached the server (or the
+  // response never finished) so retrying is safe and almost always wins.
+  if (tag === "TransportError") return true;
+  // 5xx server responses are by convention retryable.
+  if (
+    tag === "StatusCodeError" &&
+    Predicate.hasProperty("response")(reason) &&
+    Predicate.isObject((reason as { response: unknown }).response) &&
+    Predicate.hasProperty("status")((reason as { response: object }).response)
+  ) {
+    const status = (reason as { response: { status: unknown } }).response
+      .status;
+    if (typeof status === "number" && status >= 500) return true;
+  }
+  return false;
+};
+
+/**
  * Check if an error is a transient error that should be automatically retried.
  * Transient errors include:
  * - Errors marked with withRetryable()
@@ -270,6 +315,10 @@ export const isThrottling = (error: unknown): boolean => {
  * - NetworkError (connection issues)
  * - TimeoutError (request timed out)
  * - LockedError (423 - resource temporarily locked)
+ * - Effect `HttpClientError` whose `reason` is `TransportError` (undici
+ *   connect/read timeout, socket reset, DNS failure, premature stream close)
+ *   or a 5xx `StatusCodeError`. This catches wire-level failures from
+ *   `FetchHttpClient` that don't carry distilled category metadata.
  */
 export const isTransientError = (error: unknown): boolean => {
   // Check for retryable trait first
@@ -283,7 +332,8 @@ export const isTransientError = (error: unknown): boolean => {
     hasCategory(error, ServerError) ||
     hasCategory(error, NetworkError) ||
     hasCategory(error, TimeoutError) ||
-    hasCategory(error, LockedError)
+    hasCategory(error, LockedError) ||
+    isRetryableHttpClientError(error)
   );
 };
 

--- a/packages/core/test/transport-retry.test.ts
+++ b/packages/core/test/transport-retry.test.ts
@@ -21,20 +21,10 @@ describe("isTransientError — HttpClientError", () => {
     expect(Category.isTransientError(error)).toBe(true);
   });
 
-  it("retries 5xx StatusCodeError", () => {
+  it("does NOT retry StatusCodeError (left to per-SDK API client)", () => {
     const response = HttpClientResponse.fromWeb(
       fakeRequest,
       new Response(null, { status: 503 }),
-    );
-    const reason = new StatusCodeError({ request: fakeRequest, response });
-    const error = new HttpClientError({ reason });
-    expect(Category.isTransientError(error)).toBe(true);
-  });
-
-  it("does NOT retry 4xx StatusCodeError", () => {
-    const response = HttpClientResponse.fromWeb(
-      fakeRequest,
-      new Response(null, { status: 404 }),
     );
     const reason = new StatusCodeError({ request: fakeRequest, response });
     const error = new HttpClientError({ reason });
@@ -50,7 +40,7 @@ describe("isTransientError — HttpClientError", () => {
     expect(Category.isTransientError(error)).toBe(false);
   });
 
-  it("returns false for non-HttpClientError objects", () => {
+  it("returns false for non-HttpClientError values", () => {
     expect(Category.isTransientError({ some: "object" })).toBe(false);
     expect(Category.isTransientError(undefined)).toBe(false);
     expect(Category.isTransientError(null)).toBe(false);

--- a/packages/core/test/transport-retry.test.ts
+++ b/packages/core/test/transport-retry.test.ts
@@ -1,0 +1,58 @@
+import {
+  HttpClientError,
+  TransportError,
+  StatusCodeError,
+  EncodeError,
+} from "effect/unstable/http/HttpClientError";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+import { describe, expect, it } from "vitest";
+import * as Category from "../src/category.ts";
+
+const fakeRequest = HttpClientRequest.get("https://example.com");
+
+describe("isTransientError — HttpClientError", () => {
+  it("retries TransportError (undici ConnectTimeoutError, socket reset, …)", () => {
+    const reason = new TransportError({
+      request: fakeRequest,
+      cause: new Error("Connect Timeout Error"),
+    });
+    const error = new HttpClientError({ reason });
+    expect(Category.isTransientError(error)).toBe(true);
+  });
+
+  it("retries 5xx StatusCodeError", () => {
+    const response = HttpClientResponse.fromWeb(
+      fakeRequest,
+      new Response(null, { status: 503 }),
+    );
+    const reason = new StatusCodeError({ request: fakeRequest, response });
+    const error = new HttpClientError({ reason });
+    expect(Category.isTransientError(error)).toBe(true);
+  });
+
+  it("does NOT retry 4xx StatusCodeError", () => {
+    const response = HttpClientResponse.fromWeb(
+      fakeRequest,
+      new Response(null, { status: 404 }),
+    );
+    const reason = new StatusCodeError({ request: fakeRequest, response });
+    const error = new HttpClientError({ reason });
+    expect(Category.isTransientError(error)).toBe(false);
+  });
+
+  it("does NOT retry EncodeError (deterministic client bug)", () => {
+    const reason = new EncodeError({
+      request: fakeRequest,
+      cause: new Error("bad body"),
+    });
+    const error = new HttpClientError({ reason });
+    expect(Category.isTransientError(error)).toBe(false);
+  });
+
+  it("returns false for non-HttpClientError objects", () => {
+    expect(Category.isTransientError({ some: "object" })).toBe(false);
+    expect(Category.isTransientError(undefined)).toBe(false);
+    expect(Category.isTransientError(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
Wire-level failures from Effect's `FetchHttpClient` (undici `ConnectTimeoutError`, socket reset, DNS failure, premature stream close) now trip `isTransientError`, so every SDK's default retry policy retries them automatically. Previously these surfaced as `HttpClientError` with no `@distilled.cloud/error/categories` marker, fell through every category predicate, and a single flaky packet would fail the entire call.

```ts
const isHttpTransportError = (error: unknown): boolean =>
  HttpClientError.isHttpClientError(error) &&
  error.reason._tag === "TransportError";
```

Status-code retries are intentionally left to the per-SDK API client, which knows whether a given response is genuinely retryable for its protocol.
