### PR TITLE
fix(cloudflare): collapse unions containing `unknown` to `unknown` in parser

### DIFF
--- a/packages/cloudflare/patches/vectorize/listIndexMetadataIndexes.json
+++ b/packages/cloudflare/patches/vectorize/listIndexMetadataIndexes.json
@@ -1,5 +1,12 @@
 {
   "errors": {
     "NotFound": [{ "code": 3000 }]
+  },
+  "response": {
+    "properties": {
+      "metadataIndexes[].indexType": {
+        "addValues": ["String", "Number", "Boolean"]
+      }
+    }
   }
 }

--- a/packages/cloudflare/scripts/parse.ts
+++ b/packages/cloudflare/scripts/parse.ts
@@ -534,11 +534,15 @@ function tsTypeToTypeInfo(
       .filter((member) => !(member.getFlags() & ts.TypeFlags.Undefined))
       .map((member) => tsTypeToTypeInfo(member, checker, depth + 1, seen));
 
-    const knownValues = values.filter((value) => value.kind !== "unknown");
-    const candidates = knownValues.length > 0 ? knownValues : values;
-    const deduped = candidates.filter((value, index) => {
+    // A union containing `unknown` collapses to `unknown` — TypeScript's top
+    // type absorbs every other member (`unknown | string` is `unknown`).
+    if (values.some((value) => value.kind === "unknown")) {
+      return { kind: "unknown" };
+    }
+
+    const deduped = values.filter((value, index) => {
       const key = JSON.stringify(value);
-      return index === candidates.findIndex((other) => JSON.stringify(other) === key);
+      return index === values.findIndex((other) => JSON.stringify(other) === key);
     });
 
     if (deduped.length === 0) {
@@ -669,30 +673,24 @@ function typeNodeToTypeInfo(
       typeNodeToTypeInfo(t, checker, registry, seenTypeRefs),
     );
 
-    // De-duplicate and simplify unions
-    // Filter out unknown types if there are known types
-    const knownValues = values.filter((v) => v.kind !== "unknown");
-    if (knownValues.length > 0) {
-      // If we have known types, use only those (deduplicated)
-      const seen = new Set<string>();
-      const dedupedValues = knownValues.filter((v) => {
-        const key = JSON.stringify(v);
-        if (seen.has(key)) return false;
-        seen.add(key);
-        return true;
-      });
-      if (dedupedValues.length === 1) {
-        return dedupedValues[0];
-      }
-      return { kind: "union", values: dedupedValues };
-    }
-
-    // All unknowns - collapse to single unknown
-    if (values.every((v) => v.kind === "unknown")) {
+    // A union containing `unknown` collapses to `unknown` — TypeScript's top
+    // type absorbs every other member (`unknown | string` is `unknown`).
+    if (values.some((v) => v.kind === "unknown")) {
       return { kind: "unknown" };
     }
 
-    return { kind: "union", values };
+    // De-duplicate and simplify unions
+    const seen = new Set<string>();
+    const dedupedValues = values.filter((v) => {
+      const key = JSON.stringify(v);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+    if (dedupedValues.length === 1) {
+      return dedupedValues[0];
+    }
+    return { kind: "union", values: dedupedValues };
   }
 
   // Array type

--- a/packages/cloudflare/specs/cloudflare/api-gateway.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/api-gateway.openapi.yml
@@ -703,7 +703,6 @@ paths:
                                     items: {}
                                     description: An array containing the learned parameter schemas.
                                   responses:
-                                    type: "null"
                                     description: An empty response object. This field is required to yield a valid
                                       operation schema.
                                 description: An operation schema object containing a response.
@@ -1060,7 +1059,6 @@ paths:
                                     items: {}
                                     description: An array containing the learned parameter schemas.
                                   responses:
-                                    type: "null"
                                     description: An empty response object. This field is required to yield a valid
                                       operation schema.
                                 description: An operation schema object containing a response.
@@ -1305,7 +1303,6 @@ paths:
                                     items: {}
                                     description: An array containing the learned parameter schemas.
                                   responses:
-                                    type: "null"
                                     description: An empty response object. This field is required to yield a valid
                                       operation schema.
                                 description: An operation schema object containing a response.
@@ -1619,7 +1616,6 @@ paths:
                                     items: {}
                                     description: An array containing the learned parameter schemas.
                                   responses:
-                                    type: "null"
                                     description: An empty response object. This field is required to yield a valid
                                       operation schema.
                                 description: An operation schema object containing a response.
@@ -2753,7 +2749,6 @@ paths:
                                         items: {}
                                         description: An array containing the learned parameter schemas.
                                       responses:
-                                        type: "null"
                                         description: An empty response object. This field is required to yield a valid
                                           operation schema.
                                     description: An operation schema object containing a response.

--- a/packages/cloudflare/specs/cloudflare/d1.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/d1.openapi.yml
@@ -973,10 +973,7 @@ paths:
                         type: array
                         items:
                           type: array
-                          items:
-                            oneOf:
-                              - type: number
-                              - type: string
+                          items: {}
                   success:
                     type: boolean
       x-distilled-pagination-class: DatabaseRawResponsesSinglePage

--- a/packages/cloudflare/specs/cloudflare/firewall.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/firewall.openapi.yml
@@ -3537,10 +3537,7 @@ paths:
                           required:
                             - code
                             - message
-                      result:
-                        oneOf:
-                          - type: string
-                        nullable: true
+                      result: {}
                       success:
                         type: boolean
                         enum:
@@ -3650,10 +3647,7 @@ paths:
           description: Success
           content:
             application/json:
-              schema:
-                oneOf:
-                  - type: string
-                nullable: true
+              schema: {}
       x-distilled-response-path: result
     patch:
       operationId: patchWafPackageGroup
@@ -3700,10 +3694,7 @@ paths:
           description: Success
           content:
             application/json:
-              schema:
-                oneOf:
-                  - type: string
-                nullable: true
+              schema: {}
       x-distilled-response-path: result
   /zones/{zone_id}/firewall/waf/packages/{packageId}/groups:
     get:
@@ -3868,10 +3859,7 @@ paths:
           description: Success
           content:
             application/json:
-              schema:
-                oneOf:
-                  - type: string
-                nullable: true
+              schema: {}
       x-distilled-response-path: result
     patch:
       operationId: patchWafPackageRule

--- a/packages/cloudflare/specs/cloudflare/images.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/images.openapi.yml
@@ -169,8 +169,7 @@ paths:
           description: Success
           content:
             application/json:
-              schema:
-                type: string
+              schema: {}
       x-distilled-response-path: result
       x-distilled-errors:
         ImagesAccessNotEnabled:
@@ -752,8 +751,7 @@ paths:
           description: Success
           content:
             application/json:
-              schema:
-                type: string
+              schema: {}
       x-distilled-response-path: result
       x-distilled-errors:
         ImagesAccessNotEnabled:

--- a/packages/cloudflare/specs/cloudflare/load-balancers.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/load-balancers.openapi.yml
@@ -9662,10 +9662,7 @@ paths:
           description: Success
           content:
             application/json:
-              schema:
-                oneOf:
-                  - type: string
-                nullable: true
+              schema: {}
       x-distilled-response-path: result
   /accounts/{account_id}/load_balancers/regions:
     get:
@@ -9704,10 +9701,7 @@ paths:
           description: Success
           content:
             application/json:
-              schema:
-                oneOf:
-                  - type: string
-                nullable: true
+              schema: {}
       x-distilled-response-path: result
   /accounts/{account_id}/load_balancers/search:
     get:

--- a/packages/cloudflare/specs/cloudflare/logs.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/logs.openapi.yml
@@ -210,8 +210,7 @@ paths:
           description: Success
           content:
             application/json:
-              schema:
-                type: string
+              schema: {}
   /zones/{zone_id}/logs/received:
     get:
       operationId: getReceived
@@ -319,8 +318,7 @@ paths:
           description: Success
           content:
             application/json:
-              schema:
-                type: string
+              schema: {}
   /zones/{zone_id}/logs/received/fields:
     get:
       operationId: getReceivedField

--- a/packages/cloudflare/specs/cloudflare/user.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/user.openapi.yml
@@ -661,10 +661,7 @@ paths:
           description: Success
           content:
             application/json:
-              schema:
-                oneOf:
-                  - type: string
-                nullable: true
+              schema: {}
       x-distilled-response-path: result
     delete:
       operationId: deleteSubscription

--- a/packages/cloudflare/specs/cloudflare/vectorize.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/vectorize.openapi.yml
@@ -171,8 +171,7 @@ paths:
           description: Success
           content:
             application/json:
-              schema:
-                type: string
+              schema: {}
       x-distilled-response-path: result
       x-distilled-errors:
         NotFound:
@@ -498,8 +497,7 @@ paths:
                         id:
                           type: string
                           description: Identifier for a Vector
-                        metadata:
-                          type: "null"
+                        metadata: {}
                         namespace:
                           oneOf:
                             - type: string
@@ -603,6 +601,9 @@ paths:
                             - string
                             - number
                             - boolean
+                            - String
+                            - Number
+                            - Boolean
                           description: Specifies the type of indexed metadata property.
                         propertyName:
                           type: string

--- a/packages/cloudflare/specs/cloudflare/workflows.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/workflows.openapi.yml
@@ -117,8 +117,7 @@ paths:
                                 retries:
                                   type: object
                                   properties:
-                                    delay:
-                                      type: number
+                                    delay: {}
                                     limit:
                                       type: number
                                     backoff:
@@ -229,11 +228,7 @@ paths:
                               type: boolean
                             name:
                               type: string
-                            output:
-                              oneOf:
-                                - type: string
-                                - type: number
-                                - type: boolean
+                            output: {}
                             start:
                               type: string
                             type:

--- a/packages/cloudflare/specs/cloudflare/zero-trust.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/zero-trust.openapi.yml
@@ -87619,8 +87619,7 @@ paths:
           description: Success
           content:
             application/json:
-              schema:
-                type: string
+              schema: {}
       x-distilled-response-path: result
   /accounts/{account_id}/devices/posture/integration:
     get:
@@ -88491,8 +88490,7 @@ paths:
           description: Success
           content:
             application/json:
-              schema:
-                type: string
+              schema: {}
       x-distilled-response-path: result
   /accounts/{account_id}/devices/settings:
     get:
@@ -88854,8 +88852,7 @@ paths:
           description: Success
           content:
             application/json:
-              schema:
-                type: string
+              schema: {}
       x-distilled-response-path: result
   /accounts/{account_id}/dex/colos:
     get:

--- a/packages/cloudflare/src/services/api-gateway.ts
+++ b/packages/cloudflare/src/services/api-gateway.ts
@@ -650,7 +650,7 @@ export interface GetOperationResponse {
           lastUpdated?: string | null;
           parameterSchemas?: {
             parameters?: unknown[] | null;
-            responses?: null;
+            responses?: unknown | null;
           } | null;
         };
       }
@@ -718,7 +718,9 @@ export const GetOperationResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
                   parameters: Schema.optional(
                     Schema.Union([Schema.Array(Schema.Unknown), Schema.Null]),
                   ),
-                  responses: Schema.optional(Schema.Null),
+                  responses: Schema.optional(
+                    Schema.Union([Schema.Unknown, Schema.Null]),
+                  ),
                 }),
                 Schema.Null,
               ]),
@@ -1043,7 +1045,7 @@ export interface ListOperationsResponse {
             lastUpdated?: string | null;
             parameterSchemas?: {
               parameters?: unknown[] | null;
-              responses?: null;
+              responses?: unknown | null;
             } | null;
           };
         }
