### PR TITLE
feat(cloudflare): add typed errors to vectorize operations

### DIFF
--- a/packages/cloudflare/patches/vectorize/createIndex.json
+++ b/packages/cloudflare/patches/vectorize/createIndex.json
@@ -1,0 +1,5 @@
+{
+  "errors": {
+    "IndexAlreadyExists": [{ "code": 3002 }]
+  }
+}

--- a/packages/cloudflare/patches/vectorize/createIndex.json
+++ b/packages/cloudflare/patches/vectorize/createIndex.json
@@ -1,5 +1,7 @@
 {
   "errors": {
-    "IndexAlreadyExists": [{ "code": 3002 }]
+    "IndexAlreadyExists": [{ "code": 3002 }],
+    "IndexInvalidName": [{ "code": 3001 }],
+    "IndexInvalidConfig": [{ "code": 3003 }]
   }
 }

--- a/packages/cloudflare/patches/vectorize/createIndexMetadataIndex.json
+++ b/packages/cloudflare/patches/vectorize/createIndexMetadataIndex.json
@@ -1,0 +1,5 @@
+{
+  "errors": {
+    "NotFound": [{ "code": 3000 }]
+  }
+}

--- a/packages/cloudflare/patches/vectorize/createIndexMetadataIndex.json
+++ b/packages/cloudflare/patches/vectorize/createIndexMetadataIndex.json
@@ -1,5 +1,7 @@
 {
   "errors": {
-    "NotFound": [{ "code": 3000 }]
+    "NotFound": [{ "code": 3000 }],
+    "MetadataIndexAlreadyExists": [{ "code": 40004 }],
+    "MetadataIndexInvalidType": [{ "code": 40026 }]
   }
 }

--- a/packages/cloudflare/patches/vectorize/deleteIndex.json
+++ b/packages/cloudflare/patches/vectorize/deleteIndex.json
@@ -1,0 +1,5 @@
+{
+  "errors": {
+    "NotFound": [{ "code": 3000 }]
+  }
+}

--- a/packages/cloudflare/patches/vectorize/deleteIndexMetadataIndex.json
+++ b/packages/cloudflare/patches/vectorize/deleteIndexMetadataIndex.json
@@ -1,0 +1,6 @@
+{
+  "errors": {
+    "NotFound": [{ "code": 3000 }],
+    "MetadataIndexNotFound": [{ "code": 40005 }]
+  }
+}

--- a/packages/cloudflare/patches/vectorize/getIndex.json
+++ b/packages/cloudflare/patches/vectorize/getIndex.json
@@ -1,0 +1,5 @@
+{
+  "errors": {
+    "NotFound": [{ "code": 3000 }]
+  }
+}

--- a/packages/cloudflare/patches/vectorize/listIndexMetadataIndexes.json
+++ b/packages/cloudflare/patches/vectorize/listIndexMetadataIndexes.json
@@ -1,0 +1,5 @@
+{
+  "errors": {
+    "NotFound": [{ "code": 3000 }]
+  }
+}

--- a/packages/cloudflare/specs/cloudflare/vectorize.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/vectorize.openapi.yml
@@ -331,6 +331,10 @@ paths:
       x-distilled-errors:
         IndexAlreadyExists:
           - code: 3002
+        IndexInvalidName:
+          - code: 3001
+        IndexInvalidConfig:
+          - code: 3003
   /accounts/{account_id}/vectorize/v2/indexes/{indexName}/info:
     get:
       operationId: infoIndex
@@ -664,6 +668,10 @@ paths:
       x-distilled-errors:
         NotFound:
           - code: 3000
+        MetadataIndexAlreadyExists:
+          - code: 40004
+        MetadataIndexInvalidType:
+          - code: 40026
   /accounts/{account_id}/vectorize/v2/indexes/{indexName}/metadata_index/delete:
     post:
       operationId: deleteIndexMetadataIndex

--- a/packages/cloudflare/specs/cloudflare/vectorize.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/vectorize.openapi.yml
@@ -146,6 +146,9 @@ paths:
                   name:
                     type: string
       x-distilled-response-path: result
