### PR TITLE
fix(core): serialize struct query params as deepObject dot-notation

### DIFF
--- a/packages/core/src/traits.ts
+++ b/packages/core/src/traits.ts
@@ -690,6 +690,46 @@ const RFC3986_NEEDS_ENCODING = /[^A-Za-z0-9\-._~:/?#\[\]@!$&'()*+,;=]/g;
 const encodeReserved = (v: string): string =>
   v.replace(RFC3986_NEEDS_ENCODING, encodeURIComponent);
 
+const isPlainObject = (v: unknown): v is Record<string, unknown> => {
+  if (typeof v !== "object" || v === null || Array.isArray(v)) return false;
+  const proto = Object.getPrototypeOf(v);
+  return proto === Object.prototype || proto === null;
+};
+
+/**
+ * Serialize a query-param value onto `query`, flattening plain objects
+ * using OpenAPI `deepObject`-style dot notation.
+ *
+ * Several Cloudflare list endpoints model their filters as nested structs
+ * (e.g. DNS `listRecords` takes `name: { exact, contains, ... }`) that must
+ * go over the wire as `name.exact=value`. Previously these fell through to
+ * `String(value)` and were sent as `name=[object Object]`, which the server
+ * happily treats as a filter that matches nothing — the call "succeeds"
+ * with zero results and the bug is invisible to the caller.
+ *
+ * Scalars and arrays keep their existing serialization (`k=v` /
+ * repeated `k=v` pairs). Nested plain objects recurse, so deeper filter
+ * shapes flatten to `a.b.c=value`. `undefined`/`null` members are skipped
+ * like top-level params. Non-plain objects (class instances, `Date`, …)
+ * keep the legacy `String(value)` behavior.
+ */
+const setQueryValue = (
+  query: Record<string, string | string[]>,
+  wireName: string,
+  value: unknown,
+): void => {
+  if (Array.isArray(value)) {
+    query[wireName] = value.map(String);
+  } else if (isPlainObject(value)) {
+    for (const [key, member] of Object.entries(value)) {
+      if (member === undefined || member === null) continue;
+      setQueryValue(query, `${wireName}.${key}`, member);
+    }
+  } else {
+    query[wireName] = String(value);
+  }
+};
+
 export const buildRequestParts = (
   ast: AST.AST,
   httpTrait: HttpTrait,
@@ -742,11 +782,7 @@ export const buildRequestParts = (
     if (queryParam !== undefined) {
       nonBodyKeys.add(tsName);
       const wireName = typeof queryParam === "string" ? queryParam : tsName;
-      if (Array.isArray(value)) {
-        query[wireName] = value.map(String);
-      } else {
-        query[wireName] = String(value);
-      }
+      setQueryValue(query, wireName, value);
       continue;
     }
 

--- a/packages/core/test/build-request-parts.test.ts
+++ b/packages/core/test/build-request-parts.test.ts
@@ -68,3 +68,85 @@ describe("buildRequestParts — RFC 6570 path expansion", () => {
     );
   });
 });
+
+// OpenAPI `deepObject`-style query params: Cloudflare list endpoints model
+// filters as nested structs (e.g. DNS listRecords `name: { exact }`) that
+// must serialize as `name.exact=value` — NOT `name=[object Object]`, which
+// the server treats as a filter that matches nothing.
+
+describe("buildRequestParts — deepObject query params", () => {
+  const Input = Schema.Struct({
+    zoneId: Schema.String.pipe(T.HttpPath("zone_id")),
+    name: Schema.optional(
+      Schema.Struct({
+        contains: Schema.optional(Schema.String),
+        exact: Schema.optional(Schema.String),
+      }),
+    ).pipe(T.HttpQuery("name")),
+    tag: Schema.optional(
+      Schema.Struct({
+        not: Schema.optional(Schema.Array(Schema.String)),
+      }),
+    ).pipe(T.HttpQuery("tag")),
+    type: Schema.optional(Schema.String).pipe(T.HttpQuery("type")),
+  }).pipe(T.Http({ method: "GET", path: "/zones/{zone_id}/dns_records" }));
+
+  const build = (input: Record<string, unknown>) =>
+    T.buildRequestParts(Input.ast, T.getHttpTrait(Input.ast)!, input, Input);
+
+  it("flattens a struct query param to dot-notation keys", () => {
+    const parts = build({
+      zoneId: "z1",
+      name: { exact: "api.example.com" },
+      type: "A",
+    });
+
+    expect(parts.query).toEqual({
+      "name.exact": "api.example.com",
+      type: "A",
+    });
+  });
+
+  it("flattens multiple members of the same struct", () => {
+    const parts = build({
+      zoneId: "z1",
+      name: { exact: "api.example.com", contains: "example" },
+    });
+
+    expect(parts.query).toEqual({
+      "name.exact": "api.example.com",
+      "name.contains": "example",
+    });
+  });
+
+  it("serializes array members as repeated dot-notation params", () => {
+    const parts = build({ zoneId: "z1", tag: { not: ["a", "b"] } });
+
+    expect(parts.query).toEqual({ "tag.not": ["a", "b"] });
+  });
+
+  it("skips undefined and null struct members", () => {
+    const parts = build({
+      zoneId: "z1",
+      name: { exact: "api.example.com", contains: undefined },
+    });
+
+    expect(parts.query).toEqual({ "name.exact": "api.example.com" });
+  });
+
+  it("keeps scalar and array query params unchanged", () => {
+    const ScalarInput = Schema.Struct({
+      type: Schema.optional(Schema.String).pipe(T.HttpQuery("type")),
+      id: Schema.optional(Schema.Array(Schema.String)).pipe(T.HttpQuery("id")),
+    }).pipe(T.Http({ method: "GET", path: "/things" }));
+
+    const parts = T.buildRequestParts(
+      ScalarInput.ast,
+      T.getHttpTrait(ScalarInput.ast)!,
+      { type: "A", id: ["1", "2"] },
+      ScalarInput,
+    );
+
+    expect(parts.query).toEqual({ type: "A", id: ["1", "2"] });
+  });
+});


### PR DESCRIPTION
`buildRequestParts` serialized object-valued query params with `String(value)`, so Cloudflare's struct-shaped list filters went over the wire as `name=[object Object]`. The server treats that as a filter matching nothing — the call "succeeds" with zero results, so the bug is invisible to callers.

```ts
// before: GET /zones/{id}/dns_records?name=%5Bobject%20Object%5D  → always []
// after:  GET /zones/{id}/dns_records?name.exact=api.example.com
yield* dns.listRecords.items({ zoneId, name: { exact: "api.example.com" } });
```

Plain objects now flatten to OpenAPI `deepObject` dot-notation (`name.exact=value`, recursing for deeper shapes, skipping `undefined`/`null` members, arrays becoming repeated `tag.not=a&tag.not=b` pairs). Scalars, arrays, and non-plain objects (class instances, `Date`) keep their existing serialization.

Found via alchemy-effect's `Cloudflare.DnsRecord` adoption path, whose `(name, type)` lookup never matched and let the engine create duplicate A records. Cloudflare is currently the only package with struct query params (`dns`, `accounts`, `organizations`, `audit-logs`, `zero-trust`, …), and its sub-keys are already wire-format, so no generated code changes are needed.

Note: the two pre-existing `server-retry-hint-cap.test.ts` failures also fail on a clean `main` checkout (env-var caching) and are unrelated.