@@ -1124,7 +1126,9 @@ export const ListOperationsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
                             Schema.Null,
                           ]),
                         ),
-                        responses: Schema.optional(Schema.Null),
+                        responses: Schema.optional(
+                          Schema.Union([Schema.Unknown, Schema.Null]),
+                        ),
                       }),
                       Schema.Null,
                     ]),
@@ -1500,7 +1504,7 @@ export interface CreateOperationResponse {
           lastUpdated?: string | null;
           parameterSchemas?: {
             parameters?: unknown[] | null;
-            responses?: null;
+            responses?: unknown | null;
           } | null;
         };
       }
@@ -1569,7 +1573,9 @@ export const CreateOperationResponse =
                     parameters: Schema.optional(
                       Schema.Union([Schema.Array(Schema.Unknown), Schema.Null]),
                     ),
-                    responses: Schema.optional(Schema.Null),
+                    responses: Schema.optional(
+                      Schema.Union([Schema.Unknown, Schema.Null]),
+                    ),
                   }),
                   Schema.Null,
                 ]),
@@ -2018,7 +2024,7 @@ export interface BulkCreateOperationsResponse {
             lastUpdated?: string | null;
             parameterSchemas?: {
               parameters?: unknown[] | null;
-              responses?: null;
+              responses?: unknown | null;
             } | null;
           };
         }
