### PR TITLE
fix(aws): strip "Message" suffix when deriving operation name

### DIFF
--- a/packages/aws/src/client/api.ts
+++ b/packages/aws/src/client/api.ts
@@ -52,7 +52,7 @@ export const make = <Op extends Operation<any, any, any>>(
     // Extract metadata for error recording (DISTILLED_AWS_DEBUG) and error context
     const serviceSdkId = getAwsApiService(inputAst)?.sdkId;
     const operationName = getIdentifier(inputAst)?.replace(
-      /(?:Request|Input)$/,
+      /(?:Request|Input|Message)$/,
       "",
     );
 

--- a/packages/aws/src/protocols/aws-json.ts
+++ b/packages/aws/src/protocols/aws-json.ts
@@ -62,8 +62,10 @@ function createAwsJsonProtocol(version: "1.0" | "1.1"): Protocol {
 
     // Extract operation target from the input schema's identifier
     const identifier = getIdentifier(inputAst) ?? "";
-    // Remove "Request" or "Input" suffix to get operation name
-    const operationName = identifier.replace(/(?:Request|Input)$/, "");
+    // Remove "Request", "Input", or "Message" suffix to get operation name.
+    // RDS-family query services (RDS, ElastiCache, Redshift, …) name their
+    // input shapes "XxxMessage" rather than "XxxRequest".
+    const operationName = identifier.replace(/(?:Request|Input|Message)$/, "");
 
     // Build X-Amz-Target from the identifier structure
     const targetHeader = buildXAmzTarget(inputAst, operationName);

--- a/packages/aws/src/protocols/aws-query.ts
+++ b/packages/aws/src/protocols/aws-query.ts
@@ -58,9 +58,13 @@ export const awsQueryProtocol: Protocol = (
   // Pre-compute encoder (done once at init)
   const encodeInput = S.encodeEffect(inputSchema);
 
-  // Pre-compute operation name and version from annotations
+  // Pre-compute operation name and version from annotations.
+  // RDS-family query services (RDS, ElastiCache, Redshift, Neptune, DocDB, …)
+  // name their input shapes "XxxMessage" (e.g. DescribeDBInstancesMessage), so
+  // we must strip "Message" in addition to "Request"/"Input" to recover the
+  // Action name.
   const identifier = getIdentifier(inputAst) ?? "";
-  const action = identifier.replace(/(?:Request|Input)$/, "");
+  const action = identifier.replace(/(?:Request|Input|Message)$/, "");
   const version = getServiceVersion(inputAst) ?? "";
 
   return {

--- a/packages/aws/src/protocols/ec2-query.ts
+++ b/packages/aws/src/protocols/ec2-query.ts
@@ -57,7 +57,7 @@ export const ec2QueryProtocol: Protocol = (
 
   // Pre-compute operation name and version from annotations
   const identifier = getIdentifier(inputAst) ?? "";
-  const action = identifier.replace(/(?:Request|Input)$/, "");
+  const action = identifier.replace(/(?:Request|Input|Message)$/, "");
   const version = getServiceVersion(inputAst) ?? "";
 
   return {

--- a/packages/aws/test/protocols/aws-query.test.ts
+++ b/packages/aws/test/protocols/aws-query.test.ts
@@ -38,6 +38,9 @@ import {
   ModifyDBClusterSnapshotAttributeResult,
 } from "../../src/services/neptune.ts";
 
+// Import RDS for "Message"-suffixed input shape op-name derivation
+import { DescribeDBInstancesMessage } from "../../src/services/rds.ts";
+
 // Helper to build a request from an instance
 const buildRequest = <A>(schema: S.Schema<A>, instance: A) => {
   const operation: Operation<any, any, any> = {
@@ -140,6 +143,22 @@ describe("awsQuery protocol", () => {
         const params = parseFormBody(request.body as string);
         expect(params["MaxItems"]).toBe("100");
       }),
+    );
+
+    it.effect(
+      "should derive Action from a 'Message'-suffixed input shape (RDS family)",
+      () =>
+        // RDS-family query services (RDS, ElastiCache, Redshift, …) name their
+        // input shapes "XxxMessage" rather than "XxxRequest". The op-name must
+        // strip "Message" so the Action is "DescribeDBInstances", not
+        // "DescribeDBInstancesMessage" (which AWS rejects as an unknown op).
+        Effect.gen(function* () {
+          const request = yield* buildRequest(DescribeDBInstancesMessage, {});
+
+          const params = parseFormBody(request.body as string);
+          expect(params["Action"]).toBe("DescribeDBInstances");
+          expect(params["Version"]).toBe("2014-10-31");
+        }),
     );
   });
 


### PR DESCRIPTION
AWS query-protocol services in the RDS family (RDS, ElastiCache, Redshift, Neptune, DocDB, …) name their input shapes `XxxMessage` (e.g. `DescribeDBInstancesMessage`, `CreateDBInstanceMessage`) rather than `XxxRequest`. The operation-name derivation only stripped a `Request`/`Input` suffix, so the aws-query serializer emitted `Action=DescribeDBInstancesMessage` and AWS rejected the call:

```
Could not find operation DescribeDBInstancesMessage for version 2014-10-31
```

This broke **every** RDS-family operation (describe and create) through the SDK. EC2 is unaffected because its inputs end in `…Request`.

### Fix

Strip `Message` in addition to `Request`/`Input` at the four sites that derive the op name from the input shape identifier:

```diff
-identifier.replace(/(?:Request|Input)$/, "")
+identifier.replace(/(?:Request|Input|Message)$/, "")
```

- `packages/aws/src/protocols/aws-query.ts` — `Action=` for RDS-family query services (the real fix)
- `packages/aws/src/protocols/ec2-query.ts` — `Action=` for EC2 query
- `packages/aws/src/protocols/aws-json.ts` — `X-Amz-Target` op name (JSON 1.0/1.1)
- `packages/aws/src/client/api.ts` — op name used for error context

Added a regression test asserting RDS `DescribeDBInstancesMessage` serializes to `Action=DescribeDBInstances` / `Version=2014-10-31`. It fails on the old regex and passes with the fix.

### Note for maintainers

This regex is a heuristic. A more robust approach would carry the operation's real shape-id / name from codegen instead of re-deriving it from the input identifier — happy to do that instead if you'd prefer. No AWS op's name itself ends in `Message` while its input is `<name>Message`, so stripping `Message` is safe against the smithy models.
