### PR TITLE
Add license metadata to Distilled packages

### DIFF
--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/aws"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "module": "src/index.ts",

--- a/packages/axiom/package.json
+++ b/packages/axiom/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/axiom"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "module": "src/index.ts",

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/azure"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "module": "src/index.ts",

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/cloudflare"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "files": [

--- a/packages/coinbase/package.json
+++ b/packages/coinbase/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/coinbase"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "module": "src/index.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/core"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "files": [

--- a/packages/expo-eas/package.json
+++ b/packages/expo-eas/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/expo-eas"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "module": "src/index.ts",

--- a/packages/fly-io/package.json
+++ b/packages/fly-io/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/fly-io"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "module": "src/index.ts",

--- a/packages/gcp/package.json
+++ b/packages/gcp/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/gcp"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "files": [

--- a/packages/kubernetes/package.json
+++ b/packages/kubernetes/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/kubernetes"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "module": "src/index.ts",

--- a/packages/mongodb-atlas/package.json
+++ b/packages/mongodb-atlas/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/mongodb-atlas"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "module": "src/index.ts",

--- a/packages/neon/package.json
+++ b/packages/neon/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/neon"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "module": "src/index.ts",

--- a/packages/planetscale/package.json
+++ b/packages/planetscale/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/planetscale"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "module": "src/index.ts",

--- a/packages/posthog/package.json
+++ b/packages/posthog/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/posthog"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "module": "src/index.ts",

--- a/packages/prisma-postgres/package.json
+++ b/packages/prisma-postgres/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/prisma-postgres"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "module": "src/index.ts",

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/stripe"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "module": "src/index.ts",

--- a/packages/turso/package.json
+++ b/packages/turso/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/turso"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "module": "src/index.ts",

--- a/packages/typesense/package.json
+++ b/packages/typesense/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/typesense"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "module": "src/index.ts",

--- a/packages/workos/package.json
+++ b/packages/workos/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/alchemy-run/distilled",
     "directory": "packages/workos"
   },
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
   "module": "src/index.ts",


### PR DESCRIPTION
## Summary

- add `license: "Apache-2.0"` to `@distilled.cloud/stripe`
- add `license: "Apache-2.0"` to 18 additional published Distilled package manifests that currently omit license metadata
- keep `@distilled.cloud/supabase` out of this branch because it is covered by a separate PR

The added license metadata matches the repository root Apache-2.0 `LICENSE`. No runtime code, dependencies, exports, package versions, generated output, or lockfiles are changed.

Covered packages in this PR:

- `@distilled.cloud/aws`
- `@distilled.cloud/axiom`
- `@distilled.cloud/azure`
- `@distilled.cloud/cloudflare`
- `@distilled.cloud/coinbase`
- `@distilled.cloud/core`
- `@distilled.cloud/expo-eas`
- `@distilled.cloud/fly-io`
- `@distilled.cloud/gcp`
- `@distilled.cloud/kubernetes`
- `@distilled.cloud/mongodb-atlas`
- `@distilled.cloud/neon`
- `@distilled.cloud/planetscale`
- `@distilled.cloud/posthog`
- `@distilled.cloud/prisma-postgres`
- `@distilled.cloud/stripe`
- `@distilled.cloud/turso`
- `@distilled.cloud/typesense`
- `@distilled.cloud/workos`

## Validation

```sh
node manifest assertion for all 19 package manifests
git diff --check
npm pack --dry-run --ignore-scripts --json # run from each of the 18 newly added package directories
```

Each dry-run package included `package.json`.
