### PR TITLE
fix(planetscale): type plain_text as non-nullable for create/renew password

### DIFF
--- a/packages/planetscale/patches/password-with-secret.patch.json
+++ b/packages/planetscale/patches/password-with-secret.patch.json
@@ -1,0 +1,24 @@
+{
+  "description": "create_password and renew_password always return a non-null plain_text. Route those two operations through a dedicated definition where plain_text is required, so the SDK types it as Redacted<string> instead of Redacted<string> | null. get/list/update keep the shared (nullable) definition because PlanetScale never returns plain_text once the password has been created. This patch's filename sorts after password.patch.json so the copied definition inherits the nullability fixes for the other fields (cidrs, deleted_at, expires_at, last_used_at, ttl_seconds); we then drop x-nullable from plain_text on the copy.",
+  "patches": [
+    {
+      "op": "copy",
+      "from": "/definitions/DatabaseBranchPassword",
+      "path": "/definitions/DatabaseBranchPasswordWithSecret"
+    },
+    {
+      "op": "remove",
+      "path": "/definitions/DatabaseBranchPasswordWithSecret/properties/plain_text/x-nullable"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1organizations~1{organization}~1databases~1{database}~1branches~1{branch}~1passwords/post/responses/201/schema/$ref",
+      "value": "#/definitions/DatabaseBranchPasswordWithSecret"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1organizations~1{organization}~1databases~1{database}~1branches~1{branch}~1passwords~1{id}~1renew/post/responses/200/schema/$ref",
+      "value": "#/definitions/DatabaseBranchPasswordWithSecret"
+    }
+  ]
+}

--- a/packages/planetscale/src/operations/createPassword.ts
+++ b/packages/planetscale/src/operations/createPassword.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound, UnprocessableEntity } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveString } from "../sensitive.ts";
 
 // Input Schema
 export const CreatePasswordInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -62,7 +62,7 @@ export const CreatePasswordOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     postgresql_supported: Schema.Boolean,
   }),
   username: Schema.String,
-  plain_text: SensitiveNullableString,
+  plain_text: SensitiveString,
   replica: Schema.Boolean,
   renewable: Schema.Boolean,
   database_branch: Schema.Struct({

--- a/packages/planetscale/src/operations/renewPassword.ts
+++ b/packages/planetscale/src/operations/renewPassword.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveString } from "../sensitive.ts";
 
 // Input Schema
 export const RenewPasswordInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -55,7 +55,7 @@ export const RenewPasswordOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     postgresql_supported: Schema.Boolean,
   }),
   username: Schema.String,
-  plain_text: SensitiveNullableString,
+  plain_text: SensitiveString,
   replica: Schema.Boolean,
   renewable: Schema.Boolean,
   database_branch: Schema.Struct({


### PR DESCRIPTION
PlanetScale's OpenAPI spec uses a single `DatabaseBranchPassword` definition for every password endpoint. `plain_text` is patched nullable on it because `get_password` / `list_passwords` cannot return the secret — but `create_password` and `renew_password` always do.

The result today is that callers of the two operations that *do* return the secret are forced to handle `null`:

```ts
const created = yield* createPassword({ ... });
// created.plain_text: string | null | Redacted<string>
const pw = toRedacted(created.plain_text!); // unsafe assertion on every call
```

### Fix

Route `create_password` and `renew_password` through a dedicated `DatabaseBranchPasswordWithSecret` definition where `plain_text` is non-nullable. Other operations (`get`, `list`, `update`) keep the shared (nullable) definition.

```diff
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveString } from "../sensitive.ts";

   username: Schema.String,
-  plain_text: SensitiveNullableString,
+  plain_text: SensitiveString,
```

Done as a JSON Patch on the spec so it survives regenerations:

```json
{
  "op": "copy",
  "from": "/definitions/DatabaseBranchPassword",
  "path": "/definitions/DatabaseBranchPasswordWithSecret"
},
{
  "op": "remove",
  "path": "/definitions/DatabaseBranchPasswordWithSecret/properties/plain_text/x-nullable"
},
{
  "op": "replace",
  "path": ".../passwords/post/responses/201/schema/$ref",
  "value": "#/definitions/DatabaseBranchPasswordWithSecret"
}
// + renew_password 200
```

The patch filename sorts after `password.patch.json` so the copy inherits the other nullability fixes (`cidrs`, `deleted_at`, `expires_at`, `last_used_at`, `ttl_seconds`) before `x-nullable` is dropped from `plain_text` on the copy.
