### PR TITLE
fix(cloudflare/zones): add typed errors for zone CRUD

### DIFF
--- a/packages/cloudflare/patches/zones/createZone.json
+++ b/packages/cloudflare/patches/zones/createZone.json
@@ -1,0 +1,8 @@
+{
+  "errors": {
+    "ZoneAlreadyExists": [{ "code": 1061 }],
+    "InvalidDomain": [{ "code": 1002 }],
+    "DomainNotRegistered": [{ "code": 1099 }],
+    "SubdomainNotAllowed": [{ "code": 1116 }]
+  }
+}

--- a/packages/cloudflare/patches/zones/deleteZone.json
+++ b/packages/cloudflare/patches/zones/deleteZone.json
@@ -1,0 +1,7 @@
+{
+  "errors": {
+    "InvalidZoneIdentifier": [
+      { "code": 9109, "message": { "includes": "Invalid zone identifier" } }
+    ]
+  }
+}

--- a/packages/cloudflare/patches/zones/getZone.json
+++ b/packages/cloudflare/patches/zones/getZone.json
@@ -1,0 +1,7 @@
+{
+  "errors": {
+    "InvalidZoneIdentifier": [
+      { "code": 9109, "message": { "includes": "Invalid zone identifier" } }
+    ]
+  }
+}

--- a/packages/cloudflare/patches/zones/patchZone.json
+++ b/packages/cloudflare/patches/zones/patchZone.json
@@ -1,0 +1,7 @@
+{
+  "errors": {
+    "InvalidZoneIdentifier": [
+      { "code": 9109, "message": { "includes": "Invalid zone identifier" } }
+    ]
+  }
+}

--- a/packages/cloudflare/specs/cloudflare/zones.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/zones.openapi.yml
@@ -5407,6 +5407,11 @@ paths:
                   - owner
                   - plan
       x-distilled-response-path: result
+      x-distilled-errors:
+        InvalidZoneIdentifier:
+          - code: 9109
+            message:
+              includes: Invalid zone identifier
     patch:
       operationId: patchZone
       description: "Edits a zone. Only one zone property can be changed at a
@@ -5667,6 +5672,11 @@ paths:
                   - owner
                   - plan
       x-distilled-response-path: result
+      x-distilled-errors:
+        InvalidZoneIdentifier:
+          - code: 9109
+            message:
+              includes: Invalid zone identifier
     delete:
       operationId: deleteZone
       description: "Deletes an existing zone.  @example ```ts const zone = await
@@ -5693,6 +5703,11 @@ paths:
                 required:
                   - id
       x-distilled-response-path: result
+      x-distilled-errors:
+        InvalidZoneIdentifier:
+          - code: 9109
+            message:
+              includes: Invalid zone identifier
   /zones:
     get:
       operationId: listZones
@@ -6167,3 +6182,12 @@ paths:
                   - owner
                   - plan
       x-distilled-response-path: result
+      x-distilled-errors:
+        ZoneAlreadyExists:
+          - code: 1061
+        InvalidDomain:
+          - code: 1002
+        DomainNotRegistered:
+          - code: 1099
+        SubdomainNotAllowed:
+          - code: 1116

--- a/packages/cloudflare/src/services/zones.ts
+++ b/packages/cloudflare/src/services/zones.ts
@@ -13,6 +13,42 @@ import type { Credentials } from "../credentials.ts";
 import { type DefaultErrors } from "../errors.ts";
 
 // =============================================================================
+// Errors
+// =============================================================================
+
+export class DomainNotRegistered extends Schema.TaggedErrorClass<DomainNotRegistered>()(
+  "DomainNotRegistered",
+  { code: Schema.Number, message: Schema.String },
+) {}
+T.applyErrorMatchers(DomainNotRegistered, [{ code: 1099 }]);
+
+export class InvalidDomain extends Schema.TaggedErrorClass<InvalidDomain>()(
+  "InvalidDomain",
+  { code: Schema.Number, message: Schema.String },
+) {}
+T.applyErrorMatchers(InvalidDomain, [{ code: 1002 }]);
+
+export class InvalidZoneIdentifier extends Schema.TaggedErrorClass<InvalidZoneIdentifier>()(
+  "InvalidZoneIdentifier",
+  { code: Schema.Number, message: Schema.String },
+) {}
+T.applyErrorMatchers(InvalidZoneIdentifier, [
+  { code: 9109, message: { includes: "Invalid zone identifier" } },
+]);
+
+export class SubdomainNotAllowed extends Schema.TaggedErrorClass<SubdomainNotAllowed>()(
+  "SubdomainNotAllowed",
+  { code: Schema.Number, message: Schema.String },
+) {}
+T.applyErrorMatchers(SubdomainNotAllowed, [{ code: 1116 }]);
+
+export class ZoneAlreadyExists extends Schema.TaggedErrorClass<ZoneAlreadyExists>()(
+  "ZoneAlreadyExists",
+  { code: Schema.Number, message: Schema.String },
+) {}
+T.applyErrorMatchers(ZoneAlreadyExists, [{ code: 1061 }]);
+
+// =============================================================================
 // ActivationCheck
 // =============================================================================
 
