### PR TITLE
fix(cloudflare): correct browser-rendering getCrawl response schema

### DIFF
--- a/packages/cloudflare/patches/browser-rendering/getCrawl.json
+++ b/packages/cloudflare/patches/browser-rendering/getCrawl.json
@@ -1,0 +1,8 @@
+{
+  "response": {
+    "properties": {
+      "records[].metadata": { "optional": true },
+      "cursor": { "type": "number", "nullable": true }
+    }
+  }
+}

--- a/packages/cloudflare/specs/cloudflare/browser-rendering.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/browser-rendering.openapi.yml
@@ -410,7 +410,6 @@ paths:
                           type: string
                           description: Markdown of the content of the crawled URL.
                       required:
-                        - metadata
                         - status
                         - url
                     description: List of crawl job records.
@@ -427,7 +426,9 @@ paths:
                     type: number
                     description: Total current number of URLs in the crawl job.
                   cursor:
-                    type: string
+                    oneOf:
+                      - type: number
+                    nullable: true
                     description: Cursor for pagination.
                 required:
                   - id

--- a/packages/cloudflare/src/services/browser-rendering.ts
+++ b/packages/cloudflare/src/services/browser-rendering.ts
@@ -412,7 +412,7 @@ export interface GetCrawlResponse {
   finished: number;
   /** List of crawl job records. */
   records: {
-    metadata: { status: number; url: string; title?: string | null };
+    metadata?: { status: number; url: string; title?: string | null } | null;
     status:
       | "queued"
       | "errored"
@@ -433,7 +433,7 @@ export interface GetCrawlResponse {
   /** Total current number of URLs in the crawl job. */
   total: number;
   /** Cursor for pagination. */
-  cursor?: string | null;
+  cursor?: number | null;
 }
 
 export const GetCrawlResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
@@ -442,11 +442,16 @@ export const GetCrawlResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   finished: Schema.Number,
   records: Schema.Array(
     Schema.Struct({
-      metadata: Schema.Struct({
-        status: Schema.Number,
-        url: Schema.String,
-        title: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
-      }),
+      metadata: Schema.optional(
+        Schema.Union([
+          Schema.Struct({
+            status: Schema.Number,
+            url: Schema.String,
+            title: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+          }),
+          Schema.Null,
+        ]),
+      ),
       status: Schema.Union([
         Schema.Literals([
           "queued",
@@ -472,7 +477,7 @@ export const GetCrawlResponse = /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
   skipped: Schema.Number,
   status: Schema.String,
   total: Schema.Number,
-  cursor: Schema.optional(Schema.Union([Schema.String, Schema.Null])),
+  cursor: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
 }).pipe(T.ResponsePath("result")) as unknown as Schema.Schema<GetCrawlResponse>;
 
 export type GetCrawlError = DefaultErrors;


### PR DESCRIPTION
## Disclaimer

This PR was fully generated using Claude Code. I however have been running these exact schema fixes as a `pnpm patch` against `@distilled.cloud/cloudflare` as crawls and can confirm they match the live API behavior.

## Problem

The upstream `cloudflare-typescript` SDK types for `browser-rendering`'s `getCrawl` operation don't match what the API actually returns, so decoding real responses fails:

1. **`records[].metadata` is typed as required**, but Cloudflare omits it for records that have not completed yet (`queued`/`skipped`/`cancelled`/...). Polling an in-progress crawl job therefore fails to decode with a `ParseError` until every record has finished.
2. **`cursor` is typed as `string`**, but the API returns a **number** (the next record index for pagination). It is absent on the last page.

Example of a real response that the current schema rejects:

```json
{
  "result": {
    "id": "...",
    "browserSecondsUsed": 12,
    "finished": 3,
    "records": [
      { "status": "queued", "url": "https://example.com/page" }
    ],
    "skipped": 0,
    "status": "running",
    "total": 10,
    "cursor": 50
  }
}
```

## Fix

Adds `patches/browser-rendering/getCrawl.json` using the existing patch mechanism:

```json
{
  "response": {
    "properties": {
      "records[].metadata": { "optional": true },
      "cursor": { "type": "number", "nullable": true }
    }
  }
}
```

and regenerates the service (`bun run generate`). Only the `getCrawl` schema changes; the emitted `specs/cloudflare/browser-rendering.openapi.yml` is updated to match. Unrelated drift the generator produced in other emitted specs (containers/r2/secrets-store/workers info titles) was intentionally left out of this PR.

`bun run check` (tsgo + oxlint + oxfmt) passes.



## Non-issues

Two other discrepancies between the live API and the SDK types were verified to *not* need patching:

- **Extra `metadata` keys** (`og:*`, `lastModified`, ...) — the API returns more metadata fields than the SDK declares, but effect Schema's default decode ignores unknown keys, so they pass through without error.
- **Undocumented job statuses** (`running`, `cancelled_by_user`) — the top-level job `status` is a plain `Schema.String` (not a literal union), so these decode fine as-is.
