### PR TITLE
fix(cloudflare): add missing binding types to workers edge preview api

### DIFF
--- a/packages/cloudflare/specs/cloudflare-patch/edge-preview.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare-patch/edge-preview.openapi.yml
@@ -391,6 +391,8 @@ components:
               type: string
             id:
               type: string
+            internalEnv:
+              type: string
             raw:
               type: boolean
 
@@ -424,6 +426,8 @@ components:
             environment:
               type: string
             entrypoint:
+              type: string
+            cross_account_grant:
               type: string
 
         # ai — supports raw
@@ -474,6 +478,8 @@ components:
             name:
               type: string
             index_name:
+              type: string
+            internalEnv:
               type: string
             raw:
               type: boolean
@@ -750,6 +756,68 @@ components:
                 period:
                   type: number
                   enum: [10, 60]
+
+        # artifacts
+        - type: object
+          required: [type, name, namespace]
+          properties:
+            type:
+              type: string
+              enum: [artifacts]
+            name:
+              type: string
+            namespace:
+              type: string
+
+        # unsafe_hello_world
+        - type: object
+          required: [type, name]
+          properties:
+            type:
+              type: string
+              enum: [unsafe_hello_world]
+            name:
+              type: string
+            enable_timer:
+              type: boolean
+
+        # flagship
+        - type: object
+          required: [type, name, app_id]
+          properties:
+            type:
+              type: string
+              enum: [flagship]
+            name:
+              type: string
+            app_id:
+              type: string
+
+        # vpc_service
+        - type: object
+          required: [type, name, service_id]
+          properties:
+            type:
+              type: string
+              enum: [vpc_service]
+            name:
+              type: string
+            service_id:
+              type: string
+
+        # vpc_network
+        - type: object
+          required: [type, name]
+          properties:
+            type:
+              type: string
+              enum: [vpc_network]
+            name:
+              type: string
+            tunnel_id:
+              type: string
+            network_id:
+              type: string
 
         # inherit
         - type: object

--- a/packages/cloudflare/specs/cloudflare/workers.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers.openapi.yml
@@ -8700,6 +8700,8 @@ paths:
                                 type: string
                               id:
                                 type: string
+                              internalEnv:
+                                type: string
                               raw:
                                 type: boolean
                             required:
@@ -8737,6 +8739,8 @@ paths:
                               environment:
                                 type: string
                               entrypoint:
+                                type: string
+                              cross_account_grant:
                                 type: string
                             required:
                               - type
@@ -8792,6 +8796,8 @@ paths:
                               name:
                                 type: string
                               index_name:
+                                type: string
+                              internalEnv:
                                 type: string
                               raw:
                                 type: boolean
@@ -9113,6 +9119,76 @@ paths:
                               - name
                               - namespace_id
                               - simple
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - artifacts
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            required:
+                              - type
+                              - name
+                              - namespace
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - unsafe_hello_world
+                              name:
+                                type: string
+                              enable_timer:
+                                type: boolean
+                            required:
+                              - type
+                              - name
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - flagship
+                              name:
+                                type: string
+                              app_id:
+                                type: string
+                            required:
+                              - type
+                              - name
+                              - app_id
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - vpc_service
+                              name:
+                                type: string
+                              service_id:
+                                type: string
+                            required:
+                              - type
+                              - name
+                              - service_id
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - vpc_network
+                              name:
+                                type: string
+                              tunnel_id:
+                                type: string
+                              network_id:
+                                type: string
+                            required:
+                              - type
+                              - name
                           - type: object
                             properties:
                               type:
@@ -15141,6 +15217,8 @@ paths:
                                 type: string
                               id:
                                 type: string
+                              internalEnv:
+                                type: string
                               raw:
                                 type: boolean
                             required:
@@ -15178,6 +15256,8 @@ paths:
                               environment:
                                 type: string
                               entrypoint:
+                                type: string
+                              cross_account_grant:
                                 type: string
                             required:
                               - type