@@ -2093,7 +2099,9 @@ export const BulkCreateOperationsResponse =
                             Schema.Null,
                           ]),
                         ),
-                        responses: Schema.optional(Schema.Null),
+                        responses: Schema.optional(
+                          Schema.Union([Schema.Unknown, Schema.Null]),
+                        ),
                       }),
                       Schema.Null,
                     ]),
@@ -3567,7 +3575,7 @@ export interface ListUserSchemaOperationsResponse {
                 lastUpdated?: string | null;
                 parameterSchemas?: {
                   parameters?: unknown[] | null;
-                  responses?: null;
+                  responses?: unknown | null;
                 } | null;
               };
             }
@@ -3673,7 +3681,9 @@ export const ListUserSchemaOperationsResponse =
                               Schema.Null,
                             ]),
                           ),
-                          responses: Schema.optional(Schema.Null),
+                          responses: Schema.optional(
+                            Schema.Union([Schema.Unknown, Schema.Null]),
+                          ),
                         }),
                         Schema.Null,
                       ]),

--- a/packages/cloudflare/src/services/d1.ts
+++ b/packages/cloudflare/src/services/d1.ts
@@ -1102,10 +1102,7 @@ export interface RawDatabaseResponse {
       sizeAfter?: number | null;
       timings?: { sqlDurationMs?: number | null } | null;
     } | null;
