### PR TITLE
fix(planetscale): Add missing error return codes and nullable fields to branch, resize request, roles

### DIFF
--- a/packages/planetscale/patches/add-error-responses.patch.json
+++ b/packages/planetscale/patches/add-error-responses.patch.json
@@ -1,0 +1,19 @@
+{
+  "description": "Add missing error responses to branch and role delete operations",
+  "patches": [
+    {
+      "op": "add",
+      "path": "/paths/~1organizations~1{organization}~1databases~1{database}~1branches~1{branch}/delete/responses/422",
+      "value": {
+        "description": "Unprocessable Entity"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/paths/~1organizations~1{organization}~1databases~1{database}~1branches~1{branch}~1roles~1{id}/delete/responses/422",
+      "value": {
+        "description": "Unprocessable Entity"
+      }
+    }
+  ]
+}

--- a/packages/planetscale/patches/branch.patch.json
+++ b/packages/planetscale/patches/branch.patch.json
@@ -58,6 +58,11 @@
       "value": true
     },
     {
+      "op": "add",
+      "path": "/definitions/DatabaseBranch/properties/restored_from_branch/properties/deleted_at/x-nullable",
+      "value": true
+    },
+    {
       "op": "replace",
       "path": "/definitions/PaginatedDatabaseBranch/properties/data/items/required",
       "value": [
@@ -111,6 +116,11 @@
     {
       "op": "add",
       "path": "/definitions/PaginatedDatabaseBranch/properties/data/items/properties/parent_branch/x-nullable",
+      "value": true
+    },
+    {
+      "op": "add",
+      "path": "/definitions/PaginatedDatabaseBranch/properties/data/items/properties/restored_from_branch/properties/deleted_at/x-nullable",
       "value": true
     }
   ]

--- a/packages/planetscale/patches/resize-request.patch.json
+++ b/packages/planetscale/patches/resize-request.patch.json
@@ -1,0 +1,89 @@
+{
+  "description": "Fix PostgresClusterResizeRequest and PaginatedPostgresClusterResizeRequest schema: completed_at can be null",
+  "patches": [
+    {
+      "op": "replace",
+      "path": "/definitions/PostgresClusterResizeRequest/required",
+      "value": [
+        "id",
+        "restart",
+        "state",
+        "started_at",
+        "created_at",
+        "updated_at",
+        "actor",
+        "cluster_name",
+        "cluster_display_name",
+        "cluster_metal",
+        "replicas",
+        "parameters",
+        "previous_cluster_name",
+        "previous_cluster_display_name",
+        "previous_cluster_metal",
+        "previous_replicas",
+        "previous_parameters",
+        "minimum_storage_bytes",
+        "maximum_storage_bytes",
+        "storage_autoscaling",
+        "storage_shrinking",
+        "storage_type",
+        "storage_iops",
+        "storage_throughput_mibs",
+        "previous_minimum_storage_bytes",
+        "previous_maximum_storage_bytes",
+        "previous_storage_autoscaling",
+        "previous_storage_shrinking",
+        "previous_storage_type",
+        "previous_storage_iops",
+        "previous_storage_throughput_mibs"
+      ]
+    },
+    {
+      "op": "add",
+      "path": "/definitions/PostgresClusterResizeRequest/properties/completed_at/x-nullable",
+      "value": true
+    },
+    {
+      "op": "replace",
+      "path": "/definitions/PaginatedPostgresClusterResizeRequest/properties/data/items/required",
+      "value": [
+        "id",
+        "restart",
+        "state",
+        "started_at",
+        "created_at",
+        "updated_at",
+        "actor",
+        "cluster_name",
+        "cluster_display_name",
+        "cluster_metal",
+        "replicas",
+        "parameters",
+        "previous_cluster_name",
+        "previous_cluster_display_name",
+        "previous_cluster_metal",
+        "previous_replicas",
+        "previous_parameters",
+        "minimum_storage_bytes",
+        "maximum_storage_bytes",
+        "storage_autoscaling",
+        "storage_shrinking",
+        "storage_type",
+        "storage_iops",
+        "storage_throughput_mibs",
+        "previous_minimum_storage_bytes",
+        "previous_maximum_storage_bytes",
+        "previous_storage_autoscaling",
+        "previous_storage_shrinking",
+        "previous_storage_type",
+        "previous_storage_iops",
+        "previous_storage_throughput_mibs"
+      ]
+    },
+    {
+      "op": "add",
+      "path": "/definitions/PaginatedPostgresClusterResizeRequest/properties/data/items/properties/completed_at/x-nullable",
+      "value": true
+    }
+  ]
+}

--- a/packages/planetscale/src/operations/createBranch.ts
+++ b/packages/planetscale/src/operations/createBranch.ts
@@ -72,7 +72,7 @@ export const CreateBranchOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       name: Schema.String,
       created_at: Schema.String,
       updated_at: Schema.String,
-      deleted_at: Schema.String,
+      deleted_at: Schema.NullOr(Schema.String),
     }),
   ),
   private_edge_connectivity: Schema.Boolean,

