### PR TITLE
feat(cloudflare): add AI Gateway provider config update/delete (BYOK)

### DIFF
--- a/packages/cloudflare/patches/ai-gateway/createProviderConfig.json
+++ b/packages/cloudflare/patches/ai-gateway/createProviderConfig.json
@@ -1,4 +1,7 @@
 {
+  "errors": {
+    "GatewayNotFound": [{ "code": 7002 }]
+  },
   "request": {
     "properties": {
       "secret": { "optional": true },

--- a/packages/cloudflare/patches/ai-gateway/createProviderConfig.json
+++ b/packages/cloudflare/patches/ai-gateway/createProviderConfig.json
@@ -1,0 +1,8 @@
+{
+  "request": {
+    "properties": {
+      "secret": { "optional": true },
+      "secretId": { "optional": true }
+    }
+  }
+}

--- a/packages/cloudflare/patches/ai-gateway/listProviderConfigs.json
+++ b/packages/cloudflare/patches/ai-gateway/listProviderConfigs.json
@@ -1,0 +1,5 @@
+{
+  "errors": {
+    "GatewayNotFound": [{ "code": 7002 }]
+  }
+}

--- a/packages/cloudflare/specs/cloudflare-patch/ai-gateway.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare-patch/ai-gateway.openapi.yml
@@ -1,0 +1,125 @@
+openapi: 3.1.0
+info:
+  title: Cloudflare AI Gateway API (patch overrides)
+  version: 0.0.0
+  description: |
+    Operation additions for AI Gateway endpoints that exist in the public
+    Cloudflare OpenAPI schema (api-schemas) but are missing from the upstream
+    TypeScript SDK. Currently:
+      - updateProviderConfig: PUT /provider_configs/{id} — rotates the secret
+        value stored for a BYOK provider key.
+      - deleteProviderConfig: DELETE /provider_configs/{id} — removes a BYOK
+        provider key configuration from a gateway.
+servers:
+  - url: https://api.cloudflare.com/client/v4
+x-distilled-service: ai-gateway
+paths:
+  /accounts/{account_id}/ai-gateway/gateways/{gatewayId}/provider_configs/{id}:
+    put:
+      operationId: updateProviderConfig
+      summary: Update a Provider Config (rotate the secret value)
+      x-distilled-response-path: result
+      x-distilled-errors:
+        ProviderConfigNotFound:
+          - code: 7002
+            status: 404
+      parameters:
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/GatewayId"
+        - $ref: "#/components/parameters/ProviderConfigId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - secret
+              properties:
+                secret:
+                  type: string
+                  description: The new secret value for the provider key
+      responses:
+        "200":
+          description: Returns the updated provider config
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProviderConfig"
+    delete:
+      operationId: deleteProviderConfig
+      summary: Delete a Provider Config
+      x-distilled-response-path: result
+      x-distilled-errors:
+        ProviderConfigNotFound:
+          - code: 7002
+            status: 404
+      parameters:
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/GatewayId"
+        - $ref: "#/components/parameters/ProviderConfigId"
+      responses:
+        "200":
+          description: Returns the deleted provider config
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProviderConfig"
+
+components:
+  parameters:
+    AccountId:
+      name: account_id
+      in: path
+      required: true
+      description: Account identifier
+      schema:
+        type: string
+    GatewayId:
+      name: gatewayId
+      in: path
+      required: true
+      description: Gateway identifier
+      schema:
+        type: string
+    ProviderConfigId:
+      name: id
+      in: path
+      required: true
+      description: Provider config identifier
+      schema:
+        type: string
+  schemas:
+    ProviderConfig:
+      type: object
+      required:
+        - id
+        - alias
+        - default_config
+        - gateway_id
+        - modified_at
+        - provider_slug
+        - secret_id
+        - secret_preview
+      properties:
+        id:
+          type: string
+        alias:
+          type: string
+        default_config:
+          type: boolean
+        gateway_id:
+          type: string
+          description: gateway id
+        modified_at:
+          type: string
+        provider_slug:
+          type: string
+        secret_id:
+          type: string
+        secret_preview:
+          type: string
+        rate_limit:
+          type: number
+        rate_limit_period:
+          type: number

--- a/packages/cloudflare/specs/cloudflare/ai-gateway.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/ai-gateway.openapi.yml
@@ -7018,6 +7018,9 @@ paths:
                   - secret_id
                   - secret_preview
       x-distilled-pagination-class: ProviderConfigListResponsesV4PagePaginationArray
+      x-distilled-errors:
+        GatewayNotFound:
+          - code: 7002
     post:
       operationId: createProviderConfig
       description: "Creates a new AI Gateway.  @example ```ts const providerConfig =
@@ -7108,6 +7111,9 @@ paths:
                   - secret_id
                   - secret_preview
       x-distilled-response-path: result
+      x-distilled-errors:
+        GatewayNotFound:
+          - code: 7002
   /accounts/{account_id}/ai-gateway/gateways/{gatewayId}/provider_configs/{id}:
     put:
       operationId: updateProviderConfig

--- a/packages/cloudflare/specs/cloudflare/ai-gateway.openapi.yml
+++ b/packages/cloudflare/specs/cloudflare/ai-gateway.openapi.yml
@@ -1,7 +1,15 @@
 openapi: 3.1.0
 info:
-  title: Cloudflare AI-GATEWAY API
+  title: Cloudflare AI Gateway API (patch overrides)
   version: 0.0.0
+  description: |
+    Operation additions for AI Gateway endpoints that exist in the public
+    Cloudflare OpenAPI schema (api-schemas) but are missing from the upstream
+    TypeScript SDK. Currently:
+      - updateProviderConfig: PUT /provider_configs/{id} — rotates the secret
+        value stored for a BYOK provider key.
+      - deleteProviderConfig: DELETE /provider_configs/{id} — removes a BYOK
+        provider key configuration from a gateway.
 servers:
   - url: https://api.cloudflare.com/client/v4
 x-distilled-service: ai-gateway
@@ -7061,8 +7069,6 @@ paths:
                 - alias
                 - default_config
                 - provider_slug
-                - secret
-                - secret_id
       responses:
         "200":
           description: Success
@@ -7102,6 +7108,149 @@ paths:
                   - secret_id
                   - secret_preview
       x-distilled-response-path: result
+  /accounts/{account_id}/ai-gateway/gateways/{gatewayId}/provider_configs/{id}:
+    put:
+      operationId: updateProviderConfig
+      summary: Update a Provider Config (rotate the secret value)
+      parameters:
+        - name: account_id
+          in: path
+          required: true
+          description: Account identifier
+          schema:
+            type: string
+        - name: gatewayId
+          in: path
+          required: true
+          description: Gateway identifier
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          description: Provider config identifier
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                secret:
+                  type: string
+                  description: The new secret value for the provider key
+              required:
+                - secret
+      responses:
+        "200":
+          description: Returns the updated provider config
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  alias:
+                    type: string
+                  default_config:
+                    type: boolean
+                  gateway_id:
+                    type: string
+                    description: gateway id
+                  modified_at:
+                    type: string
+                  provider_slug:
+                    type: string
+                  secret_id:
+                    type: string
+                  secret_preview:
+                    type: string
+                  rate_limit:
+                    type: number
+                  rate_limit_period:
+                    type: number
+                required:
+                  - id
+                  - alias
+                  - default_config
+                  - gateway_id
+                  - modified_at
+                  - provider_slug
+                  - secret_id
+                  - secret_preview
+      x-distilled-response-path: result
+      x-distilled-errors:
+        ProviderConfigNotFound:
+          - code: 7002
+            status: 404
+    delete:
+      operationId: deleteProviderConfig
+      summary: Delete a Provider Config
+      parameters:
+        - name: account_id
+          in: path
+          required: true
+          description: Account identifier
+          schema:
+            type: string
+        - name: gatewayId
+          in: path
+          required: true
+          description: Gateway identifier
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          description: Provider config identifier
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Returns the deleted provider config
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  alias:
+                    type: string
+                  default_config:
+                    type: boolean
+                  gateway_id:
+                    type: string
+                    description: gateway id
+                  modified_at:
+                    type: string
+                  provider_slug:
+                    type: string
+                  secret_id:
+                    type: string
+                  secret_preview:
+                    type: string
+                  rate_limit:
+                    type: number
+                  rate_limit_period:
+                    type: number
+                required:
+                  - id
+                  - alias
+                  - default_config
+                  - gateway_id
+                  - modified_at
+                  - provider_slug
+                  - secret_id
+                  - secret_preview
+      x-distilled-response-path: result
+      x-distilled-errors:
+        ProviderConfigNotFound:
+          - code: 7002
+            status: 404
   /accounts/{account_id}/ai-gateway/gateways/{gatewayId}/url/{provider}:
     get:
       operationId: getUrl

--- a/packages/cloudflare/src/services/ai-gateway.ts
+++ b/packages/cloudflare/src/services/ai-gateway.ts
@@ -36,6 +36,12 @@ T.applyErrorMatchers(NoManualTopup, [
   { code: 1000, message: { includes: "NO_MANUAL_TOPUP" } },
 ]);
 
+export class ProviderConfigNotFound extends Schema.TaggedErrorClass<ProviderConfigNotFound>()(
+  "ProviderConfigNotFound",
+  { code: Schema.Number, message: Schema.String },
+) {}
+T.applyErrorMatchers(ProviderConfigNotFound, [{ code: 7002, status: 404 }]);
+
 // =============================================================================
 // AiGateway
 // =============================================================================
@@ -8165,9 +8171,9 @@ export interface CreateProviderConfigRequest {
   /** Body param */
   providerSlug: string;
   /** Body param */
-  secret: string;
+  secret?: string;
   /** Body param */
-  secretId: string;
+  secretId?: string;
   /** Body param */
   rateLimit?: number;
   /** Body param */
@@ -8181,8 +8187,8 @@ export const CreateProviderConfigRequest =
     alias: Schema.String,
     defaultConfig: Schema.Boolean,
     providerSlug: Schema.String,
-    secret: Schema.String,
-    secretId: Schema.String,
+    secret: Schema.optional(Schema.String),
+    secretId: Schema.optional(Schema.String),
     rateLimit: Schema.optional(Schema.Number),
     rateLimitPeriod: Schema.optional(Schema.Number),
   }).pipe(
@@ -8259,6 +8265,171 @@ export const createProviderConfig: API.OperationMethod<
   input: CreateProviderConfigRequest,
   output: CreateProviderConfigResponse,
   errors: [],
+}));
+
+export interface UpdateProviderConfigRequest {
+  /** Account identifier */
+  accountId: string;
+  /** Gateway identifier */
+  gatewayId: string;
+  /** Provider config identifier */
+  id: string;
+  /** The new secret value for the provider key */
+  secret: string;
+}
+
+export const UpdateProviderConfigRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    gatewayId: Schema.String.pipe(T.HttpPath("gatewayId")),
+    id: Schema.String.pipe(T.HttpPath("id")),
+    secret: Schema.String,
+  }).pipe(
+    T.Http({
+      method: "PUT",
+      path: "/accounts/{account_id}/ai-gateway/gateways/{gatewayId}/provider_configs/{id}",
+    }),
+  ) as unknown as Schema.Schema<UpdateProviderConfigRequest>;
+
+export interface UpdateProviderConfigResponse {
+  id: string;
+  alias: string;
+  defaultConfig: boolean;
+  /** gateway id */
+  gatewayId: string;
+  modifiedAt: string;
+  providerSlug: string;
+  secretId: string;
+  secretPreview: string;
+  rateLimit?: number | null;
+  rateLimitPeriod?: number | null;
+}
+
+export const UpdateProviderConfigResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    id: Schema.String,
+    alias: Schema.String,
+    defaultConfig: Schema.Boolean,
+    gatewayId: Schema.String,
+    modifiedAt: Schema.String,
+    providerSlug: Schema.String,
+    secretId: Schema.String,
+    secretPreview: Schema.String,
+    rateLimit: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    rateLimitPeriod: Schema.optional(
+      Schema.Union([Schema.Number, Schema.Null]),
+    ),
+  })
+    .pipe(
+      Schema.encodeKeys({
+        id: "id",
+        alias: "alias",
+        defaultConfig: "default_config",
+        gatewayId: "gateway_id",
+        modifiedAt: "modified_at",
+        providerSlug: "provider_slug",
+        secretId: "secret_id",
+        secretPreview: "secret_preview",
+        rateLimit: "rate_limit",
+        rateLimitPeriod: "rate_limit_period",
+      }),
+    )
+    .pipe(
+      T.ResponsePath("result"),
+    ) as unknown as Schema.Schema<UpdateProviderConfigResponse>;
+
+export type UpdateProviderConfigError = DefaultErrors | ProviderConfigNotFound;
+
+export const updateProviderConfig: API.OperationMethod<
+  UpdateProviderConfigRequest,
+  UpdateProviderConfigResponse,
+  UpdateProviderConfigError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: UpdateProviderConfigRequest,
+  output: UpdateProviderConfigResponse,
+  errors: [ProviderConfigNotFound],
+}));
+
+export interface DeleteProviderConfigRequest {
+  /** Account identifier */
+  accountId: string;
+  /** Gateway identifier */
+  gatewayId: string;
+  /** Provider config identifier */
+  id: string;
+}
+
+export const DeleteProviderConfigRequest =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    accountId: Schema.String.pipe(T.HttpPath("account_id")),
+    gatewayId: Schema.String.pipe(T.HttpPath("gatewayId")),
+    id: Schema.String.pipe(T.HttpPath("id")),
+  }).pipe(
+    T.Http({
+      method: "DELETE",
+      path: "/accounts/{account_id}/ai-gateway/gateways/{gatewayId}/provider_configs/{id}",
+    }),
+  ) as unknown as Schema.Schema<DeleteProviderConfigRequest>;
+
+export interface DeleteProviderConfigResponse {
+  id: string;
+  alias: string;
+  defaultConfig: boolean;
+  /** gateway id */
+  gatewayId: string;
+  modifiedAt: string;
+  providerSlug: string;
+  secretId: string;
+  secretPreview: string;
+  rateLimit?: number | null;
+  rateLimitPeriod?: number | null;
+}
+
+export const DeleteProviderConfigResponse =
+  /*@__PURE__*/ /*#__PURE__*/ Schema.Struct({
+    id: Schema.String,
+    alias: Schema.String,
+    defaultConfig: Schema.Boolean,
+    gatewayId: Schema.String,
+    modifiedAt: Schema.String,
+    providerSlug: Schema.String,
+    secretId: Schema.String,
+    secretPreview: Schema.String,
+    rateLimit: Schema.optional(Schema.Union([Schema.Number, Schema.Null])),
+    rateLimitPeriod: Schema.optional(
+      Schema.Union([Schema.Number, Schema.Null]),
+    ),
+  })
+    .pipe(
+      Schema.encodeKeys({
+        id: "id",
+        alias: "alias",
+        defaultConfig: "default_config",
+        gatewayId: "gateway_id",
+        modifiedAt: "modified_at",
+        providerSlug: "provider_slug",
+        secretId: "secret_id",
+        secretPreview: "secret_preview",
+        rateLimit: "rate_limit",
+        rateLimitPeriod: "rate_limit_period",
+      }),
+    )
+    .pipe(
+      T.ResponsePath("result"),
+    ) as unknown as Schema.Schema<DeleteProviderConfigResponse>;
+
+export type DeleteProviderConfigError = DefaultErrors | ProviderConfigNotFound;
+
+export const deleteProviderConfig: API.OperationMethod<
+  DeleteProviderConfigRequest,
+  DeleteProviderConfigResponse,
+  DeleteProviderConfigError,
+  Credentials | HttpClient.HttpClient
+> = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
+  input: DeleteProviderConfigRequest,
+  output: DeleteProviderConfigResponse,
+  errors: [ProviderConfigNotFound],
 }));
 
 // =============================================================================

