### PR TITLE
fix(aws): resolve legacy inline-SSO profiles

### DIFF
--- a/packages/aws/src/auth.ts
+++ b/packages/aws/src/auth.ts
@@ -73,38 +73,49 @@ export const makeAuthService = () =>
       const awsDir = path.join(ini.getHomeDir(), ".aws");
       const configPath = path.join(awsDir, "config");
 
-      if (profile.sso_session) {
-        const ssoRegion = Option.getOrUndefined(
-          yield* Effect.serviceOption(SsoRegion),
-        );
-        const ssoStartUrl = Option.getOrElse(
-          yield* Effect.serviceOption(SsoStartUrl),
-          () => profile.sso_start_url,
-        );
+      // A profile is an SSO profile in one of two config formats:
+      //   - modern: `sso_session = <name>` referencing an `[sso-session <name>]`
+      //     section that holds `sso_start_url` / `sso_region`.
+      //   - legacy inline: `sso_start_url` (and `sso_region`) set directly on the
+      //     profile, with no `sso_session`.
+      // Only the modern format needs the session lookup; both then validate the
+      // required SSO fields. (Legacy inline is still emitted by older `aws configure
+      // sso` runs and remains valid, so treat it as an SSO profile rather than
+      // reporting the profile as not found.)
+      if (profile.sso_session || profile.sso_start_url) {
+        if (profile.sso_session) {
+          const ssoRegion = Option.getOrUndefined(
+            yield* Effect.serviceOption(SsoRegion),
+          );
+          const ssoStartUrl = Option.getOrElse(
+            yield* Effect.serviceOption(SsoStartUrl),
+            () => profile.sso_start_url,
+          );
 
-        const ssoSessions = yield* fs.readFileString(configPath).pipe(
-          Effect.flatMap((config) =>
-            Effect.promise(async () => parseIni(config)),
-          ),
-          Effect.map(parseSSOSessionData),
-        );
-        const session = ssoSessions[profile.sso_session];
-        if (ssoRegion && ssoRegion !== session.sso_region) {
-          return yield* new ConflictingSSORegion({
-            message: `Conflicting SSO region`,
-            ssoRegion: ssoRegion,
-            profile: profile.sso_session,
-          });
+          const ssoSessions = yield* fs.readFileString(configPath).pipe(
+            Effect.flatMap((config) =>
+              Effect.promise(async () => parseIni(config)),
+            ),
+            Effect.map(parseSSOSessionData),
+          );
+          const session = ssoSessions[profile.sso_session];
+          if (ssoRegion && ssoRegion !== session.sso_region) {
+            return yield* new ConflictingSSORegion({
+              message: `Conflicting SSO region`,
+              ssoRegion: ssoRegion,
+              profile: profile.sso_session,
+            });
+          }
+          if (ssoStartUrl && ssoStartUrl !== session.sso_start_url) {
+            return yield* new ConflictingSSOStartUrl({
+              message: `Conflicting SSO start url`,
+              ssoStartUrl: ssoStartUrl,
+              profile: profile.sso_session,
+            });
+          }
+          profile.sso_region = session.sso_region;
+          profile.sso_start_url = session.sso_start_url;
         }
-        if (ssoStartUrl && ssoStartUrl !== session.sso_start_url) {
-          return yield* new ConflictingSSOStartUrl({
-            message: `Conflicting SSO start url`,
-            ssoStartUrl: ssoStartUrl,
-            profile: profile.sso_session,
-          });
-        }
-        profile.sso_region = session.sso_region;
-        profile.sso_start_url = session.sso_start_url;
 
         const ssoFields = [
           "sso_start_url",
@@ -141,9 +152,12 @@ export const makeAuthService = () =>
 
       const profile = yield* loadProfile(profileName);
 
-      if (profile.sso_session) {
+      // Both SSO formats cache the access token under sha1 of the cache key: the
+      // `sso_session` name (modern) or the `sso_start_url` (legacy inline format).
+      const ssoCacheKey = profile.sso_session ?? profile.sso_start_url;
+      if (ssoCacheKey) {
         const hasher = createHash("sha1");
-        const cacheName = hasher.update(profile.sso_session).digest("hex");
+        const cacheName = hasher.update(ssoCacheKey).digest("hex");
         const ssoTokenFilepath = path.join(cachePath, `${cacheName}.json`);
         const cachedCredsFilePath = path.join(
           cachePath,
@@ -199,7 +213,7 @@ export const makeAuthService = () =>
             () =>
               new InvalidSSOToken({
                 message: `The SSO session token associated with profile=${profileName} was not found or is invalid. ${REFRESH_MESSAGE}`,
-                sso_session: profile.sso_session!,
+                sso_session: ssoCacheKey,
               }),
           ),
         );

--- a/packages/aws/test/auth.test.ts
+++ b/packages/aws/test/auth.test.ts
@@ -1,0 +1,104 @@
+import { NodeServices } from "@effect/platform-node";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as Auth from "../src/auth.ts";
+
+const platform = Layer.mergeAll(NodeServices.layer, FetchHttpClient.layer);
+
+/**
+ * Run an effect against a throwaway `~/.aws/config` fixture by pointing `HOME`
+ * (and `USERPROFILE`) at a temp dir. Both the profile parse and the sso-session
+ * lookup read from the home dir, so this keeps `loadProfile` fully hermetic — no
+ * real AWS config or network. Restores the prior env afterward.
+ */
+const withAwsConfig = <A, E, R>(
+  config: string,
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const home = mkdtempSync(join(tmpdir(), "distilled-aws-auth-"));
+      mkdirSync(join(home, ".aws"), { recursive: true });
+      writeFileSync(join(home, ".aws", "config"), config);
+      const prev = {
+        HOME: process.env.HOME,
+        USERPROFILE: process.env.USERPROFILE,
+      };
+      process.env.HOME = home;
+      process.env.USERPROFILE = home;
+      return prev;
+    }),
+    () => effect,
+    (prev) =>
+      Effect.sync(() => {
+        for (const key of ["HOME", "USERPROFILE"] as const) {
+          if (prev[key] === undefined) delete process.env[key];
+          else process.env[key] = prev[key];
+        }
+      }),
+  );
+
+describe("Auth.loadProfile", () => {
+  it.effect(
+    "resolves a legacy inline-SSO profile (sso_start_url, no sso_session)",
+    () =>
+      withAwsConfig(
+        [
+          "[profile legacy-sso]",
+          "sso_start_url = https://example.awsapps.com/start",
+          "sso_region = us-east-1",
+          "sso_account_id = 123456789012",
+          "sso_role_name = AdministratorAccess",
+          "region = us-east-1",
+          "",
+        ].join("\n"),
+        Effect.gen(function* () {
+          const profile = yield* Auth.loadProfile("legacy-sso");
+          expect(profile.sso_account_id).toBe("123456789012");
+          expect(profile.sso_start_url).toBe(
+            "https://example.awsapps.com/start",
+          );
+          expect(profile.sso_role_name).toBe("AdministratorAccess");
+        }).pipe(Effect.provide(platform)),
+      ),
+  );
+
+  it.effect("still resolves a modern sso-session profile", () =>
+    withAwsConfig(
+      [
+        "[profile modern-sso]",
+        "sso_session = my-session",
+        "sso_account_id = 123456789012",
+        "sso_role_name = AdministratorAccess",
+        "region = us-east-1",
+        "",
+        "[sso-session my-session]",
+        "sso_start_url = https://example.awsapps.com/start",
+        "sso_region = us-east-1",
+        "",
+      ].join("\n"),
+      Effect.gen(function* () {
+        const profile = yield* Auth.loadProfile("modern-sso");
+        // sso_start_url / sso_region are merged in from the [sso-session] section.
+        expect(profile.sso_start_url).toBe("https://example.awsapps.com/start");
+        expect(profile.sso_region).toBe("us-east-1");
+        expect(profile.sso_account_id).toBe("123456789012");
+      }).pipe(Effect.provide(platform)),
+    ),
+  );
+
+  it.effect("returns ProfileNotFound for a non-SSO profile", () =>
+    withAwsConfig(
+      ["[profile plain]", "region = us-east-1", ""].join("\n"),
+      Effect.gen(function* () {
+        const error = yield* Effect.flip(Auth.loadProfile("plain"));
+        expect(error._tag).toBe("Alchemy::AWS::ProfileNotFound");
+      }).pipe(Effect.provide(platform)),
+    ),
+  );
+});


### PR DESCRIPTION
`Auth.loadProfile` / `loadProfileCredentials` only handled the modern `sso-session` config format — all SSO logic was gated on `profile.sso_session`. A profile in the **legacy inline-SSO** format (`sso_start_url` / `sso_account_id` / `sso_region` / `sso_role_name` set directly on the profile, with no `sso_session`) fell through to `ProfileNotFound`, even though it exists and is valid. Older `aws configure sso` runs still emit this format.

Treat a profile as SSO when it has `sso_session` **or** `sso_start_url`:

- `loadProfile`: run the `[sso-session]` lookup only for the modern format; validate the required SSO fields for both.
- `loadProfileCredentials`: the SSO access-token cache is keyed by sha1 of the `sso_session` name (modern) or the `sso_start_url` (legacy), so key on `sso_session ?? sso_start_url`.

Modern `sso-session` profiles are unaffected.

```diff
- if (profile.sso_session) {
+ if (profile.sso_session || profile.sso_start_url) {
+   if (profile.sso_session) {
      // resolve [sso-session]; merge sso_region / sso_start_url
+   }
    // validate required SSO fields; return profile
  }
```

Adds hermetic `Auth.loadProfile` tests: legacy inline resolves, modern `sso-session` still resolves, non-SSO still returns `ProfileNotFound`.