-    results?: {
-      columns?: string[] | null;
-      rows?: (number | string)[][] | null;
-    } | null;
+    results?: { columns?: string[] | null; rows?: unknown[][] | null } | null;
     success?: boolean | null;
   }[];
 }
@@ -1187,9 +1184,7 @@ export const RawDatabaseResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
             ),
             rows: Schema.optional(
               Schema.Union([
-                Schema.Array(
-                  Schema.Array(Schema.Union([Schema.Number, Schema.String])),
-                ),
+                Schema.Array(Schema.Array(Schema.Unknown)),
                 Schema.Null,
               ]),
             ),

--- a/packages/cloudflare/src/services/firewall.ts
+++ b/packages/cloudflare/src/services/firewall.ts
@@ -4158,7 +4158,7 @@ export type GetWafPackageResponse =
         documentationUrl?: string | null;
         source?: { pointer?: string | null } | null;
       }[];
-      result: string | null;
+      result: unknown;
       success: true;
     }
   | { result?: unknown | null };
@@ -4217,7 +4217,7 @@ export const GetWafPackageResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
         }),
       ),
     ),
-    result: Schema.Union([Schema.String, Schema.Null]),
+    result: Schema.Unknown,
     success: Schema.Literal(true),
   }),
   Schema.Struct({
@@ -4351,10 +4351,10 @@ export const GetWafPackageGroupRequest =
     }),
   ) as unknown as Schema.Schema<GetWafPackageGroupRequest>;
 
-export type GetWafPackageGroupResponse = string | null;
+export type GetWafPackageGroupResponse = unknown;
 
 export const GetWafPackageGroupResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Union([Schema.String, Schema.Null]).pipe(
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
     T.ResponsePath("result"),
   ) as unknown as Schema.Schema<GetWafPackageGroupResponse>;
 
@@ -4535,10 +4535,10 @@ export const PatchWafPackageGroupRequest =
     }),
   ) as unknown as Schema.Schema<PatchWafPackageGroupRequest>;
 