@@ -15233,6 +15313,8 @@ paths:
                               name:
                                 type: string
                               index_name:
+                                type: string
+                              internalEnv:
                                 type: string
                               raw:
                                 type: boolean
@@ -15554,6 +15636,76 @@ paths:
                               - name
                               - namespace_id
                               - simple
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - artifacts
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            required:
+                              - type
+                              - name
+                              - namespace
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - unsafe_hello_world
+                              name:
+                                type: string
+                              enable_timer:
+                                type: boolean
+                            required:
+                              - type
+                              - name
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - flagship
+                              name:
+                                type: string
+                              app_id:
+                                type: string
+                            required:
+                              - type
+                              - name
+                              - app_id
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - vpc_service
+                              name:
+                                type: string
+                              service_id:
+                                type: string
+                            required:
+                              - type
+                              - name
+                              - service_id
+                          - type: object
+                            properties:
+                              type:
+                                type: string
+                                enum:
+                                  - vpc_network
+                              name:
+                                type: string
+                              tunnel_id:
+                                type: string
+                              network_id:
+                                type: string
+                            required:
+                              - type
+                              - name
                           - type: object
                             properties:
                               type:

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -8777,7 +8777,13 @@ export interface CreateScriptEdgePreviewRequest {
           jurisdiction?: string;
           raw?: boolean;
         }
-      | { type: "d1"; name: string; id: string; raw?: boolean }
+      | {
+          type: "d1";
+          name: string;
+          id: string;
+          internalEnv?: string;
+          raw?: boolean;
+        }
       | {
           type: "queue";
           name: string;
@@ -8791,11 +8797,18 @@ export interface CreateScriptEdgePreviewRequest {
           service: string;
           environment?: string;
           entrypoint?: string;
+          crossAccountGrant?: string;
         }
       | { type: "ai"; name: string; staging?: boolean; raw?: boolean }
       | { type: "browser"; name: string; raw?: boolean }
       | { type: "images"; name: string; raw?: boolean }
-      | { type: "vectorize"; name: string; indexName: string; raw?: boolean }
+      | {
+          type: "vectorize";
+          name: string;
+          indexName: string;
+          internalEnv?: string;
+          raw?: boolean;
+        }
       | {
           type: "workflow";
           name: string;
@@ -8846,6 +8859,16 @@ export interface CreateScriptEdgePreviewRequest {
           name: string;
           namespaceId: string;
           simple: { limit: number; period: "10" | "60" };
+        }
+      | { type: "artifacts"; name: string; namespace: string }
+      | { type: "unsafe_hello_world"; name: string; enableTimer?: boolean }
+      | { type: "flagship"; name: string; appId: string }
+      | { type: "vpc_service"; name: string; serviceId: string }
+      | {
+          type: "vpc_network";
+          name: string;
+          tunnelId?: string;
+          networkId?: string;
         }
       | { type: "inherit"; name: string }
     )[];
@@ -9042,6 +9065,7 @@ export const CreateScriptEdgePreviewRequest =
                 type: Schema.Literal("d1"),
                 name: Schema.String,
                 id: Schema.String,
+                internalEnv: Schema.optional(Schema.String),
                 raw: Schema.optional(Schema.Boolean),
               }),
               Schema.Struct({
@@ -9065,17 +9089,29 @@ export const CreateScriptEdgePreviewRequest =
                 service: Schema.String,
                 environment: Schema.optional(Schema.String),
                 entrypoint: Schema.optional(Schema.String),
-              }),
+                crossAccountGrant: Schema.optional(Schema.String),
+              }).pipe(
+                Schema.encodeKeys({
+                  type: "type",
+                  name: "name",
+                  service: "service",
+                  environment: "environment",
+                  entrypoint: "entrypoint",
+                  crossAccountGrant: "cross_account_grant",
+                }),
+              ),
               Schema.Struct({
                 type: Schema.Literal("vectorize"),
                 name: Schema.String,
                 indexName: Schema.String,
+                internalEnv: Schema.optional(Schema.String),
                 raw: Schema.optional(Schema.Boolean),
               }).pipe(
                 Schema.encodeKeys({
                   type: "type",
                   name: "name",
                   indexName: "index_name",
+                  internalEnv: "internalEnv",
                   raw: "raw",
                 }),
               ),