@@ -5384,7 +5420,7 @@ export const GetZoneResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   )
   .pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetZoneResponse>;
 
-export type GetZoneError = DefaultErrors;
+export type GetZoneError = DefaultErrors | InvalidZoneIdentifier;
 
 export const getZone: API.OperationMethod<
   GetZoneRequest,
@@ -5394,7 +5430,7 @@ export const getZone: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: GetZoneRequest,
   output: GetZoneResponse,
-  errors: [],
+  errors: [InvalidZoneIdentifier],
 }));
 
 export interface ListZonesRequest {}
@@ -5910,7 +5946,12 @@ export const CreateZoneResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.ResponsePath("result"),
   ) as unknown as Schema.Schema<CreateZoneResponse>;
 
-export type CreateZoneError = DefaultErrors;
+export type CreateZoneError =
+  | DefaultErrors
+  | ZoneAlreadyExists
+  | InvalidDomain
+  | DomainNotRegistered
+  | SubdomainNotAllowed;
 
 export const createZone: API.OperationMethod<
   CreateZoneRequest,
@@ -5920,7 +5961,12 @@ export const createZone: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: CreateZoneRequest,
   output: CreateZoneResponse,
-  errors: [],
+  errors: [
+    ZoneAlreadyExists,
+    InvalidDomain,
+    DomainNotRegistered,
+    SubdomainNotAllowed,
+  ],
 }));
 
 export interface PatchZoneRequest {
@@ -6175,7 +6221,7 @@ export const PatchZoneResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
     T.ResponsePath("result"),
   ) as unknown as Schema.Schema<PatchZoneResponse>;
 
-export type PatchZoneError = DefaultErrors;
+export type PatchZoneError = DefaultErrors | InvalidZoneIdentifier;
 
 export const patchZone: API.OperationMethod<
   PatchZoneRequest,
@@ -6185,7 +6231,7 @@ export const patchZone: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: PatchZoneRequest,
   output: PatchZoneResponse,
-  errors: [],
+  errors: [InvalidZoneIdentifier],
 }));
 
 export interface DeleteZoneRequest {
@@ -6210,7 +6256,7 @@ export const DeleteZoneResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   T.ResponsePath("result"),
 ) as unknown as Schema.Schema<DeleteZoneResponse>;
 
-export type DeleteZoneError = DefaultErrors;
+export type DeleteZoneError = DefaultErrors | InvalidZoneIdentifier;
 
 export const deleteZone: API.OperationMethod<
   DeleteZoneRequest,
@@ -6220,5 +6266,5 @@ export const deleteZone: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: DeleteZoneRequest,
   output: DeleteZoneResponse,
-  errors: [],
+  errors: [InvalidZoneIdentifier],
 }));