-export type PatchWafPackageGroupResponse = string | null;
+export type PatchWafPackageGroupResponse = unknown;
 
 export const PatchWafPackageGroupResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Union([Schema.String, Schema.Null]).pipe(
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
     T.ResponsePath("result"),
   ) as unknown as Schema.Schema<PatchWafPackageGroupResponse>;
 
@@ -4578,10 +4578,10 @@ export const GetWafPackageRuleRequest =
     }),
   ) as unknown as Schema.Schema<GetWafPackageRuleRequest>;
 
-export type GetWafPackageRuleResponse = string | null;
+export type GetWafPackageRuleResponse = unknown;
 
 export const GetWafPackageRuleResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.Union([Schema.String, Schema.Null]).pipe(
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
     T.ResponsePath("result"),
   ) as unknown as Schema.Schema<GetWafPackageRuleResponse>;
 

--- a/packages/cloudflare/src/services/images.ts
+++ b/packages/cloudflare/src/services/images.ts
@@ -415,9 +415,9 @@ export const DeleteV1Request = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   }),
 ) as unknown as Schema.Schema<DeleteV1Request>;
 
-export type DeleteV1Response = string;
+export type DeleteV1Response = unknown;
 
-export const DeleteV1Response = /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(
+export const DeleteV1Response = /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
   T.ResponsePath("result"),
 ) as unknown as Schema.Schema<DeleteV1Response>;
 
@@ -1003,10 +1003,10 @@ export const DeleteV1VariantRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
   }),
 ) as unknown as Schema.Schema<DeleteV1VariantRequest>;
 
-export type DeleteV1VariantResponse = string;
+export type DeleteV1VariantResponse = unknown;
 
 export const DeleteV1VariantResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
     T.ResponsePath("result"),
   ) as unknown as Schema.Schema<DeleteV1VariantResponse>;
 

--- a/packages/cloudflare/src/services/load-balancers.ts
+++ b/packages/cloudflare/src/services/load-balancers.ts
@@ -8482,14 +8482,12 @@ export const GetRegionRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   }),
 ) as unknown as Schema.Schema<GetRegionRequest>;
 
-export type GetRegionResponse = string | null;
+export type GetRegionResponse = unknown;
 
-export const GetRegionResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
-  Schema.String,
-  Schema.Null,
-]).pipe(
-  T.ResponsePath("result"),
-) as unknown as Schema.Schema<GetRegionResponse>;
+export const GetRegionResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<GetRegionResponse>;
 
 export type GetRegionError = DefaultErrors;
 
@@ -8533,14 +8531,12 @@ export const ListRegionsRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   }),
 ) as unknown as Schema.Schema<ListRegionsRequest>;
 
-export type ListRegionsResponse = string | null;
+export type ListRegionsResponse = unknown;
 
-export const ListRegionsResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union([
-  Schema.String,
-  Schema.Null,
-]).pipe(
-  T.ResponsePath("result"),
-) as unknown as Schema.Schema<ListRegionsResponse>;
+export const ListRegionsResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<ListRegionsResponse>;
 
 export type ListRegionsError = DefaultErrors;
 

--- a/packages/cloudflare/src/services/logs.ts
+++ b/packages/cloudflare/src/services/logs.ts
@@ -277,10 +277,10 @@ export const GetRayidRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   T.Http({ method: "GET", path: "/zones/{zone_id}/logs/rayids/{RayID}" }),
 ) as unknown as Schema.Schema<GetRayidRequest>;
 
-export type GetRayidResponse = string;
+export type GetRayidResponse = unknown;
 
 export const GetRayidResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.String as unknown as Schema.Schema<GetRayidResponse>;
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown as unknown as Schema.Schema<GetRayidResponse>;
 
 export type GetRayidError = DefaultErrors;
 
@@ -332,10 +332,10 @@ export const GetReceivedRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   T.Http({ method: "GET", path: "/zones/{zone_id}/logs/received" }),
 ) as unknown as Schema.Schema<GetReceivedRequest>;
 
-export type GetReceivedResponse = string;
+export type GetReceivedResponse = unknown;
 
 export const GetReceivedResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.String as unknown as Schema.Schema<GetReceivedResponse>;
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown as unknown as Schema.Schema<GetReceivedResponse>;
 
 export type GetReceivedError = DefaultErrors;
 