+      x-distilled-errors:
+        NotFound:
+          - code: 3000
     delete:
       operationId: deleteIndex
       description: "Deletes the specified Vectorize Index.  @example ```ts const index
@@ -171,6 +174,9 @@ paths:
               schema:
                 type: string
       x-distilled-response-path: result
+      x-distilled-errors:
+        NotFound:
+          - code: 3000
   /accounts/{account_id}/vectorize/v2/indexes:
     get:
       operationId: listIndexes
@@ -322,6 +328,9 @@ paths:
                   name:
                     type: string
       x-distilled-response-path: result
+      x-distilled-errors:
+        IndexAlreadyExists:
+          - code: 3002
   /accounts/{account_id}/vectorize/v2/indexes/{indexName}/info:
     get:
       operationId: infoIndex
@@ -596,6 +605,9 @@ paths:
                           description: Specifies the indexed metadata property.
                     description: Array of indexed metadata properties.
       x-distilled-response-path: result
+      x-distilled-errors:
+        NotFound:
+          - code: 3000
   /accounts/{account_id}/vectorize/v2/indexes/{indexName}/metadata_index/create:
     post:
       operationId: createIndexMetadataIndex
@@ -649,6 +661,9 @@ paths:
                     description: The unique identifier for the async mutation operation containing
                       the changeset.
       x-distilled-response-path: result
+      x-distilled-errors:
+        NotFound:
+          - code: 3000
   /accounts/{account_id}/vectorize/v2/indexes/{indexName}/metadata_index/delete:
     post:
       operationId: deleteIndexMetadataIndex
@@ -695,6 +710,11 @@ paths:
                     description: The unique identifier for the async mutation operation containing
                       the changeset.
       x-distilled-response-path: result
+      x-distilled-errors:
+        NotFound:
+          - code: 3000
+        MetadataIndexNotFound:
+          - code: 40005
   /accounts/{account_id}/vectorize/v2/indexes/{indexName}/list:
     get:
       operationId: listVectorsIndex

--- a/packages/cloudflare/src/services/vectorize.ts
+++ b/packages/cloudflare/src/services/vectorize.ts
@@ -23,6 +23,30 @@ export class IndexAlreadyExists extends Schema.TaggedErrorClass<IndexAlreadyExis
 ) {}
 T.applyErrorMatchers(IndexAlreadyExists, [{ code: 3002 }]);
 
+export class IndexInvalidConfig extends Schema.TaggedErrorClass<IndexInvalidConfig>()(
+  "IndexInvalidConfig",
+  { code: Schema.Number, message: Schema.String },
+) {}
+T.applyErrorMatchers(IndexInvalidConfig, [{ code: 3003 }]);
+
+export class IndexInvalidName extends Schema.TaggedErrorClass<IndexInvalidName>()(
+  "IndexInvalidName",
+  { code: Schema.Number, message: Schema.String },
+) {}
+T.applyErrorMatchers(IndexInvalidName, [{ code: 3001 }]);
+
+export class MetadataIndexAlreadyExists extends Schema.TaggedErrorClass<MetadataIndexAlreadyExists>()(
+  "MetadataIndexAlreadyExists",
+  { code: Schema.Number, message: Schema.String },
+) {}
+T.applyErrorMatchers(MetadataIndexAlreadyExists, [{ code: 40004 }]);
+
+export class MetadataIndexInvalidType extends Schema.TaggedErrorClass<MetadataIndexInvalidType>()(
+  "MetadataIndexInvalidType",
+  { code: Schema.Number, message: Schema.String },
+) {}
+T.applyErrorMatchers(MetadataIndexInvalidType, [{ code: 40026 }]);
+
 export class MetadataIndexNotFound extends Schema.TaggedErrorClass<MetadataIndexNotFound>()(
   "MetadataIndexNotFound",
   { code: Schema.Number, message: Schema.String },
@@ -356,7 +380,11 @@ export const CreateIndexResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.ResponsePath("result"),
   ) as unknown as Schema.Schema<CreateIndexResponse>;
 
-export type CreateIndexError = DefaultErrors | IndexAlreadyExists;
+export type CreateIndexError =
+  | DefaultErrors
+  | IndexAlreadyExists
+  | IndexInvalidName
+  | IndexInvalidConfig;
 
 export const createIndex: API.OperationMethod<
   CreateIndexRequest,