--- a/packages/cloudflare/test/zones.test.ts
+++ b/packages/cloudflare/test/zones.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect } from "vitest";
+import * as Effect from "effect/Effect";
+import { getAccountId, test, testRunId } from "./test.ts";
+import * as Zones from "~/services/zones";
+
+const accountId = () => getAccountId();
+const zoneName = (name: string) => `distilled-cf-zone-${name}-${testRunId}.com`;
+
+// A 32-char hex string that is well-formed but does not correspond to any
+// real zone — Cloudflare answers these with code 9109 "Invalid zone identifier".
+const BOGUS_ZONE_ID = "0".repeat(32);
+
+describe("Zones", () => {
+  describe("createZone", () => {
+    test("error - DomainNotRegistered for a reserved pseudo-TLD", () =>
+      Zones.createZone({
+        account: { id: accountId() },
+        name: zoneName("reserved").replace(/\.com$/, ".test"),
+        type: "full",
+      }).pipe(
+        Effect.flip,
+        Effect.map((e) => expect(e._tag).toBe("DomainNotRegistered")),
+      ));
+
+    test("error - SubdomainNotAllowed when given a subdomain", () =>
+      Zones.createZone({
+        account: { id: accountId() },
+        name: `sub.${zoneName("subdomain")}`,
+        type: "full",
+      }).pipe(
+        Effect.flip,
+        Effect.map((e) => expect(e._tag).toBe("SubdomainNotAllowed")),
+      ));
+
+    test("error - InvalidDomain for a malformed name", () =>
+      Zones.createZone({
+        account: { id: accountId() },
+        name: "not a domain!!",
+        type: "full",
+      }).pipe(
+        Effect.flip,
+        Effect.map((e) => expect(e._tag).toBe("InvalidDomain")),
+      ));
+
+    test("error - ZoneAlreadyExists when creating the same zone twice", () =>
+      Effect.gen(function* () {
+        const name = zoneName("dupe");
+        const created = yield* Zones.createZone({
+          account: { id: accountId() },
+          name,
+          type: "full",
+        });
+
+        const error = yield* Zones.createZone({
+          account: { id: accountId() },
+          name,
+          type: "full",
+        }).pipe(Effect.flip);
+        expect(error._tag).toBe("ZoneAlreadyExists");
+
+        yield* Effect.addFinalizer(() =>
+          Zones.deleteZone({ zoneId: created.id }).pipe(Effect.ignore),
+        );
+      }).pipe(Effect.scoped));
+  });
+
+  describe("getZone", () => {
+    test("error - InvalidZoneIdentifier for a bogus zone id", () =>
+      Zones.getZone({ zoneId: BOGUS_ZONE_ID }).pipe(
+        Effect.flip,
+        Effect.map((e) => expect(e._tag).toBe("InvalidZoneIdentifier")),
+      ));
+  });
+
+  describe("patchZone", () => {
+    test("error - InvalidZoneIdentifier for a bogus zone id", () =>
+      Zones.patchZone({ zoneId: BOGUS_ZONE_ID, paused: true }).pipe(
+        Effect.flip,
+        Effect.map((e) => expect(e._tag).toBe("InvalidZoneIdentifier")),
+      ));
+  });
+
+  describe("deleteZone", () => {
+    test("error - InvalidZoneIdentifier for a bogus zone id", () =>
+      Zones.deleteZone({ zoneId: BOGUS_ZONE_ID }).pipe(
+        Effect.flip,
+        Effect.map((e) => expect(e._tag).toBe("InvalidZoneIdentifier")),
+      ));
+  });
+});


### PR DESCRIPTION
The zone CRUD endpoints previously collapsed every failure into generic status errors (`BadRequest`, `Unauthorized`), forcing callers to regex-match messages to tell e.g. "already exists" apart from other 400s, or to treat a deleted zone's "Invalid zone identifier" 403 as auth failure. Probed the live API to capture the stable Cloudflare error codes and mapped them to dedicated tags.

```ts
// before — regex on the message
createZone(...).pipe(
  Effect.catchIf((e) => /already exists/i.test(String(e)), () => ...),
);

// after — catch by tag
createZone(...).pipe(Effect.catch("ZoneAlreadyExists", () => ...));

// delete is now idempotent without string matching
deleteZone({ zoneId }).pipe(Effect.catch("InvalidZoneIdentifier", () => Effect.void));
```

New matchers:

- `createZone`: `1061 ZoneAlreadyExists`, `1002 InvalidDomain`, `1099 DomainNotRegistered`, `1116 SubdomainNotAllowed`
- `getZone` / `patchZone` / `deleteZone`: `9109 InvalidZoneIdentifier`

`9109` is dual-use (also "max auth failures"), so it's matched on `code` **and** `message` includes `Invalid zone identifier` to avoid hijacking genuine auth errors. Per-operation matchers run before the global code map, so these override the existing `9109 → Unauthorized` / status fallbacks.

`test/zones.test.ts` asserts each tag against the real API (the one zone it creates is torn down via a scoped finalizer).
