### PR TITLE
chore: Supabase package license metadata

### DIFF
--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@distilled.cloud/supabase",
   "version": "0.24.5",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/alchemy-run/distilled",


### PR DESCRIPTION
## Summary

Adds missing Apache-2.0 license metadata to the `@distilled.cloud/supabase` package manifest.

The repository already includes an Apache-2.0 `LICENSE`, but the package manifest does not currently publish a `license` field.

## Verification

- Confirmed current npm metadata for `@distilled.cloud/supabase@0.24.5` has no license field.
- Confirmed `LICENSE` contains Apache-2.0 license text.
- Verified the updated package manifest now declares `license: "Apache-2.0"`.
- Ran `git diff --check`.
- Ran `npm pack --dry-run --ignore-scripts --json` inside `packages/supabase`.