--- a/packages/planetscale/src/operations/deleteBranch.ts
+++ b/packages/planetscale/src/operations/deleteBranch.ts
@@ -1,7 +1,7 @@
 import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
-import { Forbidden, NotFound } from "../errors.ts";
+import { Forbidden, NotFound, UnprocessableEntity } from "../errors.ts";
 
 // Input Schema
 export const DeleteBranchInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -33,5 +33,5 @@ export type DeleteBranchOutput = typeof DeleteBranchOutput.Type;
 export const deleteBranch = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   inputSchema: DeleteBranchInput,
   outputSchema: DeleteBranchOutput,
-  errors: [Forbidden, NotFound] as const,
+  errors: [Forbidden, NotFound, UnprocessableEntity] as const,
 }));

--- a/packages/planetscale/src/operations/deleteRole.ts
+++ b/packages/planetscale/src/operations/deleteRole.ts
@@ -1,7 +1,7 @@
 import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
-import { Forbidden, NotFound } from "../errors.ts";
+import { Forbidden, NotFound, UnprocessableEntity } from "../errors.ts";
 
 // Input Schema
 export const DeleteRoleInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -35,5 +35,5 @@ export type DeleteRoleOutput = typeof DeleteRoleOutput.Type;
 export const deleteRole = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   inputSchema: DeleteRoleInput,
   outputSchema: DeleteRoleOutput,
-  errors: [Forbidden, NotFound] as const,
+  errors: [Forbidden, NotFound, UnprocessableEntity] as const,
 }));

--- a/packages/planetscale/src/operations/demoteBranch.ts
+++ b/packages/planetscale/src/operations/demoteBranch.ts
@@ -59,7 +59,7 @@ export const DemoteBranchOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       name: Schema.String,
       created_at: Schema.String,
       updated_at: Schema.String,
-      deleted_at: Schema.String,
+      deleted_at: Schema.NullOr(Schema.String),
     }),
   ),
   private_edge_connectivity: Schema.Boolean,

--- a/packages/planetscale/src/operations/disableSafeMigrations.ts
+++ b/packages/planetscale/src/operations/disableSafeMigrations.ts
@@ -61,7 +61,7 @@ export const DisableSafeMigrationsOutput =
         name: Schema.String,
         created_at: Schema.String,
         updated_at: Schema.String,
-        deleted_at: Schema.String,
+        deleted_at: Schema.NullOr(Schema.String),
       }),
     ),
     private_edge_connectivity: Schema.Boolean,

--- a/packages/planetscale/src/operations/enableSafeMigrations.ts
+++ b/packages/planetscale/src/operations/enableSafeMigrations.ts
@@ -61,7 +61,7 @@ export const EnableSafeMigrationsOutput =
         name: Schema.String,
         created_at: Schema.String,
         updated_at: Schema.String,
-        deleted_at: Schema.String,
+        deleted_at: Schema.NullOr(Schema.String),
       }),
     ),
     private_edge_connectivity: Schema.Boolean,

--- a/packages/planetscale/src/operations/getBranch.ts
+++ b/packages/planetscale/src/operations/getBranch.ts
@@ -59,7 +59,7 @@ export const GetBranchOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       name: Schema.String,
       created_at: Schema.String,
       updated_at: Schema.String,
-      deleted_at: Schema.String,
+      deleted_at: Schema.NullOr(Schema.String),
     }),
   ),
   private_edge_connectivity: Schema.Boolean,