--- a/packages/cloudflare/src/services/user.ts
+++ b/packages/cloudflare/src/services/user.ts
@@ -1122,13 +1122,12 @@ export const PutSubscriptionRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct(
   T.Http({ method: "PUT", path: "/user/subscriptions/{identifier}" }),
 ) as unknown as Schema.Schema<PutSubscriptionRequest>;
 
-export type PutSubscriptionResponse = string | null;
+export type PutSubscriptionResponse = unknown;
 
-export const PutSubscriptionResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Union(
-  [Schema.String, Schema.Null],
-).pipe(
-  T.ResponsePath("result"),
-) as unknown as Schema.Schema<PutSubscriptionResponse>;
+export const PutSubscriptionResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
+    T.ResponsePath("result"),
+  ) as unknown as Schema.Schema<PutSubscriptionResponse>;
 
 export type PutSubscriptionError = DefaultErrors;
 

--- a/packages/cloudflare/src/services/vectorize.ts
+++ b/packages/cloudflare/src/services/vectorize.ts
@@ -413,10 +413,10 @@ export const DeleteIndexRequest = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   }),
 ) as unknown as Schema.Schema<DeleteIndexRequest>;
 
-export type DeleteIndexResponse = string;
+export type DeleteIndexResponse = unknown;
 
 export const DeleteIndexResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
     T.ResponsePath("result"),
   ) as unknown as Schema.Schema<DeleteIndexResponse>;
 