@@ -9159,6 +9195,33 @@ export const CreateScriptEdgePreviewRequest =
                 }),
               ),
               Schema.Struct({
+                type: Schema.Literal("artifacts"),
+                name: Schema.String,
+                namespace: Schema.String,
+              }),
+              Schema.Struct({
+                type: Schema.Literal("flagship"),
+                name: Schema.String,
+                appId: Schema.String,
+              }).pipe(
+                Schema.encodeKeys({
+                  type: "type",
+                  name: "name",
+                  appId: "app_id",
+                }),
+              ),
+              Schema.Struct({
+                type: Schema.Literal("vpc_service"),
+                name: Schema.String,
+                serviceId: Schema.String,
+              }).pipe(
+                Schema.encodeKeys({
+                  type: "type",
+                  name: "name",
+                  serviceId: "service_id",
+                }),
+              ),
+              Schema.Struct({
                 type: Schema.Literal("ai"),
                 name: Schema.String,
                 staging: Schema.optional(Schema.Boolean),
@@ -9218,6 +9281,30 @@ export const CreateScriptEdgePreviewRequest =
                 type: Schema.Literal("worker_loader"),
                 name: Schema.String,
               }),
+              Schema.Struct({
+                type: Schema.Literal("unsafe_hello_world"),
+                name: Schema.String,
+                enableTimer: Schema.optional(Schema.Boolean),
+              }).pipe(
+                Schema.encodeKeys({
+                  type: "type",
+                  name: "name",
+                  enableTimer: "enable_timer",
+                }),
+              ),
+              Schema.Struct({
+                type: Schema.Literal("vpc_network"),
+                name: Schema.String,
+                tunnelId: Schema.optional(Schema.String),
+                networkId: Schema.optional(Schema.String),
+              }).pipe(
+                Schema.encodeKeys({
+                  type: "type",
+                  name: "name",
+                  tunnelId: "tunnel_id",
+                  networkId: "network_id",
+                }),
+              ),
               Schema.Struct({
                 type: Schema.Literal("inherit"),
                 name: Schema.String,
@@ -14393,7 +14480,13 @@ export interface CreateServiceEdgePreviewRequest {
           jurisdiction?: string;
           raw?: boolean;
         }
-      | { type: "d1"; name: string; id: string; raw?: boolean }
+      | {
+          type: "d1";
+          name: string;
+          id: string;
+          internalEnv?: string;
+          raw?: boolean;
+        }
       | {
           type: "queue";
           name: string;
@@ -14407,11 +14500,18 @@ export interface CreateServiceEdgePreviewRequest {
           service: string;
           environment?: string;
           entrypoint?: string;
+          crossAccountGrant?: string;
         }
       | { type: "ai"; name: string; staging?: boolean; raw?: boolean }
       | { type: "browser"; name: string; raw?: boolean }
       | { type: "images"; name: string; raw?: boolean }
-      | { type: "vectorize"; name: string; indexName: string; raw?: boolean }
+      | {
+          type: "vectorize";
+          name: string;
+          indexName: string;
+          internalEnv?: string;
+          raw?: boolean;
+        }
       | {
           type: "workflow";
           name: string;
@@ -14462,6 +14562,16 @@ export interface CreateServiceEdgePreviewRequest {
           name: string;
           namespaceId: string;
           simple: { limit: number; period: "10" | "60" };
+        }
+      | { type: "artifacts"; name: string; namespace: string }
+      | { type: "unsafe_hello_world"; name: string; enableTimer?: boolean }
+      | { type: "flagship"; name: string; appId: string }
+      | { type: "vpc_service"; name: string; serviceId: string }
+      | {
+          type: "vpc_network";
+          name: string;
+          tunnelId?: string;
+          networkId?: string;
         }
       | { type: "inherit"; name: string }
     )[];
@@ -14659,6 +14769,7 @@ export const CreateServiceEdgePreviewRequest =
                 type: Schema.Literal("d1"),
                 name: Schema.String,
                 id: Schema.String,
+                internalEnv: Schema.optional(Schema.String),
                 raw: Schema.optional(Schema.Boolean),
               }),
               Schema.Struct({
@@ -14682,17 +14793,29 @@ export const CreateServiceEdgePreviewRequest =
                 service: Schema.String,
                 environment: Schema.optional(Schema.String),
                 entrypoint: Schema.optional(Schema.String),
-              }),
+                crossAccountGrant: Schema.optional(Schema.String),
+              }).pipe(
+                Schema.encodeKeys({
+                  type: "type",
+                  name: "name",
+                  service: "service",
+                  environment: "environment",
+                  entrypoint: "entrypoint",
+                  crossAccountGrant: "cross_account_grant",
+                }),
+              ),
               Schema.Struct({
                 type: Schema.Literal("vectorize"),
                 name: Schema.String,
                 indexName: Schema.String,
+                internalEnv: Schema.optional(Schema.String),
                 raw: Schema.optional(Schema.Boolean),
               }).pipe(
                 Schema.encodeKeys({
                   type: "type",
                   name: "name",
                   indexName: "index_name",
+                  internalEnv: "internalEnv",
                   raw: "raw",
                 }),
               ),