@@ -366,7 +394,7 @@ export const createIndex: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: CreateIndexRequest,
   output: CreateIndexResponse,
-  errors: [IndexAlreadyExists],
+  errors: [IndexAlreadyExists, IndexInvalidName, IndexInvalidConfig],
 }));
 
 export interface DeleteIndexRequest {
@@ -742,7 +770,11 @@ export const CreateIndexMetadataIndexResponse =
     T.ResponsePath("result"),
   ) as unknown as Schema.Schema<CreateIndexMetadataIndexResponse>;
 
-export type CreateIndexMetadataIndexError = DefaultErrors | NotFound;
+export type CreateIndexMetadataIndexError =
+  | DefaultErrors
+  | NotFound
+  | MetadataIndexAlreadyExists
+  | MetadataIndexInvalidType;
 
 export const createIndexMetadataIndex: API.OperationMethod<
   CreateIndexMetadataIndexRequest,
@@ -752,7 +784,7 @@ export const createIndexMetadataIndex: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: CreateIndexMetadataIndexRequest,
   output: CreateIndexMetadataIndexResponse,
-  errors: [NotFound],
+  errors: [NotFound, MetadataIndexAlreadyExists, MetadataIndexInvalidType],
 }));
 
 export interface DeleteIndexMetadataIndexRequest {

--- a/packages/cloudflare/src/services/vectorize.ts
+++ b/packages/cloudflare/src/services/vectorize.ts
@@ -14,6 +14,28 @@ import { type DefaultErrors } from "../errors.ts";
 import { UploadableSchema } from "../schemas.ts";
 
 // =============================================================================
+// Errors
+// =============================================================================
+
+export class IndexAlreadyExists extends Schema.TaggedErrorClass<IndexAlreadyExists>()(
+  "IndexAlreadyExists",
+  { code: Schema.Number, message: Schema.String },
+) {}
+T.applyErrorMatchers(IndexAlreadyExists, [{ code: 3002 }]);
+
+export class MetadataIndexNotFound extends Schema.TaggedErrorClass<MetadataIndexNotFound>()(
+  "MetadataIndexNotFound",
+  { code: Schema.Number, message: Schema.String },
+) {}
+T.applyErrorMatchers(MetadataIndexNotFound, [{ code: 40005 }]);
+
+export class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
+  code: Schema.Number,
+  message: Schema.String,
+}) {}
+T.applyErrorMatchers(NotFound, [{ code: 3000 }]);
+
+// =============================================================================
 // ByIdsIndex
 // =============================================================================
 
@@ -161,7 +183,7 @@ export const GetIndexResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   )
   .pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetIndexResponse>;
 
-export type GetIndexError = DefaultErrors;
+export type GetIndexError = DefaultErrors | NotFound;
 
 export const getIndex: API.OperationMethod<
   GetIndexRequest,
@@ -171,7 +193,7 @@ export const getIndex: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetIndexRequest,
   output: GetIndexResponse,
-  errors: [],
+  errors: [NotFound],
 }));
 
 export interface ListIndexesRequest {
@@ -334,7 +356,7 @@ export const CreateIndexResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.ResponsePath("result"),
   ) as unknown as Schema.Schema<CreateIndexResponse>;
 
-export type CreateIndexError = DefaultErrors;
+export type CreateIndexError = DefaultErrors | IndexAlreadyExists;
 
 export const createIndex: API.OperationMethod<
   CreateIndexRequest,
@@ -344,7 +366,7 @@ export const createIndex: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: CreateIndexRequest,
   output: CreateIndexResponse,
-  errors: [],
+  errors: [IndexAlreadyExists],
 }));
 
 export interface DeleteIndexRequest {
@@ -370,7 +392,7 @@ export const DeleteIndexResponse =
     T.ResponsePath("result"),
   ) as unknown as Schema.Schema<DeleteIndexResponse>;
 
-export type DeleteIndexError = DefaultErrors;
+export type DeleteIndexError = DefaultErrors | NotFound;
 
 export const deleteIndex: API.OperationMethod<
   DeleteIndexRequest,