@@ -573,7 +573,7 @@ export interface QueryIndexResponse {
   matches?:
     | {
         id?: string | null;
-        metadata?: null;
+        metadata?: unknown | null;
         namespace?: string | null;
         score?: number | null;
         values?: number[] | null;
@@ -588,7 +588,9 @@ export const QueryIndexResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
       Schema.Array(
         Schema.Struct({
           id: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-          metadata: Schema.optional(Schema.Null),
+          metadata: Schema.optional(
+            Schema.Union([Schema.Unknown, Schema.Null]),
+          ),
           namespace: Schema.optional(
             Schema.Union([Schema.String, Schema.Null]),
           ),
@@ -692,7 +694,14 @@ export interface ListIndexMetadataIndexesResponse {
   /** Array of indexed metadata properties. */
   metadataIndexes?:
     | {
-        indexType?: "string" | "number" | "boolean" | null;
+        indexType?:
+          | "string"
+          | "number"
+          | "boolean"
+          | "String"
+          | "Number"
+          | "Boolean"
+          | null;
         propertyName?: string | null;
       }[]
     | null;
@@ -706,7 +715,14 @@ export const ListIndexMetadataIndexesResponse =
           Schema.Struct({
             indexType: Schema.optional(
               Schema.Union([
-                Schema.Literals(["string", "number", "boolean"]),
+                Schema.Literals([
+                  "string",
+                  "number",
+                  "boolean",
+                  "String",
+                  "Number",
+                  "Boolean",
+                ]),
                 Schema.Null,
               ]),
             ),

--- a/packages/cloudflare/src/services/workflows.ts
+++ b/packages/cloudflare/src/services/workflows.ts
@@ -111,7 +111,7 @@ export interface GetInstanceResponse {
         }[];
         config: {
           retries: {
-            delay: number;
+            delay: unknown;
             limit: number;
             backoff?: "constant" | "linear" | "exponential" | null;
           };
@@ -138,7 +138,7 @@ export interface GetInstanceResponse {
         error: { message: string; name: string } | null;
         finished: boolean;
         name: string;
-        output: string | number | boolean;
+        output: unknown;
         start: string;
         type: "waitForEvent";
       }
@@ -190,7 +190,7 @@ export const GetInstanceResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
         ),
         config: Schema.Struct({
           retries: Schema.Struct({
-            delay: Schema.Number,
+            delay: Schema.Unknown,
             limit: Schema.Number,
             backoff: Schema.optional(
               Schema.Union([
@@ -219,7 +219,7 @@ export const GetInstanceResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
         ]),
         finished: Schema.Boolean,
         name: Schema.String,
-        output: Schema.Union([Schema.String, Schema.Number, Schema.Boolean]),
+        output: Schema.Unknown,
         start: Schema.String,
         type: Schema.Literal("waitForEvent"),
       }),

--- a/packages/cloudflare/src/services/zero-trust.ts
+++ b/packages/cloudflare/src/services/zero-trust.ts
@@ -63469,10 +63469,10 @@ export const DeleteDevicePostureIntegrationRequest =
     }),
   ) as unknown as Schema.Schema<DeleteDevicePostureIntegrationRequest>;
 
-export type DeleteDevicePostureIntegrationResponse = string;
+export type DeleteDevicePostureIntegrationResponse = unknown;
 
 export const DeleteDevicePostureIntegrationResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
     T.ResponsePath("result"),
   ) as unknown as Schema.Schema<DeleteDevicePostureIntegrationResponse>;
 
@@ -64117,10 +64117,10 @@ export const CreateDeviceRevokeRequest =
     T.Http({ method: "POST", path: "/accounts/{account_id}/devices/revoke" }),
   ) as unknown as Schema.Schema<CreateDeviceRevokeRequest>;
 
-export type CreateDeviceRevokeResponse = string;
+export type CreateDeviceRevokeResponse = unknown;
 
 export const CreateDeviceRevokeResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
     T.ResponsePath("result"),
   ) as unknown as Schema.Schema<CreateDeviceRevokeResponse>;
 
@@ -64616,10 +64616,10 @@ export const CreateDeviceUnrevokeRequest =
     T.Http({ method: "POST", path: "/accounts/{account_id}/devices/unrevoke" }),
   ) as unknown as Schema.Schema<CreateDeviceUnrevokeRequest>;
 
-export type CreateDeviceUnrevokeResponse = string;
+export type CreateDeviceUnrevokeResponse = unknown;
 
 export const CreateDeviceUnrevokeResponse =
-  /*@__PURE__*/ /*#__PURE__*/ Schema.String.pipe(
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Unknown.pipe(
     T.ResponsePath("result"),
   ) as unknown as Schema.Schema<CreateDeviceUnrevokeResponse>;
 


### PR DESCRIPTION
The parser filtered `unknown` out of unions and kept the remaining members — the opposite of how TypeScript's top type behaves. `unknown | string` **is** `unknown` (the top type absorbs every other member), so a consumer of the upstream SDK sees `unknown`. The generator instead narrowed it to `string`, which broke response decoding.

Concretely, vectorize `deleteIndex` is `unknown | string` upstream but was emitted as `string`. The live API returns `{"result": null}`, so decode threw `CloudflareHttpError` on a 200.

Fix both union sites in `parse.ts` (the AST-node path and the type-checker path) to collapse to `unknown` when any member is `unknown`:

```diff
-const knownValues = values.filter((v) => v.kind !== "unknown");
-if (knownValues.length > 0) { /* keep only the known members */ }
+// A union containing `unknown` collapses to `unknown` — TypeScript's top
+// type absorbs every other member (`unknown | string` is `unknown`).
+if (values.some((v) => v.kind === "unknown")) {
+  return { kind: "unknown" };
+}
```

This regenerated 10 services where an `… | unknown` union was being mis-narrowed: api-gateway, d1, firewall, images, load-balancers, logs, user, vectorize, workflows, zero-trust. Examples:

```diff
# vectorize.ts — deleteIndex
-export type DeleteIndexResponse = string;
+export type DeleteIndexResponse = unknown;
```

```diff
# d1.ts — query rows, upstream `Array<Array<number | string | unknown>>`
-rows?: (number | string)[][] | null;
+rows?: unknown[][] | null;
```

Separately, vectorize `listIndexMetadataIndexes` `indexType` is extended to accept the capitalized values the API actually returns:

```diff
-indexType?: "string" | "number" | "boolean" | null;
+indexType?: "string" | "number" | "boolean" | "String" | "Number" | "Boolean" | null;
```

This is the same class of parser-union bug as #309 (which merged request-param variants instead of taking the first), in a different code path.
