### PR TITLE
feat(core): split Sensitive into input-friendly + output-strict variants

### DIFF
--- a/packages/core/scripts/generate-openapi.ts
+++ b/packages/core/scripts/generate-openapi.ts
@@ -343,8 +343,16 @@ function isSensitiveFieldName(name: string): boolean {
 // ============================================================================
 
 interface SchemaGenerationContext {
+  // Whether to emit input-friendly Sensitive* (decoded type is the union
+  // `A | Redacted<A>`) or output-strict SensitiveOutput* (decoded type is just
+  // `Redacted<A>`). Output schemas should use the strict variant so consumers
+  // never have to coerce. Defaults to "input" for backwards-compat callers
+  // that don't pass a direction.
+  direction?: "input" | "output";
   usesSensitiveString: boolean;
   usesSensitiveNullableString: boolean;
+  usesSensitiveOutputString: boolean;
+  usesSensitiveOutputNullableString: boolean;
 }
 
 function openApiTypeToEffectSchema(
@@ -442,16 +450,30 @@ function openApiTypeToEffectSchema(
     case "string":
       // Check for sensitive annotation
       if (prop["x-sensitive"]) {
+        // For response schemas use the strict SensitiveOutput* variants so
+        // the decoded type is `Redacted<string>` (no `string | Redacted<...>`
+        // union). For request bodies keep the input-friendly Sensitive*
+        // variants so callers can pass either form.
+        const useStrict = ctx?.direction === "output";
+        const nullable = isNullable(prop);
         if (ctx) {
-          if (isNullable(prop)) {
-            ctx.usesSensitiveNullableString = true;
+          if (useStrict) {
+            if (nullable) ctx.usesSensitiveOutputNullableString = true;
+            else ctx.usesSensitiveOutputString = true;
           } else {
-            ctx.usesSensitiveString = true;
+            if (nullable) ctx.usesSensitiveNullableString = true;
+            else ctx.usesSensitiveString = true;
           }
         }
-        baseSchema = isNullable(prop)
-          ? "SensitiveNullableString"
-          : "SensitiveString";
+        if (useStrict) {
+          baseSchema = nullable
+            ? "SensitiveOutputNullableString"
+            : "SensitiveOutputString";
+        } else {
+          baseSchema = nullable
+            ? "SensitiveNullableString"
+            : "SensitiveString";
+        }
         return baseSchema; // Return early since Sensitive handles null
       }
       baseSchema = "Schema.String";
@@ -975,12 +997,17 @@ function generateOutputSchema(
   sensitiveImports: {
     usesSensitiveString: boolean;
     usesSensitiveNullableString: boolean;
+    usesSensitiveOutputString: boolean;
+    usesSensitiveOutputNullableString: boolean;
   };
 } {
   const outputSchemaName = toPascalCase(operationId) + "Output";
   const ctx: SchemaGenerationContext = {
+    direction: "output",
     usesSensitiveString: false,
     usesSensitiveNullableString: false,
+    usesSensitiveOutputString: false,
+    usesSensitiveOutputNullableString: false,
   };
 
   if (!responseSchema) {
@@ -991,6 +1018,8 @@ export type ${outputSchemaName} = typeof ${outputSchemaName}.Type;`,
       sensitiveImports: {
         usesSensitiveString: false,
         usesSensitiveNullableString: false,
+        usesSensitiveOutputString: false,
+        usesSensitiveOutputNullableString: false,
       },
     };
   }
@@ -1016,6 +1045,9 @@ export type ${outputSchemaName} = typeof ${outputSchemaName}.Type;`,
       sensitiveImports: {
         usesSensitiveString: ctx.usesSensitiveString,
         usesSensitiveNullableString: ctx.usesSensitiveNullableString,
+        usesSensitiveOutputString: ctx.usesSensitiveOutputString,
+        usesSensitiveOutputNullableString:
+          ctx.usesSensitiveOutputNullableString,
       },
     };
   }
@@ -1034,6 +1066,8 @@ export type ${outputSchemaName} = typeof ${outputSchemaName}.Type;`,
     sensitiveImports: {
       usesSensitiveString: ctx.usesSensitiveString,
       usesSensitiveNullableString: ctx.usesSensitiveNullableString,
+      usesSensitiveOutputString: ctx.usesSensitiveOutputString,
+      usesSensitiveOutputNullableString: ctx.usesSensitiveOutputNullableString,
     },
   };
 }
@@ -1051,6 +1085,8 @@ function generateOperationCode(
   sensitiveImports: {
     usesSensitiveString: boolean;
     usesSensitiveNullableString: boolean;
+    usesSensitiveOutputString: boolean;
+    usesSensitiveOutputNullableString: boolean;
   },
   config: GeneratorConfig,
 ): string {
@@ -1091,6 +1127,12 @@ import * as T from "${traitsImport}.ts";`;
   }
   if (sensitiveImports.usesSensitiveNullableString) {
     sensitiveTypesToImport.push("SensitiveNullableString");
+  }
+  if (sensitiveImports.usesSensitiveOutputString) {
+    sensitiveTypesToImport.push("SensitiveOutputString");
+  }
+  if (sensitiveImports.usesSensitiveOutputNullableString) {
+    sensitiveTypesToImport.push("SensitiveOutputNullableString");
   }
   if (sensitiveTypesToImport.length > 0) {
     imports += `\nimport { ${sensitiveTypesToImport.join(", ")} } from "${sensitiveImportPath}.ts";`;
@@ -1189,8 +1231,11 @@ export function generateFromOpenAPI(config: GeneratorConfig): void {
           );
 
           const sensitiveCtx: SchemaGenerationContext = {
+            direction: "input",
             usesSensitiveString: false,
             usesSensitiveNullableString: false,
+            usesSensitiveOutputString: false,
+            usesSensitiveOutputNullableString: false,
           };
 
           const { inputSchemaCode, inputSchemaName } =
@@ -1215,8 +1260,18 @@ export function generateFromOpenAPI(config: GeneratorConfig): void {
               swagger,
             );
           const sensitiveImports = {
-            usesSensitiveString: sensitiveCtx.usesSensitiveString || outputSensitiveImports.usesSensitiveString,
-            usesSensitiveNullableString: sensitiveCtx.usesSensitiveNullableString || outputSensitiveImports.usesSensitiveNullableString,
+            usesSensitiveString:
+              sensitiveCtx.usesSensitiveString ||
+              outputSensitiveImports.usesSensitiveString,
+            usesSensitiveNullableString:
+              sensitiveCtx.usesSensitiveNullableString ||
+              outputSensitiveImports.usesSensitiveNullableString,
+            usesSensitiveOutputString:
+              sensitiveCtx.usesSensitiveOutputString ||
+              outputSensitiveImports.usesSensitiveOutputString,
+            usesSensitiveOutputNullableString:
+              sensitiveCtx.usesSensitiveOutputNullableString ||
+              outputSensitiveImports.usesSensitiveOutputNullableString,
           };
 
           // Get operation-specific errors
@@ -1295,8 +1350,11 @@ export function generateFromOpenAPI(config: GeneratorConfig): void {
           );
 
           const sensitiveCtx: SchemaGenerationContext = {
+            direction: "input",
             usesSensitiveString: false,
             usesSensitiveNullableString: false,
+            usesSensitiveOutputString: false,
+            usesSensitiveOutputNullableString: false,
           };
 
           // Detect operations that should opt out of automatic redirect-
@@ -1340,8 +1398,18 @@ export function generateFromOpenAPI(config: GeneratorConfig): void {
           const { outputSchemaCode, outputSchemaName, sensitiveImports: outputSensitiveImports } =
             generateOutputSchema(operation.operationId, responseSchema, oas);
           const sensitiveImports = {
-            usesSensitiveString: sensitiveCtx.usesSensitiveString || outputSensitiveImports.usesSensitiveString,
-            usesSensitiveNullableString: sensitiveCtx.usesSensitiveNullableString || outputSensitiveImports.usesSensitiveNullableString,
+            usesSensitiveString:
+              sensitiveCtx.usesSensitiveString ||
+              outputSensitiveImports.usesSensitiveString,
+            usesSensitiveNullableString:
+              sensitiveCtx.usesSensitiveNullableString ||
+              outputSensitiveImports.usesSensitiveNullableString,
+            usesSensitiveOutputString:
+              sensitiveCtx.usesSensitiveOutputString ||
+              outputSensitiveImports.usesSensitiveOutputString,
+            usesSensitiveOutputNullableString:
+              sensitiveCtx.usesSensitiveOutputNullableString ||
+              outputSensitiveImports.usesSensitiveOutputNullableString,
           };
 
           // Get operation-specific errors
@@ -1576,6 +1644,12 @@ import * as T from "${traitsImport}.ts";`;
   }
   if (sensitiveImports.usesSensitiveNullableString) {
     sensitiveTypesToImport.push("SensitiveNullableString");
+  }
+  if (sensitiveImports.usesSensitiveOutputString) {
+    sensitiveTypesToImport.push("SensitiveOutputString");
+  }
+  if (sensitiveImports.usesSensitiveOutputNullableString) {
+    sensitiveTypesToImport.push("SensitiveOutputNullableString");
   }
   if (sensitiveTypesToImport.length > 0) {
     imports += `\nimport { ${sensitiveTypesToImport.join(", ")} } from "${sensitiveImportPath}.ts";`;

--- a/packages/core/src/sensitive.ts
+++ b/packages/core/src/sensitive.ts
@@ -6,18 +6,17 @@
  *
  * @example
  * ```ts
- * import { SensitiveString } from "@distilled.cloud/core/sensitive";
+ * import { SensitiveString, SensitiveOutputString } from "@distilled.cloud/core/sensitive";
  *
- * const Password = Schema.Struct({ plain_text: SensitiveString });
+ * // Inputs: use Sensitive* — accepts plain string OR Redacted (convenience).
+ * const CreateInput = Schema.Struct({ plain_text: SensitiveString });
+ * API.create({ plain_text: "my-secret" });             // ok
+ * API.create({ plain_text: Redacted.make("my-secret") }); // also ok
  *
- * // Users can pass raw strings (convenient):
- * API.createPassword({ plain_text: "my-secret" })
- *
- * // Or Redacted values (explicit):
- * API.createPassword({ plain_text: Redacted.make("my-secret") })
- *
- * // Response values are always Redacted (safe):
- * console.log(result.plain_text); // logs "<redacted>"
+ * // Outputs: use SensitiveOutput* — decoded type is strictly Redacted, so
+ * // consumers never need to coerce.
+ * const CreateOutput = Schema.Struct({ plain_text: SensitiveOutputString });
+ * console.log(result.plain_text); // Redacted<string>, logs "<redacted>"
  * ```
  */
 import * as Redacted from "effect/Redacted";
@@ -25,16 +24,16 @@ import * as S from "effect/Schema";
 import * as SchemaTransformation from "effect/SchemaTransformation";
 
 /**
- * Sensitive - Marks data as sensitive, wrapping in Effect's Redacted type.
+ * Sensitive (input-friendly) - Marks data as sensitive, wrapping in Redacted.
  *
- * This schema provides a convenient way to handle sensitive data:
- * - TypeScript type: `A | Redacted.Redacted<A>` (accepts both for inputs)
- * - Decode (responses): Always wraps wire value in Redacted
- * - Encode (requests): Accepts BOTH raw values and Redacted, extracts the raw value
+ * Use for **request body** / **input** fields. The decoded TypeScript type is
+ * `A | Redacted<A>` so callers can pass either a plain value or a Redacted one.
+ * On the wire, plain values are sent through and Redacted values are unwrapped
+ * back to their underlying value. Decoded responses are always Redacted.
  *
- * The union type allows users to conveniently pass plain values for inputs while
- * still getting proper Redacted types for outputs. Response values will always
- * be Redacted, which prevents accidental logging.
+ * For **output** / **response** fields use {@link SensitiveOutput} instead —
+ * its decoded type is strictly `Redacted<A>`, removing the need for callers to
+ * narrow / coerce on every read site.
  */
 export const Sensitive = <A>(
   schema: S.Schema<A>,
@@ -56,19 +55,65 @@ export const Sensitive = <A>(
     });
 
 /**
- * Sensitive string - a string marked as sensitive.
- * Wire format is plain string, TypeScript type is string | Redacted<string>.
- * At runtime, decoded values are always Redacted<string>.
+ * Sensitive string (input-friendly).
+ * Wire format: plain string. Decoded TypeScript type: `string | Redacted<string>`.
+ * Decoded runtime values are always `Redacted<string>`.
+ *
+ * Prefer {@link SensitiveOutputString} on response schemas — its static type
+ * matches the runtime (strict `Redacted<string>`).
  */
 export const SensitiveString = Sensitive(S.String).annotate({
   identifier: "SensitiveString",
 });
 
 /**
- * Sensitive nullable string - a nullable string marked as sensitive.
- * Wire format is plain string | null, TypeScript type is string | null | Redacted<string>.
- * At runtime, decoded non-null values are always Redacted<string>.
+ * Sensitive nullable string (input-friendly).
+ * Wire format: `string | null`. Decoded type: `string | null | Redacted<string>`.
+ * Prefer {@link SensitiveOutputNullableString} on response schemas.
  */
 export const SensitiveNullableString = S.NullOr(SensitiveString).annotate({
   identifier: "SensitiveNullableString",
+});
+
+/**
+ * SensitiveOutput - strict variant of {@link Sensitive} for response fields.
+ *
+ * Decoded TypeScript type is `Redacted<A>` (no union). Wire format is the
+ * underlying `A`. Use on response schemas so consumers don't have to narrow
+ * `string | Redacted<string>` at every read site.
+ */
+export const SensitiveOutput = <A>(
+  schema: S.Schema<A>,
+): S.Schema<Redacted.Redacted<A>> =>
+  schema
+    .pipe(
+      S.decodeTo(
+        S.Redacted(S.toType(schema)),
+        SchemaTransformation.transform({
+          decode: (a) => Redacted.make(a),
+          encode: (v) => Redacted.value(v),
+        }),
+      ),
+    )
+    .annotate({
+      identifier: `SensitiveOutput<${schema.ast.annotations?.identifier ?? "unknown"}>`,
+    });
+
+/**
+ * SensitiveOutput string - strict variant of {@link SensitiveString} for
+ * response fields. Decoded type is `Redacted<string>`.
+ */
+export const SensitiveOutputString = SensitiveOutput(S.String).annotate({
+  identifier: "SensitiveOutputString",
+});
+
+/**
+ * SensitiveOutput nullable string - strict variant of
+ * {@link SensitiveNullableString} for response fields. Decoded type is
+ * `Redacted<string> | null`.
+ */
+export const SensitiveOutputNullableString = S.NullOr(
+  SensitiveOutputString,
+).annotate({
+  identifier: "SensitiveOutputNullableString",
 });

--- a/packages/planetscale/src/operations/addOrganizationTeamMember.ts
+++ b/packages/planetscale/src/operations/addOrganizationTeamMember.ts
@@ -7,7 +7,7 @@ import {
   NotFound,
   UnprocessableEntity,
 } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const AddOrganizationTeamMemberInput =
@@ -97,7 +97,7 @@ export const AddOrganizationTeamMemberOutput =
           postgresql_supported: Schema.Boolean,
         }),
         username: Schema.String,
-        plain_text: SensitiveNullableString,
+        plain_text: SensitiveOutputNullableString,
         replica: Schema.Boolean,
         renewable: Schema.Boolean,
         database_branch: Schema.Struct({

--- a/packages/planetscale/src/operations/createOauthToken.ts
+++ b/packages/planetscale/src/operations/createOauthToken.ts
@@ -2,7 +2,10 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound, UnprocessableEntity } from "../errors.ts";
-import { SensitiveString, SensitiveNullableString } from "../sensitive.ts";
+import {
+  SensitiveString,
+  SensitiveOutputNullableString,
+} from "../sensitive.ts";
 
 // Input Schema
 export const CreateOauthTokenInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -28,8 +31,8 @@ export const CreateOauthTokenOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     id: Schema.String,
     name: Schema.optional(Schema.NullOr(Schema.String)),
     display_name: Schema.String,
-    token: Schema.optional(SensitiveNullableString),
-    plain_text_refresh_token: Schema.optional(SensitiveNullableString),
+    token: Schema.optional(SensitiveOutputNullableString),
+    plain_text_refresh_token: Schema.optional(SensitiveOutputNullableString),
     avatar_url: Schema.String,
     created_at: Schema.String,
     updated_at: Schema.String,

--- a/packages/planetscale/src/operations/createPassword.ts
+++ b/packages/planetscale/src/operations/createPassword.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound, UnprocessableEntity } from "../errors.ts";
-import { SensitiveString } from "../sensitive.ts";
+import { SensitiveOutputString } from "../sensitive.ts";
 
 // Input Schema
 export const CreatePasswordInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -62,7 +62,7 @@ export const CreatePasswordOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     postgresql_supported: Schema.Boolean,
   }),
   username: Schema.String,
-  plain_text: SensitiveString,
+  plain_text: SensitiveOutputString,
   replica: Schema.Boolean,
   renewable: Schema.Boolean,
   database_branch: Schema.Struct({

--- a/packages/planetscale/src/operations/createRole.ts
+++ b/packages/planetscale/src/operations/createRole.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const CreateRoleInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -49,7 +49,7 @@ export const CreateRoleOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   private_connection_service_name: Schema.String,
   username: Schema.String,
   base_username: Schema.String,
-  password: SensitiveNullableString,
+  password: SensitiveOutputNullableString,
   database_name: Schema.String,
   created_at: Schema.String,
   updated_at: Schema.String,

--- a/packages/planetscale/src/operations/createServiceToken.ts
+++ b/packages/planetscale/src/operations/createServiceToken.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const CreateServiceTokenInput =
@@ -24,8 +24,8 @@ export const CreateServiceTokenOutput =
     id: Schema.String,
     name: Schema.optional(Schema.NullOr(Schema.String)),
     display_name: Schema.String,
-    token: Schema.optional(SensitiveNullableString),
-    plain_text_refresh_token: Schema.optional(SensitiveNullableString),
+    token: Schema.optional(SensitiveOutputNullableString),
+    plain_text_refresh_token: Schema.optional(SensitiveOutputNullableString),
     avatar_url: Schema.String,
     created_at: Schema.String,
     updated_at: Schema.String,

--- a/packages/planetscale/src/operations/createWebhook.ts
+++ b/packages/planetscale/src/operations/createWebhook.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveString } from "../sensitive.ts";
+import { SensitiveOutputString } from "../sensitive.ts";
 
 // Input Schema
 export const CreateWebhookInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -23,7 +23,7 @@ export type CreateWebhookInput = typeof CreateWebhookInput.Type;
 export const CreateWebhookOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   id: Schema.String,
   url: Schema.String,
-  secret: SensitiveString,
+  secret: SensitiveOutputString,
   enabled: Schema.Boolean,
   last_sent_result: Schema.NullOr(Schema.String),
   last_sent_success: Schema.NullOr(Schema.Boolean),

--- a/packages/planetscale/src/operations/getDefaultRole.ts
+++ b/packages/planetscale/src/operations/getDefaultRole.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const GetDefaultRoleInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -26,7 +26,7 @@ export const GetDefaultRoleOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   private_connection_service_name: Schema.String,
   username: Schema.String,
   base_username: Schema.String,
-  password: SensitiveNullableString,
+  password: SensitiveOutputNullableString,
   database_name: Schema.String,
   created_at: Schema.String,
   updated_at: Schema.String,

--- a/packages/planetscale/src/operations/getOauthToken.ts
+++ b/packages/planetscale/src/operations/getOauthToken.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const GetOauthTokenInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -22,8 +22,8 @@ export const GetOauthTokenOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   id: Schema.String,
   name: Schema.optional(Schema.NullOr(Schema.String)),
   display_name: Schema.String,
-  token: Schema.optional(SensitiveNullableString),
-  plain_text_refresh_token: Schema.optional(SensitiveNullableString),
+  token: Schema.optional(SensitiveOutputNullableString),
+  plain_text_refresh_token: Schema.optional(SensitiveOutputNullableString),
   avatar_url: Schema.String,
   created_at: Schema.String,
   updated_at: Schema.String,

--- a/packages/planetscale/src/operations/getOrganizationTeamMember.ts
+++ b/packages/planetscale/src/operations/getOrganizationTeamMember.ts
@@ -7,7 +7,7 @@ import {
   NotFound,
   UnprocessableEntity,
 } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const GetOrganizationTeamMemberInput =
@@ -97,7 +97,7 @@ export const GetOrganizationTeamMemberOutput =
           postgresql_supported: Schema.Boolean,
         }),
         username: Schema.String,
-        plain_text: SensitiveNullableString,
+        plain_text: SensitiveOutputNullableString,
         replica: Schema.Boolean,
         renewable: Schema.Boolean,
         database_branch: Schema.Struct({

--- a/packages/planetscale/src/operations/getPassword.ts
+++ b/packages/planetscale/src/operations/getPassword.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const GetPasswordInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -55,7 +55,7 @@ export const GetPasswordOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     postgresql_supported: Schema.Boolean,
   }),
   username: Schema.String,
-  plain_text: SensitiveNullableString,
+  plain_text: SensitiveOutputNullableString,
   replica: Schema.Boolean,
   renewable: Schema.Boolean,
   database_branch: Schema.Struct({

--- a/packages/planetscale/src/operations/getRole.ts
+++ b/packages/planetscale/src/operations/getRole.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const GetRoleInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -27,7 +27,7 @@ export const GetRoleOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   private_connection_service_name: Schema.String,
   username: Schema.String,
   base_username: Schema.String,
-  password: SensitiveNullableString,
+  password: SensitiveOutputNullableString,
   database_name: Schema.String,
   created_at: Schema.String,
   updated_at: Schema.String,

--- a/packages/planetscale/src/operations/getServiceToken.ts
+++ b/packages/planetscale/src/operations/getServiceToken.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const GetServiceTokenInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -21,8 +21,8 @@ export const GetServiceTokenOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   id: Schema.String,
   name: Schema.optional(Schema.NullOr(Schema.String)),
   display_name: Schema.String,
-  token: Schema.optional(SensitiveNullableString),
-  plain_text_refresh_token: Schema.optional(SensitiveNullableString),
+  token: Schema.optional(SensitiveOutputNullableString),
+  plain_text_refresh_token: Schema.optional(SensitiveOutputNullableString),
   avatar_url: Schema.String,
   created_at: Schema.String,
   updated_at: Schema.String,

--- a/packages/planetscale/src/operations/getWebhook.ts
+++ b/packages/planetscale/src/operations/getWebhook.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveString } from "../sensitive.ts";
+import { SensitiveOutputString } from "../sensitive.ts";
 
 // Input Schema
 export const GetWebhookInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -21,7 +21,7 @@ export type GetWebhookInput = typeof GetWebhookInput.Type;
 export const GetWebhookOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   id: Schema.String,
   url: Schema.String,
-  secret: SensitiveString,
+  secret: SensitiveOutputString,
   enabled: Schema.Boolean,
   last_sent_result: Schema.NullOr(Schema.String),
   last_sent_success: Schema.NullOr(Schema.Boolean),

--- a/packages/planetscale/src/operations/listOauthTokens.ts
+++ b/packages/planetscale/src/operations/listOauthTokens.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const ListOauthTokensInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -32,7 +32,7 @@ export const ListOauthTokensOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       name: Schema.optional(Schema.NullOr(Schema.String)),
       display_name: Schema.String,
       token: Schema.optional(Schema.NullOr(Schema.String)),
-      plain_text_refresh_token: Schema.optional(SensitiveNullableString),
+      plain_text_refresh_token: Schema.optional(SensitiveOutputNullableString),
       avatar_url: Schema.String,
       created_at: Schema.String,
       updated_at: Schema.String,

--- a/packages/planetscale/src/operations/listOrganizationTeamMembers.ts
+++ b/packages/planetscale/src/operations/listOrganizationTeamMembers.ts
@@ -7,7 +7,7 @@ import {
   NotFound,
   UnprocessableEntity,
 } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const ListOrganizationTeamMembersInput =
@@ -106,7 +106,7 @@ export const ListOrganizationTeamMembersOutput =
               postgresql_supported: Schema.Boolean,
             }),
             username: Schema.String,
-            plain_text: SensitiveNullableString,
+            plain_text: SensitiveOutputNullableString,
             replica: Schema.Boolean,
             renewable: Schema.Boolean,
             database_branch: Schema.Struct({

--- a/packages/planetscale/src/operations/listPasswords.ts
+++ b/packages/planetscale/src/operations/listPasswords.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const ListPasswordsInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -65,7 +65,7 @@ export const ListPasswordsOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
         postgresql_supported: Schema.Boolean,
       }),
       username: Schema.String,
-      plain_text: SensitiveNullableString,
+      plain_text: SensitiveOutputNullableString,
       replica: Schema.Boolean,
       renewable: Schema.Boolean,
       database_branch: Schema.Struct({

--- a/packages/planetscale/src/operations/listRoles.ts
+++ b/packages/planetscale/src/operations/listRoles.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const ListRolesInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -36,7 +36,7 @@ export const ListRolesOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       private_connection_service_name: Schema.String,
       username: Schema.String,
       base_username: Schema.String,
-      password: SensitiveNullableString,
+      password: SensitiveOutputNullableString,
       database_name: Schema.String,
       created_at: Schema.String,
       updated_at: Schema.String,

--- a/packages/planetscale/src/operations/listServiceTokens.ts
+++ b/packages/planetscale/src/operations/listServiceTokens.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const ListServiceTokensInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
@@ -34,7 +34,9 @@ export const ListServiceTokensOutput =
         name: Schema.optional(Schema.NullOr(Schema.String)),
         display_name: Schema.String,
         token: Schema.optional(Schema.NullOr(Schema.String)),
-        plain_text_refresh_token: Schema.optional(SensitiveNullableString),
+        plain_text_refresh_token: Schema.optional(
+          SensitiveOutputNullableString,
+        ),
         avatar_url: Schema.String,
         created_at: Schema.String,
         updated_at: Schema.String,

--- a/packages/planetscale/src/operations/listWebhooks.ts
+++ b/packages/planetscale/src/operations/listWebhooks.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveString } from "../sensitive.ts";
+import { SensitiveOutputString } from "../sensitive.ts";
 
 // Input Schema
 export const ListWebhooksInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -30,7 +30,7 @@ export const ListWebhooksOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     Schema.Struct({
       id: Schema.String,
       url: Schema.String,
-      secret: SensitiveString,
+      secret: SensitiveOutputString,
       enabled: Schema.Boolean,
       last_sent_result: Schema.NullOr(Schema.String),
       last_sent_success: Schema.NullOr(Schema.Boolean),

--- a/packages/planetscale/src/operations/renewPassword.ts
+++ b/packages/planetscale/src/operations/renewPassword.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveString } from "../sensitive.ts";
+import { SensitiveOutputString } from "../sensitive.ts";
 
 // Input Schema
 export const RenewPasswordInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -55,7 +55,7 @@ export const RenewPasswordOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     postgresql_supported: Schema.Boolean,
   }),
   username: Schema.String,
-  plain_text: SensitiveString,
+  plain_text: SensitiveOutputString,
   replica: Schema.Boolean,
   renewable: Schema.Boolean,
   database_branch: Schema.Struct({

--- a/packages/planetscale/src/operations/renewRole.ts
+++ b/packages/planetscale/src/operations/renewRole.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const RenewRoleInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -27,7 +27,7 @@ export const RenewRoleOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   private_connection_service_name: Schema.String,
   username: Schema.String,
   base_username: Schema.String,
-  password: SensitiveNullableString,
+  password: SensitiveOutputNullableString,
   database_name: Schema.String,
   created_at: Schema.String,
   updated_at: Schema.String,

--- a/packages/planetscale/src/operations/resetDefaultRole.ts
+++ b/packages/planetscale/src/operations/resetDefaultRole.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const ResetDefaultRoleInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -27,7 +27,7 @@ export const ResetDefaultRoleOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
     private_connection_service_name: Schema.String,
     username: Schema.String,
     base_username: Schema.String,
-    password: SensitiveNullableString,
+    password: SensitiveOutputNullableString,
     database_name: Schema.String,
     created_at: Schema.String,
     updated_at: Schema.String,

--- a/packages/planetscale/src/operations/resetRole.ts
+++ b/packages/planetscale/src/operations/resetRole.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const ResetRoleInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -27,7 +27,7 @@ export const ResetRoleOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   private_connection_service_name: Schema.String,
   username: Schema.String,
   base_username: Schema.String,
-  password: SensitiveNullableString,
+  password: SensitiveOutputNullableString,
   database_name: Schema.String,
   created_at: Schema.String,
   updated_at: Schema.String,

--- a/packages/planetscale/src/operations/updatePassword.ts
+++ b/packages/planetscale/src/operations/updatePassword.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const UpdatePasswordInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -57,7 +57,7 @@ export const UpdatePasswordOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     postgresql_supported: Schema.Boolean,
   }),
   username: Schema.String,
-  plain_text: SensitiveNullableString,
+  plain_text: SensitiveOutputNullableString,
   replica: Schema.Boolean,
   renewable: Schema.Boolean,
   database_branch: Schema.Struct({

--- a/packages/planetscale/src/operations/updateRole.ts
+++ b/packages/planetscale/src/operations/updateRole.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveNullableString } from "../sensitive.ts";
+import { SensitiveOutputNullableString } from "../sensitive.ts";
 
 // Input Schema
 export const UpdateRoleInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -30,7 +30,7 @@ export const UpdateRoleOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   private_connection_service_name: Schema.String,
   username: Schema.String,
   base_username: Schema.String,
-  password: SensitiveNullableString,
+  password: SensitiveOutputNullableString,
   database_name: Schema.String,
   created_at: Schema.String,
   updated_at: Schema.String,

--- a/packages/planetscale/src/operations/updateWebhook.ts
+++ b/packages/planetscale/src/operations/updateWebhook.ts
@@ -2,7 +2,7 @@ import * as Schema from "effect/Schema";
 import { API } from "../client.ts";
 import * as T from "../traits.ts";
 import { Forbidden, NotFound } from "../errors.ts";
-import { SensitiveString } from "../sensitive.ts";
+import { SensitiveOutputString } from "../sensitive.ts";
 
 // Input Schema
 export const UpdateWebhookInput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -24,7 +24,7 @@ export type UpdateWebhookInput = typeof UpdateWebhookInput.Type;
 export const UpdateWebhookOutput = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   id: Schema.String,
   url: Schema.String,
-  secret: SensitiveString,
+  secret: SensitiveOutputString,
   enabled: Schema.Boolean,
   last_sent_result: Schema.NullOr(Schema.String),
   last_sent_success: Schema.NullOr(Schema.Boolean),

--- a/packages/planetscale/tests/branches.test.ts
+++ b/packages/planetscale/tests/branches.test.ts
@@ -653,24 +653,70 @@ describe.each([{ kind: "postgresql" }, { kind: "mysql" }] as const)(
         expect(isNotFoundOrForbidden(error)).toBe(true);
       });
 
-      it("returns UnprocessableEntity when trying to delete production branch (main)", async () => {
+      it("returns UnprocessableEntity when trying to delete the production branch", async () => {
         const db = getDb();
-        const error = await runEffect(
-          deleteBranch({
+
+        // PlanetScale only refuses to delete a branch if it's *currently* the
+        // production branch. On a fresh test database "main" is the default
+        // branch but isn't always production-protected, so don't rely on its
+        // status — create a throwaway branch, promote it, then verify that
+        // delete fails. Demote afterwards so the database is left in a
+        // deletable state for teardown.
+        const branchName = `test-delete-prod-${kind}-${testRunId}`;
+        await runEffect(
+          createBranch({
             organization: db.organization,
             database: db.name,
-            branch: "main",
-          }).pipe(
-            Effect.matchEffect({
-              onFailure: (e) => Effect.succeed(e),
-              onSuccess: () => Effect.succeed(null),
-            }),
-          ),
+            name: branchName,
+            parent_branch: "main",
+          }),
+        );
+        await runEffect(
+          waitForBranchReady(db.organization, db.name, branchName),
         );
 
-        // Deleting production branch should fail with some error
-        expect(error).not.toBeNull();
-        expect(error).toBeInstanceOf(UnprocessableEntity);
+        try {
+          await runEffect(
+            promoteBranch({
+              organization: db.organization,
+              database: db.name,
+              branch: branchName,
+            }),
+          );
+
+          const error = await runEffect(
+            deleteBranch({
+              organization: db.organization,
+              database: db.name,
+              branch: branchName,
+            }).pipe(
+              Effect.matchEffect({
+                onFailure: (e) => Effect.succeed(e),
+                onSuccess: () => Effect.succeed(null),
+              }),
+            ),
+          );
+
+          expect(error).not.toBeNull();
+          expect(error).toBeInstanceOf(UnprocessableEntity);
+        } finally {
+          // Demote so the branch can be deleted; teardown will drop the
+          // whole database afterwards.
+          await runEffect(
+            demoteBranch({
+              organization: db.organization,
+              database: db.name,
+              branch: branchName,
+            }).pipe(Effect.ignore),
+          );
+          await runEffect(
+            deleteBranch({
+              organization: db.organization,
+              database: db.name,
+              branch: branchName,
+            }).pipe(Effect.ignore),
+          );
+        }
       });
     });
 


### PR DESCRIPTION
`Sensitive(<schema>)` decodes to `A | Redacted<A>`. That's useful on request bodies (callers can pass either a plain value or a Redacted, and the encoder unwraps), but it's wrong on response schemas — the decode runtime always produces `Redacted<A>`, so consumers end up coercing the union at every read site:

```ts
// alchemy today
const created = yield* createPassword({ ... });
// created.plain_text: string | Redacted<string>
const pw = toRedacted(created.plain_text); // helper exists only to satisfy the type
```

### Fix

Add a strict variant for response schemas:

```ts
// new
export const SensitiveOutput = <A>(schema: S.Schema<A>): S.Schema<Redacted<A>> => ...
export const SensitiveOutputString = SensitiveOutput(S.String);
export const SensitiveOutputNullableString = S.NullOr(SensitiveOutputString);
```

Decoded type is `Redacted<A>`. Encoded (wire) type is still the raw `A`.

Teach the OpenAPI generator to use the strict variants for response schemas and keep the input-friendly variants for request bodies:

```diff
 interface SchemaGenerationContext {
+  direction?: "input" | "output";
   usesSensitiveString: boolean;
   usesSensitiveNullableString: boolean;
+  usesSensitiveOutputString: boolean;
+  usesSensitiveOutputNullableString: boolean;
 }
```

```diff
 case "string":
   if (prop["x-sensitive"]) {
-    baseSchema = isNullable(prop) ? "SensitiveNullableString" : "SensitiveString";
+    const useStrict = ctx?.direction === "output";
+    baseSchema = useStrict
+      ? (isNullable(prop) ? "SensitiveOutputNullableString" : "SensitiveOutputString")
+      : (isNullable(prop) ? "SensitiveNullableString" : "SensitiveString");
     return baseSchema;
   }
```

`direction` is `"input"` for both swagger and openapi3 input-schema generators, `"output"` for `generateOutputSchema`.

### Generated diff (planetscale)

```diff
 // createPassword.ts (output)
-import { SensitiveString } from "../sensitive.ts";
+import { SensitiveOutputString } from "../sensitive.ts";

-  plain_text: SensitiveString,
+  plain_text: SensitiveOutputString,
```

```diff
 // createOauthToken.ts (input + output)
-import { SensitiveString, SensitiveNullableString } from "../sensitive.ts";
+import {
+  SensitiveString,
+  SensitiveOutputNullableString,
+} from "../sensitive.ts";

 // Input — unchanged
   client_secret: SensitiveString,
   refresh_token: Schema.optional(SensitiveString),

 // Output — strict
-  token: Schema.optional(SensitiveNullableString),
-  plain_text_refresh_token: Schema.optional(SensitiveNullableString),
+  token: Schema.optional(SensitiveOutputNullableString),
+  plain_text_refresh_token: Schema.optional(SensitiveOutputNullableString),
```

### Compatibility

Wire format unchanged. Decode runtime unchanged (decoded values were already `Redacted<A>` at runtime — only the static type was wider than reality).

The static type of response fields tightens from `A | Redacted<A>` to `Redacted<A>`. Consumers that relied on the union (e.g. doing `typeof x === "string"`) will need to drop those branches. In practice that's the helper code in downstream SDKs that exists only to coerce.

### Scope

Only `packages/planetscale/` is regenerated here. Other SDK packages should be regenerated in a follow-up pass to flush the new shape — keeping that out of this PR to isolate the schema split from unrelated spec drift in some of those packages.