@@ -380,7 +402,7 @@ export const deleteIndex: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: DeleteIndexRequest,
   output: DeleteIndexResponse,
-  errors: [],
+  errors: [NotFound],
 }));
 
 export interface InfoIndexRequest {
@@ -672,7 +694,7 @@ export const ListIndexMetadataIndexesResponse =
     T.ResponsePath("result"),
   ) as unknown as Schema.Schema<ListIndexMetadataIndexesResponse>;
 
-export type ListIndexMetadataIndexesError = DefaultErrors;
+export type ListIndexMetadataIndexesError = DefaultErrors | NotFound;
 
 export const listIndexMetadataIndexes: API.OperationMethod<
   ListIndexMetadataIndexesRequest,
@@ -682,7 +704,7 @@ export const listIndexMetadataIndexes: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: ListIndexMetadataIndexesRequest,
   output: ListIndexMetadataIndexesResponse,
-  errors: [],
+  errors: [NotFound],
 }));
 
 export interface CreateIndexMetadataIndexRequest {
@@ -720,7 +742,7 @@ export const CreateIndexMetadataIndexResponse =
     T.ResponsePath("result"),
   ) as unknown as Schema.Schema<CreateIndexMetadataIndexResponse>;
 
-export type CreateIndexMetadataIndexError = DefaultErrors;
+export type CreateIndexMetadataIndexError = DefaultErrors | NotFound;
 
 export const createIndexMetadataIndex: API.OperationMethod<
   CreateIndexMetadataIndexRequest,
@@ -730,7 +752,7 @@ export const createIndexMetadataIndex: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: CreateIndexMetadataIndexRequest,
   output: CreateIndexMetadataIndexResponse,
-  errors: [],
+  errors: [NotFound],
 }));
 
 export interface DeleteIndexMetadataIndexRequest {
@@ -765,7 +787,10 @@ export const DeleteIndexMetadataIndexResponse =
     T.ResponsePath("result"),
   ) as unknown as Schema.Schema<DeleteIndexMetadataIndexResponse>;
 
-export type DeleteIndexMetadataIndexError = DefaultErrors;
+export type DeleteIndexMetadataIndexError =
+  | DefaultErrors
+  | NotFound
+  | MetadataIndexNotFound;
 
 export const deleteIndexMetadataIndex: API.OperationMethod<
   DeleteIndexMetadataIndexRequest,
@@ -775,7 +800,7 @@ export const deleteIndexMetadataIndex: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: DeleteIndexMetadataIndexRequest,
   output: DeleteIndexMetadataIndexResponse,
-  errors: [],
+  errors: [NotFound, MetadataIndexNotFound],
 }));
 
 // =============================================================================


### PR DESCRIPTION
Vectorize operations declared no operation-specific errors, so callers could only catch the generic HTTP error and branch on `status`. This adds typed errors derived from the live Cloudflare API.

Error codes were captured by probing the real API (create/get/delete on missing and duplicate indexes, plus metadata-index create/delete):

```jsonc
// patches/vectorize/getIndex.json (also deleteIndex, listIndexMetadataIndexes, createIndexMetadataIndex)
{ "errors": { "NotFound": [{ "code": 3000 }] } }

// patches/vectorize/createIndex.json
{ "errors": { "IndexAlreadyExists": [{ "code": 3002 }] } }

// patches/vectorize/deleteIndexMetadataIndex.json
{ "errors": { "NotFound": [{ "code": 3000 }], "MetadataIndexNotFound": [{ "code": 40005 }] } }
```

Generated `src/services/vectorize.ts` now declares the tags per op:

```diff
-export const getIndex: ... errors: []
+export const getIndex: ... errors: [NotFound]
-export const createIndex: ... errors: []
+export const createIndex: ... errors: [IndexAlreadyExists]
-export const deleteIndexMetadataIndex: ... errors: []
+export const deleteIndexMetadataIndex: ... errors: [NotFound, MetadataIndexNotFound]
```

### Probe notes

- Duplicate index creation returns HTTP **400 / code 3002**, not 409.
- Duplicate metadata-index creation **succeeds (200)** — no conflict error to declare.