--- a/packages/planetscale/src/operations/getBranchChangeRequest.ts
+++ b/packages/planetscale/src/operations/getBranchChangeRequest.ts
@@ -32,7 +32,7 @@ export const GetBranchChangeRequestOutput =
       "completed",
     ]),
     started_at: Schema.String,
-    completed_at: Schema.String,
+    completed_at: Schema.optional(Schema.NullOr(Schema.String)),
     created_at: Schema.String,
     updated_at: Schema.String,
     actor: Schema.Struct({

--- a/packages/planetscale/src/operations/listBranchChangeRequests.ts
+++ b/packages/planetscale/src/operations/listBranchChangeRequests.ts
@@ -40,7 +40,7 @@ export const ListBranchChangeRequestsOutput =
           "completed",
         ]),
         started_at: Schema.String,
-        completed_at: Schema.String,
+        completed_at: Schema.optional(Schema.NullOr(Schema.String)),
         created_at: Schema.String,
         updated_at: Schema.String,
         actor: Schema.Struct({

--- a/packages/planetscale/src/operations/listBranches.ts
+++ b/packages/planetscale/src/operations/listBranches.ts
@@ -71,7 +71,7 @@ export const ListBranchesOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
           name: Schema.String,
           created_at: Schema.String,
           updated_at: Schema.String,
-          deleted_at: Schema.String,
+          deleted_at: Schema.NullOr(Schema.String),
         }),
       ),
       private_edge_connectivity: Schema.Boolean,

--- a/packages/planetscale/src/operations/promoteBranch.ts
+++ b/packages/planetscale/src/operations/promoteBranch.ts
@@ -59,7 +59,7 @@ export const PromoteBranchOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       name: Schema.String,
       created_at: Schema.String,
       updated_at: Schema.String,
-      deleted_at: Schema.String,
+      deleted_at: Schema.NullOr(Schema.String),
     }),
   ),
   private_edge_connectivity: Schema.Boolean,

--- a/packages/planetscale/src/operations/updateBranch.ts
+++ b/packages/planetscale/src/operations/updateBranch.ts
@@ -60,7 +60,7 @@ export const UpdateBranchOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       name: Schema.String,
       created_at: Schema.String,
       updated_at: Schema.String,
-      deleted_at: Schema.String,
+      deleted_at: Schema.NullOr(Schema.String),
     }),
   ),
   private_edge_connectivity: Schema.Boolean,

--- a/packages/planetscale/src/operations/updateBranchChangeRequest.ts
+++ b/packages/planetscale/src/operations/updateBranchChangeRequest.ts
@@ -34,7 +34,7 @@ export const UpdateBranchChangeRequestOutput =
       "completed",
     ]),
     started_at: Schema.String,
