### PR TITLE
fix(cloudflare): require `className` in worker bindings

### DIFF
--- a/packages/cloudflare/patches/workers/createBetaWorkerVersion.json
+++ b/packages/cloudflare/patches/workers/createBetaWorkerVersion.json
@@ -5,6 +5,12 @@
   "request": {
     "properties": {
       "bindings[].json": { "type": "unknown" },
+      "bindings[?type=durable_object_namespace].class_name": {
+        "optional": false
+      },
+      "bindings[?type=workflow].class_name": {
+        "optional": false
+      },
       "bindings[]": {
         "appendUnion": [
           {

--- a/packages/cloudflare/patches/workers/createScriptVersion.json
+++ b/packages/cloudflare/patches/workers/createScriptVersion.json
@@ -5,6 +5,12 @@
   "request": {
     "properties": {
       "metadata.bindings[].json": { "type": "unknown" },
+      "metadata.bindings[?type=durable_object_namespace].class_name": {
+        "optional": false
+      },
+      "metadata.bindings[?type=workflow].class_name": {
+        "optional": false
+      },
       "metadata.bindings[]": {
         "appendUnion": [
           {

--- a/packages/cloudflare/patches/workers/patchScriptScriptAndVersionSetting.json
+++ b/packages/cloudflare/patches/workers/patchScriptScriptAndVersionSetting.json
@@ -6,6 +6,12 @@
   "request": {
     "properties": {
       "settings.bindings[].json": { "type": "unknown" },
+      "settings.bindings[?type=durable_object_namespace].class_name": {
+        "optional": false
+      },
+      "settings.bindings[?type=workflow].class_name": {
+        "optional": false
+      },
       "settings.bindings[]": {
         "appendUnion": [
           {

--- a/packages/cloudflare/patches/workers/putScript.json
+++ b/packages/cloudflare/patches/workers/putScript.json
@@ -33,6 +33,12 @@
   "request": {
     "properties": {
       "metadata.bindings[].json": { "type": "unknown" },
+      "metadata.bindings[?type=durable_object_namespace].class_name": {
+        "optional": false
+      },
+      "metadata.bindings[?type=workflow].class_name": {
+        "optional": false
+      },
       "metadata.bindings[]": {
         "appendUnion": [
           {

--- a/packages/cloudflare/scripts/generate.ts
+++ b/packages/cloudflare/scripts/generate.ts
@@ -394,6 +394,45 @@ function applyPropertyPatch(
 
   const [current, ...rest] = pathSegments;
 
+  // Handle discriminated union variant access:
+  //   "bindings[?type=durable_object_namespace]" → descend into property
+  //     "bindings", into its array element (a union), then narrow to the
+  //     variant whose literal property `type` equals "durable_object_namespace".
+  //   "[?type=durable_object_namespace]" → narrow the current union directly.
+  // This lets patches target a single discriminated-union variant by its tag,
+  // instead of hitting every variant that happens to share a property name.
+  const discMatch = current.match(/^(\w*)\[\?(\w+)=([^\]]+)\]$/);
+  if (discMatch) {
+    const [, fieldName, discKey, discValue] = discMatch;
+    let unionType: TypeInfo | undefined;
+    if (fieldName === "") {
+      unionType = typeInfo;
+    } else {
+      const prop = typeInfo.properties?.find((p) => p.name === fieldName);
+      if (!prop) return;
+      const arrayType = unwrapToArray(prop.type);
+      unionType = arrayType?.elementType ?? prop.type;
+    }
+    if (unionType?.kind !== "union" || !unionType.values) return;
+    const variant = unionType.values.find(
+      (v) =>
+        v.kind === "object" &&
+        v.properties?.some(
+          (p) =>
+            p.name === discKey &&
+            p.type.kind === "literal" &&
+            p.type.value === discValue,
+        ),
+    );
+    if (!variant) return;
+    if (rest.length === 0) {
+      applyPatchToTypeInfo(variant, patch);
+    } else {
+      applyPropertyPatch(variant, rest, patch);
+    }
+    return;
+  }
+
   // Handle array element access: "buckets[]" means descend into array element type
   if (current.endsWith("[]")) {
     const fieldName = current.slice(0, -2);

--- a/packages/cloudflare/specs/cloudflare/workers.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workers.openapi.yml
@@ -2601,6 +2601,7 @@ paths:
                         required:
                           - name
                           - type
+                          - class_name
                       - type: object
                         properties:
                           id:
@@ -2990,6 +2991,7 @@ paths:
                           - name
                           - type
                           - workflow_name
+                          - class_name
                       - type: object
                         properties:
                           name:
@@ -6275,6 +6277,7 @@ paths:
                             required:
                               - name
                               - type
+                              - class_name
                           - type: object
                             properties:
                               id:
@@ -6665,6 +6668,7 @@ paths:
                               - name
                               - type
                               - workflow_name
+                              - class_name
                           - type: object
                             properties:
                               name:
@@ -10385,6 +10389,7 @@ paths:
                             required:
                               - name
                               - type
+                              - class_name
                           - type: object
                             properties:
                               id:
@@ -10775,6 +10780,7 @@ paths:
                               - name
                               - type
                               - workflow_name
+                              - class_name
                           - type: object
                             properties:
                               name:
@@ -13789,6 +13795,7 @@ paths:
                             required:
                               - name
                               - type
+                              - class_name
                           - type: object
                             properties:
                               id:
@@ -14179,6 +14186,7 @@ paths:
                               - name
                               - type
                               - workflow_name
+                              - class_name
                           - type: object
                             properties:
                               name:

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -2469,7 +2469,7 @@ export interface CreateBetaWorkerVersionRequest {
     | {
         name: string;
         type: "durable_object_namespace";
-        className?: string;
+        className: string;
         environment?: string;
         namespaceId?: string;
         scriptName?: string;
@@ -2529,7 +2529,7 @@ export interface CreateBetaWorkerVersionRequest {
         name: string;
         type: "workflow";
         workflowName: string;
-        className?: string;
+        className: string;
         scriptName?: string;
       }
     | { name: string; part: string; type: "wasm_module" }
@@ -2674,6 +2674,21 @@ export const CreateBetaWorkerVersionRequest =
             }),
           ),
           Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("workflow"),
+            workflowName: Schema.String,
+            className: Schema.String,
+            scriptName: Schema.optional(Schema.String),
+          }).pipe(
+            Schema.encodeKeys({
+              name: "name",
+              type: "type",
+              workflowName: "workflow_name",
+              className: "class_name",
+              scriptName: "script_name",
+            }),
+          ),
+          Schema.Struct({
             dataset: Schema.String,
             name: Schema.String,
             type: Schema.Literal("analytics_engine"),
@@ -2704,6 +2719,23 @@ export const CreateBetaWorkerVersionRequest =
               }),
             ),
           }),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("durable_object_namespace"),
+            className: Schema.String,
+            environment: Schema.optional(Schema.String),
+            namespaceId: Schema.optional(Schema.String),
+            scriptName: Schema.optional(Schema.String),
+          }).pipe(
+            Schema.encodeKeys({
+              name: "name",
+              type: "type",
+              className: "class_name",
+              environment: "environment",
+              namespaceId: "namespace_id",
+              scriptName: "script_name",
+            }),
+          ),
           Schema.Struct({
             id: Schema.String,
             name: Schema.String,
@@ -2799,21 +2831,6 @@ export const CreateBetaWorkerVersionRequest =
           ),
           Schema.Struct({
             name: Schema.String,
-            type: Schema.Literal("workflow"),
-            workflowName: Schema.String,
-            className: Schema.optional(Schema.String),
-            scriptName: Schema.optional(Schema.String),
-          }).pipe(
-            Schema.encodeKeys({
-              name: "name",
-              type: "type",
-              workflowName: "workflow_name",
-              className: "class_name",
-              scriptName: "script_name",
-            }),
-          ),
-          Schema.Struct({
-            name: Schema.String,
             part: Schema.String,
             type: Schema.Literal("wasm_module"),
           }),
@@ -2834,23 +2851,6 @@ export const CreateBetaWorkerVersionRequest =
             name: Schema.String,
             type: Schema.Literal("browser"),
           }),
-          Schema.Struct({
-            name: Schema.String,
-            type: Schema.Literal("durable_object_namespace"),
-            className: Schema.optional(Schema.String),
-            environment: Schema.optional(Schema.String),
-            namespaceId: Schema.optional(Schema.String),
-            scriptName: Schema.optional(Schema.String),
-          }).pipe(
-            Schema.encodeKeys({
-              name: "name",
-              type: "type",
-              className: "class_name",
-              environment: "environment",
-              namespaceId: "namespace_id",
-              scriptName: "script_name",
-            }),
-          ),
           Schema.Struct({
             name: Schema.String,
             type: Schema.Literal("inherit"),
@@ -6563,7 +6563,7 @@ export interface PutScriptRequest {
       | {
           name: string;
           type: "durable_object_namespace";
-          className?: string;
+          className: string;
           environment?: string;
           namespaceId?: string;
           scriptName?: string;
@@ -6623,7 +6623,7 @@ export interface PutScriptRequest {
           name: string;
           type: "workflow";
           workflowName: string;
-          className?: string;
+          className: string;
           scriptName?: string;
         }
       | { name: string; part: string; type: "wasm_module" }
@@ -6793,6 +6793,21 @@ export const PutScriptRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
           ),
           Schema.Struct({
             name: Schema.String,
+            type: Schema.Literal("workflow"),
+            workflowName: Schema.String,
+            className: Schema.String,
+            scriptName: Schema.optional(Schema.String),
+          }).pipe(
+            Schema.encodeKeys({
+              name: "name",
+              type: "type",
+              workflowName: "workflow_name",
+              className: "class_name",
+              scriptName: "script_name",
+            }),
+          ),
+          Schema.Struct({
+            name: Schema.String,
             type: Schema.Literal("ratelimit"),
             namespaceId: Schema.String,
             simple: Schema.Struct({
@@ -6838,6 +6853,23 @@ export const PutScriptRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
               }),
             ),
           }),
+          Schema.Struct({
+            name: Schema.String,
+            type: Schema.Literal("durable_object_namespace"),
+            className: Schema.String,
+            environment: Schema.optional(Schema.String),
+            namespaceId: Schema.optional(Schema.String),
+            scriptName: Schema.optional(Schema.String),
+          }).pipe(
+            Schema.encodeKeys({
+              name: "name",
+              type: "type",
+              className: "class_name",
+              environment: "environment",
+              namespaceId: "namespace_id",
+              scriptName: "script_name",
+            }),
+          ),
           Schema.Struct({
             id: Schema.String,
             name: Schema.String,
@@ -6933,21 +6965,6 @@ export const PutScriptRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
           ),
           Schema.Struct({
             name: Schema.String,
-            type: Schema.Literal("workflow"),
-            workflowName: Schema.String,
-            className: Schema.optional(Schema.String),
-            scriptName: Schema.optional(Schema.String),
-          }).pipe(
-            Schema.encodeKeys({
-              name: "name",
-              type: "type",
-              workflowName: "workflow_name",
-              className: "class_name",
-              scriptName: "script_name",
-            }),
-          ),
-          Schema.Struct({
-            name: Schema.String,
             part: Schema.String,
             type: Schema.Literal("wasm_module"),
           }),
@@ -6968,23 +6985,6 @@ export const PutScriptRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
             name: Schema.String,
             type: Schema.Literal("browser"),
           }),
-          Schema.Struct({
-            name: Schema.String,
-            type: Schema.Literal("durable_object_namespace"),
-            className: Schema.optional(Schema.String),
-            environment: Schema.optional(Schema.String),
-            namespaceId: Schema.optional(Schema.String),
-            scriptName: Schema.optional(Schema.String),
-          }).pipe(
-            Schema.encodeKeys({
-              name: "name",
-              type: "type",
-              className: "class_name",
-              environment: "environment",
-              namespaceId: "namespace_id",
-              scriptName: "script_name",
-            }),
-          ),
           Schema.Struct({
             name: Schema.String,
             type: Schema.Literal("inherit"),
@@ -10245,7 +10245,7 @@ export interface PatchScriptScriptAndVersionSettingRequest {
       | {
           name: string;
           type: "durable_object_namespace";
-          className?: string;
+          className: string;
           environment?: string;
           namespaceId?: string;
           scriptName?: string;
@@ -10305,7 +10305,7 @@ export interface PatchScriptScriptAndVersionSettingRequest {
           name: string;
           type: "workflow";
           workflowName: string;
-          className?: string;
+          className: string;
           scriptName?: string;
         }
       | { name: string; part: string; type: "wasm_module" }
@@ -10422,6 +10422,21 @@ export const PatchScriptScriptAndVersionSettingRequest =
                 }),
               ),
               Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("workflow"),
+                workflowName: Schema.String,
+                className: Schema.String,
+                scriptName: Schema.optional(Schema.String),
+              }).pipe(
+                Schema.encodeKeys({
+                  name: "name",
+                  type: "type",
+                  workflowName: "workflow_name",
+                  className: "class_name",
+                  scriptName: "script_name",
+                }),
+              ),
+              Schema.Struct({
                 dataset: Schema.String,
                 name: Schema.String,
                 type: Schema.Literal("analytics_engine"),
@@ -10452,6 +10467,23 @@ export const PatchScriptScriptAndVersionSettingRequest =
                   }),
                 ),
               }),
+              Schema.Struct({
+                name: Schema.String,
+                type: Schema.Literal("durable_object_namespace"),
+                className: Schema.String,
+                environment: Schema.optional(Schema.String),
+                namespaceId: Schema.optional(Schema.String),
+                scriptName: Schema.optional(Schema.String),
+              }).pipe(
+                Schema.encodeKeys({
+                  name: "name",
+                  type: "type",
+                  className: "class_name",
+                  environment: "environment",
+                  namespaceId: "namespace_id",
+                  scriptName: "script_name",
+                }),
+              ),
               Schema.Struct({
                 id: Schema.String,
                 name: Schema.String,
@@ -10549,21 +10581,6 @@ export const PatchScriptScriptAndVersionSettingRequest =
               ),
               Schema.Struct({
                 name: Schema.String,
-                type: Schema.Literal("workflow"),
-                workflowName: Schema.String,
-                className: Schema.optional(Schema.String),
-                scriptName: Schema.optional(Schema.String),
-              }).pipe(
-                Schema.encodeKeys({
-                  name: "name",
-                  type: "type",
-                  workflowName: "workflow_name",
-                  className: "class_name",
-                  scriptName: "script_name",
-                }),
-              ),
-              Schema.Struct({
-                name: Schema.String,
                 part: Schema.String,
                 type: Schema.Literal("wasm_module"),
               }),
@@ -10584,23 +10601,6 @@ export const PatchScriptScriptAndVersionSettingRequest =
                 name: Schema.String,
                 type: Schema.Literal("browser"),
               }),
-              Schema.Struct({
-                name: Schema.String,
-                type: Schema.Literal("durable_object_namespace"),
-                className: Schema.optional(Schema.String),
-                environment: Schema.optional(Schema.String),
-                namespaceId: Schema.optional(Schema.String),
-                scriptName: Schema.optional(Schema.String),
-              }).pipe(
-                Schema.encodeKeys({
-                  name: "name",
-                  type: "type",
-                  className: "class_name",
-                  environment: "environment",
-                  namespaceId: "namespace_id",
-                  scriptName: "script_name",
-                }),
-              ),
               Schema.Struct({
                 name: Schema.String,
                 type: Schema.Literal("inherit"),
@@ -13351,7 +13351,7 @@ export interface CreateScriptVersionRequest {
       | {
           name: string;
           type: "durable_object_namespace";
-          className?: string;
+          className: string;
           environment?: string;
           namespaceId?: string;
           scriptName?: string;
@@ -13411,7 +13411,7 @@ export interface CreateScriptVersionRequest {
           name: string;
           type: "workflow";
           workflowName: string;
-          className?: string;
+          className: string;
           scriptName?: string;
         }
       | { name: string; part: string; type: "wasm_module" }
@@ -13493,6 +13493,21 @@ export const CreateScriptVersionRequest =
               }),
             ),
             Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("workflow"),
+              workflowName: Schema.String,
+              className: Schema.String,
+              scriptName: Schema.optional(Schema.String),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                workflowName: "workflow_name",
+                className: "class_name",
+                scriptName: "script_name",
+              }),
+            ),
+            Schema.Struct({
               dataset: Schema.String,
               name: Schema.String,
               type: Schema.Literal("analytics_engine"),
@@ -13523,6 +13538,23 @@ export const CreateScriptVersionRequest =
                 }),
               ),
             }),
+            Schema.Struct({
+              name: Schema.String,
+              type: Schema.Literal("durable_object_namespace"),
+              className: Schema.String,
+              environment: Schema.optional(Schema.String),
+              namespaceId: Schema.optional(Schema.String),
+              scriptName: Schema.optional(Schema.String),
+            }).pipe(
+              Schema.encodeKeys({
+                name: "name",
+                type: "type",
+                className: "class_name",
+                environment: "environment",
+                namespaceId: "namespace_id",
+                scriptName: "script_name",
+              }),
+            ),
             Schema.Struct({
               id: Schema.String,
               name: Schema.String,
@@ -13618,21 +13650,6 @@ export const CreateScriptVersionRequest =
             ),
             Schema.Struct({
               name: Schema.String,
-              type: Schema.Literal("workflow"),
-              workflowName: Schema.String,
-              className: Schema.optional(Schema.String),
-              scriptName: Schema.optional(Schema.String),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                workflowName: "workflow_name",
-                className: "class_name",
-                scriptName: "script_name",
-              }),
-            ),
-            Schema.Struct({
-              name: Schema.String,
               part: Schema.String,
               type: Schema.Literal("wasm_module"),
             }),
@@ -13653,23 +13670,6 @@ export const CreateScriptVersionRequest =
               name: Schema.String,
               type: Schema.Literal("browser"),
             }),
-            Schema.Struct({
-              name: Schema.String,
-              type: Schema.Literal("durable_object_namespace"),
-              className: Schema.optional(Schema.String),
-              environment: Schema.optional(Schema.String),
-              namespaceId: Schema.optional(Schema.String),
-              scriptName: Schema.optional(Schema.String),
-            }).pipe(
-              Schema.encodeKeys({
-                name: "name",
-                type: "type",
-                className: "class_name",
-                environment: "environment",
-                namespaceId: "namespace_id",
-                scriptName: "script_name",
-              }),
-            ),
             Schema.Struct({
               name: Schema.String,
               type: Schema.Literal("inherit"),


### PR DESCRIPTION
Make the `className` property required when creating a Worker with `durable_object_namespace` and/or `workflow` bindings.