### PR TITLE
feat(planetscale): support OAuth Bearer credentials

### DIFF
--- a/packages/planetscale/src/client.ts
+++ b/packages/planetscale/src/client.ts
@@ -5,7 +5,6 @@
  * error matching and credential handling.
  */
 import * as Effect from "effect/Effect";
-import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { makeAPI } from "@distilled.cloud/core/client";
 import { parseRetryAfterForStatus } from "@distilled.cloud/core/retry-after";
@@ -18,7 +17,7 @@ import {
 
 // Re-export for backwards compatibility (tests import UnknownPlanetScaleError from client)
 export { UnknownPlanetScaleError } from "./errors.ts";
-import { Credentials } from "./credentials.ts";
+import { Credentials, formatHeaders } from "./credentials.ts";
 
 // API Error Response Schema
 const ApiErrorResponse = Schema.Struct({
@@ -64,9 +63,7 @@ const matchError = (
 export const API = makeAPI<Credentials>({
   credentials: Credentials as any,
   getBaseUrl: (creds: any) => creds.apiBaseUrl,
-  getAuthHeaders: (creds: any) => ({
-    Authorization: `${Redacted.value(creds.tokenId)}:${Redacted.value(creds.token)}`,
-  }),
+  getAuthHeaders: (creds: any) => formatHeaders(creds),
   matchError,
   ParseError: PlanetScaleParseError as any,
   retry: Retry as any,

--- a/packages/planetscale/src/credentials.ts
+++ b/packages/planetscale/src/credentials.ts
@@ -7,16 +7,71 @@ import * as Redacted from "effect/Redacted";
 
 export const DEFAULT_API_BASE_URL = "https://api.planetscale.com/v1";
 
-export interface Config {
+/**
+ * Service-token credentials. Sent as `Authorization: <tokenId>:<token>`.
+ *
+ * `type` is optional and defaults to `"serviceToken"` so existing callers
+ * that construct a bare `{ tokenId, token, organization, apiBaseUrl }`
+ * continue to work unchanged.
+ */
+export interface ServiceTokenConfig {
+  readonly type?: "serviceToken";
   readonly tokenId: Redacted.Redacted<string>;
   readonly token: Redacted.Redacted<string>;
   readonly organization: string;
   readonly apiBaseUrl: string;
 }
 
+/**
+ * OAuth credentials. Sent as `Authorization: Bearer <accessToken>`.
+ *
+ * PlanetScale OAuth has no PKCE flow and refreshes require the app's
+ * client_secret, so refresh is handled by the caller (e.g. Alchemy's
+ * AuthProvider) rather than here — this config only carries the resolved
+ * access token used to authenticate API requests.
+ */
+export interface OAuthConfig {
+  readonly type: "oauth";
+  readonly accessToken: Redacted.Redacted<string>;
+  readonly organization: string;
+  readonly apiBaseUrl: string;
+}
+
+export type Config = ServiceTokenConfig | OAuthConfig;
+
 export class Credentials extends Context.Service<Credentials, Config>()(
   "PlanetScaleCredentials",
 ) {}
+
+/**
+ * Build the `Authorization` header for a resolved set of credentials.
+ * Service tokens use PlanetScale's `<id>:<secret>` scheme; OAuth access
+ * tokens use standard `Bearer`.
+ */
+export const formatHeaders = (config: Config): Record<string, string> =>
+  config.type === "oauth"
+    ? { Authorization: `Bearer ${Redacted.value(config.accessToken)}` }
+    : {
+        Authorization: `${Redacted.value(config.tokenId)}:${Redacted.value(config.token)}`,
+      };
+
+/**
+ * Build a `Credentials` Layer from an OAuth access token.
+ */
+export const fromOAuth = (input: {
+  accessToken: string | Redacted.Redacted<string>;
+  organization: string;
+  apiBaseUrl?: string;
+}): Layer.Layer<Credentials> =>
+  Layer.succeed(Credentials, {
+    type: "oauth",
+    accessToken:
+      typeof input.accessToken === "string"
+        ? Redacted.make(input.accessToken)
+        : input.accessToken,
+    organization: input.organization,
+    apiBaseUrl: input.apiBaseUrl ?? DEFAULT_API_BASE_URL,
+  });
 
 const envConfig = EffectConfig.all({
   tokenId: EffectConfig.string("PLANETSCALE_API_TOKEN_ID"),


### PR DESCRIPTION
The PlanetScale client only spoke service-token auth, so OAuth access tokens couldn't be used.

```diff
-getAuthHeaders: (creds) => ({
-  Authorization: `${Redacted.value(creds.tokenId)}:${Redacted.value(creds.token)}`,
-})
+getAuthHeaders: (creds) => formatHeaders(creds)
```

`formatHeaders` branches on credential type:

```ts
config.type === "oauth"
  ? { Authorization: `Bearer ${Redacted.value(config.accessToken)}` }
  : { Authorization: `${Redacted.value(config.tokenId)}:${Redacted.value(config.token)}` }
```

`Config` is now `ServiceTokenConfig | OAuthConfig`. The service-token `type` is optional, so existing `{ tokenId, token, organization, apiBaseUrl }` callers are unchanged.

Also adds a `fromOAuth({ accessToken, organization, apiBaseUrl? })` Layer constructor.

Refresh stays the caller's responsibility — PlanetScale has no PKCE and refresh needs the app `client_secret`, so this only carries the resolved access token.