--- a/packages/cloudflare/src/services/ai-gateway.ts
+++ b/packages/cloudflare/src/services/ai-gateway.ts
@@ -8140,7 +8140,7 @@ export const ListProviderConfigsResponse =
     Schema.encodeKeys({ result: "result", resultInfo: "result_info" }),
   ) as unknown as Schema.Schema<ListProviderConfigsResponse>;
 
-export type ListProviderConfigsError = DefaultErrors;
+export type ListProviderConfigsError = DefaultErrors | GatewayNotFound;
 
 export const listProviderConfigs: API.PaginatedOperationMethod<
   ListProviderConfigsRequest,
@@ -8150,7 +8150,7 @@ export const listProviderConfigs: API.PaginatedOperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.makePaginated(() => ({
   input: ListProviderConfigsRequest,
   output: ListProviderConfigsResponse,
-  errors: [],
+  errors: [GatewayNotFound],
   pagination: {
     mode: "page",
     inputToken: "page",
@@ -8254,7 +8254,7 @@ export const CreateProviderConfigResponse =
       T.ResponsePath("result"),
     ) as unknown as Schema.Schema<CreateProviderConfigResponse>;
 
-export type CreateProviderConfigError = DefaultErrors;
+export type CreateProviderConfigError = DefaultErrors | GatewayNotFound;
 
 export const createProviderConfig: API.OperationMethod<
   CreateProviderConfigRequest,
@@ -8264,7 +8264,7 @@ export const createProviderConfig: API.OperationMethod<
 > = /*@__PURE__*/ /*#__PURE__*/ API.make(() => ({
   input: CreateProviderConfigRequest,
   output: CreateProviderConfigResponse,
-  errors: [],
+  errors: [GatewayNotFound],
 }));
 
 export interface UpdateProviderConfigRequest {

--- a/packages/cloudflare/test/ai-gateway.test.ts
+++ b/packages/cloudflare/test/ai-gateway.test.ts
@@ -203,4 +203,75 @@ describe("AiGateway", () => {
         Effect.map((e) => expect(e._tag).toBe("GatewayNotFound")),
       ));
   });
+
+  // --------------------------------------------------------------------------
+  // providerConfigs (BYOK provider keys)
+  // --------------------------------------------------------------------------
+  describe("providerConfigs", () => {
+    test("happy path - create, list, rotate, delete a provider config", () =>
+      withGateway(gatewayName("provider-cfg"), (name) =>
+        Effect.gen(function* () {
+          // Create a BYOK provider key with an inline (dummy) secret value.
+          // Cloudflare stores it in the account's Secrets Store under the
+          // {gateway}_{provider}_{alias} naming convention.
+          const created = yield* AiGateway.createProviderConfig({
+            accountId: accountId(),
+            gatewayId: name,
+            providerSlug: "openai",
+            alias: "default",
+            defaultConfig: true,
+            secret: "distilled-test-not-a-real-key-1",
+          });
+
+          expect(created.providerSlug).toBe("openai");
+          expect(created.alias).toBe("default");
+          expect(created.defaultConfig).toBe(true);
+          expect(created.gatewayId).toBe(name);
+          expect(typeof created.secretId).toBe("string");
+
+          // List includes the created config.
+          const listed = yield* AiGateway.listProviderConfigs({
+            accountId: accountId(),
+            gatewayId: name,
+          });
+          expect(listed.result.map((c) => c.id)).toContain(created.id);
+
+          // Rotate the secret value in place.
+          const rotated = yield* AiGateway.updateProviderConfig({
+            accountId: accountId(),
+            gatewayId: name,
+            id: created.id,
+            secret: "distilled-test-not-a-real-key-2",
+          });
+          expect(rotated.id).toBe(created.id);
+          expect(rotated.providerSlug).toBe("openai");
+
+          // Delete the config.
+          const deleted = yield* AiGateway.deleteProviderConfig({
+            accountId: accountId(),
+            gatewayId: name,
+            id: created.id,
+          });
+          expect(deleted.id).toBe(created.id);
+
+          const after = yield* AiGateway.listProviderConfigs({
+            accountId: accountId(),
+            gatewayId: name,
+          });
+          expect(after.result.map((c) => c.id)).not.toContain(created.id);
+        }),
+      ));
+
+    test("error - ProviderConfigNotFound for delete non-existent config", () =>
+      withGateway(gatewayName("provider-cfg-404"), (name) =>
+        AiGateway.deleteProviderConfig({
+          accountId: accountId(),
+          gatewayId: name,
+          id: "00000000-0000-0000-0000-000000000000",
+        }).pipe(
+          Effect.flip,
+          Effect.map((e) => expect(e._tag).toBe("ProviderConfigNotFound")),
+        ),
+      ));
+  });
 });