-    completed_at: Schema.String,
+    completed_at: Schema.optional(Schema.NullOr(Schema.String)),
     created_at: Schema.String,
     updated_at: Schema.String,
     actor: Schema.Struct({

--- a/packages/planetscale/tests/branches.test.ts
+++ b/packages/planetscale/tests/branches.test.ts
@@ -1,7 +1,7 @@
 import { Effect, Schedule } from "effect";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { UnknownPlanetScaleError } from "../src/client";
-import { Forbidden, NotFound } from "../src/errors";
+import { Forbidden, NotFound, UnprocessableEntity } from "../src/errors";
 import { createBranch } from "../src/operations/createBranch";
 import { deleteBranch } from "../src/operations/deleteBranch";
 import { demoteBranch } from "../src/operations/demoteBranch";
@@ -73,6 +73,7 @@ const isNotFoundOrForbidden = (error: unknown): boolean =>
 const isApiError = (error: unknown): boolean =>
   error instanceof NotFound ||
   error instanceof Forbidden ||
+  error instanceof UnprocessableEntity ||
   error instanceof UnknownPlanetScaleError ||
   (error !== null && typeof error === "object" && "_tag" in error);
 
@@ -536,54 +537,58 @@ describe.each([{ kind: "postgresql" }, { kind: "mysql" }] as const)(
       // verify, so the test timeout must exceed the polling window. Postgres
       // provisioning is consistently slower than mysql, so give it more headroom.
       const branchTestTimeout = kind === "postgresql" ? 900_000 : 600_000;
-      it("can create and delete a branch", { timeout: branchTestTimeout }, async () => {
-        const db = getDb();
-        const branchName = `test-${testRunId}`;
+      it(
+        "can create and delete a branch",
+        { timeout: branchTestTimeout },
+        async () => {
+          const db = getDb();
+          const branchName = `test-${testRunId}`;
 
-        // Create branch
-        const created = await runEffect(
-          createBranch({
-            organization: db.organization,
-            database: db.name,
-            name: branchName,
-            parent_branch: "main",
-          }),
-        );
-        expect(created.name).toBe(branchName);
-        expect(created.id).toBeDefined();
-        expect(created.parent_branch).toBe("main");
-
-        // Wait for ready
-        await runEffect(
-          waitForBranchReady(db.organization, db.name, branchName),
-        );
-
-        // Delete branch
-        await runEffect(
-          deleteBranch({
-            organization: db.organization,
-            database: db.name,
-            branch: branchName,
-          }),
-        );
-
-        // Verify deleted
-        const error = await runEffect(
-          getBranch({
-            organization: db.organization,
-            database: db.name,
-            branch: branchName,
-          }).pipe(
-            Effect.matchEffect({
-              onFailure: (e) => Effect.succeed(e),
-              onSuccess: () => Effect.succeed(null),
+          // Create branch
+          const created = await runEffect(
+            createBranch({
+              organization: db.organization,
+              database: db.name,
+              name: branchName,
+              parent_branch: "main",
             }),
-          ),
-        );
+          );
+          expect(created.name).toBe(branchName);
+          expect(created.id).toBeDefined();
+          expect(created.parent_branch).toBe("main");
 
-        expect(error).not.toBeNull();
-        expect((error as { _tag: string })._tag).toBe("NotFound");
-      });
+          // Wait for ready
+          await runEffect(
+            waitForBranchReady(db.organization, db.name, branchName),
+          );
+
+          // Delete branch
+          await runEffect(
+            deleteBranch({
+              organization: db.organization,
+              database: db.name,
+              branch: branchName,
+            }),
+          );
+
+          // Verify deleted
+          const error = await runEffect(
+            getBranch({
+              organization: db.organization,
+              database: db.name,
+              branch: branchName,
+            }).pipe(
+              Effect.matchEffect({
+                onFailure: (e) => Effect.succeed(e),
+                onSuccess: () => Effect.succeed(null),
+              }),
+            ),
+          );
+
+          expect(error).not.toBeNull();
+          expect((error as { _tag: string })._tag).toBe("NotFound");
+        },
+      );
     });
 
     // ============================================================================
@@ -647,7 +652,7 @@ describe.each([{ kind: "postgresql" }, { kind: "mysql" }] as const)(
         expect(isNotFoundOrForbidden(error)).toBe(true);
       });
 
-      it("returns error when trying to delete production branch (main)", async () => {
+      it("returns UnprocessableEntity when trying to delete production branch (main)", async () => {
         const db = getDb();
         const error = await runEffect(
           deleteBranch({
@@ -664,7 +669,7 @@ describe.each([{ kind: "postgresql" }, { kind: "mysql" }] as const)(
 
         // Deleting production branch should fail with some error
         expect(error).not.toBeNull();
-        expect(isApiError(error)).toBe(true);
+        expect(error).toBeInstanceOf(UnprocessableEntity);
       });
     });
 


### PR DESCRIPTION
Here we go again.. Planetscale's API is making me have trust issues lol.

This PR addresses the following:

- **deleteBranch** can return 422 if trying to delete a db's default branch
- **deleteRole** can return 422 if the role is still referenced. [See mention of this on Planetscale Docs](https://planetscale.com/docs/postgres/connecting/roles#:~:text=If%20you%20try%20to%20delete%20a%20role%20that%20is%20still%20referenced%2C%20you%20may%20see%20this%20error:%20Role%20is%20still%20referenced%20and%20cannot%20be%20dropped..)
- **PostgresClusterResizeRequest** can return completed_at = null if the operation has not finished yet
- Referenced **branches** can return deleted_at = null if not deleted