@@ -14776,6 +14899,33 @@ export const CreateServiceEdgePreviewRequest =
                 }),
               ),
               Schema.Struct({
+                type: Schema.Literal("artifacts"),
+                name: Schema.String,
+                namespace: Schema.String,
+              }),
+              Schema.Struct({
+                type: Schema.Literal("flagship"),
+                name: Schema.String,
+                appId: Schema.String,
+              }).pipe(
+                Schema.encodeKeys({
+                  type: "type",
+                  name: "name",
+                  appId: "app_id",
+                }),
+              ),
+              Schema.Struct({
+                type: Schema.Literal("vpc_service"),
+                name: Schema.String,
+                serviceId: Schema.String,
+              }).pipe(
+                Schema.encodeKeys({
+                  type: "type",
+                  name: "name",
+                  serviceId: "service_id",
+                }),
+              ),
+              Schema.Struct({
                 type: Schema.Literal("ai"),
                 name: Schema.String,
                 staging: Schema.optional(Schema.Boolean),
@@ -14835,6 +14985,30 @@ export const CreateServiceEdgePreviewRequest =
                 type: Schema.Literal("worker_loader"),
                 name: Schema.String,
               }),
+              Schema.Struct({
+                type: Schema.Literal("unsafe_hello_world"),
+                name: Schema.String,
+                enableTimer: Schema.optional(Schema.Boolean),
+              }).pipe(
+                Schema.encodeKeys({
+                  type: "type",
+                  name: "name",
+                  enableTimer: "enable_timer",
+                }),
+              ),
+              Schema.Struct({
+                type: Schema.Literal("vpc_network"),
+                name: Schema.String,
+                tunnelId: Schema.optional(Schema.String),
+                networkId: Schema.optional(Schema.String),
+              }).pipe(
+                Schema.encodeKeys({
+                  type: "type",
+                  name: "name",
+                  tunnelId: "tunnel_id",
+                  networkId: "network_id",
+                }),
+              ),
               Schema.Struct({
                 type: Schema.Literal("inherit"),
                 name: Schema.String,


### PR DESCRIPTION
The edge preview create route was missing a few binding types. This is blocking `cloudflare-runtime` from supporting them as remote bindings.

I used the `WorkerMetadataBinding` type from workers-sdk as a reference ([link](https://github.com/cloudflare/workers-sdk/blob/07336888e0bc82925e4023f5b72a0062f10d77b8/packages/workers-utils/src/types.ts#L56)), which is what Wrangler does.