### PR TITLE
fix(cloudflare/workers): remove stale code 10013 from WorkerNotFound

### DIFF
--- a/packages/cloudflare/patches/workers/deleteBetaWorkerVersion.json
+++ b/packages/cloudflare/patches/workers/deleteBetaWorkerVersion.json
@@ -1,6 +1,6 @@
 {
   "errors": {
-    "WorkerNotFound": [{ "code": 10007 }, { "code": 10013 }],
+    "WorkerNotFound": [{ "code": 10007 }],
     "WorkerVersionNotFound": [{ "code": 10071 }]
   }
 }

--- a/packages/cloudflare/patches/workers/deleteScriptDeployment.json
+++ b/packages/cloudflare/patches/workers/deleteScriptDeployment.json
@@ -1,6 +1,6 @@
 {
   "errors": {
-    "WorkerNotFound": [{ "code": 10007 }, { "code": 10013 }],
+    "WorkerNotFound": [{ "code": 10007 }],
     "DeploymentNotFound": [{ "code": 10336 }]
   }
 }

--- a/packages/cloudflare/patches/workers/getBetaWorkerVersion.json
+++ b/packages/cloudflare/patches/workers/getBetaWorkerVersion.json
@@ -1,6 +1,6 @@
 {
   "errors": {
-    "WorkerNotFound": [{ "code": 10007 }, { "code": 10013 }],
+    "WorkerNotFound": [{ "code": 10007 }],
     "WorkerVersionNotFound": [{ "code": 10071 }]
   },
   "response": {

--- a/packages/cloudflare/specs/cloudflare/workers.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers.openapi.yml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  title: Cloudflare WORKERS API
+  title: Cloudflare Workers API
   version: 0.0.0
 servers:
   - url: https://api.cloudflare.com/client/v4
@@ -1463,7 +1463,6 @@ paths:
       x-distilled-errors:
         WorkerNotFound:
           - code: 10007
-          - code: 10013
         WorkerVersionNotFound:
           - code: 10071
     delete:
@@ -1546,7 +1545,6 @@ paths:
       x-distilled-errors:
         WorkerNotFound:
           - code: 10007
-          - code: 10013
         WorkerVersionNotFound:
           - code: 10071
   /accounts/{account_id}/workers/workers/{workerId}/versions:
@@ -8348,7 +8346,6 @@ paths:
       x-distilled-errors:
         WorkerNotFound:
           - code: 10007
-          - code: 10013
         DeploymentNotFound:
           - code: 10336
   /accounts/{account_id}/workers/scripts/{scriptName}/deployments:

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -139,7 +139,7 @@ export class WorkerNotFound extends Schema.TaggedErrorClass<WorkerNotFound>()(
   "WorkerNotFound",
   { code: Schema.Number, message: Schema.String },
 ) {}
-T.applyErrorMatchers(WorkerNotFound, [{ code: 10007 }, { code: 10013 }]);
+T.applyErrorMatchers(WorkerNotFound, [{ code: 10007 }]);
 
 export class WorkerVersionNotFound extends Schema.TaggedErrorClass<WorkerVersionNotFound>()(
   "WorkerVersionNotFound",


### PR DESCRIPTION
Remove `{ code: 10013 }` from `WorkerNotFound` in three workers patches. Code 10013 is exclusively a KV namespace error and is never returned by any Workers API endpoint — including the very endpoints these patches target (`deleteBetaWorkerVersion`, `getBetaWorkerVersion`, `deleteScriptDeployment`).

Because `applyErrorMatchers` is attached at the class level and matchers are unioned across all operations in a service, those stale entries leaked into every Workers operation that throws `WorkerNotFound` — including `deleteScript`. Effect: downstream code calling `Effect.catch("WorkerNotFound", ...)` could silently swallow unrelated errors (auth, KV namespace collisions, etc.) that happened to surface 10013.

```diff
-T.applyErrorMatchers(WorkerNotFound, [{ code: 10007 }, { code: 10013 }]);
+T.applyErrorMatchers(WorkerNotFound, [{ code: 10007 }]);
```

### Probing evidence

Hit every Workers endpoint that could plausibly throw `WorkerNotFound` (legacy `scripts/*` and beta `workers/workers/*`, plus subresources: settings, schedules, secrets, subdomain, versions, deployments, script-settings). Every "worker not found" response returned:

```
{ "code": 10007, "message": "This Worker does not exist on your account." }
```

10013 only ever appeared from KV (`namespace not found`).

### Other 10013 matchers (unchanged, verified)

- `kv.ts` → `NamespaceNotFound` — legit
- `queues.ts` → `InvalidMessageBody` — out of scope
