### PR TITLE
chore: stop firing pr-package on PR close

### DIFF
--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -4,12 +4,13 @@ on:
   push:
     branches: [main]
   pull_request:
-    # `labeled` so adding the `force-ci` label re-triggers the run.
-    types: [opened, synchronize, reopened, closed, labeled]
+    # `labeled` so adding the `force-ci` label re-triggers the run. We
+    # intentionally do NOT listen to `closed` — pr-package tags persist
+    # past PR close so existing install URLs keep resolving.
+    types: [opened, synchronize, reopened, labeled]
 
 # Reusable workflows can't widen permissions — the caller must grant
-# `pull-requests: write` (sticky install-instructions comment + cleanup
-# on PR close).
+# `pull-requests: write` for the sticky install-instructions comment.
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   pr-package:
-    uses: alchemy-run/actions/.github/workflows/pr-package.yml@main
+    uses: alchemy-run/actions/.github/workflows/pr-package.yml@67b1515cf5774c16a0666f4480d21b03443e6091 # main
     with:
       install-host: pkg.distilled.cloud
       packages: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   release:
-    uses: alchemy-run/actions/.github/workflows/release.yml@main
+    uses: alchemy-run/actions/.github/workflows/release.yml@67b1515cf5774c16a0666f4480d21b03443e6091 # main
     with:
       version: ${{ inputs.version }}
       repo: alchemy-run/distilled


### PR DESCRIPTION
The shared workflow ([alchemy-run/actions@67b1515](https://github.com/alchemy-run/actions/commit/67b1515)) dropped its `cleanup:` job — pr-package tags now persist past PR close so existing install URLs keep resolving long-term, with the pkg.ing bucket's TTL handling orphan cleanup on its own schedule.

This drops the now-pointless `closed` event from our trigger list so the workflow stops firing-then-skipping on every PR merge, and updates the stale "cleanup on PR close" comment.

```diff
 on:
   push:
     branches: [main]
   pull_request:
-    # `labeled` so adding the `force-ci` label re-triggers the run.
-    types: [opened, synchronize, reopened, closed, labeled]
+    # `labeled` so adding the `force-ci` label re-triggers the run. We
+    # intentionally do NOT listen to `closed` — pr-package tags persist
+    # past PR close so existing install URLs keep resolving.
+    types: [opened, synchronize, reopened, labeled]
```