### PR DESCRIPTION
## Motivation

Cloudflare's AI Gateway BYOK feature ([docs](https://developers.cloudflare.com/ai-gateway/configuration/bring-your-own-keys/), [changelog](https://developers.cloudflare.com/changelog/2025-08-25-secrets-store-ai-gateway/)) is managed through the `provider_configs` API. The upstream TypeScript SDK only exposes **list** and **create**, but the public Cloudflare OpenAPI schema ([api-schemas](https://github.com/cloudflare/api-schemas)) also documents:

- `PUT /accounts/{account_id}/ai-gateway/gateways/{gateway_id}/provider_configs/{id}` — body `{ secret }`, rotates the stored key value (`aig-config-update-providers`)
- `DELETE /accounts/{account_id}/ai-gateway/gateways/{gateway_id}/provider_configs/{id}` — removes a provider key config (`aig-config-delete-providers`)

Without delete, a declarative resource on top of provider configs (planned for alchemy-effect) cannot implement its destroy lifecycle.

## Changes

- New `specs/cloudflare-patch/ai-gateway.openapi.yml` adding `updateProviderConfig` and `deleteProviderConfig`, with a `ProviderConfigNotFound` error matcher (code 7002, status 404) — the same code/shape the spec documents for the 404 response.
- New `patches/ai-gateway/createProviderConfig.json` marking `secret`/`secretId` optional on create. The upstream SDK requires both, but api-schemas requires only `provider_slug`, `default_config`, `alias` — `secret` (inline value, dashboard-style) and `secret_id` (reference to a pre-created Secrets Store secret, the documented API flow) are alternative inputs.
- Regenerated `src/services/ai-gateway.ts` (`bun scripts/generate.ts --service ai-gateway` + oxlint/oxfmt).
- Live test coverage in `test/ai-gateway.test.ts`: create → list → rotate → delete lifecycle plus the `ProviderConfigNotFound` path (dummy key values only).

## Validation

- `bun run typecheck` (tsgo) clean in `packages/cloudflare`.
- `oxlint` / `oxfmt --check` clean on touched files.
- Live tests not run locally (no credentials in this environment); they follow the existing `withGateway` cleanup-first pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)